### PR TITLE
Detect HTTP/1 resets during async responses

### DIFF
--- a/src/main/java/io/muserver/BaseHttpConnection.java
+++ b/src/main/java/io/muserver/BaseHttpConnection.java
@@ -76,6 +76,7 @@ abstract class BaseHttpConnection implements HttpConnection {
             if (!handled) throw new HttpException(HttpStatus.NOT_FOUND_404, "This page is not available. Sorry about that.");
 
             if (muRequest.isAsync()) {
+                beforeAsyncWait(muRequest, muResponse);
                 var asyncHandle = muRequest.getAsyncHandle();
                     // TODO set proper timeout
                 asyncHandle.waitForCompletion(Long.MAX_VALUE);
@@ -89,6 +90,9 @@ abstract class BaseHttpConnection implements HttpConnection {
                 server.exceptionHandler().handle(muRequest, muResponse, e);
             }
         }
+    }
+
+    protected void beforeAsyncWait(Mu3Request request, BaseResponse response) throws Exception {
     }
 
     protected void onExchangeEnded(ResponseInfo exchange) {

--- a/src/main/java/io/muserver/ConnectionAcceptor.java
+++ b/src/main/java/io/muserver/ConnectionAcceptor.java
@@ -308,7 +308,7 @@ class ConnectionAcceptor {
             }
             con = new Http2Connection(server, this, socket, clientCert, startTime, http2Config.initialSettings(), http2Config.settingsAckTimeoutMillis(), executorService);
         } else {
-            con = new Http1Connection(server, this, socket, clientCert, startTime);
+            con = new Http1Connection(server, this, socket, clientCert, startTime, executorService);
         }
 
         connections.add(con);

--- a/src/main/java/io/muserver/Http1Connection.java
+++ b/src/main/java/io/muserver/Http1Connection.java
@@ -11,10 +11,14 @@ import java.net.Socket;
 import java.net.SocketTimeoutException;
 import java.net.URI;
 import java.security.cert.Certificate;
+import java.text.ParseException;
 import java.time.Instant;
 import java.util.Queue;
 import java.util.Set;
 import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -25,6 +29,11 @@ class Http1Connection extends BaseHttpConnection {
 
     private static final Logger log = LoggerFactory.getLogger(Http1Connection.class);
     private final Queue<HttpRequestTemp> requestPipeline = new ConcurrentLinkedQueue<>();
+    private final ExecutorService executorService;
+    @Nullable
+    private Http1MessageParser requestParser;
+    @Nullable
+    private Future<Http1ConnectionMsg> pendingRead;
     // At most one active exchange exists on HTTP/1.1: either an HTTP request/response or a websocket takeover.
     private final AtomicReference<@Nullable ActiveExchange> activeExchange = new AtomicReference<>();
     // Lifecycle is cross-thread: connection loop + timeout thread + shutdown thread.
@@ -50,15 +59,16 @@ class Http1Connection extends BaseHttpConnection {
         }
     }
 
-    Http1Connection(Mu3ServerImpl server, ConnectionAcceptor creator, Socket clientSocket, @Nullable Certificate clientCertificate, Instant handshakeStartTime) {
+    Http1Connection(Mu3ServerImpl server, ConnectionAcceptor creator, Socket clientSocket, @Nullable Certificate clientCertificate, Instant handshakeStartTime, ExecutorService executorService) {
         super(server, creator, clientSocket, clientCertificate, handshakeStartTime);
+        this.executorService = executorService;
     }
 
     @Override
     public void start(InputStream inputStream, OutputStream outputStream) {
 
         try {
-            var requestParser = new Http1MessageParser(
+            requestParser = new Http1MessageParser(
                 HttpMessageType.REQUEST,
                 requestPipeline,
                 inputStream,
@@ -69,7 +79,7 @@ class Http1Connection extends BaseHttpConnection {
             while (!closeConnection) {
                 Http1ConnectionMsg msg;
                 try {
-                    msg = requestParser.readNext();
+                    msg = readNext();
                 } catch (SocketTimeoutException ste) {
                     throw HttpException.requestTimeout();
                 } catch (IOException e) {
@@ -167,6 +177,61 @@ class Http1Connection extends BaseHttpConnection {
         } finally {
             activeExchange.set(null);
             closeTransportQuietly();
+        }
+    }
+
+    @Override
+    protected void beforeAsyncWait(Mu3Request request, BaseResponse response) throws IOException {
+        if (!request.completedSuccessfully() || pendingRead != null) {
+            return;
+        }
+        Http1MessageParser parser = requestParser;
+        if (parser == null) {
+            throw new IllegalStateException("Request parser not initialized");
+        }
+        clientSocket.setSoTimeout(0);
+        pendingRead = executorService.submit(() -> {
+            try {
+                Http1ConnectionMsg message = parser.readNext();
+                if (message == EOFMsg) {
+                    markRemoteClosed();
+                }
+                return message;
+            } catch (IOException e) {
+                if (state.get() == HttpConnectionState.OPEN) {
+                    markRemoteClosed();
+                    ActiveExchange current = activeExchange.get();
+                    if (current != null && current.request == request && !response.responseState().endState()) {
+                        response.setState(ResponseState.CLIENT_DISCONNECTED);
+                        request.onClientDisconnected();
+                    }
+                }
+                throw e;
+            }
+        });
+    }
+
+    private Http1ConnectionMsg readNext() throws IOException, ParseException {
+        Future<Http1ConnectionMsg> read = pendingRead;
+        if (read == null) {
+            Http1MessageParser parser = requestParser;
+            if (parser == null) {
+                throw new IllegalStateException("Request parser not initialized");
+            }
+            return parser.readNext();
+        }
+        pendingRead = null;
+        try {
+            return read.get();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IOException("Interrupted while waiting for HTTP/1 input", e);
+        } catch (ExecutionException e) {
+            Throwable cause = e.getCause();
+            if (cause instanceof IOException) throw (IOException) cause;
+            if (cause instanceof ParseException) throw (ParseException) cause;
+            if (cause instanceof RuntimeException) throw (RuntimeException) cause;
+            throw new IOException("Error while reading HTTP/1 input", cause);
         }
     }
 

--- a/src/main/java/io/muserver/Mu3Request.java
+++ b/src/main/java/io/muserver/Mu3Request.java
@@ -34,6 +34,7 @@ class Mu3Request implements MuRequest {
     private boolean inputStreamAccessed;
     @Nullable private volatile Mu3AsyncHandleImpl asyncHandle;
     private boolean clientCancelled;
+    private boolean clientDisconnected;
 
     Mu3Request(HttpConnection connection,
                Method method,
@@ -256,7 +257,7 @@ class Mu3Request implements MuRequest {
             assert response != null;
             asyncHandle = new Mu3AsyncHandleImpl(this, response);
         }
-        if (clientCancelled) {
+        if (clientCancelled || clientDisconnected) {
             asyncHandle.complete();
         }
         return asyncHandle;
@@ -264,6 +265,13 @@ class Mu3Request implements MuRequest {
 
     synchronized void onClientCancelled() {
         clientCancelled = true;
+        if (asyncHandle != null) {
+            asyncHandle.complete();
+        }
+    }
+
+    synchronized void onClientDisconnected() {
+        clientDisconnected = true;
         if (asyncHandle != null) {
             asyncHandle.complete();
         }

--- a/src/test/java/io/muserver/AsyncTest.java
+++ b/src/test/java/io/muserver/AsyncTest.java
@@ -5,7 +5,6 @@ import okhttp3.*;
 import okio.BufferedSink;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import scaffolding.Http1Client;
@@ -226,7 +225,6 @@ public class AsyncTest {
     }
 
     @Test
-    @Disabled("HTTP/1 waits for an async response before reading again, so it cannot observe the connection reset until the response completes")
     public void resettingAnHttp1ConnectionCompletesASuspendedRequest() throws Exception {
         var requestStarted = new CountDownLatch(1);
         var requestCompleted = new CountDownLatch(1);


### PR DESCRIPTION
## What changed

- starts one pending HTTP/1 parser read before waiting for a suspended asynchronous response, when the current request body is already complete
- treats input EOF as a remote half-close without cancelling the active response
- treats a fatal input error such as a TCP reset as a client disconnect and completes the suspended async handle
- reuses a successfully prefetched request on the next connection-loop iteration, preserving serial HTTP/1 request execution and response ordering
- enables the reset regression test added on `mu3`

## Why

The HTTP/1 connection loop previously waited indefinitely for an `AsyncHandle` before reading the socket again. An abortive client close could therefore leave a suspended exchange active until application code resumed it or attempted a response write.

This is intentionally a narrow proposal for review. Read-ahead starts only when the current request body is already complete, and it does not introduce concurrent pipelined request execution.

## Validation

- `mvn -q -Dtest=io.muserver.AsyncTest,io.muserver.Http1ShutdownTest,io.muserver.Http1MessageParserTest,io.muserver.Http1BodyStreamTest test`
- `mvn -q test`

Both pass.
