### PR TITLE
Preserve generic return type for entity writers

### DIFF
--- a/src/main/java/io/muserver/rest/EntityProviders.java
+++ b/src/main/java/io/muserver/rest/EntityProviders.java
@@ -59,7 +59,7 @@ class EntityProviders {
                 // 4. Sort the selected MessageBodyWriter providers with a primary key of generic type where providers whose generic
                 // type is the nearest superclass of the object class are sorted first
 
-                int typeCompare = ProviderWrapper.compareTo(o1, o2, genericType);
+                int typeCompare = ProviderWrapper.compareTo(o1, o2, type);
                 if (typeCompare != 0) {
                     return typeCompare;
                 }

--- a/src/main/java/io/muserver/rest/GenericTypeResolver.java
+++ b/src/main/java/io/muserver/rest/GenericTypeResolver.java
@@ -1,0 +1,219 @@
+package io.muserver.rest;
+
+import java.lang.reflect.GenericArrayType;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.lang.reflect.TypeVariable;
+import java.lang.reflect.WildcardType;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+final class GenericTypeResolver {
+
+    private GenericTypeResolver() { }
+
+    static Type resolve(Type type, Class<?> concreteClass, Class<?> declaringClass) {
+        Map<TypeVariable<?>, Type> typeArguments = new HashMap<>();
+        if (!findTypeArguments(concreteClass, declaringClass, new HashMap<>(), typeArguments)) {
+            return type;
+        }
+        return resolve(type, typeArguments);
+    }
+
+    private static boolean findTypeArguments(Type currentType, Class<?> declaringClass,
+                                             Map<TypeVariable<?>, Type> inheritedArguments,
+                                             Map<TypeVariable<?>, Type> result) {
+        Class<?> currentClass = rawClass(currentType);
+        if (currentClass == null) {
+            return false;
+        }
+
+        Map<TypeVariable<?>, Type> currentArguments = new HashMap<>(inheritedArguments);
+        if (currentType instanceof ParameterizedType) {
+            TypeVariable<?>[] variables = currentClass.getTypeParameters();
+            Type[] arguments = ((ParameterizedType) currentType).getActualTypeArguments();
+            for (int i = 0; i < variables.length; i++) {
+                currentArguments.put(variables[i], resolve(arguments[i], inheritedArguments));
+            }
+        }
+
+        if (currentClass.equals(declaringClass)) {
+            result.putAll(currentArguments);
+            return true;
+        }
+
+        Type genericSuperclass = currentClass.getGenericSuperclass();
+        if (isOnPath(genericSuperclass, declaringClass)
+            && findTypeArguments(genericSuperclass, declaringClass, currentArguments, result)) {
+            return true;
+        }
+        for (Type genericInterface : currentClass.getGenericInterfaces()) {
+            if (isOnPath(genericInterface, declaringClass)
+                && findTypeArguments(genericInterface, declaringClass, currentArguments, result)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static boolean isOnPath(Type candidate, Class<?> declaringClass) {
+        Class<?> candidateClass = rawClass(candidate);
+        return candidateClass != null && declaringClass.isAssignableFrom(candidateClass);
+    }
+
+    private static Class<?> rawClass(Type type) {
+        if (type instanceof Class) {
+            return (Class<?>) type;
+        }
+        if (type instanceof ParameterizedType && ((ParameterizedType) type).getRawType() instanceof Class) {
+            return (Class<?>) ((ParameterizedType) type).getRawType();
+        }
+        return null;
+    }
+
+    private static Type resolve(Type type, Map<TypeVariable<?>, Type> typeArguments) {
+        if (type instanceof TypeVariable) {
+            Type resolved = typeArguments.get(type);
+            return resolved == null || resolved.equals(type) ? type : resolve(resolved, typeArguments);
+        }
+        if (type instanceof ParameterizedType) {
+            ParameterizedType parameterizedType = (ParameterizedType) type;
+            Type owner = parameterizedType.getOwnerType();
+            Type resolvedOwner = owner == null ? null : resolve(owner, typeArguments);
+            Type[] arguments = parameterizedType.getActualTypeArguments();
+            Type[] resolvedArguments = resolve(arguments, typeArguments);
+            if (resolvedOwner == owner && Arrays.equals(arguments, resolvedArguments)) {
+                return type;
+            }
+            return new ResolvedParameterizedType(resolvedOwner, parameterizedType.getRawType(), resolvedArguments);
+        }
+        if (type instanceof GenericArrayType) {
+            GenericArrayType arrayType = (GenericArrayType) type;
+            Type component = resolve(arrayType.getGenericComponentType(), typeArguments);
+            return component.equals(arrayType.getGenericComponentType()) ? type : new ResolvedGenericArrayType(component);
+        }
+        if (type instanceof WildcardType) {
+            WildcardType wildcardType = (WildcardType) type;
+            Type[] upperBounds = resolve(wildcardType.getUpperBounds(), typeArguments);
+            Type[] lowerBounds = resolve(wildcardType.getLowerBounds(), typeArguments);
+            if (Arrays.equals(upperBounds, wildcardType.getUpperBounds())
+                && Arrays.equals(lowerBounds, wildcardType.getLowerBounds())) {
+                return type;
+            }
+            return new ResolvedWildcardType(upperBounds, lowerBounds);
+        }
+        return type;
+    }
+
+    private static Type[] resolve(Type[] types, Map<TypeVariable<?>, Type> typeArguments) {
+        Type[] resolved = types.clone();
+        for (int i = 0; i < resolved.length; i++) {
+            resolved[i] = resolve(resolved[i], typeArguments);
+        }
+        return resolved;
+    }
+
+    private static final class ResolvedParameterizedType implements ParameterizedType {
+        private final Type owner;
+        private final Type rawType;
+        private final Type[] arguments;
+
+        private ResolvedParameterizedType(Type owner, Type rawType, Type[] arguments) {
+            this.owner = owner;
+            this.rawType = rawType;
+            this.arguments = arguments.clone();
+        }
+
+        @Override
+        public Type[] getActualTypeArguments() {
+            return arguments.clone();
+        }
+
+        @Override
+        public Type getRawType() {
+            return rawType;
+        }
+
+        @Override
+        public Type getOwnerType() {
+            return owner;
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            if (!(other instanceof ParameterizedType)) {
+                return false;
+            }
+            ParameterizedType that = (ParameterizedType) other;
+            return Objects.equals(owner, that.getOwnerType())
+                && Objects.equals(rawType, that.getRawType())
+                && Arrays.equals(arguments, that.getActualTypeArguments());
+        }
+
+        @Override
+        public int hashCode() {
+            return Arrays.hashCode(arguments) ^ Objects.hashCode(owner) ^ Objects.hashCode(rawType);
+        }
+    }
+
+    private static final class ResolvedGenericArrayType implements GenericArrayType {
+        private final Type componentType;
+
+        private ResolvedGenericArrayType(Type componentType) {
+            this.componentType = componentType;
+        }
+
+        @Override
+        public Type getGenericComponentType() {
+            return componentType;
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            return other instanceof GenericArrayType
+                && componentType.equals(((GenericArrayType) other).getGenericComponentType());
+        }
+
+        @Override
+        public int hashCode() {
+            return componentType.hashCode();
+        }
+    }
+
+    private static final class ResolvedWildcardType implements WildcardType {
+        private final Type[] upperBounds;
+        private final Type[] lowerBounds;
+
+        private ResolvedWildcardType(Type[] upperBounds, Type[] lowerBounds) {
+            this.upperBounds = upperBounds.clone();
+            this.lowerBounds = lowerBounds.clone();
+        }
+
+        @Override
+        public Type[] getUpperBounds() {
+            return upperBounds.clone();
+        }
+
+        @Override
+        public Type[] getLowerBounds() {
+            return lowerBounds.clone();
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            if (!(other instanceof WildcardType)) {
+                return false;
+            }
+            WildcardType that = (WildcardType) other;
+            return Arrays.equals(upperBounds, that.getUpperBounds())
+                && Arrays.equals(lowerBounds, that.getLowerBounds());
+        }
+
+        @Override
+        public int hashCode() {
+            return Arrays.hashCode(upperBounds) ^ Arrays.hashCode(lowerBounds);
+        }
+    }
+}

--- a/src/main/java/io/muserver/rest/GenericTypeResolver.java
+++ b/src/main/java/io/muserver/rest/GenericTypeResolver.java
@@ -30,7 +30,30 @@ final class GenericTypeResolver {
             return null;
         }
         Type resolved = resolve(typeVariable, typeArguments);
-        return resolved.equals(typeVariable) ? null : resolved;
+        return containsTypeVariable(resolved) ? null : resolved;
+    }
+
+    private static boolean containsTypeVariable(Type type) {
+        if (type instanceof TypeVariable) {
+            return true;
+        }
+        if (type instanceof ParameterizedType) {
+            ParameterizedType parameterizedType = (ParameterizedType) type;
+            if (parameterizedType.getOwnerType() != null && containsTypeVariable(parameterizedType.getOwnerType())) {
+                return true;
+            }
+            return Arrays.stream(parameterizedType.getActualTypeArguments())
+                .anyMatch(GenericTypeResolver::containsTypeVariable);
+        }
+        if (type instanceof GenericArrayType) {
+            return containsTypeVariable(((GenericArrayType) type).getGenericComponentType());
+        }
+        if (type instanceof WildcardType) {
+            WildcardType wildcardType = (WildcardType) type;
+            return Arrays.stream(wildcardType.getUpperBounds()).anyMatch(GenericTypeResolver::containsTypeVariable)
+                || Arrays.stream(wildcardType.getLowerBounds()).anyMatch(GenericTypeResolver::containsTypeVariable);
+        }
+        return false;
     }
 
     private static boolean findTypeArguments(Type currentType, Class<?> declaringClass,

--- a/src/main/java/io/muserver/rest/GenericTypeResolver.java
+++ b/src/main/java/io/muserver/rest/GenericTypeResolver.java
@@ -1,5 +1,7 @@
 package io.muserver.rest;
 
+import org.jspecify.annotations.Nullable;
+
 import java.lang.reflect.Array;
 import java.lang.reflect.GenericArrayType;
 import java.lang.reflect.ParameterizedType;
@@ -23,14 +25,21 @@ final class GenericTypeResolver {
         return resolve(type, typeArguments);
     }
 
-    static Type resolveTypeArgument(Type type, Class<?> targetClass, int argumentIndex) {
+    static @Nullable Type resolveConcrete(Type type, Class<?> concreteClass, Class<?> declaringClass) {
+        return concreteTypeOrNull(resolve(type, concreteClass, declaringClass));
+    }
+
+    static @Nullable Type resolveTypeArgument(Type type, Class<?> targetClass, int argumentIndex) {
         TypeVariable<?> typeVariable = targetClass.getTypeParameters()[argumentIndex];
         Map<TypeVariable<?>, Type> typeArguments = new HashMap<>();
         if (!findTypeArguments(type, targetClass, new HashMap<>(), typeArguments)) {
             return null;
         }
-        Type resolved = resolve(typeVariable, typeArguments);
-        return containsTypeVariable(resolved) ? null : resolved;
+        return concreteTypeOrNull(resolve(typeVariable, typeArguments));
+    }
+
+    private static @Nullable Type concreteTypeOrNull(Type type) {
+        return containsTypeVariable(type) ? null : type;
     }
 
     private static boolean containsTypeVariable(Type type) {

--- a/src/main/java/io/muserver/rest/GenericTypeResolver.java
+++ b/src/main/java/io/muserver/rest/GenericTypeResolver.java
@@ -23,6 +23,16 @@ final class GenericTypeResolver {
         return resolve(type, typeArguments);
     }
 
+    static Type resolveTypeArgument(Type type, Class<?> targetClass, int argumentIndex) {
+        TypeVariable<?> typeVariable = targetClass.getTypeParameters()[argumentIndex];
+        Map<TypeVariable<?>, Type> typeArguments = new HashMap<>();
+        if (!findTypeArguments(type, targetClass, new HashMap<>(), typeArguments)) {
+            return null;
+        }
+        Type resolved = resolve(typeVariable, typeArguments);
+        return resolved.equals(typeVariable) ? null : resolved;
+    }
+
     private static boolean findTypeArguments(Type currentType, Class<?> declaringClass,
                                              Map<TypeVariable<?>, Type> inheritedArguments,
                                              Map<TypeVariable<?>, Type> result) {
@@ -64,7 +74,7 @@ final class GenericTypeResolver {
         return candidateClass != null && declaringClass.isAssignableFrom(candidateClass);
     }
 
-    private static Class<?> rawClass(Type type) {
+    static Class<?> rawClass(Type type) {
         if (type instanceof Class) {
             return (Class<?>) type;
         }

--- a/src/main/java/io/muserver/rest/GenericTypeResolver.java
+++ b/src/main/java/io/muserver/rest/GenericTypeResolver.java
@@ -1,5 +1,6 @@
 package io.muserver.rest;
 
+import java.lang.reflect.Array;
 import java.lang.reflect.GenericArrayType;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
@@ -92,6 +93,9 @@ final class GenericTypeResolver {
         if (type instanceof GenericArrayType) {
             GenericArrayType arrayType = (GenericArrayType) type;
             Type component = resolve(arrayType.getGenericComponentType(), typeArguments);
+            if (component instanceof Class) {
+                return Array.newInstance((Class<?>) component, 0).getClass();
+            }
             return component.equals(arrayType.getGenericComponentType()) ? type : new ResolvedGenericArrayType(component);
         }
         if (type instanceof WildcardType) {
@@ -156,6 +160,40 @@ final class GenericTypeResolver {
         public int hashCode() {
             return Arrays.hashCode(arguments) ^ Objects.hashCode(owner) ^ Objects.hashCode(rawType);
         }
+
+        @Override
+        public String getTypeName() {
+            return toString();
+        }
+
+        @Override
+        public String toString() {
+            StringBuilder name = new StringBuilder();
+            if (owner == null) {
+                name.append(rawType.getTypeName());
+            } else {
+                name.append(owner.getTypeName()).append('$');
+                String rawName = rawType.getTypeName();
+                Type ownerRawType = owner instanceof ParameterizedType
+                    ? ((ParameterizedType) owner).getRawType()
+                    : owner;
+                String ownerRawName = ownerRawType.getTypeName();
+                name.append(rawName.startsWith(ownerRawName + '$')
+                    ? rawName.substring(ownerRawName.length() + 1)
+                    : rawName);
+            }
+            if (arguments.length > 0) {
+                name.append('<');
+                for (int i = 0; i < arguments.length; i++) {
+                    if (i > 0) {
+                        name.append(", ");
+                    }
+                    name.append(arguments[i].getTypeName());
+                }
+                name.append('>');
+            }
+            return name.toString();
+        }
     }
 
     private static final class ResolvedGenericArrayType implements GenericArrayType {
@@ -179,6 +217,16 @@ final class GenericTypeResolver {
         @Override
         public int hashCode() {
             return componentType.hashCode();
+        }
+
+        @Override
+        public String getTypeName() {
+            return componentType.getTypeName() + "[]";
+        }
+
+        @Override
+        public String toString() {
+            return getTypeName();
         }
     }
 
@@ -214,6 +262,33 @@ final class GenericTypeResolver {
         @Override
         public int hashCode() {
             return Arrays.hashCode(upperBounds) ^ Arrays.hashCode(lowerBounds);
+        }
+
+        @Override
+        public String getTypeName() {
+            return toString();
+        }
+
+        @Override
+        public String toString() {
+            if (lowerBounds.length > 0) {
+                return "? super " + boundsTypeName(lowerBounds);
+            }
+            if (upperBounds.length == 0 || upperBounds[0].equals(Object.class)) {
+                return "?";
+            }
+            return "? extends " + boundsTypeName(upperBounds);
+        }
+
+        private static String boundsTypeName(Type[] bounds) {
+            StringBuilder name = new StringBuilder();
+            for (int i = 0; i < bounds.length; i++) {
+                if (i > 0) {
+                    name.append(" & ");
+                }
+                name.append(bounds[i].getTypeName());
+            }
+            return name.toString();
         }
     }
 }

--- a/src/main/java/io/muserver/rest/JaxMethodLocator.java
+++ b/src/main/java/io/muserver/rest/JaxMethodLocator.java
@@ -1,6 +1,7 @@
 package io.muserver.rest;
 
 import java.lang.reflect.Method;
+import java.lang.reflect.Type;
 
 import org.jspecify.annotations.Nullable;
 
@@ -9,9 +10,13 @@ import org.jspecify.annotations.Nullable;
  */
 class JaxMethodLocator {
     static Method getMethodThatHasJaxRSAnnotations(Method start) {
+        return getMethodThatHasJaxRSAnnotations(start, start.getDeclaringClass());
+    }
+
+    static Method getMethodThatHasJaxRSAnnotations(Method start, Class<?> concreteClass) {
         Class<?> clazz = start.getDeclaringClass();
         while (clazz != Object.class && clazz != null) {
-            Method cur = getMethodIfGood(start, clazz);
+            Method cur = getMethodIfGood(start, clazz, concreteClass);
             if (cur != null) {
                 return cur;
             }
@@ -20,7 +25,7 @@ class JaxMethodLocator {
         clazz = start.getDeclaringClass();
         while (clazz != Object.class && clazz != null) {
             for (Class<?> interfaceClass : clazz.getInterfaces()) {
-                Method cur = getMethodIfGood(start, interfaceClass);
+                Method cur = getMethodIfGood(start, interfaceClass, concreteClass);
                 if (cur != null) {
                     return cur;
                 }
@@ -30,7 +35,7 @@ class JaxMethodLocator {
         return start;
     }
 
-    private static @Nullable Method getMethodIfGood(Method start, Class<?> clazz) {
+    private static @Nullable Method getMethodIfGood(Method start, Class<?> clazz, Class<?> concreteClass) {
         try {
             Method cur = clazz.getDeclaredMethod(start.getName(), start.getParameterTypes());
             if (JaxClassLocator.hasAtLeastOneJaxRSAnnotation(cur.getDeclaredAnnotations())) {
@@ -39,8 +44,29 @@ class JaxMethodLocator {
         } catch (NoSuchMethodException e) {
             // try parent
         }
+        for (Method candidate : clazz.getDeclaredMethods()) {
+            if (hasMatchingResolvedParameters(start, candidate, concreteClass)
+                && JaxClassLocator.hasAtLeastOneJaxRSAnnotation(candidate.getDeclaredAnnotations())) {
+                return candidate;
+            }
+        }
         return null;
     }
 
+    private static boolean hasMatchingResolvedParameters(Method start, Method candidate, Class<?> concreteClass) {
+        if (!candidate.getName().equals(start.getName()) || candidate.getParameterCount() != start.getParameterCount()) {
+            return false;
+        }
+        Type[] startParameters = start.getGenericParameterTypes();
+        Type[] candidateParameters = candidate.getGenericParameterTypes();
+        for (int i = 0; i < startParameters.length; i++) {
+            Type resolvedStart = GenericTypeResolver.resolve(startParameters[i], concreteClass, start.getDeclaringClass());
+            Type resolvedCandidate = GenericTypeResolver.resolve(candidateParameters[i], concreteClass, candidate.getDeclaringClass());
+            if (!resolvedStart.equals(resolvedCandidate)) {
+                return false;
+            }
+        }
+        return true;
+    }
 
 }

--- a/src/main/java/io/muserver/rest/JaxMethodLocator.java
+++ b/src/main/java/io/muserver/rest/JaxMethodLocator.java
@@ -1,5 +1,9 @@
 package io.muserver.rest;
 
+import jakarta.ws.rs.HttpMethod;
+import jakarta.ws.rs.NameBinding;
+
+import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.lang.reflect.Type;
 
@@ -14,43 +18,73 @@ class JaxMethodLocator {
     }
 
     static Method getMethodThatHasJaxRSAnnotations(Method start, Class<?> concreteClass) {
-        Class<?> clazz = start.getDeclaringClass();
-        while (clazz != Object.class && clazz != null) {
-            Method cur = getMethodIfGood(start, clazz, concreteClass);
-            if (cur != null) {
-                return cur;
-            }
-            clazz = clazz.getSuperclass();
-        }
-        clazz = start.getDeclaringClass();
-        while (clazz != Object.class && clazz != null) {
-            for (Class<?> interfaceClass : clazz.getInterfaces()) {
-                Method cur = getMethodIfGood(start, interfaceClass, concreteClass);
-                if (cur != null) {
-                    return cur;
-                }
-            }
-            clazz = clazz.getSuperclass();
-        }
-        return start;
+        Method annotated = findAnnotatedMethod(start, concreteClass, concreteClass);
+        return annotated == null ? start : annotated;
     }
 
-    private static @Nullable Method getMethodIfGood(Method start, Class<?> clazz, Class<?> concreteClass) {
+    private static @Nullable Method findAnnotatedMethod(Method start, Class<?> clazz, Class<?> concreteClass) {
+        if (clazz == null || clazz == Object.class) {
+            return null;
+        }
+        Method declared = findAnnotatedMethodOnClass(start, clazz, concreteClass);
+        if (declared != null) {
+            return declared;
+        }
+        Method inherited = findAnnotatedMethod(start, clazz.getSuperclass(), concreteClass);
+        if (inherited != null) {
+            return inherited;
+        }
+        for (Class<?> interfaceClass : clazz.getInterfaces()) {
+            inherited = findAnnotatedMethod(start, interfaceClass, concreteClass);
+            if (inherited != null) {
+                return inherited;
+            }
+        }
+        return null;
+    }
+
+    private static @Nullable Method findAnnotatedMethodOnClass(Method start, Class<?> clazz, Class<?> concreteClass) {
         try {
             Method cur = clazz.getDeclaredMethod(start.getName(), start.getParameterTypes());
-            if (JaxClassLocator.hasAtLeastOneJaxRSAnnotation(cur.getDeclaredAnnotations())) {
+            if (hasJaxRsAnnotations(cur)) {
                 return cur;
             }
         } catch (NoSuchMethodException e) {
             // try parent
         }
         for (Method candidate : clazz.getDeclaredMethods()) {
-            if (hasMatchingResolvedParameters(start, candidate, concreteClass)
-                && JaxClassLocator.hasAtLeastOneJaxRSAnnotation(candidate.getDeclaredAnnotations())) {
+            if (!candidate.isBridge()
+                && hasMatchingResolvedParameters(start, candidate, concreteClass)
+                && hasJaxRsAnnotations(candidate)) {
                 return candidate;
             }
         }
         return null;
+    }
+
+    private static boolean hasJaxRsAnnotations(Method method) {
+        for (Annotation annotation : method.getDeclaredAnnotations()) {
+            if (isJaxRsAnnotation(annotation)) {
+                return true;
+            }
+        }
+        for (Annotation[] annotations : method.getParameterAnnotations()) {
+            for (Annotation annotation : annotations) {
+                if (isJaxRsAnnotation(annotation)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    private static boolean isJaxRsAnnotation(Annotation annotation) {
+        Class<? extends Annotation> type = annotation.annotationType();
+        Package annotationPackage = type.getPackage();
+        String packageName = annotationPackage == null ? "" : annotationPackage.getName();
+        return (packageName.equals("jakarta.ws.rs") || packageName.startsWith("jakarta.ws.rs."))
+            || type.isAnnotationPresent(HttpMethod.class)
+            || type.isAnnotationPresent(NameBinding.class);
     }
 
     private static boolean hasMatchingResolvedParameters(Method start, Method candidate, Class<?> concreteClass) {

--- a/src/main/java/io/muserver/rest/JaxMethodLocator.java
+++ b/src/main/java/io/muserver/rest/JaxMethodLocator.java
@@ -30,6 +30,9 @@ class JaxMethodLocator {
         if (declared != null) {
             return declared;
         }
+        // Keep the class hierarchy ahead of directly implemented interfaces. If both eventual
+        // annotation sources are interfaces, JAX-RS leaves their precedence implementation-specific;
+        // this ordering also keeps an inherited method's existing annotation source stable.
         Method inherited = findAnnotatedMethod(start, clazz.getSuperclass(), concreteClass);
         if (inherited != null) {
             return inherited;

--- a/src/main/java/io/muserver/rest/ObjWithType.java
+++ b/src/main/java/io/muserver/rest/ObjWithType.java
@@ -33,6 +33,10 @@ class ObjWithType {
     }
 
     static ObjWithType objType(Object valueFromMethod) {
+        return objType(valueFromMethod, null);
+    }
+
+    static ObjWithType objType(Object valueFromMethod, Type resourceMethodReturnType) {
         if (valueFromMethod == null) {
             return EMPTY;
         }
@@ -54,7 +58,7 @@ class ObjWithType {
             genericType = ge.getType();
         } else {
             type = entity == null ? null : entity.getClass();
-            genericType = type;
+            genericType = response == null && resourceMethodReturnType != null ? resourceMethodReturnType : type;
         }
         return new ObjWithType(type, genericType, response, entity);
     }

--- a/src/main/java/io/muserver/rest/ProviderWrapper.java
+++ b/src/main/java/io/muserver/rest/ProviderWrapper.java
@@ -88,13 +88,19 @@ class ProviderWrapper<T> implements Comparable<ProviderWrapper<T>> {
         Class o1C = (Class) o1.genericType;
         Class o2C = (Class) o2.genericType;
         Class oC = (Class) genericType;
-        boolean o1Is = oC.isAssignableFrom(o1C);
-        boolean o2Is = oC.isAssignableFrom(o2C);
+        boolean o1Is = o1C.isAssignableFrom(oC);
+        boolean o2Is = o2C.isAssignableFrom(oC);
         int assignCompare = Boolean.compare(o2Is, o1Is);
         if (assignCompare != 0) {
             return assignCompare;
         }
-        return o1C.isAssignableFrom(o2C) ? -1 : 1;
+        if (o1C.isAssignableFrom(o2C)) {
+            return o1Is ? 1 : -1;
+        }
+        if (o2C.isAssignableFrom(o1C)) {
+            return o1Is ? -1 : 1;
+        }
+        return 0;
     }
 
     @Override

--- a/src/main/java/io/muserver/rest/ResourceClass.java
+++ b/src/main/java/io/muserver/rest/ResourceClass.java
@@ -74,6 +74,9 @@ class ResourceClass {
         List<ResourceMethod> resourceMethods = new ArrayList<>();
         java.lang.reflect.Method[] methods = this.resourceClass.getMethods();
         for (java.lang.reflect.Method restMethod : methods) {
+            if (restMethod.isBridge()) {
+                continue;
+            }
             java.lang.reflect.Method annotationSource = JaxMethodLocator.getMethodThatHasJaxRSAnnotations(restMethod);
             Method httpMethod = ResourceMethod.getMuMethod(annotationSource);
             restMethod.setAccessible(true);

--- a/src/main/java/io/muserver/rest/ResourceClass.java
+++ b/src/main/java/io/muserver/rest/ResourceClass.java
@@ -26,7 +26,7 @@ import static java.util.stream.Collectors.toList;
 class ResourceClass {
 
     final UriPattern pathPattern;
-    private final Class<?> resourceClass;
+    final Class<?> resourceClass;
     final Object resourceInstance;
     final List<MediaType> produces;
     final List<MediaType> consumes;

--- a/src/main/java/io/muserver/rest/ResourceClass.java
+++ b/src/main/java/io/muserver/rest/ResourceClass.java
@@ -96,7 +96,7 @@ class ResourceClass {
             Parameter[] annotationParameters = annotationSource.getParameters();
             Parameter[] methodParameters = restMethod.getParameters();
             for (int i = 0; i < annotationParameters.length; i++) {
-                ResourceMethodParam resourceMethodParam = ResourceMethodParam.fromParameter(i, methodParameters[i], annotationParameters[i], paramConverterProviders, methodPattern);
+                ResourceMethodParam resourceMethodParam = ResourceMethodParam.fromParameter(i, methodParameters[i], annotationParameters[i], resourceClass, paramConverterProviders, methodPattern);
                 params.add(resourceMethodParam);
             }
             DescriptionData descriptionData = DescriptionData.fromAnnotation(restMethod, null);

--- a/src/main/java/io/muserver/rest/ResourceClass.java
+++ b/src/main/java/io/muserver/rest/ResourceClass.java
@@ -77,7 +77,7 @@ class ResourceClass {
             if (restMethod.isBridge()) {
                 continue;
             }
-            java.lang.reflect.Method annotationSource = JaxMethodLocator.getMethodThatHasJaxRSAnnotations(restMethod);
+            java.lang.reflect.Method annotationSource = JaxMethodLocator.getMethodThatHasJaxRSAnnotations(restMethod, resourceClass);
             Method httpMethod = ResourceMethod.getMuMethod(annotationSource);
             restMethod.setAccessible(true);
             Path methodPath = annotationSource.getAnnotation(Path.class);
@@ -93,10 +93,10 @@ class ResourceClass {
             List<MediaType> methodProduces = MediaTypeDeterminer.supportedProducesTypes(annotationSource);
             List<MediaType> methodConsumes = MediaTypeDeterminer.supportedConsumesTypes(annotationSource);
             List<ResourceMethodParam> params = new ArrayList<>();
-            Parameter[] parameters = annotationSource.getParameters();
-            for (int i = 0; i < parameters.length; i++) {
-                Parameter p = parameters[i];
-                ResourceMethodParam resourceMethodParam = ResourceMethodParam.fromParameter(i, p, paramConverterProviders, methodPattern);
+            Parameter[] annotationParameters = annotationSource.getParameters();
+            Parameter[] methodParameters = restMethod.getParameters();
+            for (int i = 0; i < annotationParameters.length; i++) {
+                ResourceMethodParam resourceMethodParam = ResourceMethodParam.fromParameter(i, methodParameters[i], annotationParameters[i], paramConverterProviders, methodPattern);
                 params.add(resourceMethodParam);
             }
             DescriptionData descriptionData = DescriptionData.fromAnnotation(restMethod, null);

--- a/src/main/java/io/muserver/rest/ResourceMethod.java
+++ b/src/main/java/io/muserver/rest/ResourceMethod.java
@@ -28,6 +28,7 @@ class ResourceMethod {
     final ResourceClass resourceClass;
     final UriPattern pathPattern;
     final java.lang.reflect.Method methodHandle;
+    final Type genericReturnType;
     final Method httpMethod;
     final String pathTemplate;
     final List<MediaType> effectiveConsumes;
@@ -45,6 +46,8 @@ class ResourceMethod {
         this.resourceClass = resourceClass;
         this.pathPattern = pathPattern;
         this.methodHandle = methodHandle;
+        this.genericReturnType = GenericTypeResolver.resolve(methodHandle.getGenericReturnType(),
+            resourceClass.resourceClass, methodHandle.getDeclaringClass());
         this.params = params;
         this.httpMethod = httpMethod;
         this.pathTemplate = pathTemplate;

--- a/src/main/java/io/muserver/rest/ResourceMethod.java
+++ b/src/main/java/io/muserver/rest/ResourceMethod.java
@@ -153,8 +153,8 @@ class ResourceMethod {
             .filter(p -> p instanceof ResourceMethodParam.MessageBodyParam)
             .map(ResourceMethodParam.MessageBodyParam.class::cast)
             .map(messageBodyParam -> {
-                Class<?> bodyType = messageBodyParam.parameterHandle.getType();
-                Type bodyParameterizedType = messageBodyParam.parameterHandle.getParameterizedType();
+                Class<?> bodyType = messageBodyParam.type;
+                Type bodyParameterizedType = messageBodyParam.genericType;
                 SchemaReference schemaReference = SchemaReference.find(customSchemas, bodyType, bodyParameterizedType);
                 SchemaObjectBuilder builder = schemaReference != null ? schemaReference.schema.toBuilder() :
                     schemaObjectFrom(bodyType, bodyParameterizedType, messageBodyParam.isRequired)
@@ -197,8 +197,8 @@ class ResourceMethod {
                                                     if (n.isRequired) {
                                                         required.add(n.key);
                                                     }
-                                                    Class<?> paramType = n.parameterHandle.getType();
-                                                    Type paramParameterizedType = n.parameterHandle.getParameterizedType();
+                                                    Class<?> paramType = n.type;
+                                                    Type paramParameterizedType = n.genericType;
 
                                                     SchemaReference schemaReference = SchemaReference.find(customSchemas, paramType, paramParameterizedType);
                                                     SchemaObjectBuilder schemaObjectBuilder = schemaReference != null ? schemaReference.schema.toBuilder() : schemaObjectFrom(paramType, paramParameterizedType, n.isRequired);

--- a/src/main/java/io/muserver/rest/ResourceMethod.java
+++ b/src/main/java/io/muserver/rest/ResourceMethod.java
@@ -4,6 +4,7 @@ import io.muserver.Method;
 import io.muserver.openapi.*;
 import jakarta.ws.rs.HttpMethod;
 import jakarta.ws.rs.core.MediaType;
+import org.jspecify.annotations.Nullable;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.InvocationTargetException;
@@ -28,7 +29,7 @@ class ResourceMethod {
     final ResourceClass resourceClass;
     final UriPattern pathPattern;
     final java.lang.reflect.Method methodHandle;
-    final Type genericReturnType;
+    final @Nullable Type genericReturnType;
     final Method httpMethod;
     final String pathTemplate;
     final List<MediaType> effectiveConsumes;
@@ -46,7 +47,7 @@ class ResourceMethod {
         this.resourceClass = resourceClass;
         this.pathPattern = pathPattern;
         this.methodHandle = methodHandle;
-        this.genericReturnType = GenericTypeResolver.resolve(methodHandle.getGenericReturnType(),
+        this.genericReturnType = GenericTypeResolver.resolveConcrete(methodHandle.getGenericReturnType(),
             resourceClass.resourceClass, methodHandle.getDeclaringClass());
         this.params = params;
         this.httpMethod = httpMethod;

--- a/src/main/java/io/muserver/rest/ResourceMethodParam.java
+++ b/src/main/java/io/muserver/rest/ResourceMethodParam.java
@@ -31,51 +31,54 @@ abstract class ResourceMethodParam {
 
     final int index;
     final Parameter parameterHandle;
+    final Class<?> type;
+    final Type genericType;
+    final Annotation[] annotations;
     final ValueSource source;
     final DescriptionData descriptionData;
     final boolean isRequired;
 
-    ResourceMethodParam(int index, ValueSource source, Parameter parameterHandle, DescriptionData descriptionData, boolean isRequired) {
+    ResourceMethodParam(int index, ValueSource source, ResolvedParameter parameter, DescriptionData descriptionData, boolean isRequired) {
         this.index = index;
         this.source = source;
-        this.parameterHandle = parameterHandle;
+        this.parameterHandle = parameter.handle;
+        this.type = parameter.type;
+        this.genericType = parameter.genericType;
+        this.annotations = parameter.annotations;
         this.descriptionData = descriptionData;
         this.isRequired = isRequired;
     }
 
     static ResourceMethodParam fromParameter(int index, Parameter parameterHandle, List<ParamConverterProvider> paramConverterProviders, UriPattern methodPattern) {
-        return fromParameter(index, parameterHandle, parameterHandle, paramConverterProviders, methodPattern);
+        return fromParameter(index, parameterHandle, parameterHandle,
+            parameterHandle.getDeclaringExecutable().getDeclaringClass(), paramConverterProviders, methodPattern);
     }
 
-    static ResourceMethodParam fromParameter(int index, Parameter parameterHandle, Parameter annotationSource, List<ParamConverterProvider> paramConverterProviders, UriPattern methodPattern) {
+    static ResourceMethodParam fromParameter(int index, Parameter parameterHandle, Parameter annotationSource, Class<?> concreteClass,
+                                             List<ParamConverterProvider> paramConverterProviders, UriPattern methodPattern) {
 
+        ResolvedParameter parameter = new ResolvedParameter(parameterHandle, annotationSource, concreteClass);
         Pattern pattern = null;
         ValueSource source = getSource(annotationSource);
         boolean isRequired = source == ValueSource.PATH_PARAM || hasDeclared(annotationSource, Required.class);
         if (source == ValueSource.MESSAGE_BODY) {
             DescriptionData descriptionData = DescriptionData.fromAnnotation(annotationSource, null);
-            return new MessageBodyParam(index, source, parameterHandle, descriptionData, isRequired);
+            return new MessageBodyParam(index, source, parameter, descriptionData, isRequired);
         } else if (source == ValueSource.CONTEXT) {
-            return new ContextParam(index, source, parameterHandle);
+            return new ContextParam(index, source, parameter);
         } else if (source == ValueSource.SUSPENDED) {
-            return new SuspendedParam(index, source, parameterHandle);
+            return new SuspendedParam(index, source, parameter);
         } else {
             boolean encodedRequested = hasDeclared(annotationSource, Encoded.class);
             boolean isDeprecated = hasDeclared(annotationSource, Deprecated.class);
-            ParamConverter<?> converter = getParamConverter(parameterHandle, annotationSource, paramConverterProviders);
+            String key = parameterName(source, annotationSource);
+            ParamConverter<?> converter = getParamConverter(parameter, paramConverterProviders);
             boolean lazyDefaultValue = converter.getClass().getDeclaredAnnotation(ParamConverter.Lazy.class) != null;
             boolean explicitDefault = hasDeclared(annotationSource, DefaultValue.class);
-            Object defaultValue = getDefaultValue(parameterHandle, annotationSource, converter, lazyDefaultValue, source);
+            Object defaultValue = getDefaultValue(parameter, annotationSource, converter, lazyDefaultValue, source, key);
 
-            isRequired |= (!explicitDefault && parameterHandle.getType().isPrimitive());
+            isRequired |= (!explicitDefault && parameter.type.isPrimitive());
 
-            String key = source == ValueSource.COOKIE_PARAM ? annotationSource.getDeclaredAnnotation(CookieParam.class).value()
-                : source == ValueSource.HEADER_PARAM ? annotationSource.getDeclaredAnnotation(HeaderParam.class).value()
-                : source == ValueSource.MATRIX_PARAM ? annotationSource.getDeclaredAnnotation(MatrixParam.class).value()
-                : source == ValueSource.FORM_PARAM ? annotationSource.getDeclaredAnnotation(FormParam.class).value()
-                : source == ValueSource.PATH_PARAM ? annotationSource.getDeclaredAnnotation(PathParam.class).value()
-                : source == ValueSource.QUERY_PARAM ? annotationSource.getDeclaredAnnotation(QueryParam.class).value()
-                : "";
             if (key.length() == 0) {
                 throw new WebApplicationException("No parameter specified for the " + source + " in " + parameterHandle);
             }
@@ -87,8 +90,45 @@ abstract class ResourceMethodParam {
             }
 
             DescriptionData descriptionData = DescriptionData.fromAnnotation(annotationSource, key);
-            return new RequestBasedParam(index, source, parameterHandle, defaultValue, encodedRequested, lazyDefaultValue, converter, descriptionData, key, isDeprecated, isRequired, pattern, explicitDefault);
+            return new RequestBasedParam(index, source, parameter, defaultValue, encodedRequested, lazyDefaultValue, converter, descriptionData, key, isDeprecated, isRequired, pattern, explicitDefault);
         }
+    }
+
+    private static final class ResolvedParameter {
+        private final Parameter handle;
+        private final Class<?> type;
+        private final Type genericType;
+        private final Annotation[] annotations;
+
+        private ResolvedParameter(Parameter handle, Parameter annotationSource, Class<?> concreteClass) {
+            this.handle = handle;
+            this.genericType = GenericTypeResolver.resolve(handle.getParameterizedType(), concreteClass,
+                handle.getDeclaringExecutable().getDeclaringClass());
+            Class<?> resolvedClass = GenericTypeResolver.rawClass(genericType);
+            this.type = resolvedClass == null ? handle.getType() : resolvedClass;
+            this.annotations = combinedAnnotations(handle, annotationSource);
+        }
+
+        private static Annotation[] combinedAnnotations(Parameter handle, Parameter annotationSource) {
+            Map<Class<? extends Annotation>, Annotation> combined = new LinkedHashMap<>();
+            for (Annotation annotation : handle.getDeclaredAnnotations()) {
+                combined.put(annotation.annotationType(), annotation);
+            }
+            for (Annotation annotation : annotationSource.getDeclaredAnnotations()) {
+                combined.putIfAbsent(annotation.annotationType(), annotation);
+            }
+            return combined.values().toArray(new Annotation[0]);
+        }
+    }
+
+    private static String parameterName(ValueSource source, Parameter annotationSource) {
+        return source == ValueSource.COOKIE_PARAM ? annotationSource.getDeclaredAnnotation(CookieParam.class).value()
+            : source == ValueSource.HEADER_PARAM ? annotationSource.getDeclaredAnnotation(HeaderParam.class).value()
+            : source == ValueSource.MATRIX_PARAM ? annotationSource.getDeclaredAnnotation(MatrixParam.class).value()
+            : source == ValueSource.FORM_PARAM ? annotationSource.getDeclaredAnnotation(FormParam.class).value()
+            : source == ValueSource.PATH_PARAM ? annotationSource.getDeclaredAnnotation(PathParam.class).value()
+            : source == ValueSource.QUERY_PARAM ? annotationSource.getDeclaredAnnotation(QueryParam.class).value()
+            : "";
     }
 
     static class RequestBasedParam extends ResourceMethodParam {
@@ -118,7 +158,7 @@ abstract class ResourceMethodParam {
             }
             Pattern patternIfNotDefault = this.pattern == null || UriPattern.DEFAULT_CAPTURING_GROUP_PATTERN.equals(this.pattern.pattern()) ? null : this.pattern;
             return builder.withSchema(
-                schemaObjectFrom(parameterHandle.getType(), parameterHandle.getParameterizedType(), isRequired)
+                schemaObjectFrom(type, genericType, isRequired)
                     .withDefaultValue(source == ValueSource.PATH_PARAM || !hasExplicitDefault() ? null : defaultValue())
                     .withExternalDocs(externalDoc)
                     .withPattern(patternIfNotDefault)
@@ -126,8 +166,8 @@ abstract class ResourceMethodParam {
             );
         }
 
-        RequestBasedParam(int index, ValueSource source, Parameter parameterHandle, Object defaultValue, boolean encodedRequested, boolean lazyDefaultValue, ParamConverter paramConverter, DescriptionData descriptionData, String key, boolean isDeprecated, boolean isRequired, Pattern pattern, boolean explicitDefault) {
-            super(index, source, parameterHandle, descriptionData, isRequired);
+        RequestBasedParam(int index, ValueSource source, ResolvedParameter parameter, Object defaultValue, boolean encodedRequested, boolean lazyDefaultValue, ParamConverter paramConverter, DescriptionData descriptionData, String key, boolean isDeprecated, boolean isRequired, Pattern pattern, boolean explicitDefault) {
+            super(index, source, parameter, descriptionData, isRequired);
             this.defaultValue = defaultValue;
             this.encodedRequested = encodedRequested;
             this.lazyDefaultValue = lazyDefaultValue;
@@ -149,19 +189,19 @@ abstract class ResourceMethodParam {
 
         public Object defaultValue() {
             boolean skipConverter = defaultValue != null && !lazyDefaultValue;
-            return convertValue(parameterHandle, paramConverter, skipConverter, defaultValue, source);
+            return convertValue(parameterHandle, type, paramConverter, skipConverter, defaultValue, source, key);
         }
 
         public Object getValue(JaxRSRequest jaxRequest, RequestMatcher.MatchedMethod matchedMethod, CollectionParameterStrategy cps) throws IOException {
             MuRequest muRequest = jaxRequest.muRequest;
-            Class<?> paramClass = parameterHandle.getType();
+            Class<?> paramClass = type;
             if (UploadedFile.class.isAssignableFrom(paramClass)) {
                 return muRequest.uploadedFile(key);
             } else if (File.class.isAssignableFrom(paramClass)) {
                 UploadedFile uf = muRequest.uploadedFile(key);
                 return uf == null ? null : uf.asFile();
             } else if (Collection.class.isAssignableFrom(paramClass)) {
-                Type t = parameterHandle.getParameterizedType();
+                Type t = genericType;
                 if (t instanceof ParameterizedType) {
                     Type[] actualTypeArguments = ((ParameterizedType) t).getActualTypeArguments();
                     if (actualTypeArguments.length == 1) {
@@ -219,7 +259,7 @@ abstract class ResourceMethodParam {
             if (collection != null) {
                 if (isSpecified) {
                     for (String stringValue : specifiedValue) {
-                        collection.add(ResourceMethodParam.convertValue(parameterHandle, paramConverter, false, stringValue, source));
+                        collection.add(ResourceMethodParam.convertValue(parameterHandle, type, paramConverter, false, stringValue, source, key));
                     }
                 } else if (hasExplicitDefault()) {
                     collection.add(defaultValue());
@@ -229,7 +269,7 @@ abstract class ResourceMethodParam {
                     : (collection instanceof Set) ? Collections.unmodifiableSet((Set) collection)
                     : Collections.unmodifiableCollection(collection);
             } else {
-                return isSpecified ? ResourceMethodParam.convertValue(parameterHandle, paramConverter, false, specifiedValue.get(0), source) : defaultValue();
+                return isSpecified ? ResourceMethodParam.convertValue(parameterHandle, type, paramConverter, false, specifiedValue.get(0), source, key) : defaultValue();
             }
         }
 
@@ -280,20 +320,20 @@ abstract class ResourceMethodParam {
     }
 
     static class MessageBodyParam extends ResourceMethodParam {
-        MessageBodyParam(int index, ValueSource source, Parameter parameterHandle, DescriptionData descriptionData, boolean isRequired) {
-            super(index, source, parameterHandle, descriptionData, isRequired);
+        MessageBodyParam(int index, ValueSource source, ResolvedParameter parameter, DescriptionData descriptionData, boolean isRequired) {
+            super(index, source, parameter, descriptionData, isRequired);
         }
     }
 
     static class ContextParam extends ResourceMethodParam {
-        ContextParam(int index, ValueSource source, Parameter parameterHandle) {
-            super(index, source, parameterHandle, null, true);
+        ContextParam(int index, ValueSource source, ResolvedParameter parameter) {
+            super(index, source, parameter, null, true);
         }
     }
 
     static class SuspendedParam extends ResourceMethodParam {
-        SuspendedParam(int index, ValueSource source, Parameter parameterHandle) {
-            super(index, source, parameterHandle, null, true);
+        SuspendedParam(int index, ValueSource source, ResolvedParameter parameter) {
+            super(index, source, parameter, null, true);
         }
     }
 
@@ -314,9 +354,9 @@ abstract class ResourceMethodParam {
         return parameterHandle.getDeclaredAnnotation(annotationClass) != null;
     }
 
-    private static ParamConverter<?> getParamConverter(Parameter parameterHandle, Parameter annotationSource, List<ParamConverterProvider> paramConverterProviders) {
-        Class<?> paramType = parameterHandle.getType();
-        Type parameterizedType = parameterHandle.getParameterizedType();
+    private static ParamConverter<?> getParamConverter(ResolvedParameter parameter, List<ParamConverterProvider> paramConverterProviders) {
+        Class<?> paramType = parameter.type;
+        Type parameterizedType = parameter.genericType;
         if (Collection.class.isAssignableFrom(paramType) && parameterizedType instanceof ParameterizedType) {
             Type possiblyWildcardType = ((ParameterizedType) parameterizedType).getActualTypeArguments()[0];
             Type type = (possiblyWildcardType instanceof WildcardType) ? ((WildcardType) possiblyWildcardType).getUpperBounds()[0] : possiblyWildcardType;
@@ -324,9 +364,8 @@ abstract class ResourceMethodParam {
                 paramType = (Class<?>) type;
             }
         }
-        Annotation[] declaredAnnotations = annotationSource.getDeclaredAnnotations();
         for (ParamConverterProvider paramConverterProvider : paramConverterProviders) {
-            ParamConverter<?> converter = paramConverterProvider.getConverter(paramType, parameterizedType, declaredAnnotations);
+            ParamConverter<?> converter = paramConverterProvider.getConverter(paramType, parameterizedType, parameter.annotations);
             if (converter == null && RequestBasedParam.createCollection(paramType) != null && parameterizedType instanceof ParameterizedType) {
                 // Things like List<A> can be converted with just an 'A' param converter, so let's see if we have that
                 ParameterizedType pt = (ParameterizedType) parameterizedType;
@@ -335,24 +374,24 @@ abstract class ResourceMethodParam {
                     ParameterizedType type = (ParameterizedType) ata[0];
                     Type rawType = type.getRawType();
                     if (rawType instanceof Class) {
-                        converter = paramConverterProvider.getConverter((Class) rawType, type, declaredAnnotations);
+                        converter = paramConverterProvider.getConverter((Class) rawType, type, parameter.annotations);
                     }
                 }
             }
             if (converter != null) return converter;
         }
-        throw new MuException("Could not find a suitable ParamConverter for " + parameterizedType + " at " + parameterHandle.getDeclaringExecutable());
+        throw new MuException("Could not find a suitable ParamConverter for " + parameterizedType + " at " + parameter.handle.getDeclaringExecutable());
     }
 
-    private static Object getDefaultValue(Parameter parameterHandle, Parameter annotationSource, ParamConverter<?> converter, boolean lazyDefaultValue, ValueSource source) {
+    private static Object getDefaultValue(ResolvedParameter parameter, Parameter annotationSource, ParamConverter<?> converter, boolean lazyDefaultValue, ValueSource source, String parameterName) {
         DefaultValue annotation = annotationSource.getDeclaredAnnotation(DefaultValue.class);
         if (annotation == null) {
             return converter instanceof HasDefaultValue ? ((HasDefaultValue) converter).getDefault() : null;
         }
-        return convertValue(parameterHandle, converter, lazyDefaultValue, annotation.value(), source);
+        return convertValue(parameter.handle, parameter.type, converter, lazyDefaultValue, annotation.value(), source, parameterName);
     }
 
-    private static Object convertValue(Parameter parameterHandle, ParamConverter<?> converter, boolean skipConverter, Object value, ValueSource source) {
+    private static Object convertValue(Parameter parameterHandle, Class<?> parameterType, ParamConverter<?> converter, boolean skipConverter, Object value, ValueSource source, String parameterName) {
         if (converter == null || skipConverter) {
             return value;
         } else {
@@ -369,19 +408,12 @@ abstract class ResourceMethodParam {
                 throw e;
             } catch (Exception e) {
                 if (source == ValueSource.MATRIX_PARAM || source == ValueSource.QUERY_PARAM || source == ValueSource.PATH_PARAM) {
-                    throw new UriParameterConversionException(uriParameterName(parameterHandle, source), (String) value, parameterHandle.getType(), e);
+                    throw new UriParameterConversionException(parameterName, (String) value, parameterType, e);
                 }
-                String message = "Could not convert String value \"" + value + "\" to a " + parameterHandle.getType() + " using " + converter + " on parameter " + parameterHandle;
+                String message = "Could not convert String value \"" + value + "\" to a " + parameterType + " using " + converter + " on parameter " + parameterHandle;
                 throw new BadRequestException(message, e);
             }
         }
-    }
-
-    private static String uriParameterName(Parameter parameter, ValueSource source) {
-        if (source == ValueSource.MATRIX_PARAM) return parameter.getDeclaredAnnotation(MatrixParam.class).value();
-        if (source == ValueSource.QUERY_PARAM) return parameter.getDeclaredAnnotation(QueryParam.class).value();
-        if (source == ValueSource.PATH_PARAM) return parameter.getDeclaredAnnotation(PathParam.class).value();
-        throw new IllegalArgumentException("Not a URI parameter source: " + source);
     }
 
     enum ValueSource {

--- a/src/main/java/io/muserver/rest/ResourceMethodParam.java
+++ b/src/main/java/io/muserver/rest/ResourceMethodParam.java
@@ -44,33 +44,37 @@ abstract class ResourceMethodParam {
     }
 
     static ResourceMethodParam fromParameter(int index, Parameter parameterHandle, List<ParamConverterProvider> paramConverterProviders, UriPattern methodPattern) {
+        return fromParameter(index, parameterHandle, parameterHandle, paramConverterProviders, methodPattern);
+    }
+
+    static ResourceMethodParam fromParameter(int index, Parameter parameterHandle, Parameter annotationSource, List<ParamConverterProvider> paramConverterProviders, UriPattern methodPattern) {
 
         Pattern pattern = null;
-        ValueSource source = getSource(parameterHandle);
-        boolean isRequired = source == ValueSource.PATH_PARAM || hasDeclared(parameterHandle, Required.class);
+        ValueSource source = getSource(annotationSource);
+        boolean isRequired = source == ValueSource.PATH_PARAM || hasDeclared(annotationSource, Required.class);
         if (source == ValueSource.MESSAGE_BODY) {
-            DescriptionData descriptionData = DescriptionData.fromAnnotation(parameterHandle, null);
+            DescriptionData descriptionData = DescriptionData.fromAnnotation(annotationSource, null);
             return new MessageBodyParam(index, source, parameterHandle, descriptionData, isRequired);
         } else if (source == ValueSource.CONTEXT) {
             return new ContextParam(index, source, parameterHandle);
         } else if (source == ValueSource.SUSPENDED) {
             return new SuspendedParam(index, source, parameterHandle);
         } else {
-            boolean encodedRequested = hasDeclared(parameterHandle, Encoded.class);
-            boolean isDeprecated = hasDeclared(parameterHandle, Deprecated.class);
-            ParamConverter<?> converter = getParamConverter(parameterHandle, paramConverterProviders);
+            boolean encodedRequested = hasDeclared(annotationSource, Encoded.class);
+            boolean isDeprecated = hasDeclared(annotationSource, Deprecated.class);
+            ParamConverter<?> converter = getParamConverter(parameterHandle, annotationSource, paramConverterProviders);
             boolean lazyDefaultValue = converter.getClass().getDeclaredAnnotation(ParamConverter.Lazy.class) != null;
-            boolean explicitDefault = hasDeclared(parameterHandle, DefaultValue.class);
-            Object defaultValue = getDefaultValue(parameterHandle, converter, lazyDefaultValue, source);
+            boolean explicitDefault = hasDeclared(annotationSource, DefaultValue.class);
+            Object defaultValue = getDefaultValue(parameterHandle, annotationSource, converter, lazyDefaultValue, source);
 
             isRequired |= (!explicitDefault && parameterHandle.getType().isPrimitive());
 
-            String key = source == ValueSource.COOKIE_PARAM ? parameterHandle.getDeclaredAnnotation(CookieParam.class).value()
-                : source == ValueSource.HEADER_PARAM ? parameterHandle.getDeclaredAnnotation(HeaderParam.class).value()
-                : source == ValueSource.MATRIX_PARAM ? parameterHandle.getDeclaredAnnotation(MatrixParam.class).value()
-                : source == ValueSource.FORM_PARAM ? parameterHandle.getDeclaredAnnotation(FormParam.class).value()
-                : source == ValueSource.PATH_PARAM ? parameterHandle.getDeclaredAnnotation(PathParam.class).value()
-                : source == ValueSource.QUERY_PARAM ? parameterHandle.getDeclaredAnnotation(QueryParam.class).value()
+            String key = source == ValueSource.COOKIE_PARAM ? annotationSource.getDeclaredAnnotation(CookieParam.class).value()
+                : source == ValueSource.HEADER_PARAM ? annotationSource.getDeclaredAnnotation(HeaderParam.class).value()
+                : source == ValueSource.MATRIX_PARAM ? annotationSource.getDeclaredAnnotation(MatrixParam.class).value()
+                : source == ValueSource.FORM_PARAM ? annotationSource.getDeclaredAnnotation(FormParam.class).value()
+                : source == ValueSource.PATH_PARAM ? annotationSource.getDeclaredAnnotation(PathParam.class).value()
+                : source == ValueSource.QUERY_PARAM ? annotationSource.getDeclaredAnnotation(QueryParam.class).value()
                 : "";
             if (key.length() == 0) {
                 throw new WebApplicationException("No parameter specified for the " + source + " in " + parameterHandle);
@@ -82,7 +86,7 @@ abstract class ResourceMethodParam {
                 }
             }
 
-            DescriptionData descriptionData = DescriptionData.fromAnnotation(parameterHandle, key);
+            DescriptionData descriptionData = DescriptionData.fromAnnotation(annotationSource, key);
             return new RequestBasedParam(index, source, parameterHandle, defaultValue, encodedRequested, lazyDefaultValue, converter, descriptionData, key, isDeprecated, isRequired, pattern, explicitDefault);
         }
     }
@@ -310,7 +314,7 @@ abstract class ResourceMethodParam {
         return parameterHandle.getDeclaredAnnotation(annotationClass) != null;
     }
 
-    private static ParamConverter<?> getParamConverter(Parameter parameterHandle, List<ParamConverterProvider> paramConverterProviders) {
+    private static ParamConverter<?> getParamConverter(Parameter parameterHandle, Parameter annotationSource, List<ParamConverterProvider> paramConverterProviders) {
         Class<?> paramType = parameterHandle.getType();
         Type parameterizedType = parameterHandle.getParameterizedType();
         if (Collection.class.isAssignableFrom(paramType) && parameterizedType instanceof ParameterizedType) {
@@ -320,7 +324,7 @@ abstract class ResourceMethodParam {
                 paramType = (Class<?>) type;
             }
         }
-        Annotation[] declaredAnnotations = parameterHandle.getDeclaredAnnotations();
+        Annotation[] declaredAnnotations = annotationSource.getDeclaredAnnotations();
         for (ParamConverterProvider paramConverterProvider : paramConverterProviders) {
             ParamConverter<?> converter = paramConverterProvider.getConverter(paramType, parameterizedType, declaredAnnotations);
             if (converter == null && RequestBasedParam.createCollection(paramType) != null && parameterizedType instanceof ParameterizedType) {
@@ -340,8 +344,8 @@ abstract class ResourceMethodParam {
         throw new MuException("Could not find a suitable ParamConverter for " + parameterizedType + " at " + parameterHandle.getDeclaringExecutable());
     }
 
-    private static Object getDefaultValue(Parameter parameterHandle, ParamConverter<?> converter, boolean lazyDefaultValue, ValueSource source) {
-        DefaultValue annotation = parameterHandle.getDeclaredAnnotation(DefaultValue.class);
+    private static Object getDefaultValue(Parameter parameterHandle, Parameter annotationSource, ParamConverter<?> converter, boolean lazyDefaultValue, ValueSource source) {
+        DefaultValue annotation = annotationSource.getDeclaredAnnotation(DefaultValue.class);
         if (annotation == null) {
             return converter instanceof HasDefaultValue ? ((HasDefaultValue) converter).getDefault() : null;
         }

--- a/src/main/java/io/muserver/rest/RestHandler.java
+++ b/src/main/java/io/muserver/rest/RestHandler.java
@@ -146,7 +146,8 @@ public class RestHandler implements MuHandler {
                         }
                     });
                 } else {
-                    sendResponse(0, requestContext, muResponse, acceptHeaders, produces, directlyProduces, methodAnnotations, result);
+                    sendResponse(0, requestContext, muResponse, acceptHeaders, produces, directlyProduces, methodAnnotations, result,
+                        mm.resourceMethod.methodHandle.getGenericReturnType());
                 }
             }
         } catch (NotMatchedException e) {
@@ -206,12 +207,16 @@ public class RestHandler implements MuHandler {
     }
 
     private void sendResponse(int nestingLevel, JaxRSRequest requestContext, MuResponse muResponse, List<MediaType> acceptHeaders, List<MediaType> produces, List<MediaType> directlyProduces, Annotation[] annotations, Object result) throws Exception {
+        sendResponse(nestingLevel, requestContext, muResponse, acceptHeaders, produces, directlyProduces, annotations, result, null);
+    }
+
+    private void sendResponse(int nestingLevel, JaxRSRequest requestContext, MuResponse muResponse, List<MediaType> acceptHeaders, List<MediaType> produces, List<MediaType> directlyProduces, Annotation[] annotations, Object result, Type resourceMethodReturnType) throws Exception {
         try {
             if (requestContext.hasEntity()) {
                 requestContext.getEntityStream().close();
             }
             if (!muResponse.hasStartedSendingData()) {
-                ObjWithType obj = ObjWithType.objType(result);
+                ObjWithType obj = ObjWithType.objType(result, resourceMethodReturnType);
 
                 if (obj.entity instanceof Exception) {
                     throw (Exception) obj.entity;

--- a/src/main/java/io/muserver/rest/RestHandler.java
+++ b/src/main/java/io/muserver/rest/RestHandler.java
@@ -124,7 +124,7 @@ public class RestHandler implements MuHandler {
             List<MediaType> produces = producesRef = mm.resourceMethod.resourceClass.produces;
             List<MediaType> directlyProduces = directlyProducesRef = mm.resourceMethod.directlyProduces;
             Annotation[] methodAnnotations = mm.resourceMethod.methodAnnotations;
-            Type methodReturnType = mm.resourceMethod.methodHandle.getGenericReturnType();
+            Type methodReturnType = mm.resourceMethod.genericReturnType;
 
             filterManagerThing.onPostMatch(requestContext);
             if (requestContext.getAbortResponse() != null) {

--- a/src/main/java/io/muserver/rest/RestHandler.java
+++ b/src/main/java/io/muserver/rest/RestHandler.java
@@ -18,6 +18,7 @@ import org.slf4j.LoggerFactory;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Parameter;
+import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.net.URI;
 import java.util.*;
@@ -119,6 +120,7 @@ public class RestHandler implements MuHandler {
             List<MediaType> produces = producesRef = mm.resourceMethod.resourceClass.produces;
             List<MediaType> directlyProduces = directlyProducesRef = mm.resourceMethod.directlyProduces;
             Annotation[] methodAnnotations = mm.resourceMethod.methodAnnotations;
+            Type methodReturnType = mm.resourceMethod.methodHandle.getGenericReturnType();
 
             filterManagerThing.onPostMatch(requestContext);
 
@@ -139,7 +141,8 @@ public class RestHandler implements MuHandler {
                     CompletionStage cs = (CompletionStage) result;
                     cs.thenAccept(o -> {
                         try {
-                            sendResponse(0, requestContext, muResponse, acceptHeaders, produces, directlyProduces, methodAnnotations, o);
+                            sendResponse(0, requestContext, muResponse, acceptHeaders, produces, directlyProduces, methodAnnotations, o,
+                                completionStageResultType(methodReturnType));
                             asyncHandle1.complete();
                         } catch (Exception e) {
                             asyncHandle1.complete(e);
@@ -147,7 +150,7 @@ public class RestHandler implements MuHandler {
                     });
                 } else {
                     sendResponse(0, requestContext, muResponse, acceptHeaders, produces, directlyProduces, methodAnnotations, result,
-                        mm.resourceMethod.methodHandle.getGenericReturnType());
+                        methodReturnType);
                 }
             }
         } catch (NotMatchedException e) {
@@ -161,6 +164,17 @@ public class RestHandler implements MuHandler {
             }
         }
         return true;
+    }
+
+    private static Type completionStageResultType(Type returnType) {
+        if (returnType instanceof ParameterizedType) {
+            ParameterizedType parameterizedType = (ParameterizedType) returnType;
+            Type rawType = parameterizedType.getRawType();
+            if (rawType instanceof Class && CompletionStage.class.isAssignableFrom((Class<?>) rawType)) {
+                return parameterizedType.getActualTypeArguments()[0];
+            }
+        }
+        return null;
     }
 
     static Object invokeResourceMethod(JaxRSRequest requestContext, MuResponse muResponse, RequestMatcher.MatchedMethod mm, Function<ResourceMethod, Object> suspendedParamCallback, EntityProviders entityProviders, CollectionParameterStrategy collectionParameterStrategy) throws Exception {

--- a/src/main/java/io/muserver/rest/RestHandler.java
+++ b/src/main/java/io/muserver/rest/RestHandler.java
@@ -17,8 +17,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.lang.annotation.Annotation;
-import java.lang.reflect.Parameter;
-import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.net.URI;
 import java.util.*;
@@ -176,14 +174,7 @@ public class RestHandler implements MuHandler {
     }
 
     private static Type completionStageResultType(Type returnType) {
-        if (returnType instanceof ParameterizedType) {
-            ParameterizedType parameterizedType = (ParameterizedType) returnType;
-            Type rawType = parameterizedType.getRawType();
-            if (rawType instanceof Class && CompletionStage.class.isAssignableFrom((Class<?>) rawType)) {
-                return parameterizedType.getActualTypeArguments()[0];
-            }
-        }
-        return null;
+        return GenericTypeResolver.resolveTypeArgument(returnType, CompletionStage.class, 0);
     }
 
     static Object invokeResourceMethod(JaxRSRequest requestContext, MuResponse muResponse, RequestMatcher.MatchedMethod mm, Function<ResourceMethod, Object> suspendedParamCallback, EntityProviders entityProviders, CollectionParameterStrategy collectionParameterStrategy) throws Exception {
@@ -192,7 +183,7 @@ public class RestHandler implements MuHandler {
         for (ResourceMethodParam param : rm.params) {
             Object paramValue;
             if (param.source == ResourceMethodParam.ValueSource.MESSAGE_BODY) {
-                paramValue = readRequestEntity(requestContext, param.parameterHandle);
+                paramValue = readRequestEntity(requestContext, param);
             } else if (param.source == ResourceMethodParam.ValueSource.CONTEXT) {
                 paramValue = getContextParam(requestContext, muResponse, mm, param, entityProviders);
             } else if (param.source == ResourceMethodParam.ValueSource.SUSPENDED) {
@@ -380,7 +371,7 @@ public class RestHandler implements MuHandler {
     private static Object getContextParam(JaxRSRequest requestContext, MuResponse muResponse, RequestMatcher.MatchedMethod mm, ResourceMethodParam param, EntityProviders providers) {
         MuRequest request = requestContext.muRequest;
         Object paramValue;
-        Class<?> type = param.parameterHandle.getType();
+        Class<?> type = param.type;
         if (type.equals(UriInfo.class)) {
             paramValue = createUriInfo(requestContext.relativePath(), mm, request.uri().resolve(request.contextPath() + "/"), request.uri());
         } else if (type.equals(MuResponse.class)) {
@@ -412,10 +403,10 @@ public class RestHandler implements MuHandler {
         return new MuUriInfo(baseUri, requestUri, Mutils.trim(relativePath, "/"), mm);
     }
 
-    private static Object readRequestEntity(JaxRSRequest requestContext, Parameter parameter) throws java.io.IOException {
-        requestContext.setAnnotations(parameter.getDeclaredAnnotations());
-        requestContext.setType(parameter.getType());
-        requestContext.setGenericType(parameter.getParameterizedType());
+    private static Object readRequestEntity(JaxRSRequest requestContext, ResourceMethodParam parameter) throws java.io.IOException {
+        requestContext.setAnnotations(parameter.annotations);
+        requestContext.setType(parameter.type);
+        requestContext.setGenericType(parameter.genericType);
         return requestContext.executeInterceptors();
     }
 

--- a/src/test/java/io/muserver/rest/EntityProvidersTest.java
+++ b/src/test/java/io/muserver/rest/EntityProvidersTest.java
@@ -206,6 +206,80 @@ public class EntityProvidersTest {
     }
 
     @Test
+    public void completionStageSubtypePreservesItsResolvedEntityGenericType() throws Exception {
+        class Dog { }
+        class ResultStage<Metadata, Entity> extends CompletableFuture<Entity> { }
+        @Path("custom-async-dogs")
+        class Sample {
+            @GET
+            public ResultStage<String, List<Dog>> get() {
+                ResultStage<String, List<Dog>> result = new ResultStage<>();
+                result.complete(asList(new Dog()));
+                return result;
+            }
+        }
+        class DogListWriter implements MessageBodyWriter<List<Dog>> {
+            @Override
+            public boolean isWriteable(Class<?> type, Type genericType, Annotation[] annotations, jakarta.ws.rs.core.MediaType mediaType) {
+                return genericType instanceof ParameterizedType
+                    && ((ParameterizedType) genericType).getActualTypeArguments()[0].equals(Dog.class);
+            }
+
+            @Override
+            public void writeTo(List<Dog> dogs, Class<?> type, Type genericType, Annotation[] annotations, jakarta.ws.rs.core.MediaType mediaType, MultivaluedMap<String, Object> httpHeaders, OutputStream entityStream) throws IOException {
+                entityStream.write("dogs".getBytes(StandardCharsets.UTF_8));
+            }
+        }
+
+        this.server = httpsServerForTest().addHandler(
+            restHandler(new Sample()).addCustomWriter(new DogListWriter()).build()).start();
+        try (Response resp = call(request(server.uri().resolve("/custom-async-dogs")))) {
+            assertThat(resp.code(), equalTo(200));
+            assertThat(resp.body().string(), equalTo("dogs"));
+        }
+    }
+
+    @Test
+    public void inheritedMessageBodyParameterAnnotationsReachReaders() throws Exception {
+        class Payload {
+            final String value;
+
+            Payload(String value) {
+                this.value = value;
+            }
+        }
+        class BaseResource<T> {
+            @POST
+            public String post(@Encoded T payload) {
+                return ((Payload) payload).value;
+            }
+        }
+        @Path("inherited-body")
+        class Sample extends BaseResource<Payload> { }
+        class PayloadReader implements MessageBodyReader<Payload> {
+            @Override
+            public boolean isReadable(Class<?> type, Type genericType, Annotation[] annotations, jakarta.ws.rs.core.MediaType mediaType) {
+                return type.equals(Payload.class) && Arrays.stream(annotations)
+                    .anyMatch(annotation -> annotation.annotationType().equals(Encoded.class));
+            }
+
+            @Override
+            public Payload readFrom(Class<Payload> type, Type genericType, Annotation[] annotations, jakarta.ws.rs.core.MediaType mediaType,
+                                    MultivaluedMap<String, String> httpHeaders, InputStream entityStream) throws IOException {
+                return new Payload(new String(entityStream.readAllBytes(), StandardCharsets.UTF_8));
+            }
+        }
+
+        this.server = httpsServerForTest().addHandler(
+            restHandler(new Sample()).addCustomReader(new PayloadReader()).build()).start();
+        try (Response resp = call(request(server.uri().resolve("/inherited-body"))
+            .post(RequestBody.create("hello", MediaType.get("text/plain"))))) {
+            assertThat(resp.code(), equalTo(200));
+            assertThat(resp.body().string(), equalTo("hello"));
+        }
+    }
+
+    @Test
     public void inheritedGenericReturnTypeIsResolvedAgainstResourceClass() throws Exception {
         class Dog { }
         abstract class BaseResource<T> {

--- a/src/test/java/io/muserver/rest/EntityProvidersTest.java
+++ b/src/test/java/io/muserver/rest/EntityProvidersTest.java
@@ -259,6 +259,27 @@ public class EntityProvidersTest {
     }
 
     @Test
+    public void rawGenericResourceFallsBackToTheRuntimeEntityType() throws Exception {
+        class BaseResource<T> {
+            @GET
+            @SuppressWarnings("unchecked")
+            public T get() {
+                return (T) "entity";
+            }
+        }
+        @Path("raw-direct")
+        @SuppressWarnings("rawtypes")
+        class Sample extends BaseResource { }
+
+        this.server = httpsServerForTest().addHandler(
+            restHandler(new Sample()).addCustomWriter(new RuntimeTypeOnlyStringWriter()).build()).start();
+        try (Response resp = call(request(server.uri().resolve("/raw-direct")))) {
+            assertThat(resp.code(), equalTo(200));
+            assertThat(resp.body().string(), equalTo("runtime-type"));
+        }
+    }
+
+    @Test
     public void inheritedMessageBodyParameterAnnotationsReachReaders() throws Exception {
         class Payload {
             final String value;

--- a/src/test/java/io/muserver/rest/EntityProvidersTest.java
+++ b/src/test/java/io/muserver/rest/EntityProvidersTest.java
@@ -13,6 +13,7 @@ import okhttp3.RequestBody;
 import okhttp3.Response;
 import okio.BufferedSink;
 import org.example.MyStringReaderWriter;
+import org.example.RuntimeTypeOnlyStringWriter;
 import org.hamcrest.Matchers;
 import org.junit.After;
 import org.junit.Test;
@@ -236,6 +237,24 @@ public class EntityProvidersTest {
         try (Response resp = call(request(server.uri().resolve("/custom-async-dogs")))) {
             assertThat(resp.code(), equalTo(200));
             assertThat(resp.body().string(), equalTo("dogs"));
+        }
+    }
+
+    @Test
+    public void rawCompletionStageFallsBackToTheRuntimeEntityType() throws Exception {
+        @Path("raw-async")
+        class Sample {
+            @GET
+            @SuppressWarnings("rawtypes")
+            public CompletableFuture get() {
+                return CompletableFuture.completedFuture("entity");
+            }
+        }
+        this.server = httpsServerForTest().addHandler(
+            restHandler(new Sample()).addCustomWriter(new RuntimeTypeOnlyStringWriter()).build()).start();
+        try (Response resp = call(request(server.uri().resolve("/raw-async")))) {
+            assertThat(resp.code(), equalTo(200));
+            assertThat(resp.body().string(), equalTo("runtime-type"));
         }
     }
 

--- a/src/test/java/io/muserver/rest/EntityProvidersTest.java
+++ b/src/test/java/io/muserver/rest/EntityProvidersTest.java
@@ -188,8 +188,7 @@ public class EntityProvidersTest {
             @Override
             public boolean isWriteable(Class<?> type, Type genericType, Annotation[] annotations, jakarta.ws.rs.core.MediaType mediaType) {
                 return genericType instanceof ParameterizedType
-                    && ((ParameterizedType) genericType).getActualTypeArguments()[0].equals(Dog.class)
-                    && genericType.getTypeName().equals("java.util.List<" + Dog.class.getTypeName() + ">");
+                    && ((ParameterizedType) genericType).getActualTypeArguments()[0].equals(Dog.class);
             }
 
             @Override
@@ -221,7 +220,8 @@ public class EntityProvidersTest {
             @Override
             public boolean isWriteable(Class<?> type, Type genericType, Annotation[] annotations, jakarta.ws.rs.core.MediaType mediaType) {
                 return genericType instanceof ParameterizedType
-                    && ((ParameterizedType) genericType).getActualTypeArguments()[0].equals(Dog.class);
+                    && ((ParameterizedType) genericType).getActualTypeArguments()[0].equals(Dog.class)
+                    && genericType.getTypeName().equals("java.util.List<" + Dog.class.getTypeName() + ">");
             }
 
             @Override

--- a/src/test/java/io/muserver/rest/EntityProvidersTest.java
+++ b/src/test/java/io/muserver/rest/EntityProvidersTest.java
@@ -130,6 +130,51 @@ public class EntityProvidersTest {
     }
 
     @Test
+    public void writerRankingPrefersNearestRuntimeSuperclass() throws Exception {
+        class Animal { }
+        class Dog extends Animal { }
+        @Path("nearest-writer")
+        class Sample {
+            @GET
+            public Animal get() {
+                return new Dog();
+            }
+        }
+        class AnimalWriter implements MessageBodyWriter<Animal> {
+            @Override
+            public boolean isWriteable(Class<?> type, Type genericType, Annotation[] annotations, jakarta.ws.rs.core.MediaType mediaType) {
+                return Animal.class.isAssignableFrom(type);
+            }
+
+            @Override
+            public void writeTo(Animal animal, Class<?> type, Type genericType, Annotation[] annotations, jakarta.ws.rs.core.MediaType mediaType, MultivaluedMap<String, Object> httpHeaders, OutputStream entityStream) throws IOException {
+                entityStream.write("animal".getBytes(StandardCharsets.UTF_8));
+            }
+        }
+        class ObjectWriter implements MessageBodyWriter<Object> {
+            @Override
+            public boolean isWriteable(Class<?> type, Type genericType, Annotation[] annotations, jakarta.ws.rs.core.MediaType mediaType) {
+                return true;
+            }
+
+            @Override
+            public void writeTo(Object value, Class<?> type, Type genericType, Annotation[] annotations, jakarta.ws.rs.core.MediaType mediaType, MultivaluedMap<String, Object> httpHeaders, OutputStream entityStream) throws IOException {
+                entityStream.write("object".getBytes(StandardCharsets.UTF_8));
+            }
+        }
+
+        this.server = httpsServerForTest().addHandler(
+            restHandler(new Sample())
+                .addCustomWriter(new AnimalWriter())
+                .addCustomWriter(new ObjectWriter())
+                .build()).start();
+        try (Response resp = call(request(server.uri().resolve("/nearest-writer")))) {
+            assertThat(resp.code(), equalTo(200));
+            assertThat(resp.body().string(), equalTo("animal"));
+        }
+    }
+
+    @Test
     public void customWritersGetTheAnnotationsOfTheResourceMethod() throws Exception {
 
         @Path("dummy")

--- a/src/test/java/io/muserver/rest/EntityProvidersTest.java
+++ b/src/test/java/io/muserver/rest/EntityProvidersTest.java
@@ -206,6 +206,38 @@ public class EntityProvidersTest {
     }
 
     @Test
+    public void inheritedGenericReturnTypeIsResolvedAgainstResourceClass() throws Exception {
+        class Dog { }
+        abstract class BaseResource<T> {
+            @GET
+            public List<T> get() {
+                return new ArrayList<>();
+            }
+        }
+        @Path("inherited-dogs")
+        class DogResource extends BaseResource<Dog> { }
+        class DogListWriter implements MessageBodyWriter<List<Dog>> {
+            @Override
+            public boolean isWriteable(Class<?> type, Type genericType, Annotation[] annotations, jakarta.ws.rs.core.MediaType mediaType) {
+                return genericType instanceof ParameterizedType
+                    && ((ParameterizedType) genericType).getActualTypeArguments()[0].equals(Dog.class);
+            }
+
+            @Override
+            public void writeTo(List<Dog> dogs, Class<?> type, Type genericType, Annotation[] annotations, jakarta.ws.rs.core.MediaType mediaType, MultivaluedMap<String, Object> httpHeaders, OutputStream entityStream) throws IOException {
+                entityStream.write("dogs".getBytes(StandardCharsets.UTF_8));
+            }
+        }
+
+        this.server = httpsServerForTest().addHandler(
+            restHandler(new DogResource()).addCustomWriter(new DogListWriter()).build()).start();
+        try (Response resp = call(request(server.uri().resolve("/inherited-dogs")))) {
+            assertThat(resp.code(), equalTo(200));
+            assertThat(resp.body().string(), equalTo("dogs"));
+        }
+    }
+
+    @Test
     public void readersWithoutConsumesSupportAllMediaTypes() throws Exception {
         @Path("samples")
         class Sample {

--- a/src/test/java/io/muserver/rest/EntityProvidersTest.java
+++ b/src/test/java/io/muserver/rest/EntityProvidersTest.java
@@ -206,6 +206,12 @@ public class EntityProvidersTest {
                 GenericEntity<List<Dog>> dogList = new GenericEntity<List<Dog>>(dogs) {};
                 return jakarta.ws.rs.core.Response.ok(dogList).build();
             }
+
+            @GET
+            @Path("direct")
+            public List<Dog> direct() {
+                return asList(new Dog("Little", "Chihuahua"), new Dog("Mangle", "Mongrel"));
+            }
         }
 
         class DogWriter implements MessageBodyWriter<Dog> {
@@ -245,6 +251,10 @@ public class EntityProvidersTest {
         }
 
         try (Response resp = call(request().url(server.uri().resolve("/dogs/all").toString()))) {
+            assertThat(resp.body().string(), equalTo("Little (Chihuahua)" + NEWLINE + "Mangle (Mongrel)" + NEWLINE));
+        }
+
+        try (Response resp = call(request().url(server.uri().resolve("/dogs/direct").toString()))) {
             assertThat(resp.body().string(), equalTo("Little (Chihuahua)" + NEWLINE + "Mangle (Mongrel)" + NEWLINE));
         }
     }

--- a/src/test/java/io/muserver/rest/EntityProvidersTest.java
+++ b/src/test/java/io/muserver/rest/EntityProvidersTest.java
@@ -85,6 +85,51 @@ public class EntityProvidersTest {
     }
 
     @Test
+    public void writerRankingUsesRuntimeEntityClassWhenMethodDeclaresSupertype() throws Exception {
+        class Animal { }
+        class Dog extends Animal { }
+        @Path("animals")
+        class Sample {
+            @GET
+            public Animal get() {
+                return new Dog();
+            }
+        }
+        class AnimalWriter implements MessageBodyWriter<Animal> {
+            @Override
+            public boolean isWriteable(Class<?> type, Type genericType, Annotation[] annotations, jakarta.ws.rs.core.MediaType mediaType) {
+                return Animal.class.isAssignableFrom(type);
+            }
+
+            @Override
+            public void writeTo(Animal animal, Class<?> type, Type genericType, Annotation[] annotations, jakarta.ws.rs.core.MediaType mediaType, MultivaluedMap<String, Object> httpHeaders, OutputStream entityStream) throws IOException {
+                entityStream.write("animal".getBytes(StandardCharsets.UTF_8));
+            }
+        }
+        class DogWriter implements MessageBodyWriter<Dog> {
+            @Override
+            public boolean isWriteable(Class<?> type, Type genericType, Annotation[] annotations, jakarta.ws.rs.core.MediaType mediaType) {
+                return Dog.class.equals(type);
+            }
+
+            @Override
+            public void writeTo(Dog dog, Class<?> type, Type genericType, Annotation[] annotations, jakarta.ws.rs.core.MediaType mediaType, MultivaluedMap<String, Object> httpHeaders, OutputStream entityStream) throws IOException {
+                entityStream.write("dog".getBytes(StandardCharsets.UTF_8));
+            }
+        }
+
+        this.server = httpsServerForTest().addHandler(
+            restHandler(new Sample())
+                .addCustomWriter(new AnimalWriter())
+                .addCustomWriter(new DogWriter())
+                .build()).start();
+        try (Response resp = call(request(server.uri().resolve("/animals")))) {
+            assertThat(resp.code(), equalTo(200));
+            assertThat(resp.body().string(), equalTo("dog"));
+        }
+    }
+
+    @Test
     public void customWritersGetTheAnnotationsOfTheResourceMethod() throws Exception {
 
         @Path("dummy")

--- a/src/test/java/io/muserver/rest/EntityProvidersTest.java
+++ b/src/test/java/io/muserver/rest/EntityProvidersTest.java
@@ -175,6 +175,37 @@ public class EntityProvidersTest {
     }
 
     @Test
+    public void completionStagePreservesDeclaredEntityGenericType() throws Exception {
+        class Dog { }
+        @Path("async-dogs")
+        class Sample {
+            @GET
+            public java.util.concurrent.CompletionStage<List<Dog>> get() {
+                return CompletableFuture.completedFuture(asList(new Dog()));
+            }
+        }
+        class DogListWriter implements MessageBodyWriter<List<Dog>> {
+            @Override
+            public boolean isWriteable(Class<?> type, Type genericType, Annotation[] annotations, jakarta.ws.rs.core.MediaType mediaType) {
+                return genericType instanceof ParameterizedType
+                    && ((ParameterizedType) genericType).getActualTypeArguments()[0].equals(Dog.class);
+            }
+
+            @Override
+            public void writeTo(List<Dog> dogs, Class<?> type, Type genericType, Annotation[] annotations, jakarta.ws.rs.core.MediaType mediaType, MultivaluedMap<String, Object> httpHeaders, OutputStream entityStream) throws IOException {
+                entityStream.write("dogs".getBytes(StandardCharsets.UTF_8));
+            }
+        }
+
+        this.server = httpsServerForTest().addHandler(
+            restHandler(new Sample()).addCustomWriter(new DogListWriter()).build()).start();
+        try (Response resp = call(request(server.uri().resolve("/async-dogs")))) {
+            assertThat(resp.code(), equalTo(200));
+            assertThat(resp.body().string(), equalTo("dogs"));
+        }
+    }
+
+    @Test
     public void customWritersGetTheAnnotationsOfTheResourceMethod() throws Exception {
 
         @Path("dummy")

--- a/src/test/java/io/muserver/rest/EntityProvidersTest.java
+++ b/src/test/java/io/muserver/rest/EntityProvidersTest.java
@@ -188,7 +188,8 @@ public class EntityProvidersTest {
             @Override
             public boolean isWriteable(Class<?> type, Type genericType, Annotation[] annotations, jakarta.ws.rs.core.MediaType mediaType) {
                 return genericType instanceof ParameterizedType
-                    && ((ParameterizedType) genericType).getActualTypeArguments()[0].equals(Dog.class);
+                    && ((ParameterizedType) genericType).getActualTypeArguments()[0].equals(Dog.class)
+                    && genericType.getTypeName().equals("java.util.List<" + Dog.class.getTypeName() + ">");
             }
 
             @Override
@@ -232,6 +233,47 @@ public class EntityProvidersTest {
         this.server = httpsServerForTest().addHandler(
             restHandler(new DogResource()).addCustomWriter(new DogListWriter()).build()).start();
         try (Response resp = call(request(server.uri().resolve("/inherited-dogs")))) {
+            assertThat(resp.code(), equalTo(200));
+            assertThat(resp.body().string(), equalTo("dogs"));
+        }
+    }
+
+    @Test
+    public void inheritedGenericArrayReturnTypeIsMaterializedAsArrayClass() throws Exception {
+        class Dog { }
+        abstract class BaseResource<T> {
+            private final T[] values;
+
+            BaseResource(T[] values) {
+                this.values = values;
+            }
+
+            @GET
+            public T[] get() {
+                return values;
+            }
+        }
+        @Path("inherited-dog-array")
+        class DogResource extends BaseResource<Dog> {
+            DogResource() {
+                super(new Dog[0]);
+            }
+        }
+        class DogArrayWriter implements MessageBodyWriter<Dog[]> {
+            @Override
+            public boolean isWriteable(Class<?> type, Type genericType, Annotation[] annotations, jakarta.ws.rs.core.MediaType mediaType) {
+                return genericType.equals(Dog[].class);
+            }
+
+            @Override
+            public void writeTo(Dog[] dogs, Class<?> type, Type genericType, Annotation[] annotations, jakarta.ws.rs.core.MediaType mediaType, MultivaluedMap<String, Object> httpHeaders, OutputStream entityStream) throws IOException {
+                entityStream.write("dogs".getBytes(StandardCharsets.UTF_8));
+            }
+        }
+
+        this.server = httpsServerForTest().addHandler(
+            restHandler(new DogResource()).addCustomWriter(new DogArrayWriter()).build()).start();
+        try (Response resp = call(request(server.uri().resolve("/inherited-dog-array")))) {
             assertThat(resp.code(), equalTo(200));
             assertThat(resp.body().string(), equalTo("dogs"));
         }

--- a/src/test/java/io/muserver/rest/JaxMethodLocatorTest.java
+++ b/src/test/java/io/muserver/rest/JaxMethodLocatorTest.java
@@ -1,7 +1,10 @@
 package io.muserver.rest;
 
 import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.QueryParam;
 import org.junit.Test;
 
 import java.lang.reflect.Method;
@@ -19,6 +22,16 @@ public class JaxMethodLocatorTest {
     private interface InterfaceWithAnnotation {
         @Path("qu")
         void go();
+    }
+
+    private interface ParameterAnnotatedBase {
+        @GET
+        void get(@PathParam("id") String id);
+    }
+
+    private static class ParameterAnnotatedImplementation implements ParameterAnnotatedBase {
+        @Override
+        public void get(@QueryParam("id") String id) { }
     }
 
     @Test
@@ -75,6 +88,12 @@ public class JaxMethodLocatorTest {
             public void go() {}
         }
         assertThat(getMethodThatHasJaxRSAnnotations(goMethod(BaseClassImpl.class)), equalTo(goMethod(BaseClass.class)));
+    }
+
+    @Test
+    public void parameterAnnotationsOnImplementationPreventInheritance() throws NoSuchMethodException {
+        Method implementation = ParameterAnnotatedImplementation.class.getDeclaredMethod("get", String.class);
+        assertThat(getMethodThatHasJaxRSAnnotations(implementation), equalTo(implementation));
     }
 
     private static Method goMethod(Class<?> clazz) {

--- a/src/test/java/io/muserver/rest/JaxMethodLocatorTest.java
+++ b/src/test/java/io/muserver/rest/JaxMethodLocatorTest.java
@@ -34,6 +34,23 @@ public class JaxMethodLocatorTest {
         public void get(@QueryParam("id") String id) { }
     }
 
+    private interface InterfaceInheritedThroughSuperclass {
+        @Path("superclass-interface")
+        void go();
+    }
+
+    private interface DirectInterface {
+        @Path("direct-interface")
+        void go();
+    }
+
+    private static class InterfaceBackedSuperclass implements InterfaceInheritedThroughSuperclass {
+        @Override
+        public void go() { }
+    }
+
+    private static class SubclassWithDirectInterface extends InterfaceBackedSuperclass implements DirectInterface { }
+
     @Test
     public void returnsTheGivenMethodIfNoAnnotations() {
         class SuperClass{
@@ -94,6 +111,15 @@ public class JaxMethodLocatorTest {
     public void parameterAnnotationsOnImplementationPreventInheritance() throws NoSuchMethodException {
         Method implementation = ParameterAnnotatedImplementation.class.getDeclaredMethod("get", String.class);
         assertThat(getMethodThatHasJaxRSAnnotations(implementation), equalTo(implementation));
+    }
+
+    @Test
+    public void superclassHierarchyIsPreferredOverADirectInterface() throws NoSuchMethodException {
+        Method inheritedMethod = SubclassWithDirectInterface.class.getMethod("go");
+        Method annotationSource = InterfaceInheritedThroughSuperclass.class.getDeclaredMethod("go");
+
+        assertThat(getMethodThatHasJaxRSAnnotations(inheritedMethod, SubclassWithDirectInterface.class),
+            equalTo(annotationSource));
     }
 
     private static Method goMethod(Class<?> clazz) {

--- a/src/test/java/io/muserver/rest/ObjWithTypeTest.java
+++ b/src/test/java/io/muserver/rest/ObjWithTypeTest.java
@@ -1,9 +1,11 @@
 package io.muserver.rest;
 
 import jakarta.ws.rs.core.GenericEntity;
+import jakarta.ws.rs.core.Response;
 import org.junit.Test;
 
 import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -34,6 +36,47 @@ public class ObjWithTypeTest {
         ParameterizedType pt = (ParameterizedType) hello.genericType;
         assertThat(pt.getActualTypeArguments()[0], equalTo(Dog.class));
         assertThat(pt.getRawType(), equalTo(List.class));
+    }
+
+    @Test
+    public void declaredGenericTypeIsUsedForDirectEntities() throws NoSuchMethodException {
+        Type declaredType = Sample.class.getDeclaredMethod("direct").getGenericReturnType();
+
+        ObjWithType result = ObjWithType.objType(new ArrayList<String>(), declaredType);
+
+        assertThat(result.type, equalTo(ArrayList.class));
+        assertThat(result.genericType, equalTo(declaredType));
+    }
+
+    @Test
+    public void responseEntityMetadataDoesNotComeFromTheResourceMethod() throws NoSuchMethodException {
+        Type declaredType = Sample.class.getDeclaredMethod("response").getGenericReturnType();
+
+        ObjWithType result = ObjWithType.objType(new JaxRSResponse.Builder().entity(new ArrayList<String>()).build(), declaredType);
+
+        assertThat(result.type, equalTo(ArrayList.class));
+        assertThat(result.genericType, equalTo(ArrayList.class));
+    }
+
+    @Test
+    public void genericEntityMetadataTakesPrecedenceOverTheResourceMethod() throws NoSuchMethodException {
+        Type declaredType = Sample.class.getDeclaredMethod("direct").getGenericReturnType();
+        GenericEntity<List<Integer>> entity = new GenericEntity<List<Integer>>(new ArrayList<>()) { };
+
+        ObjWithType result = ObjWithType.objType(entity, declaredType);
+
+        assertThat(result.type, equalTo(ArrayList.class));
+        assertThat(result.genericType, equalTo(entity.getType()));
+    }
+
+    private static class Sample {
+        List<String> direct() {
+            return null;
+        }
+
+        Response response() {
+            return null;
+        }
     }
 
 }

--- a/src/test/java/io/muserver/rest/ResourceClassTest.java
+++ b/src/test/java/io/muserver/rest/ResourceClassTest.java
@@ -75,6 +75,25 @@ public class ResourceClassTest {
         assertThat(resourceMethod.params.get(0).source, equalTo(ResourceMethodParam.ValueSource.PATH_PARAM));
     }
 
+    @Test
+    public void genericParentInterfaceParameterAnnotationsAreInherited() {
+        ResourceClass resourceClass = ResourceClass.fromObject(new ChildStringLookupResource(), ResourceMethodParamTest.BUILT_IN_PARAM_PROVIDERS, customizer);
+
+        assertThat(resourceClass.resourceMethods, hasSize(1));
+        ResourceMethod resourceMethod = resourceClass.resourceMethods.get(0);
+        assertThat(resourceMethod.methodHandle.isBridge(), equalTo(false));
+        assertThat(resourceMethod.methodHandle.getParameterTypes()[0], equalTo(String.class));
+        assertThat(resourceMethod.params.get(0).source, equalTo(ResourceMethodParam.ValueSource.PATH_PARAM));
+    }
+
+    @Test
+    public void interfaceAnnotationsAreFoundWhenTheImplementationComesFromASuperclass() {
+        ResourceClass resourceClass = ResourceClass.fromObject(new InterfaceResourceWithInheritedImplementation(), ResourceMethodParamTest.BUILT_IN_PARAM_PROVIDERS, customizer);
+
+        assertThat(resourceClass.resourceMethods, hasSize(1));
+        assertThat(resourceClass.resourceMethods.get(0).methodHandle.getDeclaringClass(), equalTo(UnannotatedImplementation.class));
+    }
+
     @Path("/api/fruits")
     private static class Fruit {
 
@@ -138,5 +157,29 @@ public class ResourceClassTest {
             return String.valueOf(id);
         }
     }
+
+    private interface ChildGenericLookupResource<T> extends GenericLookupResource<T> { }
+
+    @Path("/api/child-lookup")
+    private static class ChildStringLookupResource implements ChildGenericLookupResource<String> {
+        @Override
+        public String get(String id) {
+            return id;
+        }
+    }
+
+    private interface AnnotatedResourceMethod {
+        @GET
+        String get();
+    }
+
+    private static class UnannotatedImplementation {
+        public String get() {
+            return "hello";
+        }
+    }
+
+    @Path("/api/inherited-implementation")
+    private static class InterfaceResourceWithInheritedImplementation extends UnannotatedImplementation implements AnnotatedResourceMethod { }
 
 }

--- a/src/test/java/io/muserver/rest/ResourceClassTest.java
+++ b/src/test/java/io/muserver/rest/ResourceClassTest.java
@@ -64,6 +64,17 @@ public class ResourceClassTest {
         assertThat(resourceMethod.genericReturnType.getTypeName(), equalTo("java.util.List<java.lang.String>"));
     }
 
+    @Test
+    public void genericInterfaceParameterAnnotationsAreInherited() {
+        ResourceClass resourceClass = ResourceClass.fromObject(new StringLookupResource(), ResourceMethodParamTest.BUILT_IN_PARAM_PROVIDERS, customizer);
+
+        assertThat(resourceClass.resourceMethods, hasSize(1));
+        ResourceMethod resourceMethod = resourceClass.resourceMethods.get(0);
+        assertThat(resourceMethod.methodHandle.isBridge(), equalTo(false));
+        assertThat(resourceMethod.methodHandle.getParameterTypes()[0], equalTo(String.class));
+        assertThat(resourceMethod.params.get(0).source, equalTo(ResourceMethodParam.ValueSource.PATH_PARAM));
+    }
+
     @Path("/api/fruits")
     private static class Fruit {
 
@@ -107,6 +118,24 @@ public class ResourceClassTest {
         @Override
         public List<String> get() {
             return Collections.emptyList();
+        }
+    }
+
+    private interface GenericLookupResource<T> {
+        @GET
+        @Path("{id}")
+        String get(@PathParam("id") T id);
+    }
+
+    @Path("/api/lookup")
+    private static class StringLookupResource implements GenericLookupResource<String> {
+        @Override
+        public String get(String id) {
+            return id;
+        }
+
+        public String get(Integer id) {
+            return String.valueOf(id);
         }
     }
 

--- a/src/test/java/io/muserver/rest/ResourceClassTest.java
+++ b/src/test/java/io/muserver/rest/ResourceClassTest.java
@@ -6,6 +6,9 @@ import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 import org.junit.Test;
 
+import java.util.Collections;
+import java.util.List;
+
 import static java.net.URI.create;
 import static java.util.Collections.emptyList;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -51,6 +54,16 @@ public class ResourceClassTest {
 
     }
 
+    @Test
+    public void genericOverridesDoNotRegisterSyntheticBridgeMethods() {
+        ResourceClass resourceClass = ResourceClass.fromObject(new StringListResource(), ResourceMethodParamTest.BUILT_IN_PARAM_PROVIDERS, customizer);
+
+        assertThat(resourceClass.resourceMethods, hasSize(1));
+        ResourceMethod resourceMethod = resourceClass.resourceMethods.get(0);
+        assertThat(resourceMethod.methodHandle.isBridge(), equalTo(false));
+        assertThat(resourceMethod.genericReturnType.getTypeName(), equalTo("java.util.List<java.lang.String>"));
+    }
+
     @Path("/api/fruits")
     private static class Fruit {
 
@@ -82,6 +95,19 @@ public class ResourceClassTest {
     }
     private static class ConcreteWidget extends BaseWidgetResource {
 
+    }
+
+    private static abstract class GenericResource<T> {
+        @GET
+        public abstract T get();
+    }
+
+    @Path("/api/strings")
+    private static class StringListResource extends GenericResource<List<String>> {
+        @Override
+        public List<String> get() {
+            return Collections.emptyList();
+        }
     }
 
 }

--- a/src/test/java/io/muserver/rest/ResourceMethodParamTest.java
+++ b/src/test/java/io/muserver/rest/ResourceMethodParamTest.java
@@ -410,6 +410,46 @@ public class ResourceMethodParamTest {
     }
 
     @Test
+    public void inheritedGenericUriParameterConversionFailuresStayNotFound() throws IOException {
+        class BaseResource<T> {
+            @GET
+            @Path("{breed}")
+            public String get(@PathParam("breed") T breed) {
+                return breed.toString();
+            }
+        }
+        @Path("inherited-breeds")
+        class Sample extends BaseResource<Breed> { }
+        server = httpsServerForTest().addHandler(restHandler(new Sample())).start();
+
+        try (Response resp = call(request(server.uri().resolve("/inherited-breeds/CHIHUAHUA")))) {
+            assertThat(resp.code(), is(200));
+            assertThat(resp.body().string(), is("chihuahua"));
+        }
+        try (Response resp = call(request(server.uri().resolve("/inherited-breeds/BAD_DOG")))) {
+            assertThat(resp.code(), is(404));
+        }
+    }
+
+    @Test
+    public void inheritedInterfaceParameterNamesReachConversionExceptionMappers() throws IOException {
+        server = httpsServerForTest()
+            .addHandler(restHandler(new IntegerLookupResource())
+                .addExceptionMapper(UriParameterConversionException.class, exception ->
+                    jakarta.ws.rs.core.Response.status(400)
+                        .type(jakarta.ws.rs.core.MediaType.TEXT_PLAIN_TYPE)
+                        .entity(exception.getParameterName() + "|" + exception.getParameterValue() + "|"
+                            + exception.getTargetType().getName())
+                        .build()))
+            .start();
+
+        try (Response resp = call(request(server.uri().resolve("/integer-lookup/not-an-int")))) {
+            assertThat(resp.code(), is(400));
+            assertThat(resp.body().string(), is("id|not-an-int|java.lang.Integer"));
+        }
+    }
+
+    @Test
     public void wildcardEnumsCanBeUsed() throws IOException {
         @Path("samples")
         @Produces("text/plain")
@@ -432,6 +472,20 @@ public class ResourceMethodParamTest {
             assertThat(items.opt("nullable"), is(nullValue()));
             assertThat(items.getString("type"), is("string"));
             assertThat(items.getJSONArray("enum"), containsInAnyOrder(Stream.of(Breed.values()).map(Breed::name).toArray()));
+        }
+    }
+
+    private interface GenericLookupResource<T> {
+        @GET
+        @Path("{id}")
+        String get(@PathParam("id") T id);
+    }
+
+    @Path("integer-lookup")
+    private static class IntegerLookupResource implements GenericLookupResource<Integer> {
+        @Override
+        public String get(Integer id) {
+            return id.toString();
         }
     }
 

--- a/src/test/java/org/example/RuntimeTypeOnlyStringWriter.java
+++ b/src/test/java/org/example/RuntimeTypeOnlyStringWriter.java
@@ -1,0 +1,26 @@
+package org.example;
+
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.ext.MessageBodyWriter;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.nio.charset.StandardCharsets;
+
+@Produces({"text/plain;charset=utf-8", "*/*"})
+public class RuntimeTypeOnlyStringWriter implements MessageBodyWriter<String> {
+    @Override
+    public boolean isWriteable(Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType) {
+        return type.equals(String.class) && genericType.equals(String.class);
+    }
+
+    @Override
+    public void writeTo(String value, Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType,
+                        MultivaluedMap<String, Object> httpHeaders, OutputStream entityStream) throws IOException {
+        entityStream.write("runtime-type".getBytes(StandardCharsets.UTF_8));
+    }
+}


### PR DESCRIPTION
## Summary

- preserve a resource method's declared generic entity type for direct and asynchronous results
- rank writers by the runtime entity class while passing declared generic metadata to `isWriteable` and `writeTo`
- resolve inherited generic return and parameter types against the concrete resource class
- discover inherited JAX-RS annotations without registering compiler bridge methods
- keep `Response` and `GenericEntity` metadata precedence unchanged

## Why

Jakarta REST's Java-to-entity mapping requires a direct `LinkedList<String>` return to reach message-body writers with raw type `LinkedList.class` and generic type `LinkedList<String>`. Master derived both from the runtime object, so the TCK selected the complementary error writer.

Reviewing the surrounding type flow exposed related consistency gaps: provider ranking used the wrong side of assignability, `CompletionStage` subtypes could select the wrong type argument, inherited generic parameters could remain erased, bridge methods could be registered as duplicate resources, and inherited parameter annotations/names could be lost. The implementation now computes one effective type/annotation model at resource discovery and reuses it for conversion, OpenAPI metadata, reader selection, and invocation.

## Validation

- Java 11 full Mu test suite: passed
- Java 11 focused resource/type/provider tests on final head: 71/71 passed
- Jakarta REST TCK `ee/resource/java2entity`: 4/4 passed
- `git diff --check`
