### PR TITLE
Fix URI component encoding in mu2

### DIFF
--- a/src/main/java/io/muserver/HttpExchange.java
+++ b/src/main/java/io/muserver/HttpExchange.java
@@ -316,12 +316,7 @@ class HttpExchange implements ResponseInfo, Exchange {
             if (Mutils.nullOrEmpty(s)) {
                 s = "/";
             } else {
-                // TODO: consider a redirect if the URL is changed? Handle other percent-encoded characters?
-                s = s.replace("%7E", "~")
-                    .replace("%5F", "_")
-                    .replace("%2E", ".")
-                    .replace("%2D", "-")
-                ;
+                s = Mutils.decodeUnreserved(s);
             }
             String q = requestUri.getRawQuery();
             if (q != null) {

--- a/src/main/java/io/muserver/MuRequest.java
+++ b/src/main/java/io/muserver/MuRequest.java
@@ -107,13 +107,15 @@ public interface MuRequest {
     UploadedFile uploadedFile(String name) throws IOException;
 
     /**
-     * <p>Gets the querystring parameters for this request.</p>
+     * <p>Gets query parameters decoded with {@code application/x-www-form-urlencoded} compatibility.
+     * Both {@code +} and {@code %20} are decoded to a space; use {@link #uri()}{@code .getRawQuery()} for the raw query.</p>
      * @return Returns an object allowing you to access the querystring parameters of this request.
      */
     RequestParameters query();
 
     /**
      * <p>Gets the form parameters for this request.</p>
+     * <p>For {@code application/x-www-form-urlencoded}, both {@code +} and {@code %20} decode to a space.</p>
      * <p>Note: this cannot be called after a call to {@link #inputStream()} or {@link #readBodyAsString()}</p>
      * @throws IOException Thrown when there is an error while reading the form, e.g. if a user closes their
      *                     browser before the form is fully read into memory.

--- a/src/main/java/io/muserver/Mutils.java
+++ b/src/main/java/io/muserver/Mutils.java
@@ -26,8 +26,9 @@ public class Mutils {
     public static final String NEWLINE = String.format("%n");
 
     /**
+     * Encodes a UTF-8 value using HTML-form escaping, except spaces are emitted as {@code %20} and {@code ~} is left unescaped.
      * @param value the value to encode
-     * @return Returns the UTF-8 URL encoded value
+     * @return the encoded value
      */
     public static String urlEncode(String value) {
         try {
@@ -41,8 +42,9 @@ public class Mutils {
     }
 
     /**
+     * Decodes a UTF-8 HTML-form-style value, so both {@code +} and {@code %20} become spaces.
      * @param value the value to decode
-     * @return Returns the UTF-8 URL decoded value
+     * @return the decoded value
      */
     public static String urlDecode(String value) {
         try {
@@ -279,6 +281,29 @@ public class Mutils {
             pathAndQuery += "?" + rawQuery;
         }
         return pathAndQuery;
+    }
+
+    static String decodeUnreserved(String value) {
+        int percent = value.indexOf('%');
+        if (percent < 0) return value;
+        StringBuilder result = null;
+        int copiedUntil = 0;
+        for (int i = percent; i + 2 < value.length(); i++) {
+            if (value.charAt(i) != '%') continue;
+            int high = Character.digit(value.charAt(i + 1), 16);
+            int low = Character.digit(value.charAt(i + 2), 16);
+            if (high < 0 || low < 0) continue;
+            int decoded = (high << 4) | low;
+            if ((decoded >= 'a' && decoded <= 'z') || (decoded >= 'A' && decoded <= 'Z') ||
+                (decoded >= '0' && decoded <= '9') || decoded == '-' || decoded == '.' ||
+                decoded == '_' || decoded == '~') {
+                if (result == null) result = new StringBuilder(value.length());
+                result.append(value, copiedUntil, i).append((char) decoded);
+                copiedUntil = i + 3;
+                i += 2;
+            }
+        }
+        return result == null ? value : result.append(value, copiedUntil, value.length()).toString();
     }
 
     private static final ByteBuffer EMPTY_BUFFER = ByteBuffer.allocate(0);

--- a/src/main/java/io/muserver/NettyRequestAdapter.java
+++ b/src/main/java/io/muserver/NettyRequestAdapter.java
@@ -546,4 +546,3 @@ class NettyRequestAdapter implements MuRequest {
     }
 
 }
-

--- a/src/main/java/io/muserver/RequestParameters.java
+++ b/src/main/java/io/muserver/RequestParameters.java
@@ -4,7 +4,7 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * Provides access to QueryString or Form values.
+ * Provides access to query-string or form values. Both use HTML form-compatible decoding where a plus is a space.
  */
 public interface RequestParameters {
 
@@ -91,4 +91,3 @@ public interface RequestParameters {
      */
     boolean contains(String name);
 }
-

--- a/src/main/java/io/muserver/handlers/DirectoryLister.java
+++ b/src/main/java/io/muserver/handlers/DirectoryLister.java
@@ -34,7 +34,7 @@ class DirectoryLister {
     void render() throws IOException {
         El html = new El("html").open();
         El head = new El("head").open();
-        String title = "Index of " + Mutils.urlDecode(contextPath + relativePath);
+        String title = "Index of " + java.net.URI.create(contextPath + relativePath).getPath();
         render("title", title);
         new El("style").open().contentRaw(directoryListingCss).close();
         head.close();

--- a/src/main/java/io/muserver/handlers/ResourceHandler.java
+++ b/src/main/java/io/muserver/handlers/ResourceHandler.java
@@ -48,12 +48,12 @@ public class ResourceHandler implements MuHandler {
         if (requestPath.endsWith("/") && defaultFile != null) {
             requestPath += defaultFile;
         }
-        String decodedRelativePath = Mutils.urlDecode(requestPath);
+        String decodedRelativePath = java.net.URI.create(requestPath).getPath();
 
         ResourceProvider provider = resourceProviderFactory.get(decodedRelativePath);
         if (!provider.exists()) {
             if (directoryListingEnabled) {
-                provider = resourceProviderFactory.get(Mutils.urlDecode(request.relativePath()));
+                provider = resourceProviderFactory.get(java.net.URI.create(request.relativePath()).getPath());
                 if (!provider.isDirectory()) {
                     return false;
                 }

--- a/src/main/java/io/muserver/rest/Jaxutils.java
+++ b/src/main/java/io/muserver/rest/Jaxutils.java
@@ -1,9 +1,13 @@
 package io.muserver.rest;
 
+import java.io.ByteArrayOutputStream;
+import java.nio.ByteBuffer;
+import java.nio.charset.CharacterCodingException;
+import java.nio.charset.CodingErrorAction;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import static io.muserver.Mutils.urlDecode;
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 class Jaxutils {
 
@@ -19,8 +23,42 @@ class Jaxutils {
                 return value;
             }
             String octet = matcher.group("octet");
-            value = value.replace(octet, urlDecode(octet));
+            value = value.replace(octet, uriDecode(octet));
         }
+    }
+
+    static String uriDecode(String value) {
+        int firstPercent = value.indexOf('%');
+        if (firstPercent < 0) return value;
+        StringBuilder decoded = new StringBuilder(value.length()).append(value, 0, firstPercent);
+        ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+        for (int i = firstPercent; i < value.length();) {
+            if (value.charAt(i) != '%') {
+                decoded.append(value.charAt(i++));
+                continue;
+            }
+            bytes.reset();
+            while (i < value.length() && value.charAt(i) == '%') {
+                if (i + 2 >= value.length()) throw invalid(value, null);
+                int high = Character.digit(value.charAt(i + 1), 16);
+                int low = Character.digit(value.charAt(i + 2), 16);
+                if (high < 0 || low < 0) throw invalid(value, null);
+                bytes.write((high << 4) | low);
+                i += 3;
+            }
+            try {
+                decoded.append(UTF_8.newDecoder().onMalformedInput(CodingErrorAction.REPORT)
+                    .onUnmappableCharacter(CodingErrorAction.REPORT)
+                    .decode(ByteBuffer.wrap(bytes.toByteArray())));
+            } catch (CharacterCodingException e) {
+                throw invalid(value, e);
+            }
+        }
+        return decoded.toString();
+    }
+
+    private static IllegalArgumentException invalid(String value, Exception cause) {
+        return new IllegalArgumentException("Invalid UTF-8 percent encoding in " + value, cause);
     }
 
     private Jaxutils() {

--- a/src/main/java/io/muserver/rest/MuUriInfo.java
+++ b/src/main/java/io/muserver/rest/MuUriInfo.java
@@ -12,7 +12,6 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static io.muserver.Mutils.urlDecode;
 import static io.muserver.Mutils.urlEncode;
 import static io.muserver.rest.ReadOnlyMultivaluedMap.readOnly;
 import static java.util.stream.Collectors.toList;
@@ -41,7 +40,7 @@ class MuUriInfo implements UriInfo {
 
     @Override
     public String getPath(boolean decode) {
-        return decode ? urlDecode(encodedRelativePath) : encodedRelativePath;
+        return decode ? Jaxutils.uriDecode(encodedRelativePath) : encodedRelativePath;
     }
 
     @Override
@@ -51,29 +50,36 @@ class MuUriInfo implements UriInfo {
 
     @Override
     public List<PathSegment> getPathSegments(boolean decode) {
-        return pathStringToSegments(getPath(decode), false)
+        return pathStringToSegments(encodedRelativePath, false, decode)
             .collect(Collectors.toList());
     }
 
     static Stream<MuPathSegment> pathStringToSegments(String path, boolean encodeSlashes) {
+        return pathStringToSegments(path, encodeSlashes, false);
+    }
+
+    static Stream<MuPathSegment> pathStringToSegments(String path, boolean encodeSlashes, boolean decode) {
         Stream<String> stream = encodeSlashes ? Stream.of(path) : Stream.of(path.split("/"));
         return stream
             .filter(s -> !s.isEmpty())
             .map(s -> {
-                String[] segments = s.split(";");
+                String[] segments = s.split(";", -1);
 
                 MultivaluedHashMap<String, String> params = new MultivaluedHashMap<>();
                 for (int i = 1; i < segments.length; i++) {
-                    String[] nv = segments[i].split("=");
-                    String paramName = nv[0];
+                    String[] nv = segments[i].split("=", 2);
+                    String paramName = decode ? Jaxutils.uriDecode(nv[0]) : nv[0];
                     if (nv.length == 1) {
                         params.add(paramName, "");
                     } else {
-                        String[] vals = nv[1].split(",");
+                        String[] vals = nv[1].split(",", -1);
+                        if (decode) {
+                            for (int j = 0; j < vals.length; j++) vals[j] = Jaxutils.uriDecode(vals[j]);
+                        }
                         params.addAll(paramName, vals);
                     }
                 }
-                return new MuPathSegment(segments[0], params);
+                return new MuPathSegment(decode ? Jaxutils.uriDecode(segments[0]) : segments[0], params);
             });
     }
 
@@ -137,12 +143,12 @@ class MuUriInfo implements UriInfo {
 
     @Override
     public MultivaluedMap<String, String> getQueryParameters(boolean decode) {
-        QueryStringDecoder qsd = new QueryStringDecoder(requestUri);
         MultivaluedHashMap<String, String> all = new MultivaluedHashMap<>();
+        Map<String, List<String>> parameters = new QueryStringDecoder(requestUri).parameters();
         if (decode) {
-            all.putAll(qsd.parameters());
+            all.putAll(parameters);
         } else {
-            for (Map.Entry<String, List<String>> entry : qsd.parameters().entrySet()) {
+            for (Map.Entry<String, List<String>> entry : parameters.entrySet()) {
                 all.put(entry.getKey(), entry.getValue().stream().map(Mutils::urlEncode).collect(toList()));
             }
         }
@@ -161,10 +167,10 @@ class MuUriInfo implements UriInfo {
             return Collections.emptyList();
         }
         List<String> matchedURIs = new ArrayList<>();
-        matchedURIs.add(decode ? Mutils.urlDecode(encodedRelativePath) : encodedRelativePath);
+        matchedURIs.add(decode ? Jaxutils.uriDecode(encodedRelativePath) : encodedRelativePath);
         String methodSpecific = mm.pathMatch.regexMatcher().group();
         String path = encodedRelativePath.replace("/" + methodSpecific, "");
-        matchedURIs.add(decode ? Mutils.urlDecode(path) : path);
+        matchedURIs.add(decode ? Jaxutils.uriDecode(path) : path);
         return Collections.unmodifiableList(matchedURIs);
 
     }
@@ -190,4 +196,5 @@ class MuUriInfo implements UriInfo {
     public String toString() {
         return getRequestUri().toString();
     }
+
 }

--- a/src/main/java/io/muserver/rest/UriPattern.java
+++ b/src/main/java/io/muserver/rest/UriPattern.java
@@ -8,7 +8,6 @@ import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import static io.muserver.Mutils.urlDecode;
 
 /**
  * A pattern representing a URI template, such as <code>/fruit</code> or <code>/fruit/{name}</code> etc.
@@ -76,7 +75,7 @@ public class UriPattern {
         if (matcher.matches()) {
             HashMap<String, PathSegment> params = new HashMap<>();
             for (String namedGroup : namedGroups) {
-                MuPathSegment segment = MuUriInfo.pathStringToSegments(urlDecode(matcher.group(namedGroup)), true).findFirst().orElse(null);
+                MuPathSegment segment = MuUriInfo.pathStringToSegments(matcher.group(namedGroup), true, true).findFirst().orElse(null);
                 if (segment != null) {
                     params.put(namedGroup, segment);
                 }

--- a/src/test/java/io/muserver/MutilsTest.java
+++ b/src/test/java/io/muserver/MutilsTest.java
@@ -25,6 +25,13 @@ public class MutilsTest {
     }
 
     @Test
+    public void requestPathNormalizationDecodesOnlyUnreservedCharactersRegardlessOfHexCase() {
+        assertThat(Mutils.decodeUnreserved("/%41%5a%61%7A%30%39%2d%2E%5f%7e"), equalTo("/AZaz09-._~"));
+        assertThat(Mutils.decodeUnreserved("/%2F%5c%3F%23%3B%26%3D%2B%20"),
+            equalTo("/%2F%5c%3F%23%3B%26%3D%2B%20"));
+    }
+
+    @Test
     public void joinJoinsThingsToBeJoined() {
         assertThat(join("/sample-static/", "/", "/something.txt"), equalTo("/sample-static/something.txt"));
         assertThat(join("/sample-static", "/", "/something.txt"), equalTo("/sample-static/something.txt"));

--- a/src/test/java/io/muserver/ParametersTest.java
+++ b/src/test/java/io/muserver/ParametersTest.java
@@ -1,6 +1,8 @@
 package io.muserver;
 
 import okhttp3.FormBody;
+import okhttp3.MediaType;
+import okhttp3.RequestBody;
 import okhttp3.Response;
 import org.junit.After;
 import org.junit.Test;
@@ -218,6 +220,43 @@ public class ParametersTest {
         assertThat(r, containsString("|serverRawQS=a%20space=a%20value&a+space=a+value2&a%2Bplus=a%2Bplus|"));
         assertThat(r, containsString("|qs=a space=a value&a+space=a+value2&a+plus=a+plus|"));
         assertThat(r, containsString("|rawQS=a%20space=a%20value&a+space=a+value2&a%2Bplus=a%2Bplus|"));
+    }
+
+    @Test
+    public void decodedQueriesSupportHtmlGetFormSemantics() throws Exception {
+        server = httpServer().addHandler((request, response) -> {
+            response.write(request.uri().getRawQuery() + "\n" + request.query().all());
+            return true;
+        }).start();
+        String response;
+        try (RawClient client = RawClient.create(server.uri())) {
+            client.sendStartLine("GET", "/search?q=blue%20green&q=blue+green&q=blue%2Bgreen&empty=&bare&na%20me=a=b&semi=x;y");
+            client.sendHeader("Host", server.uri().getAuthority());
+            client.endHeaders();
+            client.flushRequest();
+            while (client.bytesReceived() == 0) Thread.sleep(10);
+            response = client.responseString();
+        }
+        assertThat(response, containsString("q=blue%20green&q=blue+green&q=blue%2Bgreen&empty=&bare&na%20me=a=b&semi=x;y"));
+        assertThat(response, containsString("q=[blue green, blue green, blue+green]"));
+        assertThat(response, containsString("empty=[]"));
+        assertThat(response, containsString("bare=[]"));
+        assertThat(response, containsString("na me=[a=b]"));
+        assertThat(response, containsString("semi=[x]"));
+        assertThat(response, containsString("y=[]"));
+    }
+
+    @Test
+    public void urlEncodedFormBodiesUseFormDecoding() throws Exception {
+        server = httpServer().addHandler((request, response) -> {
+            response.write(request.form().getAll("colour").toString());
+            return true;
+        }).start();
+        RequestBody body = RequestBody.create("colour=blue%20green&colour=blue+green&colour=blue%2Bgreen&utf8=%E4%BD%A0%E5%A5%BD",
+            MediaType.get("application/x-www-form-urlencoded;charset=UTF-8"));
+        try (Response response = call(request(server.uri()).post(body))) {
+            assertThat(response.body().string(), equalTo("[blue green, blue green, blue+green]"));
+        }
     }
 
     @After

--- a/src/test/java/io/muserver/RoutesTest.java
+++ b/src/test/java/io/muserver/RoutesTest.java
@@ -77,6 +77,10 @@ public class RoutesTest {
             .start();
         assertThat(respBody(Method.GET, "/blah%20ha/hello%20goodbye/ha"),
             equalTo("hello goodbye"));
+        assertThat(respBody(Method.GET, "/blah%20ha/hello+goodbye/ha"),
+            equalTo("hello+goodbye"));
+        assertThat(respBody(Method.GET, "/blah%20ha/hello%2Bgoodbye/ha"),
+            equalTo("hello+goodbye"));
     }
 
     @Test
@@ -93,6 +97,19 @@ public class RoutesTest {
             .start();
         assertThat(respBody(Method.GET, "/context/blah%20ha;h%20i=h%20i;a=b/hello%20goodbye/ha%20ha;h%20i=h%20i;a=b"),
             equalTo("ha ha - h i"));
+    }
+
+    @Test
+    public void matrixParameterNamesAndValuesUseUriDecoding() throws IOException {
+        server = ServerUtils.httpsServerForTest()
+            .addHandler(Method.GET, "/cars/{car}", (request, response, ignored) -> {
+                PathSegment car = UriPattern.uriTemplateToRegex("/cars/{car}").matcher(request.uri()).segments().get("car");
+                response.write(car.getMatrixParameters().toString());
+            }).start();
+
+        assertThat(respBody(Method.GET, "/cars/e55;col%20our=blue%20green"), equalTo("{col our=[blue green]}"));
+        assertThat(respBody(Method.GET, "/cars/e55;col+our=blue+green"), equalTo("{col+our=[blue+green]}"));
+        assertThat(respBody(Method.GET, "/cars/e55;colour=blue%2Bgreen"), equalTo("{colour=[blue+green]}"));
     }
 
     private int call(Method method, String path) {

--- a/src/test/java/io/muserver/rest/MuUriBuilderTest.java
+++ b/src/test/java/io/muserver/rest/MuUriBuilderTest.java
@@ -29,6 +29,20 @@ public class MuUriBuilderTest {
     }
 
     @Test
+    public void spacesAndPlusesAreSerializedUnambiguouslyInComponents() {
+        URI uri = new MuUriBuilder().path("blue green").segment("blue+green")
+            .matrixParam("col our", "blue+green")
+            .queryParam("q space", "blue green", "blue+green").build();
+        assertThat(uri.toString(), equalTo("blue%20green/blue%2Bgreen;col%20our=blue%2Bgreen?q%20space=blue%20green&q%20space=blue%2Bgreen"));
+    }
+
+    @Test
+    public void replacingAQuerySupportsHtmlGetFormSemantics() {
+        assertThat(new MuUriBuilder().replaceQuery("q=blue%20green&q=blue+green&q=blue%2Bgreen").build().toString(),
+            equalTo("?q=blue%20green&q=blue%20green&q=blue%2Bgreen"));
+    }
+
+    @Test
     public void prettyMuchEverythingCanHaveTemplateParameters() {
         UriBuilder builder = new MuUriBuilder()
             .scheme("http{s}")

--- a/src/test/java/io/muserver/rest/MuUriInfoTest.java
+++ b/src/test/java/io/muserver/rest/MuUriInfoTest.java
@@ -128,6 +128,17 @@ public class MuUriInfoTest {
     }
 
     @Test
+    public void queryAndPathAccessorsDistinguishSpaceAndPlus() {
+        MuUriInfo sample = create("http://example.org/cars/blue%20green/blue+green?q=blue%20green&q=blue+green&q=blue%2Bgreen&na%20me=value");
+        assertThat(sample.getPath(true), equalTo("cars/blue green/blue+green"));
+        assertThat(sample.getPath(false), equalTo("cars/blue%20green/blue+green"));
+        assertThat(sample.getPathSegments(true), contains(segment("cars"), segment("blue green"), segment("blue+green")));
+        assertThat(sample.getQueryParameters(true).get("q"), contains("blue green", "blue green", "blue+green"));
+        assertThat(sample.getQueryParameters(false).get("q"), contains("blue%20green", "blue%20green", "blue%2Bgreen"));
+        assertThat(sample.getQueryParameters(false).get("na me"), contains("value"));
+    }
+
+    @Test
     public void uriInfoInAJaxRsContextReturnsCorrectValues() {
 
         AtomicReference<UriInfo> uriRef = new AtomicReference<>();


### PR DESCRIPTION
## Summary

- decode URI paths, route parameters, and matrix parameters without converting `+` to space
- preserve the established form-compatible query contract where both `+` and `%20` decode to space
- parse matrix delimiters before percent decoding and encode literal spaces/pluses unambiguously
- normalize percent-encoded unreserved path characters case-insensitively while preserving reserved escapes
- document the public query and legacy `Mutils` behavior

## Why

Generic URL form decoding was used for URI path components, causing literal plus signs to become spaces. Path and matrix parsing also decoded before splitting delimiters, and unreserved path normalization differed by spelling. These changes apply component-specific rules without changing the existing browser-compatible query behavior.

## Compatibility

Decoded path, route, and matrix values now preserve literal `+`. Existing decoded query APIs remain form-compatible. Mu 2 retains Netty's historical semicolon query separator behavior.

## Validation

- `mvn -q test`
- `git diff --check`
