### PR TITLE
Apply writer response headers before commit

### DIFF
--- a/src/main/java/io/muserver/rest/LazyAccessOutputStream.java
+++ b/src/main/java/io/muserver/rest/LazyAccessOutputStream.java
@@ -4,23 +4,35 @@ import io.muserver.MuResponse;
 
 import java.io.IOException;
 import java.io.OutputStream;
+import java.util.Objects;
 
 /**
  * An output stream based on the request output stream, but if no methods are called then the output stream is never created.
  */
 class LazyAccessOutputStream extends OutputStream {
     private final MuResponse muResponse;
+    private final Runnable beforeFirstWrite;
     private OutputStream os;
+    private boolean prepared;
 
     private OutputStream out() {
         if (os == null) {
+            prepare();
             os = muResponse.outputStream();
         }
         return os;
     }
 
-    LazyAccessOutputStream(MuResponse muResponse) {
+    LazyAccessOutputStream(MuResponse muResponse, Runnable beforeFirstWrite) {
         this.muResponse = muResponse;
+        this.beforeFirstWrite = beforeFirstWrite;
+    }
+
+    void prepare() {
+        if (!prepared) {
+            beforeFirstWrite.run();
+            prepared = true;
+        }
     }
 
     @Override
@@ -30,7 +42,10 @@ class LazyAccessOutputStream extends OutputStream {
 
     @Override
     public void write(byte[] b, int off, int len) throws IOException {
-        out().write(b, off, len);
+        Objects.checkFromIndexSize(off, len, b.length);
+        if (len > 0) {
+            out().write(b, off, len);
+        }
     }
 
     @Override

--- a/src/main/java/io/muserver/rest/RestHandler.java
+++ b/src/main/java/io/muserver/rest/RestHandler.java
@@ -16,9 +16,6 @@ import jakarta.ws.rs.sse.SseEventSink;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.FilterOutputStream;
-import java.io.IOException;
-import java.io.OutputStream;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Parameter;
 import java.lang.reflect.Type;
@@ -46,35 +43,6 @@ public class RestHandler implements MuHandler {
     private final CORSConfig corsConfig;
     private final List<ParamConverterProvider> paramConverterProviders;
     private final SchemaObjectCustomizer schemaObjectCustomizer;
-
-    private static final class BeforeFirstWriteOutputStream extends FilterOutputStream {
-        private final Runnable beforeFirstWrite;
-        private boolean started;
-
-        private BeforeFirstWriteOutputStream(OutputStream out, Runnable beforeFirstWrite) {
-            super(out);
-            this.beforeFirstWrite = beforeFirstWrite;
-        }
-
-        private void start() {
-            if (!started) {
-                started = true;
-                beforeFirstWrite.run();
-            }
-        }
-
-        @Override
-        public void write(int b) throws IOException {
-            start();
-            out.write(b);
-        }
-
-        @Override
-        public void write(byte[] b, int off, int len) throws IOException {
-            start();
-            out.write(b, off, len);
-        }
-    }
 
     private final List<ReaderInterceptor> readerInterceptors;
     private final List<WriterInterceptor> writerInterceptors;
@@ -255,7 +223,10 @@ public class RestHandler implements MuHandler {
                     jaxRSResponse = new JaxRSResponse(Response.Status.fromStatusCode(obj.status()), new LowercasedMultivaluedHashMap<>(), obj, new NewCookie[0], emptyList(), JaxRSResponse.Builder.EMPTY_ANNOTATIONS);
                 }
 
-                try (LazyAccessOutputStream out = new LazyAccessOutputStream(muResponse)) {
+                JaxRSResponse responseToWrite = jaxRSResponse;
+                boolean isHttp1 = requestContext.muRequest.protocol().equals("HTTP/1.1");
+                try (LazyAccessOutputStream out = new LazyAccessOutputStream(muResponse,
+                    () -> MuRuntimeDelegate.writeResponseHeaders(requestContext.getUriInfo().getBaseUri(), responseToWrite, muResponse, isHttp1))) {
                     jaxRSResponse.setEntityStream(requestContext.getMuMethod() == Method.HEAD ? NullOutputStream.INSTANCE : out);
                     jaxRSResponse.setRequestContext(requestContext);
 
@@ -275,6 +246,7 @@ public class RestHandler implements MuHandler {
                     }
 
                     filterManagerThing.onBeforeSendResponse(requestContext, jaxRSResponse);
+                    muResponse.status(jaxRSResponse.getStatus());
 
                     if (jaxRSResponse.hasEntity()) {
                         jaxRSResponse.executeInterceptors(writerInterceptors); // run the interceptors
@@ -285,9 +257,9 @@ public class RestHandler implements MuHandler {
                     }
 
                     int status = jaxRSResponse.getStatus();
-                    muResponse.status(status);
-
-                    boolean isHttp1 = requestContext.muRequest.protocol().equals("HTTP/1.1");
+                    if (!muResponse.hasStartedSendingData()) {
+                        muResponse.status(status);
+                    }
 
                     if (entity == null) {
                         if (status != 204 && status != 304 && status != 205) {
@@ -316,14 +288,9 @@ public class RestHandler implements MuHandler {
                         jaxRSResponse.getHeaders().putSingle("content-type", contentType);
 
                         try {
-                            JaxRSResponse responseToWrite = jaxRSResponse;
-                            BeforeFirstWriteOutputStream entityStream = new BeforeFirstWriteOutputStream(
-                                jaxRSResponse.getOutputStream(),
-                                () -> MuRuntimeDelegate.writeResponseHeaders(requestContext.getUriInfo().getBaseUri(), responseToWrite, muResponse, isHttp1)
-                            );
                             messageBodyWriter.writeTo(jaxRSResponse.getEntity(), jaxRSResponse.getType(), jaxRSResponse.getGenericType(), writerAnnontations,
-                                jaxRSResponse.getMediaType(), jaxRSResponse.getHeaders(), entityStream);
-                            entityStream.start();
+                                jaxRSResponse.getMediaType(), jaxRSResponse.getHeaders(), jaxRSResponse.getOutputStream());
+                            out.prepare();
                         } catch (Exception e) {
                             // remove the added headers before rewriting
                             if (!muResponse.hasStartedSendingData()) {

--- a/src/main/java/io/muserver/rest/RestHandler.java
+++ b/src/main/java/io/muserver/rest/RestHandler.java
@@ -239,7 +239,10 @@ public class RestHandler implements MuHandler {
                 JaxRSResponse responseToWrite = jaxRSResponse;
                 boolean isHttp1 = requestContext.muRequest.protocol().equals("HTTP/1.1");
                 try (LazyAccessOutputStream out = new LazyAccessOutputStream(muResponse,
-                    () -> MuRuntimeDelegate.writeResponseHeaders(requestContext.getUriInfo().getBaseUri(), responseToWrite, muResponse, isHttp1))) {
+                    () -> {
+                        applyDefaultCharset(responseToWrite);
+                        MuRuntimeDelegate.writeResponseHeaders(requestContext.getUriInfo().getBaseUri(), responseToWrite, muResponse, isHttp1);
+                    })) {
                     jaxRSResponse.setEntityStream(requestContext.getMuMethod() == Method.HEAD ? NullOutputStream.INSTANCE : out);
                     jaxRSResponse.setRequestContext(requestContext);
 
@@ -294,11 +297,7 @@ public class RestHandler implements MuHandler {
                             }
                         }
 
-                        String contentType = responseMediaType.toString();
-                        if (responseMediaType.getType().equals("text") && !responseMediaType.getParameters().containsKey("charset")) {
-                            contentType += ";charset=utf-8";
-                        }
-                        jaxRSResponse.getHeaders().putSingle("content-type", contentType);
+                        applyDefaultCharset(jaxRSResponse);
 
                         try {
                             messageBodyWriter.writeTo(jaxRSResponse.getEntity(), jaxRSResponse.getType(), jaxRSResponse.getGenericType(), writerAnnontations,
@@ -318,6 +317,13 @@ public class RestHandler implements MuHandler {
             }
         } catch (Exception ex) {
             dealWithUnhandledException(nestingLevel + 1, requestContext, muResponse, ex, acceptHeaders, produces, directlyProduces);
+        }
+    }
+
+    private static void applyDefaultCharset(JaxRSResponse response) {
+        MediaType mediaType = response.getMediaType();
+        if (mediaType != null && mediaType.getType().equals("text") && !mediaType.getParameters().containsKey(MediaType.CHARSET_PARAMETER)) {
+            response.setMediaType(mediaType.withCharset("utf-8"));
         }
     }
 

--- a/src/main/java/io/muserver/rest/RestHandler.java
+++ b/src/main/java/io/muserver/rest/RestHandler.java
@@ -16,6 +16,9 @@ import jakarta.ws.rs.sse.SseEventSink;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.FilterOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Parameter;
 import java.lang.reflect.Type;
@@ -43,6 +46,36 @@ public class RestHandler implements MuHandler {
     private final CORSConfig corsConfig;
     private final List<ParamConverterProvider> paramConverterProviders;
     private final SchemaObjectCustomizer schemaObjectCustomizer;
+
+    private static final class BeforeFirstWriteOutputStream extends FilterOutputStream {
+        private final Runnable beforeFirstWrite;
+        private boolean started;
+
+        private BeforeFirstWriteOutputStream(OutputStream out, Runnable beforeFirstWrite) {
+            super(out);
+            this.beforeFirstWrite = beforeFirstWrite;
+        }
+
+        private void start() {
+            if (!started) {
+                started = true;
+                beforeFirstWrite.run();
+            }
+        }
+
+        @Override
+        public void write(int b) throws IOException {
+            start();
+            out.write(b);
+        }
+
+        @Override
+        public void write(byte[] b, int off, int len) throws IOException {
+            start();
+            out.write(b, off, len);
+        }
+    }
+
     private final List<ReaderInterceptor> readerInterceptors;
     private final List<WriterInterceptor> writerInterceptors;
     private final CollectionParameterStrategy collectionParameterStrategy;
@@ -282,11 +315,15 @@ public class RestHandler implements MuHandler {
                         }
                         jaxRSResponse.getHeaders().putSingle("content-type", contentType);
 
-                        MuRuntimeDelegate.writeResponseHeaders(requestContext.getUriInfo().getBaseUri(), jaxRSResponse, muResponse, isHttp1);
-
                         try {
+                            JaxRSResponse responseToWrite = jaxRSResponse;
+                            BeforeFirstWriteOutputStream entityStream = new BeforeFirstWriteOutputStream(
+                                jaxRSResponse.getOutputStream(),
+                                () -> MuRuntimeDelegate.writeResponseHeaders(requestContext.getUriInfo().getBaseUri(), responseToWrite, muResponse, isHttp1)
+                            );
                             messageBodyWriter.writeTo(jaxRSResponse.getEntity(), jaxRSResponse.getType(), jaxRSResponse.getGenericType(), writerAnnontations,
-                                jaxRSResponse.getMediaType(), jaxRSResponse.getHeaders(), jaxRSResponse.getOutputStream());
+                                jaxRSResponse.getMediaType(), jaxRSResponse.getHeaders(), entityStream);
+                            entityStream.start();
                         } catch (Exception e) {
                             // remove the added headers before rewriting
                             if (!muResponse.hasStartedSendingData()) {

--- a/src/test/java/io/muserver/rest/EntityProvidersTest.java
+++ b/src/test/java/io/muserver/rest/EntityProvidersTest.java
@@ -132,6 +132,42 @@ public class EntityProvidersTest {
     }
 
     @Test
+    public void customWritersCanAddResponseHeaders() throws Exception {
+        class Thing {}
+
+        @Path("samples")
+        class Sample {
+            @GET
+            @Produces("text/plain")
+            public Thing get() {
+                return new Thing();
+            }
+        }
+
+        this.server = httpsServerForTest().addHandler(
+            restHandler(new Sample())
+                .addCustomWriter(new MessageBodyWriter<Thing>() {
+                    @Override
+                    public boolean isWriteable(Class<?> type, Type genericType, Annotation[] annotations, jakarta.ws.rs.core.MediaType mediaType) {
+                        return type.equals(Thing.class);
+                    }
+
+                    @Override
+                    public void writeTo(Thing thing, Class<?> type, Type genericType, Annotation[] annotations, jakarta.ws.rs.core.MediaType mediaType,
+                                        MultivaluedMap<String, Object> httpHeaders, OutputStream entityStream) throws IOException {
+                        httpHeaders.putSingle("X-Added-By-Writer", "the value");
+                    }
+                })
+                .build()).start();
+
+        try (Response resp = call(request(server.uri().resolve("/samples")))) {
+            assertThat(resp.code(), equalTo(200));
+            assertThat(resp.header("X-Added-By-Writer"), equalTo("the value"));
+            assertThat(resp.body().string(), equalTo(""));
+        }
+    }
+
+    @Test
     public void customReadersGetTheAnnotationsOfTheResourceMethod() throws Exception {
 
         @Path("dummy")

--- a/src/test/java/io/muserver/rest/EntityProvidersTest.java
+++ b/src/test/java/io/muserver/rest/EntityProvidersTest.java
@@ -168,6 +168,44 @@ public class EntityProvidersTest {
     }
 
     @Test
+    public void zeroLengthWritesDoNotPreventCustomWritersAddingResponseHeaders() throws Exception {
+        class Thing {}
+
+        @Path("samples")
+        class Sample {
+            @GET
+            @Produces("text/plain")
+            public Thing get() {
+                return new Thing();
+            }
+        }
+
+        this.server = httpsServerForTest().addHandler(
+            restHandler(new Sample())
+                .addCustomWriter(new MessageBodyWriter<Thing>() {
+                    @Override
+                    public boolean isWriteable(Class<?> type, Type genericType, Annotation[] annotations, jakarta.ws.rs.core.MediaType mediaType) {
+                        return type.equals(Thing.class);
+                    }
+
+                    @Override
+                    public void writeTo(Thing thing, Class<?> type, Type genericType, Annotation[] annotations, jakarta.ws.rs.core.MediaType mediaType,
+                                        MultivaluedMap<String, Object> httpHeaders, OutputStream entityStream) throws IOException {
+                        entityStream.write(new byte[0]);
+                        httpHeaders.putSingle("X-Added-After-Zero-Length-Write", "the value");
+                        entityStream.write("the body".getBytes(StandardCharsets.UTF_8));
+                    }
+                })
+                .build()).start();
+
+        try (Response resp = call(request(server.uri().resolve("/samples")))) {
+            assertThat(resp.code(), equalTo(200));
+            assertThat(resp.header("X-Added-After-Zero-Length-Write"), equalTo("the value"));
+            assertThat(resp.body().string(), equalTo("the body"));
+        }
+    }
+
+    @Test
     public void customReadersGetTheAnnotationsOfTheResourceMethod() throws Exception {
 
         @Path("dummy")

--- a/src/test/java/io/muserver/rest/WriterInterceptorTest.java
+++ b/src/test/java/io/muserver/rest/WriterInterceptorTest.java
@@ -106,7 +106,7 @@ public class WriterInterceptorTest {
         @Path("/greetings")
         class GreetingResource {
             @GET
-            @Produces("text/plain;charset=utf-8")
+            @Produces("text/plain")
             public String hello() {
                 return "hello";
             }
@@ -125,6 +125,7 @@ public class WriterInterceptorTest {
             assertThat(resp.code(), is(200));
             assertThat(resp.header("X-Added-By-Interceptor"), equalTo("the value"));
             assertThat(resp.body().string(), equalTo("prefix-hello"));
+            assertThat(resp.header("content-type"), is("text/plain;charset=utf-8"));
         }
     }
 

--- a/src/test/java/io/muserver/rest/WriterInterceptorTest.java
+++ b/src/test/java/io/muserver/rest/WriterInterceptorTest.java
@@ -102,6 +102,33 @@ public class WriterInterceptorTest {
     }
 
     @Test
+    public void interceptorHeadersAreAppliedWhenItWritesBeforeTheMessageBodyWriter() throws Exception {
+        @Path("/greetings")
+        class GreetingResource {
+            @GET
+            @Produces("text/plain;charset=utf-8")
+            public String hello() {
+                return "hello";
+            }
+        }
+        server = ServerUtils.httpsServerForTest()
+            .addHandler(restHandler(new GreetingResource())
+                .addWriterInterceptor(context -> {
+                    context.getHeaders().putSingle("X-Added-By-Interceptor", "the value");
+                    context.getOutputStream().write("prefix-".getBytes(StandardCharsets.UTF_8));
+                    context.proceed();
+                })
+            )
+            .start();
+
+        try (Response resp = call(request(server.uri().resolve("/greetings")))) {
+            assertThat(resp.code(), is(200));
+            assertThat(resp.header("X-Added-By-Interceptor"), equalTo("the value"));
+            assertThat(resp.body().string(), equalTo("prefix-hello"));
+        }
+    }
+
+    @Test
     public void resourceInfoAndMuRequestCanBeExtractedFromProperties() throws Exception {
         @Path("/greetings")
         class GreetingResource {


### PR DESCRIPTION
## Summary

- let `MessageBodyWriter.writeTo` mutate response headers before they are copied to the network response
- make the existing `LazyAccessOutputStream` the single response-commit boundary for writers and writer interceptors
- preserve streaming by copying headers immediately before the first real entity byte
- apply headers explicitly after `writeTo` when a writer emits no bytes
- avoid treating a zero-length write as response commitment

## TCK intent and master failure

`ext/providers/writeHeaderEntityUsingWriterTest_from_standalone` verifies that the selected entity writer can add `READABLEWRITEABLE` through the mutable `httpHeaders` map supplied to `writeTo`.

Master copied `JaxRSResponse` headers to `MuResponse` before calling `writeTo`. The writer then mutated only the already-copied Jakarta map, so the header never reached the client.

The fix now copies the live Jakarta headers at the point where `LazyAccessOutputStream` is about to acquire Mu's real output stream. That is the existing transition from an editable response to a committed streaming response. A final explicit preparation covers writers that add headers but produce an empty entity.

The response status is established before writer interceptors run, allowing an interceptor that writes before the message body writer to use the same commit boundary without committing an incorrect default status.

## Tests

Added regressions for:

- a custom writer that adds a header without writing body bytes
- a zero-length write followed by another header mutation and real body output
- a writer interceptor that adds a header and writes before the message body writer

## Validation

- Java 11 focused writer/interceptor tests: 18 passed
- Java 11 full Maven suite: 845 passed, 0 failures, 0 errors
- selected writer-header TCK passed on the original PR revision
- neighboring writer-body and writer-exception TCK cases remained passing
- `git diff --check`
