### PR TITLE
Match requests without Content-Type as wildcard

### DIFF
--- a/src/main/java/io/muserver/rest/RequestMatcher.java
+++ b/src/main/java/io/muserver/rest/RequestMatcher.java
@@ -264,7 +264,9 @@ class RequestMatcher {
             return result.get(0);
         }
 
-        List<MediaType> requestBodyTypeAsList = Collections.singletonList(requestBodyMediaType);
+        List<MediaType> requestBodyTypeAsList = requestHasEntity || requestBodyContentType != null
+            ? Collections.singletonList(requestBodyMediaType)
+            : WILDCARD_AS_LIST;
         return result.stream()
             .max(Comparator.comparing((MatchedMethod o) -> bestMediaType(requestBodyTypeAsList, o.resourceMethod.effectiveConsumes))
                 .thenComparing(o -> bestMediaType(clientAccepts, o.resourceMethod.effectiveProduces))).get();

--- a/src/main/java/io/muserver/rest/RequestMatcher.java
+++ b/src/main/java/io/muserver/rest/RequestMatcher.java
@@ -43,7 +43,7 @@ class RequestMatcher {
         Set<MatchedMethod> candidateMethods = getMatchedMethodsForPath(path, subResourceLocator);
         MuRequest req = requestContext.muRequest;
         String requestBodyContentType = req.headers().get(HeaderNames.CONTENT_TYPE);
-        return stepThreeIdentifyTheMethodThatWillHandleTheRequest(httpMethod, candidateMethods, requestBodyContentType, acceptHeaders);
+        return stepThreeIdentifyTheMethodThatWillHandleTheRequest(httpMethod, candidateMethods, requestBodyContentType, req.headers().hasBody(), acceptHeaders);
     }
 
     Set<MatchedMethod> getMatchedMethodsForPath(String path, Function<MatchedMethod, ResourceClass> subResourceLocator) throws NotMatchedException {
@@ -231,7 +231,7 @@ class RequestMatcher {
         }
     }
 
-    private MatchedMethod stepThreeIdentifyTheMethodThatWillHandleTheRequest(Method method, Set<MatchedMethod> candidates, String requestBodyContentType, List<MediaType> acceptHeaders) throws NotAllowedException, NotAcceptableException, NotSupportedException {
+    private MatchedMethod stepThreeIdentifyTheMethodThatWillHandleTheRequest(Method method, Set<MatchedMethod> candidates, String requestBodyContentType, boolean requestHasEntity, List<MediaType> acceptHeaders) throws NotAllowedException, NotAcceptableException, NotSupportedException {
         List<MatchedMethod> result = candidates.stream().filter(rm -> rm.resourceMethod.httpMethod == method).collect(toList());
         if (result.isEmpty()) {
             List<String> allowed = candidates.stream().map(c -> c.resourceMethod.httpMethod.name()).distinct().collect(toList());
@@ -241,10 +241,14 @@ class RequestMatcher {
         // The media type of the request entity body (if any) is a supported input data format (see Section3.5).
         // If no methods support the media type of the request entity body an implementation MUST generate a
         // NotSupportedException (415 status) and no entity.
-        MediaType requestBodyMediaType = requestBodyContentType == null ? MediaTypeHeaderDelegate.NONE : MediaType.valueOf(requestBodyContentType);
-        result = result.stream().filter(rm -> rm.resourceMethod.canConsume(requestBodyMediaType)).collect(toList());
-        if (result.isEmpty()) {
-            throw new NotSupportedException();
+        MediaType requestBodyMediaType = requestBodyContentType == null
+            ? (requestHasEntity ? MediaType.APPLICATION_OCTET_STREAM_TYPE : MediaTypeHeaderDelegate.NONE)
+            : MediaType.valueOf(requestBodyContentType);
+        if (requestHasEntity || requestBodyContentType != null) {
+            result = result.stream().filter(rm -> rm.resourceMethod.canConsume(requestBodyMediaType)).collect(toList());
+            if (result.isEmpty()) {
+                throw new NotSupportedException();
+            }
         }
 
         // At least one of the acceptable response entity body media types is a supported output data format (see Section 3.5).

--- a/src/main/java/io/muserver/rest/RequestMatcher.java
+++ b/src/main/java/io/muserver/rest/RequestMatcher.java
@@ -43,7 +43,7 @@ class RequestMatcher {
         Set<MatchedMethod> candidateMethods = getMatchedMethodsForPath(path, subResourceLocator);
         MuRequest req = requestContext.muRequest;
         String requestBodyContentType = req.headers().get(HeaderNames.CONTENT_TYPE);
-        return stepThreeIdentifyTheMethodThatWillHandleTheRequest(httpMethod, candidateMethods, requestBodyContentType, req.headers().hasBody(), acceptHeaders);
+        return stepThreeIdentifyTheMethodThatWillHandleTheRequest(httpMethod, candidateMethods, requestBodyContentType, acceptHeaders);
     }
 
     Set<MatchedMethod> getMatchedMethodsForPath(String path, Function<MatchedMethod, ResourceClass> subResourceLocator) throws NotMatchedException {
@@ -231,7 +231,7 @@ class RequestMatcher {
         }
     }
 
-    private MatchedMethod stepThreeIdentifyTheMethodThatWillHandleTheRequest(Method method, Set<MatchedMethod> candidates, String requestBodyContentType, boolean requestHasEntity, List<MediaType> acceptHeaders) throws NotAllowedException, NotAcceptableException, NotSupportedException {
+    private MatchedMethod stepThreeIdentifyTheMethodThatWillHandleTheRequest(Method method, Set<MatchedMethod> candidates, String requestBodyContentType, List<MediaType> acceptHeaders) throws NotAllowedException, NotAcceptableException, NotSupportedException {
         List<MatchedMethod> result = candidates.stream().filter(rm -> rm.resourceMethod.httpMethod == method).collect(toList());
         if (result.isEmpty()) {
             List<String> allowed = candidates.stream().map(c -> c.resourceMethod.httpMethod.name()).distinct().collect(toList());
@@ -241,14 +241,10 @@ class RequestMatcher {
         // The media type of the request entity body (if any) is a supported input data format (see Section3.5).
         // If no methods support the media type of the request entity body an implementation MUST generate a
         // NotSupportedException (415 status) and no entity.
-        MediaType requestBodyMediaType = requestBodyContentType == null
-            ? (requestHasEntity ? MediaType.APPLICATION_OCTET_STREAM_TYPE : MediaTypeHeaderDelegate.NONE)
-            : MediaType.valueOf(requestBodyContentType);
-        if (requestHasEntity || requestBodyContentType != null) {
-            result = result.stream().filter(rm -> rm.resourceMethod.canConsume(requestBodyMediaType)).collect(toList());
-            if (result.isEmpty()) {
-                throw new NotSupportedException();
-            }
+        MediaType requestBodyMediaType = requestBodyContentType == null ? MediaType.WILDCARD_TYPE : MediaType.valueOf(requestBodyContentType);
+        result = result.stream().filter(rm -> rm.resourceMethod.canConsume(requestBodyMediaType)).collect(toList());
+        if (result.isEmpty()) {
+            throw new NotSupportedException();
         }
 
         // At least one of the acceptable response entity body media types is a supported output data format (see Section 3.5).
@@ -264,9 +260,7 @@ class RequestMatcher {
             return result.get(0);
         }
 
-        List<MediaType> requestBodyTypeAsList = requestHasEntity || requestBodyContentType != null
-            ? Collections.singletonList(requestBodyMediaType)
-            : WILDCARD_AS_LIST;
+        List<MediaType> requestBodyTypeAsList = Collections.singletonList(requestBodyMediaType);
         return result.stream()
             .max(Comparator.comparing((MatchedMethod o) -> bestMediaType(requestBodyTypeAsList, o.resourceMethod.effectiveConsumes))
                 .thenComparing(o -> bestMediaType(clientAccepts, o.resourceMethod.effectiveProduces))).get();

--- a/src/main/java/io/muserver/rest/RequestMatcher.java
+++ b/src/main/java/io/muserver/rest/RequestMatcher.java
@@ -270,9 +270,9 @@ class RequestMatcher {
 
     private static CombinedMediaType bestMediaType(List<MediaType> requestedTypes, List<MediaType> serverProvided) {
         return serverProvided.stream()
-            .map(serverType -> requestedTypes.stream().map(clientType -> CombinedMediaType.s(clientType, serverType))
-                .min(Comparator.naturalOrder()).get())
-            .min(Comparator.naturalOrder()).get();
+            .flatMap(serverType -> requestedTypes.stream().map(clientType -> CombinedMediaType.s(clientType, serverType)))
+            .filter(combined -> combined != CombinedMediaType.NONMATCH)
+            .max(Comparator.naturalOrder()).get();
     }
 
     static class StepOneOutput {

--- a/src/test/java/io/muserver/rest/RequestMatcherTest.java
+++ b/src/test/java/io/muserver/rest/RequestMatcherTest.java
@@ -399,6 +399,28 @@ public class RequestMatcherTest {
         assertThat(findResourceMethod(rm, Method.POST, "pictures", emptyList(), null).resourceMethod.methodHandle.getName(), equalTo("concrete"));
     }
 
+    @Test
+    public void bodylessRequestsUseBestConsumesValueFromEachMethod() throws NotMatchedException {
+        @Path("pictures")
+        class PictureThat {
+
+            @POST
+            @Consumes({"text/plain", "*/*"})
+            public String concreteAndWildcard() {
+                return "concrete and wildcard";
+            }
+
+            @POST
+            @Consumes("text/*")
+            public String typeWildcard() {
+                return "type wildcard";
+            }
+        }
+
+        RequestMatcher rm = new RequestMatcher(singletonList(ResourceClass.fromObject(new PictureThat(), paramConverterProviders, customizer)));
+        assertThat(findResourceMethod(rm, Method.POST, "pictures", emptyList(), null).resourceMethod.methodHandle.getName(), equalTo("concreteAndWildcard"));
+    }
+
     private static String nameOf(RequestMatcher rm, List<MediaType> acceptHeaders, String requestBodyContentType) throws NotMatchedException {
         return findResourceMethod(rm, Method.GET, "pictures", acceptHeaders, requestBodyContentType).resourceMethod.methodHandle.getName();
     }

--- a/src/test/java/io/muserver/rest/RequestMatcherTest.java
+++ b/src/test/java/io/muserver/rest/RequestMatcherTest.java
@@ -334,7 +334,7 @@ public class RequestMatcherTest {
 
         RequestMatcher rm = new RequestMatcher(singletonList(ResourceClass.fromObject(new PictureThat(), paramConverterProviders, customizer)));
         assertThat(nameOf(rm, emptyList(), "text/plain"), equalTo("text"));
-        assertThat(nameOf(rm, emptyList(), null, true), equalTo("json"));
+        assertThat(nameOf(rm, emptyList(), null), equalTo("text"));
 
         assertNotAcceptable(rm, singletonList(MediaType.valueOf("text/plain")), "application/json");
     }
@@ -353,6 +353,23 @@ public class RequestMatcherTest {
 
         RequestMatcher rm = new RequestMatcher(singletonList(ResourceClass.fromObject(new PictureThat(), paramConverterProviders, customizer)));
         assertThat(findResourceMethod(rm, Method.POST, "pictures", emptyList(), null).resourceMethod.methodHandle.getName(), equalTo("text"));
+    }
+
+    @Test
+    public void entityWithoutContentTypeDoesNotPreventConsumesMatch() throws NotMatchedException {
+        @Path("pictures")
+        class PictureThat {
+
+            @POST
+            @Consumes("text/html")
+            public String html() {
+                return "hi";
+            }
+        }
+
+        RequestMatcher rm = new RequestMatcher(singletonList(ResourceClass.fromObject(new PictureThat(), paramConverterProviders, customizer)));
+        RequestMatcher.MatchedMethod match = findResourceMethod(rm, Method.POST, "pictures", emptyList(), null, true);
+        assertThat(match.resourceMethod.methodHandle.getName(), equalTo("html"));
     }
 
     @Test
@@ -383,11 +400,7 @@ public class RequestMatcherTest {
     }
 
     private static String nameOf(RequestMatcher rm, List<MediaType> acceptHeaders, String requestBodyContentType) throws NotMatchedException {
-        return nameOf(rm, acceptHeaders, requestBodyContentType, requestBodyContentType != null);
-    }
-
-    private static String nameOf(RequestMatcher rm, List<MediaType> acceptHeaders, String requestBodyContentType, boolean requestHasEntity) throws NotMatchedException {
-        return findResourceMethod(rm, Method.GET, "pictures", acceptHeaders, requestBodyContentType, requestHasEntity).resourceMethod.methodHandle.getName();
+        return findResourceMethod(rm, Method.GET, "pictures", acceptHeaders, requestBodyContentType).resourceMethod.methodHandle.getName();
     }
 
     private static void assertNotAcceptable(RequestMatcher rm, List<MediaType> acceptHeaders, String requestBodyContentType) {

--- a/src/test/java/io/muserver/rest/RequestMatcherTest.java
+++ b/src/test/java/io/muserver/rest/RequestMatcherTest.java
@@ -334,13 +334,33 @@ public class RequestMatcherTest {
 
         RequestMatcher rm = new RequestMatcher(singletonList(ResourceClass.fromObject(new PictureThat(), paramConverterProviders, customizer)));
         assertThat(nameOf(rm, emptyList(), "text/plain"), equalTo("text"));
-        assertThat(nameOf(rm, emptyList(), null), equalTo("json"));
+        assertThat(nameOf(rm, emptyList(), null, true), equalTo("json"));
 
         assertNotAcceptable(rm, singletonList(MediaType.valueOf("text/plain")), "application/json");
     }
 
+    @Test
+    public void consumesIsNotCheckedWhenThereIsNoRequestEntityOrContentType() throws NotMatchedException {
+        @Path("pictures")
+        class PictureThat {
+
+            @POST
+            @Consumes("text/plain")
+            public String text() {
+                return "hi";
+            }
+        }
+
+        RequestMatcher rm = new RequestMatcher(singletonList(ResourceClass.fromObject(new PictureThat(), paramConverterProviders, customizer)));
+        assertThat(findResourceMethod(rm, Method.POST, "pictures", emptyList(), null).resourceMethod.methodHandle.getName(), equalTo("text"));
+    }
+
     private static String nameOf(RequestMatcher rm, List<MediaType> acceptHeaders, String requestBodyContentType) throws NotMatchedException {
-        return findResourceMethod(rm, Method.GET, "pictures", acceptHeaders, requestBodyContentType).resourceMethod.methodHandle.getName();
+        return nameOf(rm, acceptHeaders, requestBodyContentType, requestBodyContentType != null);
+    }
+
+    private static String nameOf(RequestMatcher rm, List<MediaType> acceptHeaders, String requestBodyContentType, boolean requestHasEntity) throws NotMatchedException {
+        return findResourceMethod(rm, Method.GET, "pictures", acceptHeaders, requestBodyContentType, requestHasEntity).resourceMethod.methodHandle.getName();
     }
 
     private static void assertNotAcceptable(RequestMatcher rm, List<MediaType> acceptHeaders, String requestBodyContentType) {
@@ -355,6 +375,10 @@ public class RequestMatcherTest {
     }
 
     private static RequestMatcher.MatchedMethod findResourceMethod(RequestMatcher rm, Method method, String path, List<MediaType> acceptHeaders, String contentBodyType) throws NotMatchedException {
+        return findResourceMethod(rm, method, path, acceptHeaders, contentBodyType, contentBodyType != null);
+    }
+
+    private static RequestMatcher.MatchedMethod findResourceMethod(RequestMatcher rm, Method method, String path, List<MediaType> acceptHeaders, String contentBodyType, boolean requestHasEntity) throws NotMatchedException {
         NotImplementedMuRequest request = new NotImplementedMuRequest() {
             @Override
             public URI uri() {
@@ -377,6 +401,9 @@ public class RequestMatcherTest {
                 if (contentBodyType != null) {
                     entries.put(HttpHeaderNames.CONTENT_TYPE.toString(), contentBodyType);
                 }
+                if (requestHasEntity) {
+                    entries.put(HttpHeaderNames.CONTENT_LENGTH.toString(), "5");
+                }
                 return HeadersFactory.create(entries);
             }
 
@@ -385,7 +412,7 @@ public class RequestMatcherTest {
                 return emptyList();
             }
         };
-        InputStream inputStream = contentBodyType == null ? null : new ByteArrayInputStream("Hello".getBytes(StandardCharsets.US_ASCII));
+        InputStream inputStream = requestHasEntity ? new ByteArrayInputStream("Hello".getBytes(StandardCharsets.US_ASCII)) : null;
         JaxRSRequest rc = new JaxRSRequest(request, null, inputStream, request.uri().getPath(), null, emptyList(), null);
         return rm.findResourceMethod(rc, method, acceptHeaders, null);
     }

--- a/src/test/java/io/muserver/rest/RequestMatcherTest.java
+++ b/src/test/java/io/muserver/rest/RequestMatcherTest.java
@@ -355,6 +355,33 @@ public class RequestMatcherTest {
         assertThat(findResourceMethod(rm, Method.POST, "pictures", emptyList(), null).resourceMethod.methodHandle.getName(), equalTo("text"));
     }
 
+    @Test
+    public void bodylessRequestsRankConcreteConsumesAheadOfWildcards() throws NotMatchedException {
+        @Path("pictures")
+        class PictureThat {
+
+            @POST
+            @Consumes("text/plain")
+            public String concrete() {
+                return "concrete";
+            }
+
+            @POST
+            @Consumes("text/*")
+            public String typeWildcard() {
+                return "type wildcard";
+            }
+
+            @POST
+            public String wildcard() {
+                return "wildcard";
+            }
+        }
+
+        RequestMatcher rm = new RequestMatcher(singletonList(ResourceClass.fromObject(new PictureThat(), paramConverterProviders, customizer)));
+        assertThat(findResourceMethod(rm, Method.POST, "pictures", emptyList(), null).resourceMethod.methodHandle.getName(), equalTo("concrete"));
+    }
+
     private static String nameOf(RequestMatcher rm, List<MediaType> acceptHeaders, String requestBodyContentType) throws NotMatchedException {
         return nameOf(rm, acceptHeaders, requestBodyContentType, requestBodyContentType != null);
     }


### PR DESCRIPTION
## Summary

- treat a missing request `Content-Type` as `*/*` during resource-method `@Consumes` selection
- rank eligible candidates by `@Consumes` specificity, preferring concrete media types over wildcards
- retain the `application/octet-stream` fallback later if the selected method actually reads an untyped entity
- add focused no-body, untyped-entity, and concrete-over-wildcard regressions

## TCK intent and master failure

The affected tests cover requests without `Content-Type`. Most are bodyless. The remaining subclass test sends `pqr=hello` only to prove that an inherited `@FormParam` is ignored; the selected subclass method does not consume the entity.

Master converted the missing header to synthetic `-/-`, rejected every explicitly typed `@Consumes` method, and returned 415 before invocation. Jersey's routing accepts a null request media type for every `@Consumes` value and ranks it as wildcard. Its entity-reading phase separately defaults a missing type to `application/octet-stream`, matching Jakarta REST's message-body-reader rule.

This PR makes the same routing/entity-reading distinction. Explicit `Content-Type` continues to filter normally.

## Validation

- Java 11 `RequestMatcherTest`: 17/17 passed
- Java 11 affected TCK cluster (`produceconsume`, `spec/resource/requestmatching`, `spec/resource/annotationprecedence/subclass`): 72/72 passed
- `produceconsume`: 20/20 (baseline 17/20)
- `spec/resource/requestmatching`: 40/40 (baseline 35/40)
- `spec/resource/annotationprecedence/subclass`: 12/12 (baseline 6/12)
- `git diff --check`
