### PR TITLE
Preserve reader interceptor media type changes

### DIFF
--- a/src/main/java/io/muserver/rest/JaxRSRequest.java
+++ b/src/main/java/io/muserver/rest/JaxRSRequest.java
@@ -36,6 +36,8 @@ class JaxRSRequest implements Request, ContainerRequestContext, ReaderIntercepto
     private final List<ReaderInterceptor> readerInterceptors;
     private final EntityProviders entityProviders;
     private String httpMethod;
+    private MediaType readerMediaType;
+    private boolean readerMediaTypeSet;
 
     JaxRSRequest(MuRequest muRequest, MuResponse muResponse, InputStream inputStream, String relativePath, SecurityContext securityContext, List<ReaderInterceptor> readerInterceptors, EntityProviders entityProviders) {
         this.muRequest = muRequest;
@@ -391,11 +393,13 @@ class JaxRSRequest implements Request, ContainerRequestContext, ReaderIntercepto
 
     @Override
     public MediaType getMediaType() {
-        return jaxHeaders.getMediaType();
+        return readerMediaTypeSet ? readerMediaType : jaxHeaders.getMediaType();
     }
 
     @Override
     public void setMediaType(MediaType mediaType) {
+        readerMediaType = mediaType;
+        readerMediaTypeSet = true;
         if (mediaType == null) {
             jaxHeaders.getMutableRequestHeaders().remove("content-type");
         } else {

--- a/src/test/java/io/muserver/rest/ReaderInterceptorTest.java
+++ b/src/test/java/io/muserver/rest/ReaderInterceptorTest.java
@@ -113,6 +113,34 @@ public class ReaderInterceptorTest {
     }
 
     @Test
+    public void interceptorsCanChangeTheRequestMediaType() throws Exception {
+        @Path("/greetings")
+        class GreetingResource {
+            @POST
+            public String hello(String body) {
+                return body;
+            }
+        }
+
+        server = ServerUtils.httpsServerForTest()
+            .addHandler(restHandler(new GreetingResource())
+                .addReaderInterceptor(context -> {
+                    context.setMediaType(jakarta.ws.rs.core.MediaType.APPLICATION_JSON_TYPE);
+                    assertThat(context.getMediaType(), is(jakarta.ws.rs.core.MediaType.APPLICATION_JSON_TYPE));
+                    return context.proceed();
+                })
+            )
+            .start();
+
+        try (Response resp = call(request(server.uri().resolve("/greetings"))
+            .post(requestBody("hello"))
+        )) {
+            assertThat(resp.code(), is(200));
+            assertThat(resp.body().string(), equalTo("hello"));
+        }
+    }
+
+    @Test
     public void resourceInfoAndMuRequestCanBeExtractedFromProperties() throws Exception {
         @Path("/greetings")
         class GreetingResource {


### PR DESCRIPTION
## Summary

- retain explicit reader-interceptor media-type changes as mutable context state
- keep the existing mutable `Content-Type` header update
- add an integration regression covering set/get followed by entity reading

## TCK intent and master failure

The test calls `ReaderInterceptorContext.setMediaType(application/x-www-form-urlencoded)`, immediately reads it back with `getMediaType()`, and returns that value through the resource. The changed media type must also be used by subsequent reader processing.

Mu master updated the mutable JAX-RS header copy in `setMediaType`, but `getMediaType` reread the original Mu request headers and returned the original `*/*`. This change stores explicit interceptor media-type state and uses it after the setter is called, including the valid null case. Jersey similarly keeps media type as mutable interceptor-context state.

## Validation

- Java 11 `ReaderInterceptorTest,JaxRsHttpHeadersAdapterTest`: 17/17 passed
- Java 11 target `containerreader/interceptorcontext` leaf: 15/15 passed (baseline 14/15)
- Java 11 adjacent `containerreader/readerinterceptorcontext` leaf: 7/7 passed
- `git diff --check`
