### PR TITLE
Enable TCP_NODELAY on accepted sockets

### DIFF
--- a/src/main/java/io/muserver/ConnectionAcceptor.java
+++ b/src/main/java/io/muserver/ConnectionAcceptor.java
@@ -25,6 +25,7 @@ import java.util.concurrent.RejectedExecutionException;
 
 class ConnectionAcceptor {
     private static final Logger log = LoggerFactory.getLogger(ConnectionAcceptor.class);
+    private static final int ACCEPT_BACKLOG = 50;
 
     private final Mu3ServerImpl server;
     private final ServerSocket socketServer;
@@ -96,6 +97,7 @@ class ConnectionAcceptor {
         while (state == State.STARTED) {
             try {
                 Socket clientSocket = socketServer.accept();
+                clientSocket.setTcpNoDelay(true);
                 Instant startTime = Instant.now();
                 try {
                     executorService.submit(() -> {
@@ -399,7 +401,7 @@ class ConnectionAcceptor {
         ExecutorService executor,
         List<ContentEncoder> contentEncoders) throws IOException {
 
-        ServerSocket socketServer = new ServerSocket(bindPort, 50, address);
+        ServerSocket socketServer = new ServerSocket(bindPort, ACCEPT_BACKLOG, address);
         configureSocketOptions(socketServer);
 
         String uriHost = address != null ? address.getHostName() : "localhost";


### PR DESCRIPTION
## What changed

Enable `TCP_NODELAY` on each accepted socket in `mu3`, and keep the accept backlog at the original `50`.

## Why

The JSON benchmark had a flat ~45 ms latency floor. That pattern matched Nagle plus delayed ACK interacting with the server's small response writes. Turning off Nagle at accept time removes that artificial delay.

## Impact

Local JSON benchmarking moved from the ~45 ms plateau to sub-millisecond latency at low concurrency, with throughput scaling normally again.

## Validation

- Rebuilt `mu3` and the local FrameworkBenchmarks app
- Ran the JSON ladder at concurrency `16, 32, 64, 128, 256, 512` with `wrk`
- Confirmed the latency floor disappeared after `TCP_NODELAY` was enabled
