### PR TITLE
fix the async write state

### DIFF
--- a/src/main/java/io/muserver/NettyResponseAdaptor.java
+++ b/src/main/java/io/muserver/NettyResponseAdaptor.java
@@ -64,13 +64,20 @@ abstract class NettyResponseAdaptor implements MuResponse {
      * @param successState The state to set if the future completes successfully
      */
     protected void outputState(io.netty.util.concurrent.Future<? super Void> future, ResponseState successState) {
-        if (future == null || future.isSuccess()) {
+        if (future == null) {
             outputState(successState);
-        } else {
-            if (!state.endState()) {
-                outputState(ResponseState.ERRORED);
-            }
+            return;
         }
+
+        future.addListener(result -> {
+            if (result.isSuccess()) {
+                outputState(successState);
+            } else {
+                if (!state.endState()) {
+                    outputState(ResponseState.ERRORED);
+                }
+            }
+        });
     }
 
 


### PR DESCRIPTION
We found a case on HTTP2,  when client receive FIN, and later it received RST_STREAM. 

this is very likely caused by the write state not handled correctly, this fix is aim to to update the state on the write future complete, rather then do it immediately before the action finished.