### PR TITLE
Resolve relative JAX-RS locations against application base URI

### DIFF
--- a/src/main/java/io/muserver/rest/MuRuntimeDelegate.java
+++ b/src/main/java/io/muserver/rest/MuRuntimeDelegate.java
@@ -70,12 +70,12 @@ public class MuRuntimeDelegate extends RuntimeDelegate {
 
     /**
      * Writes headers from a JAX-RS response to a MuResponse
-     * @param requestUri The URI of the current request
+     * @param baseUri The base URI of the current JAX-RS application
      * @param from The JAX-RS response containing headers
      * @param to The response to write the headers to
      * @param isHttp1 The response is an HTTP-1 response
      */
-    public static void writeResponseHeaders(URI requestUri, Response from, MuResponse to, boolean isHttp1) {
+    public static void writeResponseHeaders(URI baseUri, Response from, MuResponse to, boolean isHttp1) {
         for (Map.Entry<String, List<String>> entry : from.getStringHeaders().entrySet()) {
             String key = entry.getKey();
             if (isHttp1 || !key.equalsIgnoreCase("connection")) {
@@ -91,7 +91,7 @@ public class MuRuntimeDelegate extends RuntimeDelegate {
                     } catch (IllegalArgumentException e) {
                         throw new ServerErrorException("Invalid redirect location: " + values.get(0) + " - " + e.getMessage(), 500);
                     }
-                    to.headers().add(key, requestUri.resolve(location).toString());
+                    to.headers().add(key, baseUri.resolve(location).toString());
                 } else {
                     to.headers().add(key, values);
                 }

--- a/src/main/java/io/muserver/rest/RestHandler.java
+++ b/src/main/java/io/muserver/rest/RestHandler.java
@@ -260,7 +260,7 @@ public class RestHandler implements MuHandler {
                         if (status != 204 && status != 304 && status != 205) {
                             jaxRSResponse.getHeaders().putSingle("content-length", "0");
                         }
-                        MuRuntimeDelegate.writeResponseHeaders(requestContext.muRequest.uri(), jaxRSResponse, muResponse, isHttp1);
+                        MuRuntimeDelegate.writeResponseHeaders(requestContext.getUriInfo().getBaseUri(), jaxRSResponse, muResponse, isHttp1);
                     } else {
 
                         MediaType responseMediaType = jaxRSResponse.getMediaType();
@@ -282,7 +282,7 @@ public class RestHandler implements MuHandler {
                         }
                         jaxRSResponse.getHeaders().putSingle("content-type", contentType);
 
-                        MuRuntimeDelegate.writeResponseHeaders(requestContext.muRequest.uri(), jaxRSResponse, muResponse, isHttp1);
+                        MuRuntimeDelegate.writeResponseHeaders(requestContext.getUriInfo().getBaseUri(), jaxRSResponse, muResponse, isHttp1);
 
                         try {
                             messageBodyWriter.writeTo(jaxRSResponse.getEntity(), jaxRSResponse.getType(), jaxRSResponse.getGenericType(), writerAnnontations,

--- a/src/test/java/io/muserver/rest/JaxRSResponseTest.java
+++ b/src/test/java/io/muserver/rest/JaxRSResponseTest.java
@@ -33,6 +33,38 @@ public class JaxRSResponseTest {
     private MuServer server;
 
     @Test
+    public void relativeLocationsAreResolvedAgainstTheApplicationBaseUri() {
+        @Path("/resource")
+        class ResourceWithRelativeLocation {
+            @GET
+            @Path("/created")
+            public Response created() {
+                return Response.created(URI.create("created")).status(200).build();
+            }
+        }
+
+        RestHandler handler = restHandler(new ResourceWithRelativeLocation()).build();
+        server = ServerUtils.httpsServerForTest()
+            .addHandler(handler)
+            .addHandler(io.muserver.ContextHandlerBuilder.context("/app")
+                .addHandler(handler))
+            .addHandler(io.muserver.ContextHandlerBuilder.context("/outer")
+                .addHandler(io.muserver.ContextHandlerBuilder.context("/inner")
+                    .addHandler(handler)))
+            .start();
+
+        assertRelativeLocation("/resource/created", "/created");
+        assertRelativeLocation("/app/resource/created", "/app/created");
+        assertRelativeLocation("/outer/inner/resource/created", "/outer/inner/created");
+    }
+
+    private void assertRelativeLocation(String requestPath, String expectedLocationPath) {
+        try (okhttp3.Response response = call(request(server.uri().resolve(requestPath)))) {
+            assertThat(response.header(HttpHeaders.LOCATION), is(server.uri().resolve(expectedLocationPath).toString()));
+        }
+    }
+
+    @Test
     public void headersCanBeGottenFromIt() {
         Response.ResponseBuilder builder = new JaxRSResponse.Builder()
             .allow("GET", "HEAD")


### PR DESCRIPTION
## What changed

- Resolve relative `Location` response headers against the JAX-RS application base URI.
- Pass `UriInfo.getBaseUri()` through both response serialization paths.
- Mirror the Mu2 regression coverage by mounting the same REST handler at the server root, a context, and a nested context.

## Why

Mu resolved relative locations against the full request URI. For a request to `/app/resource/created`, `Response.created(URI.create("created"))` therefore produced `/app/resource/created` instead of the required application-relative `/app/created`.

## Impact

Relative JAX-RS locations now follow the application mount point, including nested contexts. Absolute locations are unchanged. This keeps shared JAX-RS behavior consistent with Mu2.

## Validation

- Java 11: `mvn -Dtest=JaxRSResponseTest test` — 13 passed.
- Focused regression method passed independently.

## Related PRs

- Mu2 fix: https://github.com/3redronin/mu-server/pull/86
- TCK workbench record: https://github.com/3redronin/mu-jaxrs-tck-harness/pull/1