### PR TITLE
Honor request filter abort and priority semantics

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -97,6 +97,11 @@
             <version>3.0.0</version>
         </dependency>
         <dependency>
+            <groupId>jakarta.annotation</groupId>
+            <artifactId>jakarta.annotation-api</artifactId>
+            <version>2.0.0</version>
+        </dependency>
+        <dependency>
             <groupId>org.jspecify</groupId>
             <artifactId>jspecify</artifactId>
             <version>1.0.0</version>
@@ -316,6 +321,7 @@
                                     <includes>
                                         <include>org.slf4j:slf4j-api</include>
                                         <include>jakarta.ws.rs:jakarta.ws.rs-api</include>
+                                        <include>jakarta.annotation:jakarta.annotation-api</include>
                                         <include>io.netty:*</include>
                                         <include>org.jspecify:jspecify</include>
                                     </includes>

--- a/src/main/java/io/muserver/rest/CustomExceptionMapper.java
+++ b/src/main/java/io/muserver/rest/CustomExceptionMapper.java
@@ -31,10 +31,6 @@ class CustomExceptionMapper {
 
         Class<? extends Throwable> exClass = ex.getClass();
 
-        if (exClass.equals(JaxRSRequest.FilterAbortedException.class)) {
-            return ((JaxRSRequest.FilterAbortedException)ex).getResponse();
-        }
-
         int maxDepth = Integer.MAX_VALUE;
         ExceptionMapper exceptionMapper = findBestMatchingExceptionMapper(exClass, maxDepth);
 

--- a/src/main/java/io/muserver/rest/FilterManagerThing.java
+++ b/src/main/java/io/muserver/rest/FilterManagerThing.java
@@ -1,11 +1,15 @@
 package io.muserver.rest;
 
+import jakarta.annotation.Priority;
+import jakarta.ws.rs.Priorities;
 import jakarta.ws.rs.container.ContainerRequestFilter;
 import jakarta.ws.rs.container.ContainerResponseContext;
 import jakarta.ws.rs.container.ContainerResponseFilter;
 
 import java.io.IOException;
 import java.lang.annotation.Annotation;
+import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 
 class FilterManagerThing {
@@ -14,15 +18,29 @@ class FilterManagerThing {
     private final List<ContainerResponseFilter> responseFilters;
 
     FilterManagerThing(List<ContainerRequestFilter> preMatchRequestFilters, List<ContainerRequestFilter> requestFilters, List<ContainerResponseFilter> responseFilters) {
-        this.preMatchRequestFilters = preMatchRequestFilters;
-        this.requestFilters = requestFilters;
-        this.responseFilters = responseFilters;
+        this.preMatchRequestFilters = sortedByPriority(preMatchRequestFilters, false);
+        this.requestFilters = sortedByPriority(requestFilters, false);
+        this.responseFilters = sortedByPriority(responseFilters, true);
+    }
+
+    private static <T> List<T> sortedByPriority(List<T> filters, boolean reversed) {
+        List<T> sorted = new ArrayList<>(filters);
+        Comparator<T> comparator = Comparator.comparingInt(FilterManagerThing::priority);
+        sorted.sort(reversed ? comparator.reversed() : comparator);
+        return sorted;
+    }
+
+    private static int priority(Object filter) {
+        Priority priority = filter.getClass().getAnnotation(Priority.class);
+        return priority == null ? Priorities.USER : priority.value();
     }
 
     void onPreMatch(JaxRSRequest requestContext) throws IOException {
         for (ContainerRequestFilter preMatchRequestFilter : preMatchRequestFilters) {
-
             preMatchRequestFilter.filter(requestContext);
+            if (requestContext.getAbortResponse() != null) {
+                return;
+            }
         }
     }
 
@@ -31,11 +49,15 @@ class FilterManagerThing {
             List<Class<? extends Annotation>> filterBindings = ResourceClass.getNameBindingAnnotations(requestFilter.getClass());
             if (requestContext.methodHasAnnotations(filterBindings)) {
                 requestFilter.filter(requestContext);
+                if (requestContext.getAbortResponse() != null) {
+                    return;
+                }
             }
         }
     }
 
     void onBeforeSendResponse(JaxRSRequest requestContext, ContainerResponseContext responseContext) throws IOException {
+        requestContext.markResponseFilterChainStarted();
         for (ContainerResponseFilter responseFilter : responseFilters) {
             List<Class<? extends Annotation>> filterBindings = ResourceClass.getNameBindingAnnotations(responseFilter.getClass());
             if (requestContext.methodHasAnnotations(filterBindings)) {

--- a/src/main/java/io/muserver/rest/FilterManagerThing.java
+++ b/src/main/java/io/muserver/rest/FilterManagerThing.java
@@ -36,23 +36,33 @@ class FilterManagerThing {
     }
 
     void onPreMatch(JaxRSRequest requestContext) throws IOException {
-        for (ContainerRequestFilter preMatchRequestFilter : preMatchRequestFilters) {
-            preMatchRequestFilter.filter(requestContext);
-            if (requestContext.getAbortResponse() != null) {
-                return;
-            }
-        }
-    }
-
-    void onPostMatch(JaxRSRequest requestContext) throws IOException {
-        for (ContainerRequestFilter requestFilter : requestFilters) {
-            List<Class<? extends Annotation>> filterBindings = ResourceClass.getNameBindingAnnotations(requestFilter.getClass());
-            if (requestContext.methodHasAnnotations(filterBindings)) {
-                requestFilter.filter(requestContext);
+        requestContext.setRequestFilterChainRunning(true);
+        try {
+            for (ContainerRequestFilter preMatchRequestFilter : preMatchRequestFilters) {
+                preMatchRequestFilter.filter(requestContext);
                 if (requestContext.getAbortResponse() != null) {
                     return;
                 }
             }
+        } finally {
+            requestContext.setRequestFilterChainRunning(false);
+        }
+    }
+
+    void onPostMatch(JaxRSRequest requestContext) throws IOException {
+        requestContext.setRequestFilterChainRunning(true);
+        try {
+            for (ContainerRequestFilter requestFilter : requestFilters) {
+                List<Class<? extends Annotation>> filterBindings = ResourceClass.getNameBindingAnnotations(requestFilter.getClass());
+                if (requestContext.methodHasAnnotations(filterBindings)) {
+                    requestFilter.filter(requestContext);
+                    if (requestContext.getAbortResponse() != null) {
+                        return;
+                    }
+                }
+            }
+        } finally {
+            requestContext.setRequestFilterChainRunning(false);
         }
     }
 

--- a/src/main/java/io/muserver/rest/JaxRSRequest.java
+++ b/src/main/java/io/muserver/rest/JaxRSRequest.java
@@ -36,6 +36,8 @@ class JaxRSRequest implements Request, ContainerRequestContext, ReaderIntercepto
     private final List<ReaderInterceptor> readerInterceptors;
     private final EntityProviders entityProviders;
     private String httpMethod;
+    private Response abortResponse;
+    private boolean responseFilterChainStarted;
 
     JaxRSRequest(MuRequest muRequest, MuResponse muResponse, InputStream inputStream, String relativePath, SecurityContext securityContext, List<ReaderInterceptor> readerInterceptors, EntityProviders entityProviders) {
         this.muRequest = muRequest;
@@ -442,7 +444,18 @@ class JaxRSRequest implements Request, ContainerRequestContext, ReaderIntercepto
 
     @Override
     public void abortWith(Response response) {
-        throw new FilterAbortedException(response);
+        if (responseFilterChainStarted) {
+            throw new IllegalStateException("abortWith cannot be called from a response filter");
+        }
+        this.abortResponse = Objects.requireNonNull(response, "response");
+    }
+
+    Response getAbortResponse() {
+        return abortResponse;
+    }
+
+    void markResponseFilterChainStarted() {
+        this.responseFilterChainStarted = true;
     }
 
     void setMatchedMethod(RequestMatcher.MatchedMethod matchedMethod) {
@@ -457,16 +470,6 @@ class JaxRSRequest implements Request, ContainerRequestContext, ReaderIntercepto
 
     String relativePath() {
         return getUriInfo().getPath(false);
-    }
-
-    /**
-     * This special exception doesn't get mapped by an exception mapper, so that the {@link #abortWith(Response)} method
-     * can just return the Response passed to it without mapping it.
-     */
-    static class FilterAbortedException extends WebApplicationException {
-        public FilterAbortedException(Response response) {
-            super(response);
-        }
     }
 
     private static class MuResourceInfo implements ResourceInfo {

--- a/src/main/java/io/muserver/rest/JaxRSRequest.java
+++ b/src/main/java/io/muserver/rest/JaxRSRequest.java
@@ -37,6 +37,7 @@ class JaxRSRequest implements Request, ContainerRequestContext, ReaderIntercepto
     private final EntityProviders entityProviders;
     private String httpMethod;
     private Response abortResponse;
+    private boolean requestFilterChainRunning;
     private boolean responseFilterChainStarted;
 
     JaxRSRequest(MuRequest muRequest, MuResponse muResponse, InputStream inputStream, String relativePath, SecurityContext securityContext, List<ReaderInterceptor> readerInterceptors, EntityProviders entityProviders) {
@@ -447,7 +448,11 @@ class JaxRSRequest implements Request, ContainerRequestContext, ReaderIntercepto
         if (responseFilterChainStarted) {
             throw new IllegalStateException("abortWith cannot be called from a response filter");
         }
-        this.abortResponse = Objects.requireNonNull(response, "response");
+        response = Objects.requireNonNull(response, "response");
+        if (!requestFilterChainRunning) {
+            throw new FilterAbortedException(response);
+        }
+        this.abortResponse = response;
     }
 
     Response getAbortResponse() {
@@ -456,6 +461,10 @@ class JaxRSRequest implements Request, ContainerRequestContext, ReaderIntercepto
 
     void markResponseFilterChainStarted() {
         this.responseFilterChainStarted = true;
+    }
+
+    void setRequestFilterChainRunning(boolean requestFilterChainRunning) {
+        this.requestFilterChainRunning = requestFilterChainRunning;
     }
 
     void setMatchedMethod(RequestMatcher.MatchedMethod matchedMethod) {
@@ -470,6 +479,16 @@ class JaxRSRequest implements Request, ContainerRequestContext, ReaderIntercepto
 
     String relativePath() {
         return getUriInfo().getPath(false);
+    }
+
+    /**
+     * This special exception preserves the immediate abort behavior when the request context is used outside a
+     * request-filter callback.
+     */
+    static class FilterAbortedException extends WebApplicationException {
+        FilterAbortedException(Response response) {
+            super(response);
+        }
     }
 
     private static class MuResourceInfo implements ResourceInfo {

--- a/src/main/java/io/muserver/rest/RestHandler.java
+++ b/src/main/java/io/muserver/rest/RestHandler.java
@@ -80,6 +80,10 @@ public class RestHandler implements MuHandler {
         JaxRSRequest requestContext = new JaxRSRequest(muRequest, muResponse, new LazyAccessInputStream(muRequest), Mutils.trim(muRequest.relativePath(), "/"), securityContext, readerInterceptors, entityProviders);
         try {
             filterManagerThing.onPreMatch(requestContext);
+            if (requestContext.getAbortResponse() != null) {
+                sendResponse(0, requestContext, muResponse, acceptHeaders, emptyList(), emptyList(), JaxRSResponse.Builder.EMPTY_ANNOTATIONS, requestContext.getAbortResponse());
+                return true;
+            }
 
             Function<RequestMatcher.MatchedMethod,ResourceClass> subResourceLocator = matchedMethod -> {
                 Function<ResourceMethod, Object> onSuspended = resourceMethod -> {
@@ -121,6 +125,10 @@ public class RestHandler implements MuHandler {
             Annotation[] methodAnnotations = mm.resourceMethod.methodAnnotations;
 
             filterManagerThing.onPostMatch(requestContext);
+            if (requestContext.getAbortResponse() != null) {
+                sendResponse(0, requestContext, muResponse, acceptHeaders, produces, directlyProduces, JaxRSResponse.Builder.EMPTY_ANNOTATIONS, requestContext.getAbortResponse());
+                return true;
+            }
 
             Function<ResourceMethod, Object> suspendedParamCallback = rm -> {
                 if (muRequest.isAsync()) {

--- a/src/main/java/io/muserver/rest/RestHandler.java
+++ b/src/main/java/io/muserver/rest/RestHandler.java
@@ -203,6 +203,11 @@ public class RestHandler implements MuHandler {
             }
             return;
         }
+        if (ex instanceof JaxRSRequest.FilterAbortedException) {
+            sendResponse(nestingLevel, request, muResponse, acceptHeaders, producesRef, directlyProducesRef,
+                JaxRSResponse.Builder.EMPTY_ANNOTATIONS, ((WebApplicationException) ex).getResponse());
+            return;
+        }
         Response response = customExceptionMapper.toResponse(ex);
         if (response == null && ex instanceof WebApplicationException) {
             dealWithWebApplicationException(nestingLevel, request, muResponse, (WebApplicationException) ex, acceptHeaders, producesRef == null ? emptyList() : producesRef, directlyProducesRef == null ? emptyList() : directlyProducesRef);

--- a/src/test/java/io/muserver/rest/FilterTest.java
+++ b/src/test/java/io/muserver/rest/FilterTest.java
@@ -3,6 +3,7 @@ package io.muserver.rest;
 import io.muserver.MuRequest;
 import io.muserver.MuServer;
 import io.muserver.Mutils;
+import jakarta.annotation.Priority;
 import jakarta.ws.rs.*;
 import jakarta.ws.rs.container.*;
 import jakarta.ws.rs.core.*;
@@ -23,6 +24,7 @@ import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
@@ -95,6 +97,57 @@ public class FilterTest {
             "REQUEST POST " + server.uri().resolve("/something") + " - a-value",
             "RESPONSE OK"
         ));
+    }
+
+    @Test
+    public void filtersAreCalledInPriorityOrder() throws IOException {
+        @Path("priority")
+        class PriorityResource {
+            @GET
+            public String get() {
+                received.add("resource");
+                return "done";
+            }
+        }
+        @Priority(100)
+        class FirstFilter implements ContainerRequestFilter, ContainerResponseFilter {
+            @Override
+            public void filter(ContainerRequestContext requestContext) {
+                received.add("request-100");
+            }
+
+            @Override
+            public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext) {
+                received.add("response-100");
+            }
+        }
+        @Priority(500)
+        class SecondFilter implements ContainerRequestFilter, ContainerResponseFilter {
+            @Override
+            public void filter(ContainerRequestContext requestContext) {
+                received.add("request-500");
+            }
+
+            @Override
+            public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext) {
+                received.add("response-500");
+            }
+        }
+
+        FirstFilter first = new FirstFilter();
+        SecondFilter second = new SecondFilter();
+        server = httpsServerForTest()
+            .addHandler(restHandler(new PriorityResource())
+                .addRequestFilter(second)
+                .addRequestFilter(first)
+                .addResponseFilter(first)
+                .addResponseFilter(second))
+            .start();
+
+        try (Response resp = call(request(server.uri().resolve("/priority")))) {
+            assertThat(resp.body().string(), is("done"));
+        }
+        assertThat(received, contains("request-100", "request-500", "resource", "response-500", "response-100"));
     }
 
     @Test
@@ -253,10 +306,14 @@ public class FilterTest {
 
     @Test
     public void requestsCanBeAborted() throws IOException {
+        AtomicBoolean continuedAfterAbort = new AtomicBoolean();
+        AtomicBoolean nextFilterCalled = new AtomicBoolean();
+        AtomicBoolean resourceCalled = new AtomicBoolean();
         @Path("something")
         class TheWay {
             @GET
             public String itMoves() {
+                resourceCalled.set(true);
                 return "Not called";
             }
         }
@@ -265,18 +322,30 @@ public class FilterTest {
             @Override
             public void filter(ContainerRequestContext requestContext) throws IOException {
                 requestContext.abortWith(jakarta.ws.rs.core.Response.status(409).entity("Blocked!").build());
+                continuedAfterAbort.set(true);
+            }
+        }
+        @PreMatching
+        class NextFilter implements ContainerRequestFilter {
+            @Override
+            public void filter(ContainerRequestContext requestContext) throws IOException {
+                nextFilterCalled.set(true);
             }
         }
         server = httpsServerForTest()
             .addHandler(
                 restHandler(new TheWay())
                     .addRequestFilter(new MethodChangingFilter())
+                    .addRequestFilter(new NextFilter())
             ).start();
         try (Response resp = call(request().url(server.uri().resolve("/something").toString()))) {
             assertThat(resp.code(), is(409));
             assertThat(resp.body().string(), is("Blocked!"));
             assertThat(resp.header("content-type"), is("text/plain;charset=utf-8"));
         }
+        assertThat(continuedAfterAbort.get(), is(true));
+        assertThat(nextFilterCalled.get(), is(false));
+        assertThat(resourceCalled.get(), is(false));
     }
 
 
@@ -660,7 +729,7 @@ public class FilterTest {
             assertThat(response.body().string(), containsString("500 Internal Server Error"));
         }
 
-        assertThat(responseFilterCalls.get(), equalTo(2));
+        assertThat(responseFilterCalls.get(), equalTo(1));
     }
 
     @Path("/broken")

--- a/src/test/java/io/muserver/rest/FilterTest.java
+++ b/src/test/java/io/muserver/rest/FilterTest.java
@@ -483,7 +483,8 @@ public class FilterTest {
         }
 
         server = httpsServerForTest()
-            .addHandler(restHandler(new Resource()))
+            .addHandler(restHandler(new Resource())
+                .addExceptionMapper(Exception.class, exception -> jakarta.ws.rs.core.Response.status(418).entity("Mapped").build()))
             .start();
 
         try (Response resp = call(request(server.uri().resolve("/abort-from-resource")))) {

--- a/src/test/java/io/muserver/rest/FilterTest.java
+++ b/src/test/java/io/muserver/rest/FilterTest.java
@@ -472,6 +472,27 @@ public class FilterTest {
     }
 
     @Test
+    public void abortWithFromInjectedRequestContextStillShortCircuits() throws IOException {
+        @Path("abort-from-resource")
+        class Resource {
+            @GET
+            public String get(@Context ContainerRequestContext requestContext) {
+                requestContext.abortWith(jakarta.ws.rs.core.Response.status(409).entity("Blocked!").build());
+                return "Not blocked";
+            }
+        }
+
+        server = httpsServerForTest()
+            .addHandler(restHandler(new Resource()))
+            .start();
+
+        try (Response resp = call(request(server.uri().resolve("/abort-from-resource")))) {
+            assertThat(resp.code(), is(409));
+            assertThat(resp.body().string(), is("Blocked!"));
+        }
+    }
+
+    @Test
     public void resourceInfoAndMuRequestCanBeFoundOnPreMatchingFilters() throws IOException {
 
         @Path("/blah")


### PR DESCRIPTION
## What changed

- Make `ContainerRequestContext.abortWith` record an abort response and return normally.
- Stop request-filter processing after the active filter returns from an abort.
- Send aborted responses before resource matching or invocation.
- Run request filters in ascending `@Priority` order and response filters in descending order.
- Reject `abortWith` calls after response-filter processing has started.
- Add regression coverage for abort control flow and filter ordering.

## Why

Mu previously implemented `abortWith` by throwing an internal exception. When a filter called the method reflectively, that exception was wrapped in `InvocationTargetException`, so the filter treated the abort as a failure and replaced the intended response with HTTP 503. Mu also retained provider registration order instead of applying JAX-RS `@Priority`, allowing guard filters to run before functional filters when providers came from an unordered set.

These defects share the request-filter execution path and both are required to satisfy the Jakarta REST request-context tests.

## Impact

Request filters can abort processing without invoking later filters or the resource, and request/response filters now execute in specification priority order. The Jakarta REST TCK `container/requestcontext` group improves from 0/39 passing to 35/39; the four residual failures exercise separate field-injection, servlet-integration, or URI-authority behavior.

## Validation

- Full Mu test suite: 842 tests passed.
- `FilterTest`: 18 tests passed.
- Jakarta REST TCK `container/requestcontext`: 35 passed, 4 failed, plus 8 expected unsupported child-suite cases.
- `git diff --check` passed before commit.
