### PR TITLE
adding MuServer.stop(long duration, TimeUnit unit) to support graceful shutdown

### DIFF
--- a/src/main/java/io/muserver/MuServer.java
+++ b/src/main/java/io/muserver/MuServer.java
@@ -18,7 +18,21 @@ public interface MuServer {
     /**
      * Shuts down the server
      */
-    void stop();
+    default void stop() {
+        stop(0, TimeUnit.MILLISECONDS);
+    }
+
+
+    /**
+     * Graceful shut down the server with timeout. During the graceful period, the server will not accept
+     * new connections and wait for in flight requests to finish.
+     * <p>
+     * It's a blocking call, so it will not return until the server is stopped or the timeout is reached.
+     *
+     * @param duration the graceful timeout period, or 0 to shut down immediately.
+     * @param unit The unit of the period.
+     */
+    void stop(long duration, TimeUnit unit);
 
     /**
      * @return The HTTPS (or if unavailable the HTTP) URI of the web server.

--- a/src/main/java/io/muserver/MuServer.java
+++ b/src/main/java/io/muserver/MuServer.java
@@ -22,18 +22,20 @@ public interface MuServer {
         stop(0, TimeUnit.MILLISECONDS);
     }
 
-
-   /**
-      * Gracefully shuts down the server with a timeout. During the graceful shutdown period, the server will stop
-      * accepting new connections and wait for in-flight requests to complete.
-      * <p>
-      * This is a blocking call and will not return until the server is fully stopped or the timeout is reached.
-      * </p>
-      *
-      * @param duration The duration of the graceful timeout period, or 0 to shut down immediately.
-      * @param unit     The time unit of the duration.
-      */
-    void stop(long duration, TimeUnit unit);
+    /**
+     * Gracefully shuts down the server with a timeout. During the graceful shutdown period, the server will stop
+     * accepting new connections and wait for in-flight requests to complete. When timeout is reached and there
+     * are still in-flight requests, all the http connections will be aborted, no exception will be thrown.
+     *
+     * <p>
+     * This is a blocking call and will not return until the server is fully stopped or the timeout is reached.
+     * </p>
+     *
+     * @param duration The duration of the graceful timeout period, or 0 to shut down immediately.
+     * @param unit     The time unit of the duration.
+     * @return false if there were in-flight requests not completed.
+     */
+    boolean stop(long duration, TimeUnit unit);
 
     /**
      * @return The HTTPS (or if unavailable the HTTP) URI of the web server.
@@ -91,6 +93,7 @@ public interface MuServer {
     /**
      * The size a response body must be before GZIP is enabled, if {@link #gzipEnabled()} is true and the mime type is in {@link #mimeTypesToGzip()}
      * <p>This can only be set at point of server creation with {@link MuServerBuilder#withGzip(long, Set)}</p>
+     *
      * @return Size in bytes.
      */
     long minimumGzipSize();
@@ -98,6 +101,7 @@ public interface MuServer {
     /**
      * The maximum allowed size of request headers.
      * <p>This can only be set at point of server creation with {@link MuServerBuilder#withMaxHeadersSize(int)}</p>
+     *
      * @return Size in bytes.
      */
     int maxRequestHeadersSize();
@@ -105,6 +109,7 @@ public interface MuServer {
     /**
      * The maximum idle timeout for reading request bodies.
      * <p>This can only be set at point of server creation with {@link MuServerBuilder#withIdleTimeout(long, TimeUnit)}</p>
+     *
      * @return Timeout in milliseconds.
      */
     long requestIdleTimeoutMillis();
@@ -112,6 +117,7 @@ public interface MuServer {
     /**
      * The maximum allowed size of a request body.
      * <p>This can only be set at point of server creation with {@link MuServerBuilder#withMaxRequestSize(long)}</p>
+     *
      * @return Size in bytes.
      */
     long maxRequestSize();
@@ -119,6 +125,7 @@ public interface MuServer {
     /**
      * The maximum allowed size of the URI sent in a request line.
      * <p>This can only be set at point of server creation with {@link MuServerBuilder#withMaxUrlSize(int)}</p>
+     *
      * @return Length of allowed URI string.
      */
     int maxUrlSize();
@@ -127,6 +134,7 @@ public interface MuServer {
      * Specifies whether GZIP is on or not.
      * <p>This can only be set at point of server creation with {@link MuServerBuilder#withGzipEnabled(boolean)} or
      * {@link MuServerBuilder#withGzip(long, Set)}</p>
+     *
      * @return True if gzip is enabled for responses that match gzip criteria; otherwise false.
      */
     boolean gzipEnabled();
@@ -134,18 +142,21 @@ public interface MuServer {
     /**
      * Specifies the mime-types that GZIP should be applied to.
      * <p>This can only be set at point of server creation with {@link MuServerBuilder#withGzip(long, Set)}</p>
+     *
      * @return A set of mime-types.
      */
     Set<String> mimeTypesToGzip();
 
     /**
      * Changes the HTTPS certificate. This can be changed without restarting the server.
+     *
      * @param newHttpsConfig The new SSL Context to use.
      */
     void changeHttpsConfig(HttpsConfigBuilder newHttpsConfig);
 
     /**
      * Gets the SSL info of the server, or null if SSL is not enabled.
+     *
      * @return A description of the actual SSL settings used, or null.
      */
     SSLInfo sslInfo();

--- a/src/main/java/io/muserver/MuServer.java
+++ b/src/main/java/io/muserver/MuServer.java
@@ -23,15 +23,16 @@ public interface MuServer {
     }
 
 
-    /**
-     * Graceful shut down the server with timeout. During the graceful period, the server will not accept
-     * new connections and wait for in flight requests to finish.
-     * <p>
-     * It's a blocking call, so it will not return until the server is stopped or the timeout is reached.
-     *
-     * @param duration the graceful timeout period, or 0 to shut down immediately.
-     * @param unit The unit of the period.
-     */
+   /**
+      * Gracefully shuts down the server with a timeout. During the graceful shutdown period, the server will stop
+      * accepting new connections and wait for in-flight requests to complete.
+      * <p>
+      * This is a blocking call and will not return until the server is fully stopped or the timeout is reached.
+      * </p>
+      *
+      * @param duration The duration of the graceful timeout period, or 0 to shut down immediately.
+      * @param unit     The time unit of the duration.
+      */
     void stop(long duration, TimeUnit unit);
 
     /**

--- a/src/main/java/io/muserver/MuServerBuilder.java
+++ b/src/main/java/io/muserver/MuServerBuilder.java
@@ -694,16 +694,15 @@ public class MuServerBuilder {
 
     }
 
-    private static void gracefulWait(Duration gracefulDuration, MuStatsImpl stats) throws InterruptedException {
-        long start = System.currentTimeMillis();
-        while(!stats.activeRequests().isEmpty()
-            && (System.currentTimeMillis() - start) < gracefulDuration.toMillis()) {
-            Thread.sleep(100);
-        }
-        if (!stats.activeRequests().isEmpty()) {
-            log.info("Shutting down worker threads. Active requests: {}", stats.activeRequests());
-        }
+private static void gracefulWait(Duration gracefulDuration, MuStatsImpl stats) throws InterruptedException {
+    long endTime = System.currentTimeMillis() + gracefulDuration.toMillis();
+    while (!stats.activeRequests().isEmpty() && System.currentTimeMillis() < endTime) {
+        Thread.sleep(100);
     }
+    if (!stats.activeRequests().isEmpty()) {
+        log.info("Shutting down worker threads. Active requests: {}", stats.activeRequests());
+    }
+}
 
     private static URI getUriFromChannel(Channel httpChannel, String protocol, String host) {
         host = host == null ? "localhost" : host;

--- a/src/main/java/io/muserver/MuServerImpl.java
+++ b/src/main/java/io/muserver/MuServerImpl.java
@@ -10,14 +10,14 @@ import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
-import java.util.function.Consumer;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 class MuServerImpl implements MuServer {
 
     private URI httpUri;
     private URI httpsUri;
-    private Consumer<Duration> shutdown;
+    private Function<Duration, Boolean> shutdown;
     final MuStatsImpl stats;
     private InetSocketAddress address;
     private SslContextProvider sslContextProvider;
@@ -26,7 +26,7 @@ class MuServerImpl implements MuServer {
     private final Set<HttpConnection> connections = ConcurrentHashMap.newKeySet();
     final UnhandledExceptionHandler unhandledExceptionHandler;
 
-    void onStarted(URI httpUri, URI httpsUri, Consumer<Duration> shutdown, InetSocketAddress address, SslContextProvider sslContextProvider) {
+    void onStarted(URI httpUri, URI httpsUri, Function<Duration, Boolean> shutdown, InetSocketAddress address, SslContextProvider sslContextProvider) {
         this.address = address;
         this.sslContextProvider = sslContextProvider;
         if (httpUri == null && httpsUri == null) {
@@ -46,8 +46,8 @@ class MuServerImpl implements MuServer {
 
 
     @Override
-    public void stop(long duration, TimeUnit unit) {
-        shutdown.accept(Duration.ofMillis(unit.toMillis(duration)));
+    public boolean stop(long duration, TimeUnit unit) {
+        return shutdown.apply(Duration.ofMillis(unit.toMillis(duration)));
     }
 
     @Override

--- a/src/main/java/io/muserver/MuServerImpl.java
+++ b/src/main/java/io/muserver/MuServerImpl.java
@@ -4,17 +4,20 @@ import io.netty.handler.ssl.SslContext;
 
 import java.net.InetSocketAddress;
 import java.net.URI;
+import java.time.Duration;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
 class MuServerImpl implements MuServer {
 
     private URI httpUri;
     private URI httpsUri;
-    private Runnable shutdown;
+    private Consumer<Duration> shutdown;
     final MuStatsImpl stats;
     private InetSocketAddress address;
     private SslContextProvider sslContextProvider;
@@ -23,7 +26,7 @@ class MuServerImpl implements MuServer {
     private final Set<HttpConnection> connections = ConcurrentHashMap.newKeySet();
     final UnhandledExceptionHandler unhandledExceptionHandler;
 
-    void onStarted(URI httpUri, URI httpsUri, Runnable shutdown, InetSocketAddress address, SslContextProvider sslContextProvider) {
+    void onStarted(URI httpUri, URI httpsUri, Consumer<Duration> shutdown, InetSocketAddress address, SslContextProvider sslContextProvider) {
         this.address = address;
         this.sslContextProvider = sslContextProvider;
         if (httpUri == null && httpsUri == null) {
@@ -41,9 +44,10 @@ class MuServerImpl implements MuServer {
         this.unhandledExceptionHandler = unhandledExceptionHandler;
     }
 
+
     @Override
-    public void stop() {
-        shutdown.run();
+    public void stop(long duration, TimeUnit unit) {
+        shutdown.accept(Duration.ofMillis(unit.toMillis(duration)));
     }
 
     @Override

--- a/src/test/java/io/muserver/StopTest.java
+++ b/src/test/java/io/muserver/StopTest.java
@@ -1,0 +1,72 @@
+package io.muserver;
+
+import okhttp3.Response;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThrows;
+import static scaffolding.ClientUtils.call;
+import static scaffolding.ClientUtils.request;
+
+public class StopTest {
+
+    private static final Logger log = LoggerFactory.getLogger(StopTest.class);
+
+    @Test
+    public void gracefulShutdown() throws InterruptedException {
+
+        CountDownLatch serverReceivedLatch = new CountDownLatch(1);
+        CountDownLatch clientReceivedLatch = new CountDownLatch(1);
+        AtomicInteger clientReceivedStatus = new AtomicInteger();
+
+        MuServer server = MuServerBuilder
+            .httpServer()
+            .addHandler((request, response) -> {
+                log.info("received request {}", request);
+                serverReceivedLatch.countDown();
+
+                AsyncHandle asyncHandle = request.handleAsync();
+                asyncHandle.addResponseCompleteHandler(info -> log.info("request completed {}", info));
+
+                Thread.sleep(2000L);
+                response.status(200);
+                asyncHandle.write(Mutils.toByteBuffer("Hello"));
+                asyncHandle.complete();
+
+                return true;
+            })
+            .start();
+
+
+
+        new Thread(() -> {
+            try (Response resp = call(request().url(server.uri().toString()))) {
+                clientReceivedStatus.set(resp.code());
+                clientReceivedLatch.countDown();
+            }
+        }).start();
+
+        assertThat(serverReceivedLatch.await(2, TimeUnit.SECONDS), is(true));
+
+        new Thread(() -> server.stop(2, TimeUnit.SECONDS)).start();
+
+        // new request should fail
+        Thread.sleep(200L);
+        assertThrows(Exception.class, () -> {
+            try (Response resp = call(request().url(server.uri().toString()))) {
+                assertThat(resp.code(), is(200));
+            }
+        });
+
+        // the previous in flight request should completed
+        assertThat(clientReceivedLatch.await(2, TimeUnit.SECONDS), is(true));
+        assertThat(clientReceivedStatus.get(), is(200));
+    }
+}

--- a/src/test/java/io/muserver/StopTest.java
+++ b/src/test/java/io/muserver/StopTest.java
@@ -12,8 +12,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.instanceOf;
-import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.assertThrows;
 import static scaffolding.ClientUtils.call;
 import static scaffolding.ClientUtils.request;
@@ -78,7 +77,7 @@ public class StopTest {
         });
         Throwable rootCause = exception.getCause().getCause();
         assertThat(rootCause, is(instanceOf(java.net.ConnectException.class)));
-        assertThat(rootCause.getMessage(), is("Connection refused"));
+        assertThat(rootCause.getMessage(), containsString("Connection refused"));
 
         // the previous in flight request should complete
         assertThat(clientReceivedLatch.await(2, TimeUnit.SECONDS), is(true));


### PR DESCRIPTION
Support graceful shutdown

* After calling MuServer.stop(long duration, TimeUnit unit), the inflight request will continue till timeout, and new request will be rejected.
* MuServer.stop(long duration, TimeUnit unit) is a blocking call, it will return when inflight request finished or timeout
 