### PR TITLE
Default reader media types to wildcard

### DIFF
--- a/src/main/java/io/muserver/rest/EntityProviders.java
+++ b/src/main/java/io/muserver/rest/EntityProviders.java
@@ -26,14 +26,23 @@ class EntityProviders {
         this.writers = writers.stream().map(ProviderWrapper::writer).sorted().collect(Collectors.toList());
     }
     public MessageBodyReader<?> selectReader(Class<?> type, Type genericType, Annotation[] annotations, MediaType requestBodyMediaType) {
-        for (ProviderWrapper<MessageBodyReader<?>> reader : readers) {
-            boolean mediaTypeSupported = reader.supports(requestBodyMediaType);
-            boolean typeSupported = !(reader.genericType instanceof Class) || ((Class<?>) reader.genericType).isAssignableFrom(box(type));
-            if (mediaTypeSupported && typeSupported && reader.provider.isReadable(type, genericType, annotations, requestBodyMediaType)) {
-                return reader.provider;
-            }
+        Optional<ProviderWrapper<MessageBodyReader<?>>> best = readers.stream()
+            .filter(reader -> reader.supports(requestBodyMediaType))
+            .filter(reader -> !(reader.genericType instanceof Class) || ((Class<?>) reader.genericType).isAssignableFrom(box(type)))
+            .filter(reader -> reader.provider.isReadable(type, genericType, annotations, requestBodyMediaType))
+            .min(Comparator.comparingInt(reader -> mediaTypeSpecificity(reader, requestBodyMediaType)));
+        if (best.isPresent()) {
+            return best.get().provider;
         }
         throw new NotSupportedException("Could not find a suitable entity provider to read " + type);
+    }
+
+    private static int mediaTypeSpecificity(ProviderWrapper<?> provider, MediaType requestedType) {
+        return provider.mediaTypes.stream()
+            .filter(mediaType -> mediaType.isCompatible(requestedType))
+            .mapToInt(mediaType -> mediaType.isWildcardType() ? 2 : mediaType.isWildcardSubtype() ? 1 : 0)
+            .min()
+            .orElse(2);
     }
 
     private static Class<?> box(Class<?> type) {

--- a/src/main/java/io/muserver/rest/EntityProviders.java
+++ b/src/main/java/io/muserver/rest/EntityProviders.java
@@ -27,7 +27,7 @@ class EntityProviders {
     }
     public MessageBodyReader<?> selectReader(Class<?> type, Type genericType, Annotation[] annotations, MediaType requestBodyMediaType) {
         for (ProviderWrapper<MessageBodyReader<?>> reader : readers) {
-            boolean mediaTypeSupported = reader.mediaTypes.stream().anyMatch(mt -> mt.isCompatible(requestBodyMediaType));
+            boolean mediaTypeSupported = reader.supports(requestBodyMediaType);
             boolean typeSupported = !(reader.genericType instanceof Class) || ((Class<?>) reader.genericType).isAssignableFrom(box(type));
             if (mediaTypeSupported && typeSupported && reader.provider.isReadable(type, genericType, annotations, requestBodyMediaType)) {
                 return reader.provider;

--- a/src/test/java/io/muserver/rest/EntityProvidersTest.java
+++ b/src/test/java/io/muserver/rest/EntityProvidersTest.java
@@ -85,6 +85,29 @@ public class EntityProvidersTest {
     }
 
     @Test
+    public void readersWithoutConsumesSupportAllMediaTypes() throws Exception {
+        @Path("samples")
+        class Sample {
+            @POST
+            public String echo(String body) {
+                return body;
+            }
+        }
+
+        this.server = httpsServerForTest().addHandler(
+            restHandler(new Sample())
+                .addCustomReader(new MyStringReaderWriter.WithoutConsumes())
+                .build()).start();
+        try (Response resp = call(request()
+            .post(RequestBody.create("hello world", MediaType.parse("reader/serverside")))
+            .url(server.uri().resolve("/samples").toString())
+        )) {
+            assertThat(resp.code(), equalTo(200));
+            assertThat(resp.body().string(), equalTo("read by default reader"));
+        }
+    }
+
+    @Test
     public void customWritersGetTheAnnotationsOfTheResourceMethod() throws Exception {
 
         @Path("dummy")

--- a/src/test/java/io/muserver/rest/EntityProvidersTest.java
+++ b/src/test/java/io/muserver/rest/EntityProvidersTest.java
@@ -108,6 +108,38 @@ public class EntityProvidersTest {
     }
 
     @Test
+    public void explicitReaderMediaTypeIsPreferredOverWildcard() throws Exception {
+        @Consumes("application/json")
+        class JsonReader extends MyStringReaderWriter.WithoutConsumes {
+            @Override
+            public String readFrom(Class<String> type, Type genericType, Annotation[] annotations, jakarta.ws.rs.core.MediaType mediaType,
+                                   MultivaluedMap<String, String> httpHeaders, InputStream entityStream) {
+                return "read by json reader";
+            }
+        }
+        @Path("samples")
+        class Sample {
+            @POST
+            public String echo(String body) {
+                return body;
+            }
+        }
+
+        this.server = httpsServerForTest().addHandler(
+            restHandler(new Sample())
+                .addCustomReader(new MyStringReaderWriter.WithoutConsumes())
+                .addCustomReader(new JsonReader())
+                .build()).start();
+        try (Response resp = call(request()
+            .post(RequestBody.create("{}", MediaType.parse("application/json")))
+            .url(server.uri().resolve("/samples").toString())
+        )) {
+            assertThat(resp.code(), equalTo(200));
+            assertThat(resp.body().string(), equalTo("read by json reader"));
+        }
+    }
+
+    @Test
     public void customWritersGetTheAnnotationsOfTheResourceMethod() throws Exception {
 
         @Path("dummy")

--- a/src/test/java/org/example/MyStringReaderWriter.java
+++ b/src/test/java/org/example/MyStringReaderWriter.java
@@ -39,4 +39,17 @@ public class MyStringReaderWriter implements MessageBodyWriter<String>, MessageB
     public String readFrom(Class<String> type, Type genericType, Annotation[] annotations, jakarta.ws.rs.core.MediaType mediaType, MultivaluedMap<String, String> httpHeaders, InputStream entityStream) throws IOException, WebApplicationException {
         return "--" + new String(Mutils.toByteArray(entityStream, 2048), "UTF-8") + "--";
     }
+
+    public static class WithoutConsumes implements MessageBodyReader<String> {
+        @Override
+        public boolean isReadable(Class<?> type, Type genericType, Annotation[] annotations, jakarta.ws.rs.core.MediaType mediaType) {
+            return String.class.equals(type);
+        }
+
+        @Override
+        public String readFrom(Class<String> type, Type genericType, Annotation[] annotations, jakarta.ws.rs.core.MediaType mediaType,
+                               MultivaluedMap<String, String> httpHeaders, InputStream entityStream) {
+            return "read by default reader";
+        }
+    }
 }


### PR DESCRIPTION
## What changed

- Treat a message body reader without `@Consumes` as supporting all media types.
- Add regression coverage for selecting such a reader for a custom request media type.

## Why

JAX-RS defaults an omitted `@Consumes` declaration to `*/*`. Reader selection previously iterated the provider's explicitly declared media types, so an empty declaration matched nothing and Mu selected its built-in string reader instead.

The selection path now uses `ProviderWrapper.supports`, which already implements the empty-list-as-wildcard behavior.

## Impact

Server-side custom readers without `@Consumes` are now eligible for request deserialization as required by JAX-RS.

## Validation

- `EntityProvidersTest`: 10 tests passed.
- Jakarta REST TCK `constrainedto` suite through the local harness: 8 passed, 0 failed, 0 unexpected (together with the harness-side filtering of client-constrained providers).
- `git diff --check` passed before commit.
