### PR TITLE
Enforce WebSocket control frame rules and optimize single-fragment text send

### DIFF
--- a/src/main/java/io/muserver/WebsocketConnection.java
+++ b/src/main/java/io/muserver/WebsocketConnection.java
@@ -128,6 +128,19 @@ class WebsocketConnection implements MuWebSocketSession {
                     readAtLeast(8);
                     payloadLength = buffer.getLong();
                 }
+                if (payloadLength < 0) {
+                    throw frameError(1002, "Invalid payload length");
+                }
+
+                boolean controlFrame = (opcode & 0x08) != 0;
+                if (controlFrame) {
+                    if (!fin) {
+                        throw frameError(1002, "Fragmented control frame");
+                    }
+                    if (payloadLength > 125) {
+                        throw frameError(1002, "Control frame payload cannot exceed 125 bytes");
+                    }
+                }
                 if (payloadLength > settings.maxFramePayloadLength) {
                     throw frameError(1009, "Max payload length of " + settings.maxFramePayloadLength + " exceeded with frame size " + payloadLength);
                 }
@@ -186,6 +199,9 @@ class WebsocketConnection implements MuWebSocketSession {
                         webSocket.onBinaryFragment(slice, false);
                     }
                 } else if (opcode == 0x8) {
+                    if (payloadLen == 1) {
+                        throw frameError(1002, "Close frame payload of 1 byte is invalid");
+                    }
                     if (state == WebsocketSessionState.OPEN) {
                         state = WebsocketSessionState.CLIENT_CLOSING;
                     }
@@ -325,13 +341,13 @@ class WebsocketConnection implements MuWebSocketSession {
     public void sendTextFragment(ByteBuffer fragment, boolean isLastFragment) throws IOException {
         writeLock.lock();
         try {
+            var payload = arrayBuffer(fragment);
+            int off = payload.arrayOffset() + payload.position();
+            int len = payload.remaining();
             if (isLastFragment && messageWritingState == MessageWritingState.NONE) {
                 // this is just a non-fragmented full message, so use the plain send
-                sendText(StandardCharsets.UTF_8.decode(fragment).toString());
+                writeFragment((byte) 0b10000001, payload.array(), off, len, MessageWritingState.NONE, MessageWritingState.NONE);
             } else {
-                var payload = arrayBuffer(fragment);
-                int off = payload.arrayOffset() + payload.position();
-                int len = payload.remaining();
                 if (!isLastFragment && messageWritingState == MessageWritingState.NONE) {
                     // the first message of a fragmented text message
                     writeFragment((byte) 0b00000001, payload.array(), off, len, MessageWritingState.NONE, MessageWritingState.TEXT);

--- a/src/test/java/io/muserver/WebSocketsTest.java
+++ b/src/test/java/io/muserver/WebSocketsTest.java
@@ -439,9 +439,132 @@ public class WebSocketsTest {
 
     }
 
+    @Test
+    public void fragmentedControlFramesAreRejectedWith1002() throws Exception {
+        server = MuServerBuilder.httpServer()
+            .addHandler(webSocketHandler((request, responseHeaders) -> serverSocket)
+                .withPingInterval(0, TimeUnit.MILLISECONDS))
+            .start();
+
+        try (Socket socket = new Socket(server.uri().getHost(), server.uri().getPort());
+             OutputStream out = socket.getOutputStream();
+             InputStream in = socket.getInputStream()) {
+
+            socket.setSoTimeout(2_000);
+            handshake(out, in);
+
+            sendMaskedFrame(out, false, 0x9, "abc".getBytes(StandardCharsets.UTF_8), new byte[]{0x01, 0x02, 0x03, 0x04});
+            out.flush();
+
+            CloseFrame close = readCloseFrame(in);
+            assertThat(close.code, equalTo(1002));
+        }
+    }
+
+    @Test
+    public void controlFramesLargerThan125BytesAreRejectedWith1002() throws Exception {
+        server = MuServerBuilder.httpServer()
+            .addHandler(webSocketHandler((request, responseHeaders) -> serverSocket)
+                .withPingInterval(0, TimeUnit.MILLISECONDS))
+            .start();
+
+        try (Socket socket = new Socket(server.uri().getHost(), server.uri().getPort());
+             OutputStream out = socket.getOutputStream();
+             InputStream in = socket.getInputStream()) {
+
+            socket.setSoTimeout(2_000);
+            handshake(out, in);
+
+            byte[] payload = StringUtils.randomAsciiStringOfLength(126).getBytes(StandardCharsets.UTF_8);
+            sendMaskedFrame(out, true, 0x9, payload, new byte[]{0x11, 0x22, 0x33, 0x44});
+            out.flush();
+
+            CloseFrame close = readCloseFrame(in);
+            assertThat(close.code, equalTo(1002));
+        }
+    }
+
+    @Test
+    public void framesWithNegative64BitPayloadLengthAreRejectedWith1002() throws Exception {
+        server = MuServerBuilder.httpServer()
+            .addHandler(webSocketHandler((request, responseHeaders) -> serverSocket)
+                .withPingInterval(0, TimeUnit.MILLISECONDS))
+            .start();
+
+        try (Socket socket = new Socket(server.uri().getHost(), server.uri().getPort());
+             OutputStream out = socket.getOutputStream();
+             InputStream in = socket.getInputStream()) {
+
+            socket.setSoTimeout(2_000);
+            handshake(out, in);
+
+            // FIN + text opcode
+            out.write(0x81);
+            // masked + 64-bit payload length marker
+            out.write(0xFF);
+            // an invalid negative length (MSB set)
+            out.write(new byte[]{(byte) 0x80, 0, 0, 0, 0, 0, 0, 0});
+            // mask key
+            out.write(new byte[]{0x01, 0x02, 0x03, 0x04});
+            out.flush();
+
+            CloseFrame close = readCloseFrame(in);
+            assertThat(close.code, equalTo(1002));
+        }
+    }
+
     private static void maskPayload(int payloadLength, byte[] payload, byte[] maskKey) {
         for (int i = 0; i < payloadLength; i++) {
             payload[i] ^= maskKey[i % 4];
+        }
+    }
+
+    private static void sendMaskedFrame(OutputStream out, boolean fin, int opcode, byte[] payload, byte[] maskKey) throws IOException {
+        var frame = new ByteArrayOutputStream();
+        int firstByte = (fin ? 0x80 : 0x00) | (opcode & 0x0F);
+        frame.write(firstByte);
+
+        int payloadLength = payload.length;
+        if (payloadLength <= 125) {
+            frame.write(0x80 | payloadLength);
+        } else if (payloadLength <= 65535) {
+            frame.write(0x80 | 126);
+            frame.write((payloadLength >> 8) & 0xFF);
+            frame.write(payloadLength & 0xFF);
+        } else {
+            throw new IllegalArgumentException("Payload too large for test helper");
+        }
+
+        frame.write(maskKey);
+        byte[] maskedPayload = payload.clone();
+        maskPayload(maskedPayload.length, maskedPayload, maskKey);
+        frame.write(maskedPayload);
+        out.write(frame.toByteArray());
+    }
+
+    private static CloseFrame readCloseFrame(InputStream in) throws IOException {
+        int firstByte = in.read();
+        assertThat(firstByte, equalTo(0b10001000));
+        int secondByte = in.read();
+        int payloadLength = secondByte & 0x7F;
+        if (payloadLength == 126) {
+            payloadLength = ((in.read() & 0xFF) << 8) | (in.read() & 0xFF);
+        } else if (payloadLength == 127) {
+            throw new AssertionError("Close frame should not have 64-bit length");
+        }
+        byte[] payload = in.readNBytes(payloadLength);
+        int closeCode = payloadLength >= 2 ? ((payload[0] & 0xFF) << 8) | (payload[1] & 0xFF) : 1005;
+        String reason = payloadLength > 2 ? new String(payload, 2, payloadLength - 2, StandardCharsets.UTF_8) : "";
+        return new CloseFrame(closeCode, reason);
+    }
+
+    private static class CloseFrame {
+        private final int code;
+        private final String reason;
+
+        private CloseFrame(int code, String reason) {
+            this.code = code;
+            this.reason = reason;
         }
     }
 
@@ -693,6 +816,38 @@ public class WebSocketsTest {
         assertThat(listener.toString(), listener.events, contains(
             "onOpen", "onMessage text: Partial one Partial two Last one", "onMessage binary: Hello from binary",
             "onClosing 1000 Done", "onClosed 1000 Done"));
+    }
+
+    @Test
+    public void singleFinalTextFragmentCanBeSentWithoutFragmentMode() throws Exception {
+        CompletableFuture<String> result = new CompletableFuture<>();
+        server = ServerUtils.httpsServerForTest()
+            .addHandler(webSocketHandler((request, responseHeaders) -> new SimpleWebSocket() {
+                @Override
+                public void onConnect(MuWebSocketSession session) throws Exception {
+                    super.onConnect(session);
+                    session.sendTextFragment(Mutils.toByteBuffer("Single chunk"), true);
+                    result.complete("Success");
+                }
+
+                @Override
+                public void onText(String message) {
+                }
+
+                @Override
+                public void onBinary(ByteBuffer buffer) {
+                }
+            }).withPath("/routed-websocket"))
+            .start();
+
+        ClientListener listener = new ClientListener();
+        WebSocket clientSocket = client.newWebSocket(webSocketRequest(server.uri().resolve("/routed-websocket")), listener);
+        assertThat(result.get(10, TimeUnit.SECONDS), is("Success"));
+        assertNotTimedOut("Client got message", listener.messageLatch);
+        clientSocket.close(1000, "Done");
+        assertNotTimedOut("Client closed", listener.closedLatch);
+        assertThat(listener.events, contains(
+            "onOpen", "onMessage text: Single chunk", "onClosing 1000 Done", "onClosed 1000 Done"));
     }
 
     @Test


### PR DESCRIPTION
### Motivation
- Ensure WebSocket implementation strictly follows RFC rules for control frames and 64-bit lengths to avoid protocol abuses and crashes.
- Prevent invalid close frames (1-byte payload) and negative 64-bit lengths from being accepted.
- Avoid unnecessary UTF-8 decoding when sending a single final text fragment to reduce overhead.

### Description
- Added a check for negative 64-bit `payloadLength` and throw a protocol error (`1002`) when detected in `WebsocketConnection`.
- Enforced control-frame constraints by rejecting fragmented control frames and control frames with payloads larger than 125 bytes with `1002` errors.
- Rejected close frames with a 1-byte payload as invalid and return `1002` in that case, and preserved existing close-code parsing logic for other lengths.
- Optimized `sendTextFragment` to use the byte-array payload directly for the common case of a single final fragment instead of decoding to a `String` and resending.
- Added unit tests and test helpers to validate the new behavior in `WebSocketsTest`, including `sendMaskedFrame`, `readCloseFrame`, and a small `CloseFrame` helper.

### Testing
- Added and ran `fragmentedControlFramesAreRejectedWith1002`, which asserts fragmented control frames are closed with `1002`, and it passed.
- Added and ran `controlFramesLargerThan125BytesAreRejectedWith1002`, which asserts oversized control frames are closed with `1002`, and it passed.
- Added and ran `framesWithNegative64BitPayloadLengthAreRejectedWith1002`, which sends an invalid negative 64-bit length and expects `1002`, and it passed.
- Added and ran `singleFinalTextFragmentCanBeSentWithoutFragmentMode`, which verifies sending a single final text fragment works without entering fragment mode, and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e468c0a0a4832f94e833f303ae1d13)