### PR TITLE
Reject null variant lists

### DIFF
--- a/src/main/java/io/muserver/rest/JaxRSRequest.java
+++ b/src/main/java/io/muserver/rest/JaxRSRequest.java
@@ -155,6 +155,9 @@ class JaxRSRequest implements Request, ContainerRequestContext, ReaderIntercepto
 
     @Override
     public Variant selectVariant(List<Variant> variants) {
+        if (variants == null) {
+            throw new IllegalArgumentException("variants is null");
+        }
         for (Variant variant : variants) {
             if (variant.getMediaType() != null) {
                 if (!muResponse.headers().contains(HeaderNames.VARY, HeaderNames.ACCEPT, true)) {

--- a/src/test/java/io/muserver/rest/VariantTest.java
+++ b/src/test/java/io/muserver/rest/VariantTest.java
@@ -30,6 +30,28 @@ public class VariantTest {
     private MuServer server;
 
     @Test
+    public void nullVariantListsAreRejectedWithIllegalArgumentException() throws Exception {
+        @Path("samples")
+        class Sample {
+            @GET
+            public String get(@Context Request jaxRequest) {
+                try {
+                    jaxRequest.selectVariant(null);
+                    return "no exception";
+                } catch (IllegalArgumentException expected) {
+                    return "expected exception";
+                }
+            }
+        }
+        this.server = httpsServerForTest()
+            .addHandler(restHandler(new Sample())).start();
+        try (Response resp = call(request(server.uri().resolve("/samples")))) {
+            assertThat(resp.code(), equalTo(200));
+            assertThat(resp.body().string(), equalTo("expected exception"));
+        }
+    }
+
+    @Test
     public void jaxRSRequestObjectCanBeInjected() throws Exception {
         @Path("samples")
         class Sample {


### PR DESCRIPTION
## What changed

- Make `Request.selectVariant(null)` throw `IllegalArgumentException` as required by the Jakarta REST contract.
- Add regression coverage through an injected server-side `Request` instance.

## Why

Mu previously iterated the supplied list immediately, so a null list produced `NullPointerException`. The Jakarta REST TCK explicitly expects `IllegalArgumentException`. The same resource assertion is exercised over GET, PUT, POST, and DELETE.

## Impact

Callers now receive the specified exception type for invalid null input. Four `core/request` TCK failures pass with this guard; the separate response-Vary negotiation case remains unchanged.

## Validation

- `VariantTest`: 6 tests passed.
- Jakarta REST TCK `core/request`: 27 passed, 1 failed, improving from 23 passed / 5 failed. The remaining failure is `selectVariantResponseVaryTest_from_standalone`.
- `git diff --check` passed before commit.
