### PR TITLE
Honor interceptor priority ordering

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -97,6 +97,11 @@
             <version>3.0.0</version>
         </dependency>
         <dependency>
+            <groupId>jakarta.annotation</groupId>
+            <artifactId>jakarta.annotation-api</artifactId>
+            <version>2.0.0</version>
+        </dependency>
+        <dependency>
             <groupId>org.jspecify</groupId>
             <artifactId>jspecify</artifactId>
             <version>1.0.0</version>
@@ -316,6 +321,7 @@
                                     <includes>
                                         <include>org.slf4j:slf4j-api</include>
                                         <include>jakarta.ws.rs:jakarta.ws.rs-api</include>
+                                        <include>jakarta.annotation:jakarta.annotation-api</include>
                                         <include>io.netty:*</include>
                                         <include>org.jspecify:jspecify</include>
                                     </includes>

--- a/src/main/java/io/muserver/rest/RestHandlerBuilder.java
+++ b/src/main/java/io/muserver/rest/RestHandlerBuilder.java
@@ -7,6 +7,8 @@ import io.muserver.openapi.InfoObject;
 import io.muserver.openapi.OpenAPIObjectBuilder;
 import io.muserver.openapi.SchemaObject;
 import io.muserver.openapi.SchemaObjectBuilder;
+import jakarta.annotation.Priority;
+import jakarta.ws.rs.Priorities;
 import jakarta.ws.rs.container.ContainerRequestFilter;
 import jakarta.ws.rs.container.ContainerResponseFilter;
 import jakarta.ws.rs.container.PreMatching;
@@ -29,6 +31,8 @@ import static java.util.Arrays.asList;
  * @see #restHandler(Object...)
  */
 public class RestHandlerBuilder implements MuHandlerBuilder<RestHandler> {
+
+    private static final Comparator<Object> INTERCEPTOR_PRIORITY = Comparator.comparingInt(RestHandlerBuilder::priority);
 
     private final List<Object> resources = new ArrayList<>();
     private final List<MessageBodyWriter> customWriters = new ArrayList<>();
@@ -367,8 +371,8 @@ public class RestHandlerBuilder implements MuHandlerBuilder<RestHandler> {
 
     /**
      * Registers a writer interceptor allowing for inspection and alteration of response bodies.
-     * <p>Interceptors are executed in the order added, and are called before any message body
-     * writers added by {@link #addCustomWriter(MessageBodyWriter)}.</p>
+     * <p>Interceptors are executed in ascending {@link Priority} order, defaulting to {@link Priorities#USER}, and are
+     * called before any message body writers added by {@link #addCustomWriter(MessageBodyWriter)}.</p>
      * <p>To access the {@link jakarta.ws.rs.container.ResourceInfo} or {@link io.muserver.MuRequest} for the current
      * request, the following code can be used:</p>
      * <pre><code>
@@ -380,14 +384,15 @@ public class RestHandlerBuilder implements MuHandlerBuilder<RestHandler> {
     public RestHandlerBuilder addWriterInterceptor(@Nullable WriterInterceptor writerInterceptor) {
         if (writerInterceptor != null) {
             this.writerInterceptors.add(writerInterceptor);
+            this.writerInterceptors.sort(INTERCEPTOR_PRIORITY);
         }
         return this;
     }
 
     /**
      * Registers a reader interceptor allowing for inspection and alteration of request bodies.
-     * <p>Interceptors are executed in the order added, and are called before any message body
-     * readers added by {@link #addCustomReader(MessageBodyReader)}.</p>
+     * <p>Interceptors are executed in ascending {@link Priority} order, defaulting to {@link Priorities#USER}, and are
+     * called before any message body readers added by {@link #addCustomReader(MessageBodyReader)}.</p>
      * <p>To access the {@link jakarta.ws.rs.container.ResourceInfo} or {@link io.muserver.MuRequest} for the current
      * request, the following code can be used:</p>
      * <pre><code>
@@ -399,8 +404,14 @@ public class RestHandlerBuilder implements MuHandlerBuilder<RestHandler> {
     public RestHandlerBuilder addReaderInterceptor(@Nullable ReaderInterceptor readerInterceptor) {
         if (readerInterceptor != null) {
             this.readerInterceptors.add(0, readerInterceptor);
+            this.readerInterceptors.sort(INTERCEPTOR_PRIORITY);
         }
         return this;
+    }
+
+    private static int priority(Object interceptor) {
+        Priority priority = interceptor.getClass().getAnnotation(Priority.class);
+        return priority == null ? Priorities.USER : priority.value();
     }
 
     /**

--- a/src/test/java/io/muserver/rest/ReaderInterceptorTest.java
+++ b/src/test/java/io/muserver/rest/ReaderInterceptorTest.java
@@ -2,6 +2,7 @@ package io.muserver.rest;
 
 import io.muserver.MuRequest;
 import io.muserver.MuServer;
+import jakarta.annotation.Priority;
 import jakarta.ws.rs.*;
 import jakarta.ws.rs.container.ResourceInfo;
 import jakarta.ws.rs.ext.ReaderInterceptor;
@@ -23,6 +24,8 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
 
 import static io.muserver.rest.RestHandlerBuilder.restHandler;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -34,6 +37,45 @@ import static scaffolding.MuAssert.stopAndCheck;
 public class ReaderInterceptorTest {
 
     private MuServer server;
+
+    @Test
+    public void lowerPriorityValueExecutesFirstRegardlessOfRegistrationOrder() throws Exception {
+        List<String> calls = new ArrayList<>();
+        @Priority(100)
+        class First implements ReaderInterceptor {
+            @Override
+            public Object aroundReadFrom(ReaderInterceptorContext context) throws IOException {
+                calls.add("first");
+                return context.proceed();
+            }
+        }
+        @Priority(200)
+        class Second implements ReaderInterceptor {
+            @Override
+            public Object aroundReadFrom(ReaderInterceptorContext context) throws IOException {
+                calls.add("second");
+                return context.proceed();
+            }
+        }
+        @Path("/priority")
+        class PriorityResource {
+            @POST
+            public String post(String body) {
+                return body;
+            }
+        }
+
+        server = ServerUtils.httpsServerForTest()
+            .addHandler(restHandler(new PriorityResource())
+                .addReaderInterceptor(new First())
+                .addReaderInterceptor(new Second()))
+            .start();
+
+        try (Response resp = call(request(server.uri().resolve("/priority")).post(requestBody("hello")))) {
+            assertThat(resp.code(), is(200));
+            assertThat(calls, contains("first", "second"));
+        }
+    }
 
     private static class UpperCaserInputStream extends FilterInputStream {
         public UpperCaserInputStream(InputStream in) {

--- a/src/test/java/io/muserver/rest/WriterInterceptorTest.java
+++ b/src/test/java/io/muserver/rest/WriterInterceptorTest.java
@@ -2,6 +2,7 @@ package io.muserver.rest;
 
 import io.muserver.MuRequest;
 import io.muserver.MuServer;
+import jakarta.annotation.Priority;
 import jakarta.ws.rs.*;
 import jakarta.ws.rs.container.ResourceInfo;
 import jakarta.ws.rs.ext.WriterInterceptor;
@@ -19,6 +20,8 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
 
 import static io.muserver.rest.RestHandlerBuilder.restHandler;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -30,6 +33,45 @@ import static scaffolding.MuAssert.stopAndCheck;
 public class WriterInterceptorTest {
 
     private MuServer server;
+
+    @Test
+    public void lowerPriorityValueExecutesFirstRegardlessOfRegistrationOrder() throws Exception {
+        List<String> calls = new ArrayList<>();
+        @Priority(100)
+        class First implements WriterInterceptor {
+            @Override
+            public void aroundWriteTo(WriterInterceptorContext context) throws IOException {
+                calls.add("first");
+                context.proceed();
+            }
+        }
+        @Priority(200)
+        class Second implements WriterInterceptor {
+            @Override
+            public void aroundWriteTo(WriterInterceptorContext context) throws IOException {
+                calls.add("second");
+                context.proceed();
+            }
+        }
+        @Path("/priority")
+        class PriorityResource {
+            @GET
+            public String get() {
+                return "hello";
+            }
+        }
+
+        server = ServerUtils.httpsServerForTest()
+            .addHandler(restHandler(new PriorityResource())
+                .addWriterInterceptor(new Second())
+                .addWriterInterceptor(new First()))
+            .start();
+
+        try (Response resp = call(request(server.uri().resolve("/priority")))) {
+            assertThat(resp.code(), is(200));
+            assertThat(calls, contains("first", "second"));
+        }
+    }
 
     @Test
     public void interceptorsCanChangeTheResponseEntityAndWrapEachOtherInOrderRegistered() throws Exception {


### PR DESCRIPTION
## Summary

- order reader and writer interceptor chains by ascending `@Priority`
- default unannotated interceptors to `Priorities.USER`
- retain stable existing order when priorities are equal
- add adverse-registration regressions for both chains

## TCK intent and master failure

The three reader-interceptor tests require the priority-100 interceptor to wrap priority 200: it mutates headers before the second reads them, catches an `IOException` thrown downstream, and replaces the input stream before downstream consumption.

Mu master did not inspect `@Priority`; reader registration prepended instances, so execution depended on the TCK application's unspecified `HashSet` iteration order. Current runs happened to pass, but the historical failures are exactly the reverse-order outcomes. Jakarta REST requires both ReadFrom and WriteTo interceptor chains to run in ascending priority order.

This change sorts both chains and adds the Jakarta Annotation API used for `@Priority` metadata.

## Validation

- Java 11 `ReaderInterceptorTest,WriterInterceptorTest`: 14/14 passed
- Java 11 target `readerinterceptorcontext`: 7/7 passed
- four neighboring reader/writer context leaves: 42 passed; 4 unrelated already-queued failures unchanged
- `git diff --check`
