### PR TITLE
Replace the default response date

### DIFF
--- a/src/main/java/io/muserver/rest/MuRuntimeDelegate.java
+++ b/src/main/java/io/muserver/rest/MuRuntimeDelegate.java
@@ -87,6 +87,8 @@ public class MuRuntimeDelegate extends RuntimeDelegate {
                         throw new ServerErrorException("Invalid redirect location: " + values.get(0) + " - " + e.getMessage(), 500);
                     }
                     to.headers().add(key, baseUri.resolve(location).toString());
+                } else if (key.equalsIgnoreCase("date")) {
+                    to.headers().set(key, values);
                 } else {
                     to.headers().add(key, values);
                 }

--- a/src/test/java/io/muserver/rest/JaxRSResponseTest.java
+++ b/src/test/java/io/muserver/rest/JaxRSResponseTest.java
@@ -65,6 +65,25 @@ public class JaxRSResponseTest {
     }
 
     @Test
+    public void applicationDateReplacesTheDefaultResponseDate() {
+        Date date = Mutils.fromHttpDate("Mon, 1 Jan 2018 02:23:20 GMT");
+        @Path("/date")
+        class DateResource {
+            @GET
+            public Response get() {
+                return Response.ok().header(HttpHeaders.DATE, date).build();
+            }
+        }
+
+        server = ServerUtils.httpsServerForTest()
+            .addHandler(restHandler(new DateResource()))
+            .start();
+        try (okhttp3.Response response = call(request(server.uri().resolve("/date")))) {
+            assertThat(response.headers(HttpHeaders.DATE), contains("Mon, 1 Jan 2018 02:23:20 GMT"));
+        }
+    }
+
+    @Test
     public void headersCanBeGottenFromIt() {
         Response.ResponseBuilder builder = new JaxRSResponse.Builder()
             .allow("GET", "HEAD")


### PR DESCRIPTION
## What changed

- Replace Mu's automatic response `Date` when a JAX-RS response supplies its own Date value.
- Add end-to-end regression coverage asserting that exactly one application-supplied Date is sent.

## Why

Every Mu response starts with an automatic `Date` header. JAX-RS response transfer previously appended the application Date, producing two values. Jakarta REST clients require Date to be a single-valued header and rejected the response before `Response.getDate()` could be tested.

## Impact

Application-supplied JAX-RS Date headers now override the server default instead of creating an invalid multi-value response.

## Validation

- `JaxRSResponseTest`: 14 tests passed.
- Jakarta REST TCK `core/response`: 68 passed, 0 failed, 0 unexpected (baseline 67 passed / 1 failed).
- `git diff --check` passed before commit.
