### PR TITLE
Support HTTP/1.0 close-delimited responses and preserve connection semantics

### DIFF
--- a/src/main/java/io/muserver/CloseDelimitedOutputStream.java
+++ b/src/main/java/io/muserver/CloseDelimitedOutputStream.java
@@ -1,0 +1,41 @@
+package io.muserver;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+class CloseDelimitedOutputStream extends OutputStream {
+    private final OutputStream out;
+    private final AtomicBoolean isClosed = new AtomicBoolean(false);
+
+    CloseDelimitedOutputStream(OutputStream out) {
+        this.out = out;
+    }
+
+    @Override
+    public void write(int b) throws IOException {
+        out.write(b);
+    }
+
+    @Override
+    public void write(byte[] b) throws IOException {
+        out.write(b);
+    }
+
+    @Override
+    public void write(byte[] b, int off, int len) throws IOException {
+        out.write(b, off, len);
+    }
+
+    @Override
+    public void flush() throws IOException {
+        out.flush();
+    }
+
+    @Override
+    public void close() throws IOException {
+        if (isClosed.compareAndSet(false, true)) {
+            out.flush();
+        }
+    }
+}

--- a/src/main/java/io/muserver/Http1Connection.java
+++ b/src/main/java/io/muserver/Http1Connection.java
@@ -151,6 +151,9 @@ class Http1Connection extends BaseHttpConnection {
         if (!reallyClose) {
             reallyClose = muResponse.headers().closeConnectionRequested(muRequest.httpVersion());
         }
+        if (!reallyClose && muResponse.shouldCloseConnectionAfterResponse()) {
+            reallyClose = true;
+        }
         try {
             if (!muRequest.cleanup()) {
                 reallyClose = true;
@@ -265,4 +268,3 @@ class Http1Connection extends BaseHttpConnection {
 
     }
 }
-

--- a/src/main/java/io/muserver/Http1Response.java
+++ b/src/main/java/io/muserver/Http1Response.java
@@ -13,6 +13,7 @@ class Http1Response extends BaseResponse implements MuResponse, ResponseInfo {
     private WebsocketConnection websocket;
     @Nullable
     private Long endMillis;
+    private boolean shouldCloseConnectionAfterResponse;
 
     Http1Response(Mu3Request muRequest, OutputStream socketOut) {
         super(muRequest, new FieldBlock());
@@ -58,8 +59,16 @@ class Http1Response extends BaseResponse implements MuResponse, ResponseInfo {
             OutputStream rawOut = request.method().isHead() ? DiscardingOutputStream.INSTANCE : socketOut;
 
             if (fixedLen == -1L) {
-                headers().set(HeaderNames.TRANSFER_ENCODING, HeaderValues.CHUNKED);
-                wrappedOut = new ChunkedOutputStream(rawOut);
+                if (request.httpVersion() == HttpVersion.HTTP_1_1) {
+                    headers().set(HeaderNames.TRANSFER_ENCODING, HeaderValues.CHUNKED);
+                    wrappedOut = new ChunkedOutputStream(rawOut);
+                } else {
+                    wrappedOut = new CloseDelimitedOutputStream(rawOut);
+                    if (!request.method().isHead() && status().canHaveContent()) {
+                        shouldCloseConnectionAfterResponse = true;
+                        headers().set(HeaderNames.CONNECTION, HeaderValues.CLOSE);
+                    }
+                }
             } else {
                 wrappedOut = new FixedSizeOutputStream(fixedLen, rawOut);
             }
@@ -140,5 +149,9 @@ class Http1Response extends BaseResponse implements MuResponse, ResponseInfo {
     @Nullable
     public WebsocketConnection getWebsocket() {
         return websocket;
+    }
+
+    boolean shouldCloseConnectionAfterResponse() {
+        return shouldCloseConnectionAfterResponse;
     }
 }

--- a/src/test/java/io/muserver/MuServerTest.java
+++ b/src/test/java/io/muserver/MuServerTest.java
@@ -328,6 +328,147 @@ public class MuServerTest {
     }
 
     @Test
+    public void http10ResponsesWithoutContentLengthAreCloseDelimited() throws Exception {
+        server = httpServer()
+            .addHandler(Method.GET, "/", (request, response, pathParams) -> {
+                response.outputStream().write("hello".getBytes(StandardCharsets.UTF_8));
+            })
+            .start();
+
+        try (RawClient rawClient = RawClient.create(server.uri())) {
+            rawClient.sendLine("GET / HTTP/1.0");
+            rawClient.sendHeader("Host", server.uri().getAuthority());
+            rawClient.sendHeader("Connection", "keep-alive");
+            rawClient.endHeaders();
+            rawClient.flushRequest();
+            rawClient.waitForFullResponse();
+
+            String response = rawClient.responseString();
+            String lower = response.toLowerCase();
+            assertThat(response, startsWith("HTTP/1.1 200 OK\r\n"));
+            assertThat(response, containsString("\r\n\r\nhello"));
+            assertThat(lower, not(containsString("transfer-encoding: chunked")));
+            assertThat(lower, containsString("connection: close"));
+        }
+    }
+
+    @Test
+    public void http10ResponsesWithOutputStreamButNoBodyBytesAreCloseDelimited() throws Exception {
+        server = httpServer()
+            .addHandler(Method.GET, "/", (request, response, pathParams) -> {
+                response.outputStream().flush();
+            })
+            .start();
+
+        try (RawClient rawClient = RawClient.create(server.uri())) {
+            rawClient.sendLine("GET / HTTP/1.0");
+            rawClient.sendHeader("Host", server.uri().getAuthority());
+            rawClient.sendHeader("Connection", "keep-alive");
+            rawClient.endHeaders();
+            rawClient.flushRequest();
+            rawClient.waitForFullResponse();
+
+            String response = rawClient.responseString();
+            String lower = response.toLowerCase();
+            assertThat(response, startsWith("HTTP/1.1 200 OK\r\n"));
+            assertThat(response, endsWith("\r\n\r\n"));
+            assertThat(lower, not(containsString("transfer-encoding: chunked")));
+            assertThat(lower, not(containsString("content-length:")));
+            assertThat(lower, containsString("connection: close"));
+        }
+    }
+
+    @Test
+    public void http10UnknownLengthOutputStreamSupportsMultipleFlushes() throws Exception {
+        server = httpServer()
+            .addHandler(Method.GET, "/", (request, response, pathParams) -> {
+                var out = response.outputStream();
+                out.write("abc".getBytes(StandardCharsets.UTF_8));
+                out.flush();
+                out.write("123".getBytes(StandardCharsets.UTF_8));
+                out.flush();
+            })
+            .start();
+
+        try (RawClient rawClient = RawClient.create(server.uri())) {
+            rawClient.sendLine("GET / HTTP/1.0");
+            rawClient.sendHeader("Host", server.uri().getAuthority());
+            rawClient.sendHeader("Connection", "keep-alive");
+            rawClient.endHeaders();
+            rawClient.flushRequest();
+            rawClient.waitForFullResponse();
+
+            String response = rawClient.responseString();
+            String lower = response.toLowerCase();
+            assertThat(response, containsString("\r\n\r\nabc123"));
+            assertThat(lower, not(containsString("transfer-encoding: chunked")));
+            assertThat(lower, not(containsString("content-length:")));
+            assertThat(lower, containsString("connection: close"));
+        }
+    }
+
+    @Test
+    public void http10SendChunkUsesCloseDelimitedSemantics() throws Exception {
+        server = httpServer()
+            .addHandler(Method.GET, "/", (request, response, pathParams) -> {
+                response.sendChunk("first-");
+                response.sendChunk("second");
+            })
+            .start();
+
+        try (RawClient rawClient = RawClient.create(server.uri())) {
+            rawClient.sendLine("GET / HTTP/1.0");
+            rawClient.sendHeader("Host", server.uri().getAuthority());
+            rawClient.sendHeader("Connection", "keep-alive");
+            rawClient.endHeaders();
+            rawClient.flushRequest();
+            rawClient.waitForFullResponse();
+
+            String response = rawClient.responseString();
+            String lower = response.toLowerCase();
+            assertThat(response, containsString("\r\n\r\nfirst-second"));
+            assertThat(lower, not(containsString("transfer-encoding: chunked")));
+            assertThat(lower, not(containsString("content-length:")));
+            assertThat(lower, containsString("connection: close"));
+        }
+    }
+
+    @Test
+    public void http10FixedLengthResponsesCanRemainPersistent() throws Exception {
+        server = httpServer()
+            .addHandler(Method.GET, "/", (request, response, pathParams) -> {
+                response.headers().set(HeaderNames.CONNECTION, HeaderValues.KEEP_ALIVE);
+                response.write("hello");
+            })
+            .start();
+
+        try (RawClient rawClient = RawClient.create(server.uri())) {
+            rawClient.sendLine("GET / HTTP/1.0");
+            rawClient.sendHeader("Host", server.uri().getAuthority());
+            rawClient.sendHeader("Connection", "keep-alive");
+            rawClient.endHeaders();
+            rawClient.flushRequest();
+            assertEventually(() -> rawClient.responseString(), containsString("\r\n\r\nhello"));
+
+            String firstResponse = rawClient.responseString().toLowerCase();
+            assertThat(firstResponse, containsString("content-length: 5"));
+            assertThat(firstResponse, not(containsString("connection: close")));
+
+            rawClient.sendLine("GET / HTTP/1.0");
+            rawClient.sendHeader("Host", server.uri().getAuthority());
+            rawClient.sendHeader("Connection", "keep-alive");
+            rawClient.endHeaders();
+            rawClient.flushRequest();
+            assertEventually(() -> rawClient.responseString().split("HTTP/1.1 200 OK\\r\\n", -1).length - 1, is(2));
+
+            String response = rawClient.responseString();
+            assertThat(response, containsString("HTTP/1.1 200 OK\r\n"));
+            assertThat(response.split("HTTP/1.1 200 OK\\r\\n", -1).length - 1, is(2));
+            assertThat(response, containsString("\r\n\r\nhelloHTTP/1.1 200 OK\r\n"));
+        }
+    }
+
+    @Test
     public void nonUTF8IsSupported() throws IOException {
         File warAndPeaceInRussian = FileUtils.warAndPeaceInRussian();
 


### PR DESCRIPTION
### Motivation
- Ensure HTTP/1.0 responses without a `Content-Length` are sent using close-delimited semantics instead of chunked encoding.
- Preserve correct connection keep-alive/close behavior for HTTP/1.0 clients so the server can signal when it will close the connection.
- Allow cleanup logic to take server-decided connection-closing for these responses into account.

### Description
- Added `CloseDelimitedOutputStream` which forwards writes/flushes to an underlying `OutputStream` and only flushes once when `close()` is first called.
- Updated `Http1Response.outputStream` to use `ChunkedOutputStream` for HTTP/1.1 as before, and to use `CloseDelimitedOutputStream` for HTTP/1.0 responses that have no `Content-Length`.
- When using the close-delimited stream for HTTP/1.0 and the response can have content, the code now sets `Connection: close` and marks the response with `shouldCloseConnectionAfterResponse` so the connection will be closed after the body.
- Exposed `shouldCloseConnectionAfterResponse()` on `Http1Response` and updated `Http1Connection.cleanUpNicely` to consult this flag when deciding whether to close the connection.
- Added tests in `MuServerTest` covering HTTP/1.0 behaviors: close-delimited responses with body bytes, responses that flush but write no bytes, multiple flushes, `sendChunk` semantics, and ensuring fixed-length HTTP/1.0 responses can remain persistent.

### Testing
- Ran the server unit tests including the modified `MuServerTest` suite and the newly added HTTP/1.0 tests, and they passed. 
- Verified that the HTTP/1.0 tests assert that responses do not contain `Transfer-Encoding: chunked`, include `Connection: close` when appropriate, and that fixed-length responses remain persistent; all assertions succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e461b0f5c4832f8a6fd1ffb33a6a2f)