### PR TITLE
Preserve request URI authority in absolute path

### DIFF
--- a/src/main/java/io/muserver/rest/MuUriInfo.java
+++ b/src/main/java/io/muserver/rest/MuUriInfo.java
@@ -95,7 +95,7 @@ class MuUriInfo implements UriInfo {
 
     @Override
     public URI getAbsolutePath() {
-        return getBaseUri().resolve(getPath(false));
+        return UriBuilder.fromUri(requestUri).replaceQuery(null).fragment(null).build();
     }
 
     @Override

--- a/src/main/java/io/muserver/rest/MuUriInfo.java
+++ b/src/main/java/io/muserver/rest/MuUriInfo.java
@@ -95,7 +95,14 @@ class MuUriInfo implements UriInfo {
 
     @Override
     public URI getAbsolutePath() {
-        return UriBuilder.fromUri(requestUri).replaceQuery(null).fragment(null).build();
+        String uri = requestUri.toString();
+        int queryStart = uri.indexOf('?');
+        int fragmentStart = uri.indexOf('#');
+        int end = queryStart < 0 ? uri.length() : queryStart;
+        if (fragmentStart >= 0) {
+            end = Math.min(end, fragmentStart);
+        }
+        return end == uri.length() ? requestUri : URI.create(uri.substring(0, end));
     }
 
     @Override

--- a/src/test/java/io/muserver/rest/MuUriInfoTest.java
+++ b/src/test/java/io/muserver/rest/MuUriInfoTest.java
@@ -83,6 +83,18 @@ public class MuUriInfoTest {
         assertThat(sample.getAbsolutePath(), equalTo(URI.create("http://example.org:8182/some%20path/path")));
     }
 
+    @Test
+    public void getAbsolutePathUsesTheRequestUriAuthority() {
+        MuUriInfo sample = new MuUriInfo(
+            URI.create("http://localhost:888/otherbase"),
+            URI.create("http://xx.yy:888/base/resource/sub?query=yo#ha"),
+            "base/resource/sub",
+            null
+        );
+
+        assertThat(sample.getAbsolutePath(), equalTo(URI.create("http://xx.yy:888/base/resource/sub")));
+    }
+
 
     @Test
     public void getPathSegmentsWorks() {

--- a/src/test/java/io/muserver/rest/MuUriInfoTest.java
+++ b/src/test/java/io/muserver/rest/MuUriInfoTest.java
@@ -95,6 +95,18 @@ public class MuUriInfoTest {
         assertThat(sample.getAbsolutePath(), equalTo(URI.create("http://xx.yy:888/base/resource/sub")));
     }
 
+    @Test
+    public void getAbsolutePathPreservesEncodedPathDelimiters() {
+        MuUriInfo sample = new MuUriInfo(
+            URI.create("http://example.org:8182/"),
+            URI.create("http://example.org:8182/a%2Fb?query=yo#ha"),
+            "a%2Fb",
+            null
+        );
+
+        assertThat(sample.getAbsolutePath(), equalTo(URI.create("http://example.org:8182/a%2Fb")));
+    }
+
 
     @Test
     public void getPathSegmentsWorks() {


### PR DESCRIPTION
## Summary

- preserve the request URI authority when calculating `UriInfo.getAbsolutePath()`
- continue removing query and fragment as required for an absolute path
- add regression coverage where base and request URI authorities differ

## TCK intent and master failure

`container/requestcontext/setRequestUriTwoUrisTest_from_standalone` calls `ContainerRequestContext.setRequestUri(base, request)` from a pre-matching filter with base `http://localhost:888/otherbase` and absolute request `http://xx.yy:888/base/resource/sub`. It verifies that `UriInfo.getAbsolutePath()` reflects the effective request URI.

Master stores the absolute request URI correctly, but `MuUriInfo.getAbsolutePath()` reconstructs it with `baseUri.resolve(path)`. That substitutes the base authority (`localhost`) for the request authority (`xx.yy`). This PR builds the absolute path from the stored request URI and removes only query and fragment.

PR #93 is a prerequisite for this TCK case to reach URI rewriting because it fixes the earlier filter-abort failure; it is not included in this branch.

## Validation

- Java 11 `MuUriInfoTest`: 15 passed
- focused request-context TCK on a separate validation tree containing PR #93 plus this patch: selected test passed with `http://xx.yy:888/base/resource/sub`; suite improved to 36 passed, 3 unrelated failures, and 8 known unsupported
- `git diff --check`
