### PR TITLE
Fix serving resources from multiple classpath jars

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -147,6 +147,18 @@
             <version>20200518</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.webjars</groupId>
+            <artifactId>jquery</artifactId>
+            <version>1.12.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.webjars</groupId>
+            <artifactId>jquery-ui</artifactId>
+            <version>1.12.1</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <inceptionYear>2017</inceptionYear>

--- a/src/main/java/io/muserver/handlers/ResourceProvider.java
+++ b/src/main/java/io/muserver/handlers/ResourceProvider.java
@@ -57,8 +57,6 @@ interface ResourceProviderFactory {
 
 
 class ClasspathCache implements ResourceProviderFactory {
-    private static FileSystem zipFileSystem;
-
     private final String basePath;
     private final Map<String, ClasspathResourceProvider> all = new HashMap<>();
 
@@ -72,13 +70,14 @@ class ClasspathCache implements ResourceProviderFactory {
             URI uri = resource.toURI();
             Path myPath;
             if (uri.getScheme().equals("jar")) {
-                if (zipFileSystem == null) {
+                FileSystem zipFileSystem;
+                try {
+                    zipFileSystem = FileSystems.getFileSystem(uri);
+                } catch (FileSystemNotFoundException e) {
                     try {
                         zipFileSystem = FileSystems.newFileSystem(uri, Collections.emptyMap());
-                    } catch (FileSystemAlreadyExistsException e) {
-                        if (zipFileSystem == null) {
-                            throw new MuException("Cannot create the classpath handler as the Zip File System for this jar file has already been created");
-                        }
+                    } catch (FileSystemAlreadyExistsException e2) {
+                        throw new MuException("Cannot create the classpath handler as the Zip File System for this jar file has already been created");
                     }
                 }
                 myPath = zipFileSystem.getPath(basePath);

--- a/src/test/java/io/muserver/rest/ContextTest.java
+++ b/src/test/java/io/muserver/rest/ContextTest.java
@@ -82,15 +82,16 @@ public class ContextTest {
             }
         }
         this.server = muServer()
-            .withHttpsPort(50378)
+            .withHttpsPort(0)
             .addHandler(
                 context("/api/ha ha/").addHandler(restHandler(new Sample()))
             )
             .start();
+        int port = server.uri().getPort();
         try (Response resp = call(request().url(server.uri().resolve("/api/ha%20ha/samples/zample/barmpit?hoo=har%20har").toString()))) {
-            assertThat(resp.body().string(), equalTo("https://localhost:50378/api/ha%20ha/\nsamples/zample/barmpit\n" +
-                "https://localhost:50378/api/ha%20ha/samples/zample/barmpit\n" +
-                "https://localhost:50378/api/ha%20ha/samples/zample/barmpit?hoo=har%20har\nhar har\nhar%20har\n" +
+            assertThat(resp.body().string(), equalTo("https://localhost:" + port + "/api/ha%20ha/\nsamples/zample/barmpit\n" +
+                "https://localhost:" + port + "/api/ha%20ha/samples/zample/barmpit\n" +
+                "https://localhost:" + port + "/api/ha%20ha/samples/zample/barmpit?hoo=har%20har\nhar har\nhar%20har\n" +
                 "Sample Resource Class\nsamples/zample/barmpit:samples"));
         }
     }


### PR DESCRIPTION
ResourceProvider - try to get an existing FileSystem for a jar resource,
rather than keeping a static reference to the first one opened,
before trying to create a new one.