### PR TITLE
Reject request listener

### DIFF
--- a/src/main/java/io/muserver/Http1Connection.java
+++ b/src/main/java/io/muserver/Http1Connection.java
@@ -118,6 +118,7 @@ class Http1Connection extends SimpleChannelInboundHandler<Object> implements Htt
                     connectionStats.onInvalidRequest();
                     serverStats.onInvalidRequest();
                 }
+                nettyHandlerAdapter.onRequestRejected(new RejectedRequestImpl(ihr.code, ihr.getMessage(), this));
                 sendSimpleResponse(ctx, ihr.getMessage(), ihr.code);
                 ctx.channel().read();
             } catch (RedirectException e) {

--- a/src/main/java/io/muserver/Http1Connection.java
+++ b/src/main/java/io/muserver/Http1Connection.java
@@ -118,7 +118,10 @@ class Http1Connection extends SimpleChannelInboundHandler<Object> implements Htt
                     connectionStats.onInvalidRequest();
                     serverStats.onInvalidRequest();
                 }
-                nettyHandlerAdapter.onRequestRejected(new RejectedRequestImpl(ihr.code, ihr.getMessage(), this));
+                HttpRequest rejectedReq = (HttpRequest) msg;
+                String method = rejectedReq.method() == null ? null : rejectedReq.method().name();
+                String uri = rejectedReq.uri();
+                nettyHandlerAdapter.onRequestRejected(new RejectedRequestImpl(ihr.code, ihr.getMessage(), method, uri, this));
                 sendSimpleResponse(ctx, ihr.getMessage(), ihr.code);
                 ctx.channel().read();
             } catch (RedirectException e) {

--- a/src/main/java/io/muserver/Http2Connection.java
+++ b/src/main/java/io/muserver/Http2Connection.java
@@ -384,6 +384,16 @@ final class Http2Connection extends Http2ConnectionFlowControl implements HttpCo
                 log.warn("Unexpected exception for " + httpExchange + " .onException " + toy, e);
                 super.onStreamError(ctx, outbound, cause, http2Ex);
             }
+        } else if (http2Ex instanceof Http2Exception.HeaderListSizeException
+            && ((Http2Exception.HeaderListSizeException) http2Ex).duringDecode()) {
+            // The request headers were too large to decode. Netty's super.onStreamError sends the
+            // 431 to the client itself (only when duringDecode() is true), so we just notify the
+            // listener here. An outbound HeaderListSizeException (response headers too large for the
+            // client's settings) is a response failure, not a rejected request, so it is excluded.
+            connectionStats.onInvalidRequest();
+            server.stats.onInvalidRequest();
+            nettyHandlerAdapter.onRequestRejected(new RejectedRequestImpl(431, "431 Request Header Fields Too Large", this));
+            super.onStreamError(ctx, outbound, cause, http2Ex);
         } else {
             super.onStreamError(ctx, outbound, cause, http2Ex);
         }

--- a/src/main/java/io/muserver/Http2Connection.java
+++ b/src/main/java/io/muserver/Http2Connection.java
@@ -309,6 +309,7 @@ final class Http2Connection extends Http2ConnectionFlowControl implements HttpCo
                 connectionStats.onInvalidRequest();
                 server.stats.onInvalidRequest();
             }
+            nettyHandlerAdapter.onRequestRejected(new RejectedRequestImpl(ihr.code, ihr.getMessage(), this));
             sendSimpleResponse(ctx, streamId, ihr.getMessage(), ihr.code);
         } catch (RedirectException e) {
             sendRedirect(ctx, streamId, e.location);

--- a/src/main/java/io/muserver/Http2Connection.java
+++ b/src/main/java/io/muserver/Http2Connection.java
@@ -309,7 +309,9 @@ final class Http2Connection extends Http2ConnectionFlowControl implements HttpCo
                 connectionStats.onInvalidRequest();
                 server.stats.onInvalidRequest();
             }
-            nettyHandlerAdapter.onRequestRejected(new RejectedRequestImpl(ihr.code, ihr.getMessage(), this));
+            String method = headers.method() == null ? null : headers.method().toString();
+            String uri = headers.path() == null ? null : headers.path().toString();
+            nettyHandlerAdapter.onRequestRejected(new RejectedRequestImpl(ihr.code, ihr.getMessage(), method, uri, this));
             sendSimpleResponse(ctx, streamId, ihr.getMessage(), ihr.code);
         } catch (RedirectException e) {
             sendRedirect(ctx, streamId, e.location);
@@ -392,7 +394,8 @@ final class Http2Connection extends Http2ConnectionFlowControl implements HttpCo
             // client's settings) is a response failure, not a rejected request, so it is excluded.
             connectionStats.onInvalidRequest();
             server.stats.onInvalidRequest();
-            nettyHandlerAdapter.onRequestRejected(new RejectedRequestImpl(431, "431 Request Header Fields Too Large", this));
+            // The header block could not be decoded, so the method and target are not available here.
+            nettyHandlerAdapter.onRequestRejected(new RejectedRequestImpl(431, "431 Request Header Fields Too Large", null, null, this));
             super.onStreamError(ctx, outbound, cause, http2Ex);
         } else {
             super.onStreamError(ctx, outbound, cause, http2Ex);

--- a/src/main/java/io/muserver/MuServerBuilder.java
+++ b/src/main/java/io/muserver/MuServerBuilder.java
@@ -64,6 +64,7 @@ public class MuServerBuilder {
     private ExecutorService executor;
     private long maxRequestSize = 24 * 1024 * 1024;
     private List<ResponseCompleteListener> responseCompleteListeners;
+    private List<RequestRejectListener> requestRejectListeners;
     private HashedWheelTimer wheelTimer;
     private List<RateLimiterImpl> rateLimiters;
     private WriteBufferWaterMark writeBufferWaterMark = WriteBufferWaterMark.DEFAULT;
@@ -354,6 +355,25 @@ public class MuServerBuilder {
         return this;
     }
 
+    /**
+     * Adds a listener that is notified when a request is rejected at the protocol level before it
+     * becomes a normal request/response exchange (for example a <code>431</code> when the request
+     * headers are too large). Such rejections are never reported to
+     * {@link #addResponseCompleteListener(ResponseCompleteListener)}.
+     *
+     * @param listener A listener. If null, then nothing is added.
+     * @return Returns the server builder
+     */
+    public MuServerBuilder addRequestRejectListener(RequestRejectListener listener) {
+        if (listener != null) {
+            if (this.requestRejectListeners == null) {
+                this.requestRejectListeners = new ArrayList<>();
+            }
+            this.requestRejectListeners.add(listener);
+        }
+        return this;
+    }
+
     MuServerBuilder withWriteBufferWaterMark(int low, int high) {
         this.writeBufferWaterMark = new WriteBufferWaterMark(low, high);
         return this;
@@ -557,6 +577,13 @@ public class MuServerBuilder {
     /**
      * @return The current value of this property
      */
+    public List<RequestRejectListener> requestRejectListeners() {
+        return Collections.unmodifiableList(requestRejectListeners);
+    }
+
+    /**
+     * @return The current value of this property
+     */
     public List<RateLimiter> rateLimiters() {
         return rateLimiters.stream().map(RateLimiter.class::cast).collect(Collectors.toList());
     }
@@ -625,7 +652,7 @@ public class MuServerBuilder {
             DefaultThreadFactory threadFactory = new DefaultThreadFactory("muhandler");
             handlerExecutor = new ThreadPoolExecutor(8, 400, 60, TimeUnit.SECONDS, new SynchronousQueue<>(), threadFactory);
         }
-        NettyHandlerAdapter nettyHandlerAdapter = new NettyHandlerAdapter(handlerExecutor, handlers, responseCompleteListeners);
+        NettyHandlerAdapter nettyHandlerAdapter = new NettyHandlerAdapter(handlerExecutor, handlers, responseCompleteListeners, requestRejectListeners);
 
         NioEventLoopGroup bossGroup = new NioEventLoopGroup(1);
         NioEventLoopGroup workerGroup = new NioEventLoopGroup(this.nioThreads);
@@ -802,6 +829,7 @@ private  boolean gracefulWait(Duration gracefulDuration, MuStatsImpl stats) thro
             ", executor=" + executor +
             ", maxRequestSize=" + maxRequestSize +
             ", responseCompleteListeners=" + responseCompleteListeners +
+            ", requestRejectListeners=" + requestRejectListeners +
             ", rateLimiters=" + rateLimiters +
             '}';
     }

--- a/src/main/java/io/muserver/NettyHandlerAdapter.java
+++ b/src/main/java/io/muserver/NettyHandlerAdapter.java
@@ -15,11 +15,13 @@ class NettyHandlerAdapter {
     private final List<MuHandler> muHandlers;
     private final ExecutorService executor;
     private final List<ResponseCompleteListener> completeListeners;
+    private final List<RequestRejectListener> rejectListeners;
 
-    NettyHandlerAdapter(ExecutorService executor, List<MuHandler> muHandlers, List<ResponseCompleteListener> completeListeners) {
+    NettyHandlerAdapter(ExecutorService executor, List<MuHandler> muHandlers, List<ResponseCompleteListener> completeListeners, List<RequestRejectListener> rejectListeners) {
         this.executor = executor;
         this.muHandlers = muHandlers;
         this.completeListeners = completeListeners;
+        this.rejectListeners = rejectListeners;
     }
 
     void onHeaders(HttpExchange muCtx) {
@@ -77,6 +79,18 @@ class NettyHandlerAdapter {
                     listener.onComplete(info);
                 } catch (Exception e) {
                     log.error("Error from completion listener", e);
+                }
+            }
+        }
+    }
+
+    void onRequestRejected(RejectedRequest info) {
+        if (rejectListeners != null) {
+            for (RequestRejectListener listener : rejectListeners) {
+                try {
+                    listener.onRejected(info);
+                } catch (Exception e) {
+                    log.error("Error from request reject listener", e);
                 }
             }
         }

--- a/src/main/java/io/muserver/RejectedRequest.java
+++ b/src/main/java/io/muserver/RejectedRequest.java
@@ -1,0 +1,27 @@
+package io.muserver;
+
+/**
+ * Information about a request that was rejected before it became a normal request/response
+ * exchange (for example a <code>431</code> when the request headers are too large).
+ * @see RequestRejectListener
+ */
+public interface RejectedRequest {
+
+    /**
+     * @return The HTTP status code sent to the client, for example <code>431</code> or <code>503</code>.
+     */
+    int status();
+
+    /**
+     * @return The plain-text message sent to the client, for example
+     * <code>431 Request Header Fields Too Large</code>.
+     */
+    String reason();
+
+    /**
+     * @return The connection the rejected request arrived on, which can be used to find details such as
+     * the {@link HttpConnection#remoteAddress()} and {@link HttpConnection#protocol()}.
+     */
+    HttpConnection connection();
+
+}

--- a/src/main/java/io/muserver/RejectedRequest.java
+++ b/src/main/java/io/muserver/RejectedRequest.java
@@ -1,5 +1,8 @@
 package io.muserver;
 
+import java.net.URI;
+import java.util.Optional;
+
 /**
  * Information about a request that was rejected before it became a normal request/response
  * exchange (for example a <code>431</code> when the request headers are too large).
@@ -17,6 +20,28 @@ public interface RejectedRequest {
      * <code>431 Request Header Fields Too Large</code>.
      */
     String reason();
+
+    /**
+     * The HTTP method of the rejected request, on a best-effort basis.
+     * <p>This is the raw method token sent by the client (such as <code>GET</code> or <code>POST</code>),
+     * rather than a {@link Method} enum value, so that an unrecognised method that caused the rejection is
+     * preserved as-is.</p>
+     * <p>It is empty when the request was rejected before the method could be decoded, for example a
+     * <code>431</code> over HTTP/2 where the header block is rejected during HPACK decoding.</p>
+     *
+     * @return The request method, or an empty optional if it was not decoded.
+     */
+    Optional<String> method();
+
+    /**
+     * The request target of the rejected request, on a best-effort basis.
+     * <p>It is empty when the request was rejected before the target could be decoded (for example a
+     * <code>431</code> over HTTP/2), or when the target could not be parsed as a URI. For a <code>414</code>
+     * the value may be a truncated or placeholder target.</p>
+     *
+     * @return The request target, or an empty optional if it was not decoded or could not be parsed.
+     */
+    Optional<URI> uri();
 
     /**
      * @return The connection the rejected request arrived on, which can be used to find details such as

--- a/src/main/java/io/muserver/RejectedRequestImpl.java
+++ b/src/main/java/io/muserver/RejectedRequestImpl.java
@@ -1,15 +1,33 @@
 package io.muserver;
 
+import java.net.URI;
+import java.util.Optional;
+
 class RejectedRequestImpl implements RejectedRequest {
 
     private final int status;
     private final String reason;
+    private final String method;
+    private final URI uri;
     private final HttpConnection connection;
 
-    RejectedRequestImpl(int status, String reason, HttpConnection connection) {
+    RejectedRequestImpl(int status, String reason, String method, String uri, HttpConnection connection) {
         this.status = status;
         this.reason = reason;
+        this.method = method;
+        this.uri = parseUriOrNull(uri);
         this.connection = connection;
+    }
+
+    private static URI parseUriOrNull(String rawTarget) {
+        if (rawTarget == null || rawTarget.isEmpty()) {
+            return null;
+        }
+        try {
+            return URI.create(rawTarget);
+        } catch (IllegalArgumentException e) {
+            return null;
+        }
     }
 
     @Override
@@ -23,6 +41,16 @@ class RejectedRequestImpl implements RejectedRequest {
     }
 
     @Override
+    public Optional<String> method() {
+        return Optional.ofNullable(method);
+    }
+
+    @Override
+    public Optional<URI> uri() {
+        return Optional.ofNullable(uri);
+    }
+
+    @Override
     public HttpConnection connection() {
         return connection;
     }
@@ -32,6 +60,8 @@ class RejectedRequestImpl implements RejectedRequest {
         return "RejectedRequest{" +
             "status=" + status +
             ", reason='" + reason + '\'' +
+            ", method='" + method + '\'' +
+            ", uri=" + uri +
             ", connection=" + connection +
             '}';
     }

--- a/src/main/java/io/muserver/RejectedRequestImpl.java
+++ b/src/main/java/io/muserver/RejectedRequestImpl.java
@@ -1,0 +1,38 @@
+package io.muserver;
+
+class RejectedRequestImpl implements RejectedRequest {
+
+    private final int status;
+    private final String reason;
+    private final HttpConnection connection;
+
+    RejectedRequestImpl(int status, String reason, HttpConnection connection) {
+        this.status = status;
+        this.reason = reason;
+        this.connection = connection;
+    }
+
+    @Override
+    public int status() {
+        return status;
+    }
+
+    @Override
+    public String reason() {
+        return reason;
+    }
+
+    @Override
+    public HttpConnection connection() {
+        return connection;
+    }
+
+    @Override
+    public String toString() {
+        return "RejectedRequest{" +
+            "status=" + status +
+            ", reason='" + reason + '\'' +
+            ", connection=" + connection +
+            '}';
+    }
+}

--- a/src/main/java/io/muserver/RequestRejectListener.java
+++ b/src/main/java/io/muserver/RequestRejectListener.java
@@ -1,0 +1,19 @@
+package io.muserver;
+
+/**
+ * A callback for listening to requests that are rejected at the protocol level, before they
+ * become a normal request/response exchange. This happens, for example, when a request is
+ * rejected with a <code>431</code> because its headers are too large, or a <code>503</code>
+ * because the server is overloaded.
+ * <p>Because no {@link MuRequest} or {@link MuResponse} is created for these requests, they are
+ * never reported to a {@link ResponseCompleteListener}.</p>
+ * @see MuServerBuilder#addRequestRejectListener(RequestRejectListener)
+ */
+public interface RequestRejectListener {
+
+    /**
+     * Called when a request is rejected before it becomes a normal exchange.
+     * @param info Information about the rejected request.
+     */
+    void onRejected(RejectedRequest info);
+}

--- a/src/test/java/io/muserver/EventsTest.java
+++ b/src/test/java/io/muserver/EventsTest.java
@@ -1,14 +1,18 @@
 package io.muserver;
 
+import okhttp3.MediaType;
 import okhttp3.Request;
+import okhttp3.RequestBody;
 import okhttp3.Response;
 import org.junit.After;
 import org.junit.Test;
+import scaffolding.Http1Client;
 import scaffolding.MuAssert;
 import scaffolding.ServerUtils;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -16,6 +20,7 @@ import static org.hamcrest.Matchers.*;
 import static scaffolding.ClientUtils.call;
 import static scaffolding.ClientUtils.request;
 import static scaffolding.MuAssert.assertEventually;
+import static scaffolding.StringUtils.randomAsciiStringOfLength;
 
 public class EventsTest {
 
@@ -66,6 +71,91 @@ public class EventsTest {
         }
 
         assertEventually(completeStateSnapshot::get, is("true"));
+    }
+
+    @Test
+    public void rejectListenerIsCalledWhenHeadersAreTooLarge431_OverHttp1() throws Exception {
+        CompletableFuture<RejectedRequest> rejected = new CompletableFuture<>();
+        AtomicBoolean completeListenerCalled = new AtomicBoolean(false);
+        server = ServerUtils.httpsServerForTest()
+            .withHttp2Config(Http2ConfigBuilder.http2Config().enabled(false))
+            .withMaxHeadersSize(1024)
+            .addRequestRejectListener(rejected::complete)
+            .addResponseCompleteListener(info -> completeListenerCalled.set(true))
+            .addHandler(Method.GET, "/blah", (req, resp, pp) -> resp.write("Hello"))
+            .start();
+
+        try (Http1Client client = Http1Client.connect(server)) {
+            client.writeRequestLine(Method.GET, "/blah")
+                .writeHeader("X-Big", randomAsciiStringOfLength(2000))
+                .endHeaders()
+                .flush();
+            assertThat(client.readLine(), containsString("431"));
+        }
+
+        RejectedRequest info = rejected.get(10, TimeUnit.SECONDS);
+        assertThat(info.status(), is(431));
+        assertThat(info.reason(), is("431 Request Header Fields Too Large"));
+        assertThat(info.connection(), notNullValue());
+        assertThat(info.connection().protocol(), is("HTTP/1.1"));
+        assertThat(info.connection().remoteAddress(), notNullValue());
+        assertThat("The response complete listener should not fire for a rejected request",
+            completeListenerCalled.get(), is(false));
+    }
+
+    @Test
+    public void rejectListenerIsCalledWhenBodyIsTooLarge413_OverHttp2() throws Exception {
+        CompletableFuture<RejectedRequest> rejected = new CompletableFuture<>();
+        server = ServerUtils.httpsServerForTest()
+            .withHttp2Config(Http2ConfigBuilder.http2Enabled())
+            .withMaxRequestSize(100)
+            .addRequestRejectListener(rejected::complete)
+            .addHandler(Method.POST, "/blah", (req, resp, pp) -> resp.write("Hello"))
+            .start();
+
+        RequestBody body = RequestBody.create(randomAsciiStringOfLength(1000), MediaType.get("text/plain"));
+        try (Response resp = call(request(server.uri().resolve("/blah")).post(body))) {
+            assertThat(resp.code(), is(413));
+        }
+
+        RejectedRequest info = rejected.get(10, TimeUnit.SECONDS);
+        assertThat(info.status(), is(413));
+        assertThat(info.reason(), is("413 Payload Too Large"));
+        assertThat(info.connection().protocol(), is("HTTP/2"));
+    }
+
+    @Test
+    public void rejectListenerIsCalledWhenBodyIsTooLarge413_OverHttp1() throws Exception {
+        CompletableFuture<RejectedRequest> rejected = new CompletableFuture<>();
+        server = ServerUtils.httpsServerForTest()
+            .withHttp2Config(Http2ConfigBuilder.http2Config().enabled(false))
+            .withMaxRequestSize(100)
+            .addRequestRejectListener(rejected::complete)
+            .addHandler(Method.POST, "/blah", (req, resp, pp) -> resp.write("Hello"))
+            .start();
+
+        RequestBody body = RequestBody.create(randomAsciiStringOfLength(1000), MediaType.get("text/plain"));
+        try (Response resp = call(request(server.uri().resolve("/blah")).post(body))) {
+            assertThat(resp.code(), is(413));
+        }
+
+        RejectedRequest info = rejected.get(10, TimeUnit.SECONDS);
+        assertThat(info.status(), is(413));
+        assertThat(info.reason(), is("413 Payload Too Large"));
+        assertThat(info.connection().protocol(), is("HTTP/1.1"));
+    }
+
+    @Test
+    public void rejectListenerIsNotCalledForSuccessfulRequests() {
+        AtomicBoolean rejectListenerCalled = new AtomicBoolean(false);
+        server = ServerUtils.httpsServerForTest()
+            .addRequestRejectListener(info -> rejectListenerCalled.set(true))
+            .addHandler(Method.GET, "/blah", (req, resp, pp) -> resp.write("Hello"))
+            .start();
+        try (Response resp = call(request(server.uri().resolve("/blah")))) {
+            assertThat(resp.code(), is(200));
+        }
+        assertThat(rejectListenerCalled.get(), is(false));
     }
 
     @After

--- a/src/test/java/io/muserver/EventsTest.java
+++ b/src/test/java/io/muserver/EventsTest.java
@@ -10,6 +10,7 @@ import scaffolding.Http1Client;
 import scaffolding.MuAssert;
 import scaffolding.ServerUtils;
 
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -96,6 +97,8 @@ public class EventsTest {
         RejectedRequest info = rejected.get(10, TimeUnit.SECONDS);
         assertThat(info.status(), is(431));
         assertThat(info.reason(), is("431 Request Header Fields Too Large"));
+        assertThat(info.method(), is(Optional.of("GET")));
+        assertThat(info.uri().get().getPath(), is("/blah"));
         assertThat(info.connection(), notNullValue());
         assertThat(info.connection().protocol(), is("HTTP/1.1"));
         assertThat(info.connection().remoteAddress(), notNullValue());
@@ -121,6 +124,8 @@ public class EventsTest {
         RejectedRequest info = rejected.get(10, TimeUnit.SECONDS);
         assertThat(info.status(), is(413));
         assertThat(info.reason(), is("413 Payload Too Large"));
+        assertThat(info.method(), is(Optional.of("POST")));
+        assertThat(info.uri().get().getPath(), is("/blah"));
         assertThat(info.connection().protocol(), is("HTTP/2"));
     }
 
@@ -142,6 +147,8 @@ public class EventsTest {
         RejectedRequest info = rejected.get(10, TimeUnit.SECONDS);
         assertThat(info.status(), is(413));
         assertThat(info.reason(), is("413 Payload Too Large"));
+        assertThat(info.method(), is(Optional.of("POST")));
+        assertThat(info.uri().get().getPath(), is("/blah"));
         assertThat(info.connection().protocol(), is("HTTP/1.1"));
     }
 

--- a/src/test/java/io/muserver/HeadersTest.java
+++ b/src/test/java/io/muserver/HeadersTest.java
@@ -16,12 +16,17 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static io.muserver.MuServerBuilder.httpServer;
 import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static scaffolding.ClientUtils.*;
 import static scaffolding.StringUtils.randomAsciiStringOfLength;
@@ -128,9 +133,11 @@ public class HeadersTest {
     }
 
     @Test
-    public void a431IsReturnedIfTheHeadersAreTooLarge() throws IOException {
+    public void a431IsReturnedIfTheHeadersAreTooLarge() throws IOException, ExecutionException, InterruptedException, TimeoutException {
+        CompletableFuture<RejectedRequest> rejected = new CompletableFuture<>();
         server = ServerUtils.httpsServerForTest()
             .withMaxHeadersSize(1024)
+            .addRequestRejectListener(rejected::complete)
             .addHandler((request, response) -> {
                 response.headers().add(request.headers());
                 return true;
@@ -144,6 +151,10 @@ public class HeadersTest {
                 assertThat(resp.header("Content-Type"), is("text/plain;charset=utf-8"));
             }
         }
+
+        RejectedRequest info = rejected.get(10, TimeUnit.SECONDS);
+        assertThat(info.status(), is(431));
+        assertThat(info.reason(), is("431 Request Header Fields Too Large"));
     }
 
     @Test

--- a/src/test/java/io/muserver/HeadersTest.java
+++ b/src/test/java/io/muserver/HeadersTest.java
@@ -15,6 +15,7 @@ import java.net.URI;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -143,9 +144,11 @@ public class HeadersTest {
                 return true;
             }).start();
 
+        boolean isHttp2;
         try (Response resp = call(xSomethingHeader(randomAsciiStringOfLength(1025)))) {
             assertThat(resp.code(), is(431));
-            if (!isHttp2(resp)) { // for HTTP2, netty sends a 431 with no body
+            isHttp2 = isHttp2(resp);
+            if (!isHttp2) { // for HTTP2, netty sends a 431 with no body
                 assertThat(resp.body().string(), is("431 Request Header Fields Too Large"));
                 assertThat(resp.header("X-Something"), is(nullValue()));
                 assertThat(resp.header("Content-Type"), is("text/plain;charset=utf-8"));
@@ -155,6 +158,15 @@ public class HeadersTest {
         RejectedRequest info = rejected.get(10, TimeUnit.SECONDS);
         assertThat(info.status(), is(431));
         assertThat(info.reason(), is("431 Request Header Fields Too Large"));
+        if (isHttp2) {
+            // over HTTP/2 the header block is rejected during HPACK decoding, before the method or
+            // target can be read, so they are not available
+            assertThat(info.method(), is(Optional.empty()));
+            assertThat(info.uri(), is(Optional.empty()));
+        } else {
+            assertThat(info.method(), is(Optional.of("GET")));
+            assertThat(info.uri().get().getPath(), is("/"));
+        }
     }
 
     @Test


### PR DESCRIPTION
When a request is rejected very early in the connection lifecycle — before mu-server has constructed a normal request/response exchange — there is currently no way for application code to observe that the rejection happened.

The PR is trying to add RequestRejectListener in mu-server so that it allow application to observe it. HTTP/1.1 and HTTP/2 cases are covered.

Summary of new public API

| Element | Kind | Description |
|---------|------|-------------|
| `RequestRejectListener` | interface | `void onRejected(RejectedRequest info)` |
| `RejectedRequest` | interface | `status()`, `reason()`, `connection()` |
| `MuServerBuilder#addRequestRejectListener(RequestRejectListener)` | method | Registers a listener |
| `MuServerBuilder#requestRejectListeners()` | method | Returns the registered listeners |
