### PR TITLE
Honor wildcard variant encodings

### DIFF
--- a/src/main/java/io/muserver/rest/JaxRSRequest.java
+++ b/src/main/java/io/muserver/rest/JaxRSRequest.java
@@ -158,17 +158,17 @@ class JaxRSRequest implements Request, ContainerRequestContext, ReaderIntercepto
         for (Variant variant : variants) {
             if (variant.getMediaType() != null) {
                 if (!muResponse.headers().contains(HeaderNames.VARY, HeaderNames.ACCEPT, true)) {
-                    muResponse.headers().add(HeaderNames.VARY, "Accept");
+                    muResponse.headers().add(HeaderNames.VARY, HttpHeaders.ACCEPT);
                 }
             }
             if (variant.getEncoding() != null) {
                 if (!muResponse.headers().contains(HeaderNames.VARY, HeaderNames.ACCEPT_ENCODING, true)) {
-                    muResponse.headers().add(HeaderNames.VARY, "Accept-Encoding");
+                    muResponse.headers().add(HeaderNames.VARY, HttpHeaders.ACCEPT_ENCODING);
                 }
             }
             if (variant.getLanguage() != null) {
                 if (!muResponse.headers().contains(HeaderNames.VARY, HeaderNames.ACCEPT_LANGUAGE, true)) {
-                    muResponse.headers().add(HeaderNames.VARY, "Accept-Language");
+                    muResponse.headers().add(HeaderNames.VARY, HttpHeaders.ACCEPT_LANGUAGE);
                 }
             }
         }

--- a/src/main/java/io/muserver/rest/JaxRSRequest.java
+++ b/src/main/java/io/muserver/rest/JaxRSRequest.java
@@ -158,17 +158,17 @@ class JaxRSRequest implements Request, ContainerRequestContext, ReaderIntercepto
         for (Variant variant : variants) {
             if (variant.getMediaType() != null) {
                 if (!muResponse.headers().contains(HeaderNames.VARY, HeaderNames.ACCEPT, true)) {
-                    muResponse.headers().add(HeaderNames.VARY, HeaderNames.ACCEPT);
+                    muResponse.headers().add(HeaderNames.VARY, "Accept");
                 }
             }
             if (variant.getEncoding() != null) {
                 if (!muResponse.headers().contains(HeaderNames.VARY, HeaderNames.ACCEPT_ENCODING, true)) {
-                    muResponse.headers().add(HeaderNames.VARY, HeaderNames.ACCEPT_ENCODING);
+                    muResponse.headers().add(HeaderNames.VARY, "Accept-Encoding");
                 }
             }
             if (variant.getLanguage() != null) {
                 if (!muResponse.headers().contains(HeaderNames.VARY, HeaderNames.ACCEPT_LANGUAGE, true)) {
-                    muResponse.headers().add(HeaderNames.VARY, HeaderNames.ACCEPT_LANGUAGE);
+                    muResponse.headers().add(HeaderNames.VARY, "Accept-Language");
                 }
             }
         }

--- a/src/main/java/io/muserver/rest/MuVariantListBuilder.java
+++ b/src/main/java/io/muserver/rest/MuVariantListBuilder.java
@@ -81,7 +81,7 @@ class MuVariantListBuilder extends Variant.VariantListBuilder {
             boolean mtOkay = cmt == null || MediaTypeHeaderDelegate.atLeastOneCompatible(singletonList(cmt), acceptableMediaTypes, "charset");
 
             String cenc = candidate.getEncoding();
-            boolean encOkay = cenc == null || acceptableEncodings.stream().anyMatch(ae -> ae.value().equals(cenc));
+            boolean encOkay = cenc == null || encodingScore(acceptableEncodings, cenc) > 0;
 
             Locale clang = candidate.getLanguage();
             boolean langOk = clang == null || (Locale.lookup(preferredLanguages, singleton(clang)) != null) || preferredLanguages.contains(wildcardRanger);
@@ -148,7 +148,23 @@ class MuVariantListBuilder extends Variant.VariantListBuilder {
     }
 
     private static double bestEncodingScore(List<ParameterizedHeaderWithValue> acceptableEncodings, Variant variant) {
-        return acceptableEncodings.stream().filter(enc -> variant.getEncoding().equals(enc.value())).min((o1, o2) -> Double.compare(qScore(o2), qScore(o1))).map(MuVariantListBuilder::qScore).orElse(1.0);
+        return encodingScore(acceptableEncodings, variant.getEncoding());
+    }
+
+    private static double encodingScore(List<ParameterizedHeaderWithValue> acceptableEncodings, String encoding) {
+        double explicitScore = acceptableEncodings.stream()
+            .filter(enc -> encoding.equalsIgnoreCase(enc.value()))
+            .mapToDouble(MuVariantListBuilder::qScore)
+            .max()
+            .orElse(-1);
+        if (explicitScore >= 0) {
+            return explicitScore;
+        }
+        return acceptableEncodings.stream()
+            .filter(enc -> "*".equals(enc.value()))
+            .mapToDouble(MuVariantListBuilder::qScore)
+            .max()
+            .orElse(0);
     }
 
     private static double qScore(ParameterizedHeaderWithValue p) {

--- a/src/test/java/io/muserver/rest/MuVariantListBuilderTest.java
+++ b/src/test/java/io/muserver/rest/MuVariantListBuilderTest.java
@@ -150,6 +150,8 @@ public class MuVariantListBuilderTest {
         assertThat(MuVariantListBuilder.selectVariant(availableVariants, acceptLang("*"), emptyList(), ParameterizedHeaderWithValue.fromString("pkunzip, compress")), equalTo(pkunzip));
         assertThat(MuVariantListBuilder.selectVariant(availableVariants, acceptLang("*"), emptyList(), ParameterizedHeaderWithValue.fromString("pkunzip;q=0.5, compress, gzip")), equalTo(gzip));
         assertThat(MuVariantListBuilder.selectVariant(availableVariants, acceptLang("*"), emptyList(), ParameterizedHeaderWithValue.fromString("pkunzip;q=0.8,gzip;q=0.5")), equalTo(pkunzip));
+        assertThat(MuVariantListBuilder.selectVariant(availableVariants, acceptLang("*"), emptyList(), ParameterizedHeaderWithValue.fromString("*")), oneOf(gzip, pkunzip));
+        assertThat(MuVariantListBuilder.selectVariant(availableVariants, acceptLang("*"), emptyList(), ParameterizedHeaderWithValue.fromString("gzip;q=0, *")), equalTo(pkunzip));
         assertThat(MuVariantListBuilder.selectVariant(availableVariants, acceptLang("*"), emptyList(), ParameterizedHeaderWithValue.fromString("compress")), nullValue());
     }
 

--- a/src/test/java/io/muserver/rest/VariantTest.java
+++ b/src/test/java/io/muserver/rest/VariantTest.java
@@ -7,6 +7,7 @@ import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Request;
 import jakarta.ws.rs.core.Variant;
@@ -61,7 +62,7 @@ public class VariantTest {
             assertThat(resp.header("content-type"), equalTo("application/json"));
             assertThat(resp.header("content-encoding"), equalTo("identity"));
             assertThat(resp.header("content-language"), equalTo("es"));
-            assertThat(resp.headers("vary"), hasItems("Accept-Language", "Accept", "Accept-Encoding"));
+            assertThat(resp.headers("vary"), hasItems(HttpHeaders.ACCEPT_LANGUAGE, HttpHeaders.ACCEPT, HttpHeaders.ACCEPT_ENCODING));
             assertThat(resp.body().string(), equalTo("{}"));
         }
 
@@ -73,7 +74,7 @@ public class VariantTest {
             assertThat(resp.header("content-type"), equalTo("application/json"));
             assertThat(resp.header("content-encoding"), equalTo("identity"));
             assertThat(resp.header("content-language"), oneOf("es", "en"));
-            assertThat(resp.headers("vary"), hasItems("Accept-Language", "Accept", "Accept-Encoding"));
+            assertThat(resp.headers("vary"), hasItems(HttpHeaders.ACCEPT_LANGUAGE, HttpHeaders.ACCEPT, HttpHeaders.ACCEPT_ENCODING));
             assertThat(resp.body().string(), equalTo("{}"));
         }
 

--- a/src/test/java/io/muserver/rest/VariantTest.java
+++ b/src/test/java/io/muserver/rest/VariantTest.java
@@ -61,7 +61,7 @@ public class VariantTest {
             assertThat(resp.header("content-type"), equalTo("application/json"));
             assertThat(resp.header("content-encoding"), equalTo("identity"));
             assertThat(resp.header("content-language"), equalTo("es"));
-            assertThat(resp.headers("vary"), hasItems("accept-language", "accept", "accept-encoding"));
+            assertThat(resp.headers("vary"), hasItems("Accept-Language", "Accept", "Accept-Encoding"));
             assertThat(resp.body().string(), equalTo("{}"));
         }
 
@@ -73,7 +73,7 @@ public class VariantTest {
             assertThat(resp.header("content-type"), equalTo("application/json"));
             assertThat(resp.header("content-encoding"), equalTo("identity"));
             assertThat(resp.header("content-language"), oneOf("es", "en"));
-            assertThat(resp.headers("vary"), hasItems("accept-language", "accept", "accept-encoding"));
+            assertThat(resp.headers("vary"), hasItems("Accept-Language", "Accept", "Accept-Encoding"));
             assertThat(resp.body().string(), equalTo("{}"));
         }
 


### PR DESCRIPTION
## What changed

- Match `Accept-Encoding: *` against available variant encodings.
- Respect an explicit encoding range, including `q=0`, before falling back to the wildcard range.
- Emit conventional `Accept`, `Accept-Encoding`, and `Accept-Language` tokens in generated `Vary` headers.
- Add and update variant negotiation coverage.

## Why

Variant selection previously required exact encoding-name equality, so a wildcard request matched neither `CP1250` nor `UTF-8` and returned 406. Once selected, Mu emitted lowercase field-name tokens in `Vary`, while Jakarta REST's conformance assertion checks the conventional spellings.

## Impact

Wildcard encoding negotiation now selects eligible variants without overriding explicit exclusions, and generated `Vary` values use standard field-name casing.

## Validation

- `MuVariantListBuilderTest` and `VariantTest`: 16 tests passed.
- `selectVariantResponseVaryTest_from_standalone`: passed on `master` plus only this patch.
- Full Jakarta REST TCK `core/request` run: 24 passed / 4 failed; the four remaining failures are independently fixed by mu-server PR #94.
- `git diff --check` passed before commit.
