### PR TITLE
enhance MuWebSocket.onBinary() for separation of control for pulling more data and releasing byteBuffer.

### DIFF
--- a/src/main/java/io/muserver/MuWebSocket.java
+++ b/src/main/java/io/muserver/MuWebSocket.java
@@ -77,6 +77,24 @@ public interface MuWebSocket {
     }
 
     /**
+     * Called when a message is received from the client. Consider using this API when separation of control for pulling data and releasing buffer are required.
+     * Otherwise, please use {@link #onBinary(ByteBuffer, boolean, DoneCallback)} instead.
+     *
+     * @param buffer     The message as a byte buffer.
+     * @param isLast     Returns <code>true</code> if this message is the last part of the complete message. This is only <code>false</code>
+     *                   when clients send fragmented messages in which case only the last part of the fragmented message will return <code>true</code>.
+     * @param doneAndPullData A callback that must be run with <code>doneAndPullData.onComplete()</code> when ready to pull more data from websocket.
+     * @param releaseBuffer A callback that must be run with <code>releaseBuffer.run()</code> when the byte buffer is no longer needed. Failure to call this will result in memory leaks.
+     * @throws Exception Any exceptions thrown will result in the onError method being called with the thrown exception being used as the <code>cause</code> parameter.
+     */
+    default void onBinary(ByteBuffer buffer, boolean isLast, DoneCallback doneAndPullData, Runnable releaseBuffer) throws Exception {
+        onBinary(buffer, isLast, error -> {
+            releaseBuffer.run();
+            doneAndPullData.onComplete(error);
+        });
+    }
+
+    /**
      * Called when the client has closed the connection.
      * <p>The connection should be closed on the server side when this is received. If overriding {@link BaseWebSocket} this occurs automatically.</p>
      *

--- a/src/main/java/io/muserver/MuWebSocketSessionImpl.java
+++ b/src/main/java/io/muserver/MuWebSocketSessionImpl.java
@@ -202,10 +202,9 @@ class MuWebSocketSessionImpl implements MuWebSocketSession, Exchange {
                 receivingState = (frame.isFinalFragment()) ? ContinuationState.NONE : ContinuationState.BINARY;
                 ByteBuf content = frame.content();
                 retained = content.retain();
-                muWebSocket.onBinary(content.nioBuffer(), frame.isFinalFragment(), error -> {
-                    content.release();
-                    onComplete.onComplete(error);
-                });
+                muWebSocket.onBinary(content.nioBuffer(), frame.isFinalFragment(),
+                    onComplete,
+                    content::release);
             } else if (frame instanceof PingWebSocketFrame) {
                 ByteBuf content = frame.content();
                 retained = content.retain();


### PR DESCRIPTION
It's an advanced API to control pulling data from websocket and releasing byteBuffer separately. This will give more control to the framework user. 

If we reference to the API design of jdk-http-client Websocket.Listener, it has something similar

```java
CompletionStage<?> onBinary(WebSocket webSocket, ByteBuffer data, boolean last)
```

* for pulling more data, calling websocket.request(1)
* for releasing byteBuffer, resolve the return CompletionStage

I had think about the `return CompletionStage` way to release buffer, but the current implementation is not very friendly to it and need more refactor. So I suggest to use the way in PR to keep things consistent. 

FYI. mucranker need that to avoid byteBuffer copying, this will improve the performance quite a lot for the multiplexing protocol implementation. When we doing 20 client each sending 100 requests concurrently. adopting this will improve the QPS from 100 to 160, and lower CPU consumption. 
