### PR TITLE
Add HTTP/1.0 request parsing/behavior coverage and reject chunked requests

### DIFF
--- a/src/main/java/io/muserver/RequestVerifierHandler.java
+++ b/src/main/java/io/muserver/RequestVerifierHandler.java
@@ -8,6 +8,10 @@ class RequestVerifierHandler implements MuHandler {
         if (!request.headers().contains(HeaderNames.HOST) && request.httpVersion() != HttpVersion.HTTP_1_0) {
             throw HttpException.badRequest("No host header");
         }
+        if (request.httpVersion() == HttpVersion.HTTP_1_0
+            && request.headers().containsValue(HeaderNames.TRANSFER_ENCODING, HeaderValues.CHUNKED, true)) {
+            throw HttpException.badRequest("Chunked transfer encoding is not supported for HTTP/1.0 requests");
+        }
         return false;
     }
 }

--- a/src/test/java/io/muserver/Http1MessageParserTest.java
+++ b/src/test/java/io/muserver/Http1MessageParserTest.java
@@ -12,6 +12,7 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.sameInstance;
 
 class Http1MessageParserTest {
@@ -106,6 +107,25 @@ class Http1MessageParserTest {
         assertThat(bit, sameInstance(MessageBodyBit.EndOfBodyBit));
     }
 
+    @Test
+    void http10RequestsDoNotRequireHostHeader() throws IOException, ParseException {
+        String requestString = "GET /legacy HTTP/1.0\r\n" +
+            "content-length: 0\r\n" +
+            "\r\n";
+        var parser = new Http1MessageParser(
+            HttpMessageType.REQUEST,
+            new ConcurrentLinkedQueue<>(),
+            new ByteArrayInputStream(requestString.getBytes(StandardCharsets.UTF_8)),
+            8192,
+            8192
+        );
+
+        var req = (HttpRequestTemp) parser.readNext();
+        assertThat(req.getHttpVersion(), equalTo(HttpVersion.HTTP_1_0));
+        assertThat(req.headers().contains(HeaderNames.HOST), equalTo(false));
+        assertThat(req.getRejectRequest(), nullValue());
+    }
+
     private static class MaxReadLengthInputStream extends FilterInputStream {
         private final byte[] temp;
 
@@ -128,5 +148,4 @@ class Http1MessageParserTest {
     }
 
 }
-
 

--- a/src/test/java/io/muserver/RequestBodyReaderInputStreamAdapterTest.java
+++ b/src/test/java/io/muserver/RequestBodyReaderInputStreamAdapterTest.java
@@ -200,6 +200,58 @@ public class RequestBodyReaderInputStreamAdapterTest {
     }
 
     @Test
+    public void http10ExpectContinueIsIgnored() throws Exception {
+        server = httpServer()
+            .addHandler((request, response) -> {
+                response.write(request.readBodyAsString());
+                return true;
+            })
+            .start();
+
+        try (var client = Http1Client.connect(server.uri())) {
+            client.writeRequestLine(Method.POST, server.uri().resolve("/"), HttpVersion.HTTP_1_0, false)
+                .writeHeader("expect", "100-continue")
+                .writeHeader("content-type", "text/plain")
+                .writeHeader("content-length", "5")
+                .endHeaders()
+                .writeAscii("hello")
+                .flush();
+
+            String statusLine = client.readLine();
+            assertThat(statusLine, equalTo("HTTP/1.1 200 OK"));
+            var headers = client.readHeaders();
+            var body = client.readBody(headers);
+            assertThat(body, equalTo("hello"));
+            assertThat(statusLine, not(containsString("100 Continue")));
+        }
+    }
+
+    @Test
+    public void chunkedTransferEncodingIsRejectedForHttp10() throws Exception {
+        server = httpServer()
+            .addHandler((request, response) -> {
+                response.write("unexpected");
+                return true;
+            })
+            .start();
+
+        try (var client = Http1Client.connect(server.uri())) {
+            client.writeRequestLine(Method.POST, server.uri().resolve("/"), HttpVersion.HTTP_1_0, false)
+                .writeHeader("content-type", "text/plain")
+                .writeHeader("transfer-encoding", "chunked")
+                .endHeaders()
+                .writeAscii("5\r\nHello\r\n0\r\n\r\n")
+                .flush();
+
+            String statusLine = client.readLine();
+            assertThat(statusLine, equalTo("HTTP/1.1 400 Bad Request"));
+            var headers = client.readHeaders();
+            var body = client.readBody(headers);
+            assertThat(body, containsString("Chunked transfer encoding is not supported"));
+        }
+    }
+
+    @Test
     public void chunkedRequestTrailersCanBeReadAfterTheBody() throws Exception {
         server = httpServer()
             .addHandler((request, response) -> {


### PR DESCRIPTION
### Motivation

- Ensure clear, consistent handling of HTTP/1.0 requests: they should be accepted without a `Host` header and should not receive ambiguous chunked semantics.  
- Follow the existing policy to ignore `Expect: 100-continue` for HTTP/1.0 while allowing HTTP/1.1 behavior to remain unchanged.  
- Prefer explicit rejection of `Transfer-Encoding: chunked` for HTTP/1.0 to avoid ambiguous body framing and unsafe heuristics.

### Description

- Added an HTTP/1.0-specific rejection in `RequestVerifierHandler` to return `400 Bad Request` when a request contains `Transfer-Encoding: chunked` and the version is `HTTP/1.0`, with a clear message. (`src/main/java/io/muserver/RequestVerifierHandler.java`).
- Added a parser-level unit test `http10RequestsDoNotRequireHostHeader` to `Http1MessageParserTest` that feeds a raw HTTP/1.0 request (no `Host`) into `Http1MessageParser` and asserts it is accepted as HTTP/1.0 without a rejection. (`src/test/java/io/muserver/Http1MessageParserTest.java`).
- Added two behavior tests to the request body suite that force HTTP/1.0 using raw request lines via `Http1Client`: `http10ExpectContinueIsIgnored` (confirms `Expect: 100-continue` is ignored for 1.0) and `chunkedTransferEncodingIsRejectedForHttp10` (confirms an explicit `400` is returned and the response body contains the rejection message). (`src/test/java/io/muserver/RequestBodyReaderInputStreamAdapterTest.java`).
- Tests use raw request lines/explicit version writes to ensure the parser and connection code operate in HTTP/1.0 mode.

### Testing

- Ran the focused Maven test command `mvn -Dtest=Http1MessageParserTest,RequestBodyReaderInputStreamAdapterTest test`.  
- Initial run surfaced a test assertion mismatch for the chunked-rejection message which was adjusted to match the actual response body; tests were re-run.  
- Final test run: `Tests run: 23, Failures: 0, Errors: 0` and the build succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e467d1f8d4832f8fec0a0f89773934)