### PR TITLE
Complete JSpecify nullness coverage

### DIFF
--- a/src/main/java/io/muserver/Headers.java
+++ b/src/main/java/io/muserver/Headers.java
@@ -282,7 +282,7 @@ public interface Headers extends Iterable<Map.Entry<String, String>> {
      * @param value The value
      * @return This headers object
      */
-    default Headers set(String name, Object value) {
+    default Headers set(String name, @Nullable Object value) {
         return set((CharSequence) name, value);
     }
 
@@ -294,7 +294,7 @@ public interface Headers extends Iterable<Map.Entry<String, String>> {
      * @return This headers object
      * @throws NullPointerException if name is <code>null</code>
      */
-    Headers set(CharSequence name, Object value);
+    Headers set(CharSequence name, @Nullable Object value);
 
     /**
      * Sets a header value list. If a header with the given name already exists then this replaces it.

--- a/src/main/java/io/muserver/ParameterizedHeader.java
+++ b/src/main/java/io/muserver/ParameterizedHeader.java
@@ -182,7 +182,7 @@ public class ParameterizedHeader {
     }
 
     @Override
-    public boolean equals(Object o) {
+    public boolean equals(@Nullable Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         ParameterizedHeader that = (ParameterizedHeader) o;

--- a/src/main/java/io/muserver/openapi/package-info.java
+++ b/src/main/java/io/muserver/openapi/package-info.java
@@ -3,4 +3,7 @@
  * <p>This package can be used to specify overview documentation when creating REST resources using
  * {@link io.muserver.rest.RestHandlerBuilder#withOpenApiDocument(io.muserver.openapi.OpenAPIObjectBuilder)}</p>
  */
+@NullMarked
 package io.muserver.openapi;
+
+import org.jspecify.annotations.NullMarked;

--- a/src/main/java/io/muserver/rest/package-info.java
+++ b/src/main/java/io/muserver/rest/package-info.java
@@ -2,4 +2,7 @@
  * <p>This package contains the JAX-RS implementation for mu-server. To create a JAX-RS Rest Resource handler,
  * see {@link io.muserver.rest.RestHandlerBuilder#restHandler(java.lang.Object...)}</p>
  */
+@NullMarked
 package io.muserver.rest;
+
+import org.jspecify.annotations.NullMarked;


### PR DESCRIPTION
## Summary

- mark the REST and OpenAPI production packages as non-null by default
- declare the documented nullable `Headers.set()` value contract at the interface
- allow `ParameterizedHeader.equals()` to receive null as required by `Object.equals()`

## Why

These changes close the remaining discrepancies found while comparing the hand-annotated `mu3` API with the comprehensive JSpecify pass on `master`. Internal and public classes in every production package now share the same package-level nullness default.

This is annotation-only and does not intentionally change runtime behavior.

## Validation

- `mvn clean test`
- 1,352 tests passed with no failures or errors; 5 existing tests were skipped
