### PR TITLE
flush the buffer on writability become true again

### DIFF
--- a/src/main/java/io/muserver/BackPressureHandler.java
+++ b/src/main/java/io/muserver/BackPressureHandler.java
@@ -62,8 +62,11 @@ class BackPressureHandler extends ChannelDuplexHandler {
 
     private void deliverTasks(ChannelHandlerContext ctx, boolean evenIfUnwriteable) {
         Delivery task;
+        boolean hasSent = false;
         while ( (evenIfUnwriteable || ctx.channel().isWritable()) && (task = toSend.poll()) != null) {
             task.send(ctx);
+            hasSent = true;
         }
+        if (hasSent) ctx.flush();
     }
 }


### PR DESCRIPTION
This is for fixing the bug for back pressure handling, without the flush, the data will never arrive client side when the writability become true again. 