### PR TITLE
Fix URI component encoding in mu3

### DIFF
--- a/BREAKINGCHANGES.md
+++ b/BREAKINGCHANGES.md
@@ -15,6 +15,16 @@ MuRequest and MuResponse API
 * `MuResponse.status()` now returns a `HttpStatus` value rather than an `int`. For the int, call
   `MuResponse.status().code()`
 
+Query string semicolons
+-----------------------
+
+Mu 3 only treats `&` as a query-parameter separator. Semicolons are data in parameter names and values, including when
+query parameters are decoded with HTML form compatibility. For example, `?value=a;b` produces a single parameter named
+`value` with the value `a;b`.
+
+This differs from Mu 2's Netty query decoder, which treats both `&` and `;` as separators. Applications that used
+semicolon-separated query parameters such as `?one=1;two=2` must change them to `?one=1&two=2` when upgrading to Mu 3.
+
 SSE
 ---
 
@@ -56,4 +66,3 @@ Mu 3 todo
 
 * Websocket permessage-deflate
 * Better HTTP 103 Early Hints support (especially for creating links)
-

--- a/src/main/java/io/muserver/Http2Stream.java
+++ b/src/main/java/io/muserver/Http2Stream.java
@@ -323,8 +323,9 @@ class Http2Stream implements ResponseInfo {
             bodySize = BodySize.UNSPECIFIED;
         }
 
-        var serverUri = connection.creator.uri().resolve(path.toString());
-        var requestUri = Headtils.getUri(log, headers, path.toString(), serverUri);
+        var relativeUrl = Mutils.getRelativeUrl(path.toString());
+        var serverUri = connection.creator.uri().resolve(relativeUrl);
+        var requestUri = Headtils.getUri(log, headers, relativeUrl, serverUri);
 
         var outgoingFlowControl = new Http2OutgoingFlowController(id, clientSettings.initialWindowSize);
         var incomingFlowControl = new Http2IncomingFlowController(id, serverSettings.initialWindowSize);

--- a/src/main/java/io/muserver/Mu3Request.java
+++ b/src/main/java/io/muserver/Mu3Request.java
@@ -8,7 +8,6 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.URI;
 import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
 import java.util.*;
 
 import static java.lang.Math.min;
@@ -176,7 +175,7 @@ class Mu3Request implements MuRequest {
                 String type = bodyType.getType().toLowerCase();
                 String subtype = bodyType.getSubtype().toLowerCase();
                 if ("application".equals(type) && "x-www-form-urlencoded".equals(subtype)) {
-                    String text = streamBodyToString(StandardCharsets.UTF_8);
+                    String text = streamBodyToString(Headtils.bodyCharset(mu3Headers, true));
                     this.form = UrlEncodedMuForm.parse(text);
                 } else if ("multipart".equals(type) && "form-data".equals(subtype)) {
                     var charset = Headtils.bodyCharset(mu3Headers, true);

--- a/src/main/java/io/muserver/MuRequest.java
+++ b/src/main/java/io/muserver/MuRequest.java
@@ -149,13 +149,15 @@ public interface MuRequest {
     }
 
     /**
-     * <p>Gets the querystring parameters for this request.</p>
+     * <p>Gets query parameters decoded with {@code application/x-www-form-urlencoded} compatibility.
+     * Both {@code +} and {@code %20} are decoded to a space; use {@link #uri()}{@code .getRawQuery()} for the raw query.</p>
      * @return Returns an object allowing you to access the querystring parameters of this request.
      */
     RequestParameters query();
 
     /**
      * <p>Gets the form parameters for this request.</p>
+     * <p>For {@code application/x-www-form-urlencoded}, both {@code +} and {@code %20} decode to a space.</p>
      * <p>Note: this cannot be called after a call to {@link #inputStream()} or {@link #readBodyAsString()}</p>
      * @throws IOException Thrown when there is an error while reading the form, e.g. if a user closes their
      *                     browser before the form is fully read into memory.

--- a/src/main/java/io/muserver/Mutils.java
+++ b/src/main/java/io/muserver/Mutils.java
@@ -26,8 +26,9 @@ public class Mutils {
     public static final String NEWLINE = String.format("%n");
 
     /**
+     * Encodes a UTF-8 value using HTML-form escaping, except spaces are emitted as {@code %20} and {@code ~} is left unescaped.
      * @param value the value to encode
-     * @return Returns the UTF-8 URL encoded value
+     * @return the encoded value
      */
     public static String urlEncode(String value) {
         return URLEncoder.encode(value, UTF_8)
@@ -37,8 +38,9 @@ public class Mutils {
     }
 
     /**
+     * Decodes a UTF-8 HTML-form-style value, so both {@code +} and {@code %20} become spaces.
      * @param value the value to decode
-     * @return Returns the UTF-8 URL decoded value
+     * @return the decoded value
      */
     public static String urlDecode(String value) {
         return URLDecoder.decode(value, UTF_8);
@@ -303,12 +305,7 @@ public class Mutils {
             if (Mutils.nullOrEmpty(s)) {
                 s = "/";
             } else {
-                // TODO: consider a redirect if the URL is changed? Handle other percent-encoded characters?
-                s = s.replace("%7E", "~")
-                    .replace("%5F", "_")
-                    .replace("%2E", ".")
-                    .replace("%2D", "-")
-                ;
+                s = decodeUnreserved(s);
             }
             String q = requestUri.getRawQuery();
             if (q != null) {
@@ -319,6 +316,29 @@ public class Mutils {
             if (e instanceof HttpException) throw (HttpException) e;
             throw new HttpException(HttpStatus.BAD_REQUEST_400, "Invalid request URL");
         }
+    }
+
+    static String decodeUnreserved(String value) {
+        int percent = value.indexOf('%');
+        if (percent < 0) return value;
+        StringBuilder result = null;
+        int copiedUntil = 0;
+        for (int i = percent; i + 2 < value.length(); i++) {
+            if (value.charAt(i) != '%') continue;
+            int high = Character.digit(value.charAt(i + 1), 16);
+            int low = Character.digit(value.charAt(i + 2), 16);
+            if (high < 0 || low < 0) continue;
+            int decoded = (high << 4) | low;
+            if ((decoded >= 'a' && decoded <= 'z') || (decoded >= 'A' && decoded <= 'Z') ||
+                (decoded >= '0' && decoded <= '9') || decoded == '-' || decoded == '.' ||
+                decoded == '_' || decoded == '~') {
+                if (result == null) result = new StringBuilder(value.length());
+                result.append(value, copiedUntil, i).append((char) decoded);
+                copiedUntil = i + 3;
+                i += 2;
+            }
+        }
+        return result == null ? value : result.append(value, copiedUntil, value.length()).toString();
     }
 
     private static final ByteBuffer EMPTY_BUFFER = ByteBuffer.allocate(0);

--- a/src/main/java/io/muserver/QueryString.java
+++ b/src/main/java/io/muserver/QueryString.java
@@ -73,7 +73,7 @@ public class QueryString implements RequestParameters {
         for (String key : map.keySet()) {
             String encodedKey = urlEncode(key);
             for (String value : map.get(key)) {
-                if (sb.length() > 1) sb.append('&');
+                if (sb.length() > 0) sb.append('&');
                 sb.append(encodedKey).append('=').append(urlEncode(value));
             }
         }

--- a/src/main/java/io/muserver/RequestParameters.java
+++ b/src/main/java/io/muserver/RequestParameters.java
@@ -7,7 +7,7 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * Provides access to QueryString or Form values.
+ * Provides access to query-string or form values. Both use HTML form-compatible decoding where a plus is a space.
  */
 public interface RequestParameters {
 
@@ -155,4 +155,3 @@ public interface RequestParameters {
         return all().size();
     }
 }
-

--- a/src/main/java/io/muserver/handlers/DirectoryLister.java
+++ b/src/main/java/io/muserver/handlers/DirectoryLister.java
@@ -35,7 +35,7 @@ class DirectoryLister {
     void render() throws IOException {
         El html = new El("html").open();
         El head = new El("head").open();
-        String title = "Index of " + Mutils.urlDecode(contextPath + relativePath);
+        String title = "Index of " + java.net.URI.create(contextPath + relativePath).getPath();
         render("title", title);
         new El("style").open().contentRaw(directoryListingCss).close();
         head.close();

--- a/src/main/java/io/muserver/handlers/ResourceHandler.java
+++ b/src/main/java/io/muserver/handlers/ResourceHandler.java
@@ -49,12 +49,12 @@ public class ResourceHandler implements MuHandler {
         if (requestPath.endsWith("/") && defaultFile != null) {
             requestPath += defaultFile;
         }
-        String decodedRelativePath = Mutils.urlDecode(requestPath);
+        String decodedRelativePath = java.net.URI.create(requestPath).getPath();
 
         ResourceProvider provider = resourceProviderFactory.get(decodedRelativePath);
         if (!provider.exists()) {
             if (directoryListingEnabled) {
-                provider = resourceProviderFactory.get(Mutils.urlDecode(request.relativePath()));
+                provider = resourceProviderFactory.get(java.net.URI.create(request.relativePath()).getPath());
                 if (!provider.isDirectory()) {
                     return false;
                 }

--- a/src/main/java/io/muserver/rest/Jaxutils.java
+++ b/src/main/java/io/muserver/rest/Jaxutils.java
@@ -1,9 +1,13 @@
 package io.muserver.rest;
 
+import java.io.ByteArrayOutputStream;
+import java.nio.ByteBuffer;
+import java.nio.charset.CharacterCodingException;
+import java.nio.charset.CodingErrorAction;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import static io.muserver.Mutils.urlDecode;
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 class Jaxutils {
 
@@ -19,8 +23,42 @@ class Jaxutils {
                 return value;
             }
             String octet = matcher.group("octet");
-            value = value.replace(octet, urlDecode(octet));
+            value = value.replace(octet, uriDecode(octet));
         }
+    }
+
+    static String uriDecode(String value) {
+        int firstPercent = value.indexOf('%');
+        if (firstPercent < 0) return value;
+        var decoded = new StringBuilder(value.length()).append(value, 0, firstPercent);
+        var bytes = new ByteArrayOutputStream();
+        for (int i = firstPercent; i < value.length();) {
+            if (value.charAt(i) != '%') {
+                decoded.append(value.charAt(i++));
+                continue;
+            }
+            bytes.reset();
+            while (i < value.length() && value.charAt(i) == '%') {
+                if (i + 2 >= value.length()) throw invalid(value, null);
+                int high = Character.digit(value.charAt(i + 1), 16);
+                int low = Character.digit(value.charAt(i + 2), 16);
+                if (high < 0 || low < 0) throw invalid(value, null);
+                bytes.write((high << 4) | low);
+                i += 3;
+            }
+            try {
+                decoded.append(UTF_8.newDecoder().onMalformedInput(CodingErrorAction.REPORT)
+                    .onUnmappableCharacter(CodingErrorAction.REPORT)
+                    .decode(ByteBuffer.wrap(bytes.toByteArray())));
+            } catch (CharacterCodingException e) {
+                throw invalid(value, e);
+            }
+        }
+        return decoded.toString();
+    }
+
+    private static IllegalArgumentException invalid(String value, Exception cause) {
+        return new IllegalArgumentException("Invalid UTF-8 percent encoding in " + value, cause);
     }
 
     private Jaxutils() {

--- a/src/main/java/io/muserver/rest/MuUriInfo.java
+++ b/src/main/java/io/muserver/rest/MuUriInfo.java
@@ -12,7 +12,6 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static io.muserver.Mutils.urlDecode;
 import static io.muserver.Mutils.urlEncode;
 import static io.muserver.rest.ReadOnlyMultivaluedMap.readOnly;
 import static java.util.stream.Collectors.toList;
@@ -41,7 +40,7 @@ class MuUriInfo implements UriInfo {
 
     @Override
     public String getPath(boolean decode) {
-        return decode ? urlDecode(encodedRelativePath) : encodedRelativePath;
+        return decode ? Jaxutils.uriDecode(encodedRelativePath) : encodedRelativePath;
     }
 
     @Override
@@ -51,29 +50,36 @@ class MuUriInfo implements UriInfo {
 
     @Override
     public List<PathSegment> getPathSegments(boolean decode) {
-        return pathStringToSegments(getPath(decode), false)
+        return pathStringToSegments(encodedRelativePath, false, decode)
             .collect(Collectors.toList());
     }
 
     static Stream<MuPathSegment> pathStringToSegments(String path, boolean encodeSlashes) {
+        return pathStringToSegments(path, encodeSlashes, false);
+    }
+
+    static Stream<MuPathSegment> pathStringToSegments(String path, boolean encodeSlashes, boolean decode) {
         Stream<String> stream = encodeSlashes ? Stream.of(path) : Stream.of(path.split("/"));
         return stream
             .filter(s -> !s.isEmpty())
             .map(s -> {
-                String[] segments = s.split(";");
+                String[] segments = s.split(";", -1);
 
                 MultivaluedHashMap<String, String> params = new MultivaluedHashMap<>();
                 for (int i = 1; i < segments.length; i++) {
-                    String[] nv = segments[i].split("=");
-                    String paramName = nv[0];
+                    String[] nv = segments[i].split("=", 2);
+                    String paramName = decode ? Jaxutils.uriDecode(nv[0]) : nv[0];
                     if (nv.length == 1) {
                         params.add(paramName, "");
                     } else {
-                        String[] vals = nv[1].split(",");
+                        String[] vals = nv[1].split(",", -1);
+                        if (decode) {
+                            for (int j = 0; j < vals.length; j++) vals[j] = Jaxutils.uriDecode(vals[j]);
+                        }
                         params.addAll(paramName, vals);
                     }
                 }
-                return new MuPathSegment(segments[0], params);
+                return new MuPathSegment(decode ? Jaxutils.uriDecode(segments[0]) : segments[0], params);
             });
     }
 
@@ -161,10 +167,10 @@ class MuUriInfo implements UriInfo {
             return Collections.emptyList();
         }
         List<String> matchedURIs = new ArrayList<>();
-        matchedURIs.add(decode ? Mutils.urlDecode(encodedRelativePath) : encodedRelativePath);
+        matchedURIs.add(decode ? Jaxutils.uriDecode(encodedRelativePath) : encodedRelativePath);
         String methodSpecific = mm.pathMatch.regexMatcher().group();
         String path = encodedRelativePath.replace("/" + methodSpecific, "");
-        matchedURIs.add(decode ? Mutils.urlDecode(path) : path);
+        matchedURIs.add(decode ? Jaxutils.uriDecode(path) : path);
         return Collections.unmodifiableList(matchedURIs);
 
     }

--- a/src/main/java/io/muserver/rest/UriPattern.java
+++ b/src/main/java/io/muserver/rest/UriPattern.java
@@ -8,7 +8,6 @@ import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import static io.muserver.Mutils.urlDecode;
 
 /**
  * A pattern representing a URI template, such as <code>/fruit</code> or <code>/fruit/{name}</code> etc.
@@ -76,7 +75,7 @@ public class UriPattern {
         if (matcher.matches()) {
             HashMap<String, PathSegment> params = new HashMap<>();
             for (String namedGroup : namedGroups) {
-                MuPathSegment segment = MuUriInfo.pathStringToSegments(urlDecode(matcher.group(namedGroup)), true).findFirst().orElse(null);
+                MuPathSegment segment = MuUriInfo.pathStringToSegments(matcher.group(namedGroup), true, true).findFirst().orElse(null);
                 if (segment != null) {
                     params.put(namedGroup, segment);
                 }

--- a/src/test/java/io/muserver/ContextHandlerTest.java
+++ b/src/test/java/io/muserver/ContextHandlerTest.java
@@ -6,6 +6,8 @@ import jakarta.ws.rs.Path;
 import okhttp3.Response;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import scaffolding.ServerUtils;
 
 import java.io.IOException;
@@ -184,9 +186,10 @@ public class ContextHandlerTest {
         }
     }
 
-    @Test
-    public void unreservedCharactersComeThroughUnencoded() throws Exception {
-        server = ServerUtils.httpsServerForTest()
+    @ParameterizedTest
+    @ValueSource(strings = {"https", "h2"})
+    public void unreservedCharactersComeThroughUnencoded(String protocol) throws Exception {
+        server = ServerUtils.httpsServerForTest(protocol)
             .addHandler(context("~.-_")
                 .addHandler(Method.GET, "~.-_", (request, response, pathParams) -> {
                     response.write(request.contextPath() + " - " + request.relativePath());
@@ -198,6 +201,10 @@ public class ContextHandlerTest {
             assertThat(resp.code(), is(200));
         }
         try (Response resp = call(request(server.uri().resolve("/%7E%2E%2D%5F/%7E%2E%2D%5F")))) {
+            assertThat(resp.body().string(), is("/~.-_ - /~.-_"));
+            assertThat(resp.code(), is(200));
+        }
+        try (Response resp = call(request(server.uri().resolve("/%7e%2e%2d%5f/%7e%2e%2d%5f")))) {
             assertThat(resp.body().string(), is("/~.-_ - /~.-_"));
             assertThat(resp.code(), is(200));
         }

--- a/src/test/java/io/muserver/MutilsTest.java
+++ b/src/test/java/io/muserver/MutilsTest.java
@@ -26,6 +26,13 @@ public class MutilsTest {
     }
 
     @Test
+    public void requestPathNormalizationDecodesOnlyUnreservedCharactersRegardlessOfHexCase() {
+        assertThat(Mutils.decodeUnreserved("/%41%5a%61%7A%30%39%2d%2E%5f%7e"), equalTo("/AZaz09-._~"));
+        assertThat(Mutils.decodeUnreserved("/%2F%5c%3F%23%3B%26%3D%2B%20"),
+            equalTo("/%2F%5c%3F%23%3B%26%3D%2B%20"));
+    }
+
+    @Test
     public void joinJoinsThingsToBeJoined() {
         assertThat(join("/sample-static/", "/", "/something.txt"), equalTo("/sample-static/something.txt"));
         assertThat(join("/sample-static", "/", "/something.txt"), equalTo("/sample-static/something.txt"));

--- a/src/test/java/io/muserver/ParametersTest.java
+++ b/src/test/java/io/muserver/ParametersTest.java
@@ -20,6 +20,7 @@ import static java.util.Arrays.asList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 import static scaffolding.ClientUtils.call;
+import static scaffolding.ClientUtils.isHttp2;
 import static scaffolding.ClientUtils.request;
 import static scaffolding.MuAssert.assertEventually;
 
@@ -216,6 +217,18 @@ public class ParametersTest {
         assertThat(r, containsString("|serverRawQS=a%20space=a%20value&a+space=a+value2&a%2Bplus=a%2Bplus|"));
         assertThat(r, containsString("|qs=a space=a value&a+space=a+value2&a+plus=a+plus|"));
         assertThat(r, containsString("|rawQS=a%20space=a%20value&a+space=a+value2&a%2Bplus=a%2Bplus|"));
+    }
+
+    @Test
+    public void http2UsesTheSameRawAndDecodedUriSemantics() throws IOException {
+        server = ServerUtils.httpsServerForTest("h2").addHandler((request, response) -> {
+            response.write(request.uri().getRawPath() + "|" + request.uri().getRawQuery() + "|" + request.query().getAll("q"));
+            return true;
+        }).start();
+        try (var response = call(request().url(server.uri().resolve("/cars/blue%20green+plus?q=blue%20green&q=blue+green&q=blue%2Bgreen").toString()))) {
+            assertThat(isHttp2(response), is(true));
+            assertThat(response.body().string(), equalTo("/cars/blue%20green+plus|q=blue%20green&q=blue+green&q=blue%2Bgreen|[blue green, blue green, blue+green]"));
+        }
     }
 
     @AfterEach

--- a/src/test/java/io/muserver/QueryStringTest.java
+++ b/src/test/java/io/muserver/QueryStringTest.java
@@ -77,6 +77,38 @@ public class QueryStringTest {
     }
 
     @Test
+    public void queryDecodingSupportsHtmlGetFormSemantics() {
+        assertThat(QueryString.parse("q=blue%20green&q=blue+green&q=blue%2Bgreen").getAll("q"),
+            contains("blue green", "blue green", "blue+green"));
+    }
+
+    @Test
+    public void valuesMayContainEqualsAndSemicolonsAreData() {
+        assertThat(qs("na%20me=a=b&bare&empty=&semi=x;y").all(), equalTo(Map.of(
+            "na me", List.of("a=b"), "bare", List.of(""), "empty", List.of(""), "semi", List.of("x;y"))));
+    }
+
+    @Test
+    public void literalSemicolonsDoNotSeparateQueryParameters() {
+        assertThat(qs("value=a;b&other=c;d=e&bare;name").all(), equalTo(Map.of(
+            "value", List.of("a;b"),
+            "other", List.of("c;d=e"),
+            "bare;name", List.of(""))));
+    }
+
+    @Test
+    public void encodedSemicolonsAreDataInNamesAndValues() {
+        assertThat(qs("na%3Bme=one%3Btwo&na;me=three").all(), equalTo(Map.of(
+            "na;me", List.of("one;two", "three"))));
+    }
+
+    @Test
+    public void semicolonsArePercentEncodedWhenSerializing() {
+        assertThat(qs("na;me=one;two&other=three").toString(),
+            equalTo("na%3Bme=one%3Btwo&other=three"));
+    }
+
+    @Test
     public void french() {
         assertThat(qs("prénom=Jean&âge=25&ville=Paris"), equalTo(qs(Map.of("prénom", "Jean", "âge", "25", "ville", "Paris"))));
         assertThat(qs("pr%C3%A9nom=Jean&âge=25&ville=Paris"), equalTo(qs(Map.of("prénom", "Jean", "âge", "25", "ville", "Paris"))));

--- a/src/test/java/io/muserver/RequestFormUrlEncodedTest.java
+++ b/src/test/java/io/muserver/RequestFormUrlEncodedTest.java
@@ -1,6 +1,8 @@
 package io.muserver;
 
 import okhttp3.FormBody;
+import okhttp3.MediaType;
+import okhttp3.RequestBody;
 import okhttp3.Response;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
@@ -96,6 +98,19 @@ public class RequestFormUrlEncodedTest {
         assertThat(actual[0], equalTo(asList("something", "somethingAgain")));
         assertThat(actual[1], equalTo(asList("something else i think")));
         assertThat(actual[2], equalTo(Collections.<String>emptyList()));
+    }
+
+    @Test
+    public void percentSpacePlusAndEncodedPlusUseFormSemantics() throws IOException {
+        server = ServerUtils.httpsServerForTest().addHandler((request, response) -> {
+            response.write(request.form().getAll("colour").toString());
+            return true;
+        }).start();
+        var body = RequestBody.create("colour=blue%20green&colour=blue+green&colour=blue%2Bgreen&utf8=%E4%BD%A0%E5%A5%BD",
+            MediaType.get("application/x-www-form-urlencoded;charset=UTF-8"));
+        try (var response = call(request(server.uri()).post(body))) {
+            assertThat(response.body().string(), equalTo("[blue green, blue green, blue+green]"));
+        }
     }
 
     @Test

--- a/src/test/java/io/muserver/RoutesTest.java
+++ b/src/test/java/io/muserver/RoutesTest.java
@@ -77,6 +77,8 @@ public class RoutesTest {
             .start();
         assertThat(respBody(Method.GET, "/blah%20ha/hello%20goodbye/ha"),
             equalTo("hello goodbye"));
+        assertThat(respBody(Method.GET, "/blah%20ha/hello+goodbye/ha"), equalTo("hello+goodbye"));
+        assertThat(respBody(Method.GET, "/blah%20ha/hello%2Bgoodbye/ha"), equalTo("hello+goodbye"));
     }
 
     @Test
@@ -93,6 +95,27 @@ public class RoutesTest {
             .start();
         assertThat(respBody(Method.GET, "/context/blah%20ha;h%20i=h%20i;a=b/hello%20goodbye/ha%20ha;h%20i=h%20i;a=b"),
             equalTo("ha ha - h i"));
+    }
+
+    @Test
+    public void matrixParameterNamesAndValuesUseUriDecoding() throws IOException {
+        server = ServerUtils.httpsServerForTest()
+            .addHandler(Method.GET, "/cars/{car}", (request, response, ignored) -> {
+                PathSegment car = UriPattern.uriTemplateToRegex("/cars/{car}").matcher(request.uri()).segments().get("car");
+                response.write(car.getMatrixParameters().toString());
+            }).start();
+        assertThat(respBody(Method.GET, "/cars/e55;col%20our=blue%20green"), equalTo("{col our=[blue green]}"));
+        assertThat(respBody(Method.GET, "/cars/e55;col+our=blue+green"), equalTo("{col+our=[blue+green]}"));
+        assertThat(respBody(Method.GET, "/cars/e55;colour=blue%2Bgreen"), equalTo("{colour=[blue+green]}"));
+    }
+
+    @Test
+    public void catchAllRouteParametersUseUriDecoding() throws IOException {
+        server = ServerUtils.httpsServerForTest()
+            .addHandler(Method.GET, "/cars/{tail : .*}", (request, response, params) -> response.write(params.get("tail")))
+            .start();
+        assertThat(respBody(Method.GET, "/cars/blue%20green/and%20red"), equalTo("blue green/and red"));
+        assertThat(respBody(Method.GET, "/cars/blue+green/and+red"), equalTo("blue+green/and+red"));
     }
 
     private int call(Method method, String path) {

--- a/src/test/java/io/muserver/rest/MuUriBuilderTest.java
+++ b/src/test/java/io/muserver/rest/MuUriBuilderTest.java
@@ -29,6 +29,20 @@ public class MuUriBuilderTest {
     }
 
     @Test
+    public void spacesAndPlusesAreSerializedUnambiguouslyInComponents() {
+        URI uri = new MuUriBuilder().path("blue green").segment("blue+green")
+            .matrixParam("col our", "blue+green")
+            .queryParam("q space", "blue green", "blue+green").build();
+        assertThat(uri.toString(), equalTo("blue%20green/blue%2Bgreen;col%20our=blue%2Bgreen?q%20space=blue%20green&q%20space=blue%2Bgreen"));
+    }
+
+    @Test
+    public void replacingAQuerySupportsHtmlGetFormSemantics() {
+        assertThat(new MuUriBuilder().replaceQuery("q=blue%20green&q=blue+green&q=blue%2Bgreen").build().toString(),
+            equalTo("?q=blue%20green&q=blue%20green&q=blue%2Bgreen"));
+    }
+
+    @Test
     public void prettyMuchEverythingCanHaveTemplateParameters() {
         UriBuilder builder = new MuUriBuilder()
             .scheme("http{s}")

--- a/src/test/java/io/muserver/rest/MuUriInfoTest.java
+++ b/src/test/java/io/muserver/rest/MuUriInfoTest.java
@@ -128,6 +128,17 @@ public class MuUriInfoTest {
     }
 
     @Test
+    public void queryAndPathAccessorsDistinguishSpaceAndPlus() {
+        MuUriInfo sample = create("http://example.org/cars/blue%20green/blue+green?q=blue%20green&q=blue+green&q=blue%2Bgreen&na%20me=value");
+        assertThat(sample.getPath(true), equalTo("cars/blue green/blue+green"));
+        assertThat(sample.getPath(false), equalTo("cars/blue%20green/blue+green"));
+        assertThat(sample.getPathSegments(true), contains(segment("cars"), segment("blue green"), segment("blue+green")));
+        assertThat(sample.getQueryParameters(true).get("q"), contains("blue green", "blue green", "blue+green"));
+        assertThat(sample.getQueryParameters(false).get("q"), contains("blue%20green", "blue%20green", "blue%2Bgreen"));
+        assertThat(sample.getQueryParameters(false).get("na me"), contains("value"));
+    }
+
+    @Test
     public void uriInfoInAJaxRsContextReturnsCorrectValues() {
 
         AtomicReference<UriInfo> uriRef = new AtomicReference<>();

--- a/src/test/java/io/muserver/rest/StringEntityProvidersTest.java
+++ b/src/test/java/io/muserver/rest/StringEntityProvidersTest.java
@@ -176,6 +176,12 @@ public class StringEntityProvidersTest {
             assertThat(resp.header("Content-Type"), equalTo("application/x-www-form-urlencoded"));
             assertThat(resp.body().string(), equalTo("Umm=umm+what%3F%22%5C%2F%3A&Blah=hello+1&Blah=hello+2"));
         }
+        try (Response resp = call(request().url(server.uri().resolve("/samples").toString())
+            .addHeader("Accept", "text/plain")
+            .post(RequestBody.create("colour=blue%20green&colour=blue+green&colour=blue%2Bgreen",
+                MediaType.parse("application/x-www-form-urlencoded;charset=UTF-8"))))) {
+            assertThat(resp.body().string(), equalTo("Got colour = [blue green, blue green, blue+green] - "));
+        }
 
     }
 


### PR DESCRIPTION
## Summary

- decode URI paths, route parameters, and matrix parameters without converting `+` to space
- preserve form-compatible query parsing for browser GET forms and URL-encoded bodies
- parse matrix delimiters before percent decoding and encode literal spaces/pluses unambiguously
- normalize HTTP/1 and HTTP/2 request paths consistently, including case-insensitive unreserved escapes such as `%7E` and `%7e`
- document Mu 3's semicolon query parsing difference from Mu 2
- add explicit HTTP/1, HTTP/2, query, form, path, matrix, builder, UTF-8, and raw-accessor coverage

## Why

Generic form decoding was incorrectly applied to URI path components, causing literal plus signs to become spaces. HTTP/2 `:path` also bypassed the HTTP/1 unreserved-character normalization path. The fixes apply component-specific decoding while retaining established form-compatible query behavior.

## Compatibility

Decoded path, route, and matrix values now preserve literal `+`. Existing query APIs still decode `+` as space. Mu 3 treats only `&` as a query separator; semicolons remain data, which is documented as a breaking change from Mu 2's Netty behavior.

## Validation

- URL-related and protocol-specific suites pass
- full suite: 1,342 tests, zero assertion failures, with the acknowledged `AsynchronousProcessingTest.completionCallbacksCanBeRegistered` timeout
- `git diff --check`
