### PR TITLE
Preserve entity-bearing WebApplicationException responses

### DIFF
--- a/src/main/java/io/muserver/rest/RestHandler.java
+++ b/src/main/java/io/muserver/rest/RestHandler.java
@@ -195,7 +195,9 @@ public class RestHandler implements MuHandler {
             }
             return;
         }
-        Response response = customExceptionMapper.toResponse(ex);
+        Response response = ex instanceof WebApplicationException && ((WebApplicationException) ex).getResponse().hasEntity()
+            ? null
+            : customExceptionMapper.toResponse(ex);
         if (response == null && ex instanceof WebApplicationException) {
             dealWithWebApplicationException(nestingLevel, request, muResponse, (WebApplicationException) ex, acceptHeaders, producesRef == null ? emptyList() : producesRef, directlyProducesRef == null ? emptyList() : directlyProducesRef);
         } else if (response == null) {

--- a/src/test/java/io/muserver/rest/ExceptionMappingProviderTest.java
+++ b/src/test/java/io/muserver/rest/ExceptionMappingProviderTest.java
@@ -109,6 +109,32 @@ public class ExceptionMappingProviderTest {
         }
     }
 
+    @Test
+    public void webApplicationExceptionsWithResponseEntitiesAreNotMapped() throws IOException {
+        @Path("samples")
+        class Sample {
+            @GET
+            public String get() {
+                throw new WebApplicationException(jakarta.ws.rs.core.Response.ok("Original response")
+                    .type(MediaType.TEXT_PLAIN_TYPE)
+                    .build());
+            }
+        }
+        this.server = ServerUtils.httpsServerForTest()
+            .addHandler(
+                restHandler(new Sample())
+                    .addExceptionMapper(Throwable.class, exception -> jakarta.ws.rs.core.Response.status(555)
+                        .entity("Mapped response")
+                        .type(MediaType.TEXT_PLAIN_TYPE)
+                        .build())
+            ).start();
+        try (Response resp = call(request().url(server.uri().resolve("/samples").toString()))) {
+            assertThat(resp.code(), is(200));
+            assertThat(resp.headers("content-type"), contains("text/plain;charset=utf-8"));
+            assertThat(resp.body().string(), is("Original response"));
+        }
+    }
+
 
     @Test
     public void customWritersCanBeUsedInExceptions() throws Exception {


### PR DESCRIPTION
## Summary

- preserve an entity-bearing `WebApplicationException` response instead of invoking a registered mapper
- retain mapper lookup for entity-less `WebApplicationException` instances
- add an integration regression with a generic `Throwable` mapper

## TCK intent and master failure

Jakarta REST requires the response embedded in a `WebApplicationException` to be used directly when it contains an entity. An available exception mapper is used only when that response has no entity.

Mu master selected and invoked `CustomExceptionMapper` before checking the embedded response. The TCK's mapper therefore replaced the intended 200/entity response with 202. This change skips mapper invocation in that case and lets the existing embedded-response path handle it. Jersey applies the same entity check before mapper lookup.

## Validation

- Java 11 `ExceptionMappingProviderTest,ProblemDetailsExceptionsTest`: 8/8 passed
- Java 11 `ee/resource/webappexception/mapper`: 11/11 passed (baseline 9/11)
- `git diff --check`
