### PR TITLE
Fix TCK form encoding and cookie path handling (Mu3)

### DIFF
--- a/src/main/java/io/muserver/rest/FormUrlEncoder.java
+++ b/src/main/java/io/muserver/rest/FormUrlEncoder.java
@@ -1,0 +1,20 @@
+package io.muserver.rest;
+
+import io.muserver.MuException;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+
+final class FormUrlEncoder {
+
+    static String formUrlEncode(String value) {
+        try {
+            return URLEncoder.encode(value, "UTF-8");
+        } catch (UnsupportedEncodingException e) {
+            throw new MuException("Error encoding " + value, e);
+        }
+    }
+
+    private FormUrlEncoder() {
+    }
+}

--- a/src/main/java/io/muserver/rest/NewCookieHeaderDelegate.java
+++ b/src/main/java/io/muserver/rest/NewCookieHeaderDelegate.java
@@ -25,7 +25,7 @@ class NewCookieHeaderDelegate implements RuntimeDelegate.HeaderDelegate<NewCooki
         io.muserver.Cookie muc = CookieBuilder.newCookie()
             .withName(cookie.getName())
             .withValue(cookie.getValue())
-            .withPath(cookie.getPath())
+            .withPath(cookie.getPath() == null ? "/" : cookie.getPath())
             .withDomain(cookie.getDomain())
             .secure(cookie.isSecure())
             .httpOnly(cookie.isHttpOnly())

--- a/src/main/java/io/muserver/rest/ResourceMethodParam.java
+++ b/src/main/java/io/muserver/rest/ResourceMethodParam.java
@@ -207,7 +207,9 @@ abstract class ResourceMethodParam {
                     : emptyList();
             boolean isSpecified = specifiedValue != null && !specifiedValue.isEmpty();
             if (encodedRequested && isSpecified) {
-                specifiedValue = specifiedValue.stream().map(Mutils::urlEncode).collect(Collectors.toList());
+                specifiedValue = specifiedValue.stream()
+                    .map(value -> source == ValueSource.FORM_PARAM ? FormUrlEncoder.formUrlEncode(value) : Mutils.urlEncode(value))
+                    .collect(Collectors.toList());
             }
             if (collection != null) {
                 if (isSpecified) {

--- a/src/main/java/io/muserver/rest/StringEntityProviders.java
+++ b/src/main/java/io/muserver/rest/StringEntityProviders.java
@@ -26,7 +26,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
-import static io.muserver.Mutils.urlEncode;
 import static java.util.Arrays.asList;
 
 class StringEntityProviders {
@@ -256,10 +255,10 @@ class StringEntityProviders {
         public void writeTo(MultivaluedMap<String, String> form, Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType, MultivaluedMap<String, Object> httpHeaders, OutputStream entityStream) throws IOException, WebApplicationException {
             var sb = new StringBuilder();
             for (String key : form.keySet()) {
-                String encodedKey = urlEncode(key);
+                String encodedKey = FormUrlEncoder.formUrlEncode(key);
                 for (String value : form.get(key)) {
                     if (sb.length() > 1) sb.append('&');
-                    sb.append(encodedKey).append('=').append(urlEncode(value));
+                    sb.append(encodedKey).append('=').append(FormUrlEncoder.formUrlEncode(value));
                 }
             }
             entityStream.write(sb.toString().getBytes(EntityProviders.charsetFor(mediaType)));

--- a/src/test/java/io/muserver/CookieTest.java
+++ b/src/test/java/io/muserver/CookieTest.java
@@ -150,6 +150,37 @@ public class CookieTest {
     }
 
     @Test
+    public void newCookiesWithoutAnExplicitPathStillRoundTrip() throws IOException {
+        @Path("biscuits")
+        class Biscuits {
+            @GET
+            @Path("set")
+            public jakarta.ws.rs.core.Response setCookie() {
+                return jakarta.ws.rs.core.Response.noContent()
+                    .cookie(new NewCookie("Something", "123456"))
+                    .build();
+            }
+
+            @GET
+            @Path("get")
+            public String getCookie(@CookieParam("Something") String cookieValue) {
+                return cookieValue;
+            }
+        }
+
+        server = ServerUtils.httpsServerForTest()
+            .addHandler(restHandler(new Biscuits())).start();
+
+        try (Response setResp = client.newCall(request().url(server.uri().resolve("/biscuits/set").toString()).build()).execute()) {
+            assertThat(setResp.code(), equalTo(204));
+        }
+        try (Response getResp = client.newCall(request().url(server.uri().resolve("/biscuits/get").toString()).build()).execute()) {
+            assertThat(getResp.code(), equalTo(200));
+            assertThat(getResp.body().string(), equalTo("123456"));
+        }
+    }
+
+    @Test
     public void multipleCookiesCanBeSetAndAreAllSentBackToTheServer() throws IOException {
         Set<Cookie> actualSentCookies = new HashSet<>();
         AtomicReference<Optional<String>> sessionLookup = new AtomicReference<>();

--- a/src/test/java/io/muserver/rest/ResourceMethodParamTest.java
+++ b/src/test/java/io/muserver/rest/ResourceMethodParamTest.java
@@ -87,17 +87,19 @@ public class ResourceMethodParamTest {
 
         @Path("samples")
         class Sample {
-            @GET
+            @POST
             public String getIt(@QueryParam("one") String one,
                                 @QueryParam("two") @DefaultValue("Some default") String two,
-                                @QueryParam("three") @Encoded String three
+                                @QueryParam("three") @Encoded String three,
+                                @FormParam("four") @Encoded String four
             ) {
-                return one + " / " + two + " / " + three;
+                return one + " / " + two + " / " + three + " / " + four;
             }
         }
         server = httpsServerForTest().addHandler(restHandler(new Sample())).start();
-        try (Response resp = call(request().url(server.uri().resolve("/samples?one=some%20thing%2F&one=ignored&three=some%20thing%2F").toString()))) {
-            assertThat(resp.body().string(), equalTo("some thing/ / Some default / some%20thing%2F"));
+        try (Response resp = call(request().url(server.uri().resolve("/samples?one=some%20thing%2F&one=ignored&three=some%20thing%2F").toString())
+            .post(new FormBody.Builder().add("four", "some thing/").build()))) {
+            assertThat(resp.body().string(), equalTo("some thing/ / Some default / some%20thing%2F / some+thing%2F"));
         }
     }
 

--- a/src/test/java/io/muserver/rest/StringEntityProvidersTest.java
+++ b/src/test/java/io/muserver/rest/StringEntityProvidersTest.java
@@ -174,7 +174,7 @@ public class StringEntityProvidersTest {
         )) {
             assertThat(resp.code(), equalTo(200));
             assertThat(resp.header("Content-Type"), equalTo("application/x-www-form-urlencoded"));
-            assertThat(resp.body().string(), equalTo("Umm=umm%20what%3F%22%5C%2F%3A&Blah=hello%201&Blah=hello%202"));
+            assertThat(resp.body().string(), equalTo("Umm=umm+what%3F%22%5C%2F%3A&Blah=hello+1&Blah=hello+2"));
         }
 
     }


### PR DESCRIPTION
Draft PR for the Mu3 TCK harness fixes.

Changes:
- Encode form data the way the TCK expects for encoded values.
- Default JAX-RS cookies to the root path.

This branch is intended to be validated by GitHub Actions against the TCK harness.