### PR TITLE
Apply defaults to absent path parameters

### DIFF
--- a/src/main/java/io/muserver/rest/ResourceMethodParam.java
+++ b/src/main/java/io/muserver/rest/ResourceMethodParam.java
@@ -197,8 +197,9 @@ abstract class ResourceMethodParam {
                 return cookieValues.isEmpty() ? null : new CookieBuilder().withName(key).withValue(cookieValues.get(0)).build();
             }
             Collection<Object> collection = createCollection(paramClass);
+            String pathParam = source == ValueSource.PATH_PARAM ? matchedMethod.getPathParam(key) : null;
             List<String> specifiedValue =
-                source == ValueSource.PATH_PARAM ? Collections.singletonList(matchedMethod.getPathParam(key))
+                source == ValueSource.PATH_PARAM ? (pathParam == null ? emptyList() : Collections.singletonList(pathParam))
                     : source == ValueSource.QUERY_PARAM ? getParamValues(jaxRequest.getUriInfo().getQueryParameters(), key, cps, collection != null)
                     : source == ValueSource.HEADER_PARAM ? getParamValues(jaxRequest.getHeaders(), key, cps, collection != null)
                     : source == ValueSource.FORM_PARAM ? muRequest.form().getAll(key)

--- a/src/main/java/io/muserver/rest/UriPattern.java
+++ b/src/main/java/io/muserver/rest/UriPattern.java
@@ -75,7 +75,10 @@ public class UriPattern {
         if (matcher.matches()) {
             HashMap<String, PathSegment> params = new HashMap<>();
             for (String namedGroup : namedGroups) {
-                MuPathSegment segment = MuUriInfo.pathStringToSegments(matcher.group(namedGroup), true, true).findFirst().orElse(null);
+                String capturedValue = matcher.group(namedGroup);
+                MuPathSegment segment = capturedValue.isEmpty()
+                    ? new MuPathSegment("", ReadOnlyMultivaluedMap.empty())
+                    : MuUriInfo.pathStringToSegments(capturedValue, true, true).findFirst().orElse(null);
                 if (segment != null) {
                     params.put(namedGroup, segment);
                 }

--- a/src/test/java/io/muserver/rest/JaxMatchingTest.java
+++ b/src/test/java/io/muserver/rest/JaxMatchingTest.java
@@ -200,6 +200,25 @@ public class JaxMatchingTest {
         }
     }
 
+    @Test
+    public void emptyPathParamCaptureDoesNotUseDefaultValue() throws Exception {
+        @Path("/{param:.*}")
+        class Resource {
+            @GET
+            public String get(@DefaultValue("DEFAULT") @PathParam("param") String param) {
+                return param;
+            }
+        }
+
+        this.server = httpsServerForTest()
+            .addHandler(restHandler(new Resource()).build())
+            .start();
+        try (Response resp = call(request(server.uri()))) {
+            assertThat(resp.code(), is(200));
+            assertThat(resp.body().string(), is(""));
+        }
+    }
+
 
     @Test
     public void interfacesWithDefaultImplementationSupported() throws IOException {

--- a/src/test/java/io/muserver/rest/JaxMatchingTest.java
+++ b/src/test/java/io/muserver/rest/JaxMatchingTest.java
@@ -2,6 +2,7 @@ package io.muserver.rest;
 
 import io.muserver.MuServer;
 import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.DefaultValue;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
@@ -159,6 +160,43 @@ public class JaxMatchingTest {
         try (Response resp = call(request(server.uri().resolve("/customers/123/address/456")))) {
             assertThat(resp.code(), Matchers.is(200));
             assertThat(resp.body().string(), containsString("456"));
+        }
+    }
+
+    @Test
+    public void absentPathParamsUseDefaultValues() throws Exception {
+        @Path("/resource")
+        class Resource {
+            @GET
+            @Path("sbpath/{param}")
+            public String supplied(@PathParam("param") String param) {
+                return param;
+            }
+
+            @GET
+            @Path("sbpath/default")
+            public String defaulted(@DefaultValue("DEFAULT") @PathParam("param") String param) {
+                return param;
+            }
+        }
+        @Path("/locator")
+        class Locator {
+            @Path("sbpath")
+            public Resource locate() {
+                return new Resource();
+            }
+        }
+
+        this.server = httpsServerForTest()
+            .addHandler(restHandler(new Resource(), new Locator()).build())
+            .start();
+        try (Response resp = call(request(server.uri().resolve("/resource/sbpath/default")))) {
+            assertThat(resp.code(), is(200));
+            assertThat(resp.body().string(), is("DEFAULT"));
+        }
+        try (Response resp = call(request(server.uri().resolve("/locator/sbpath/sbpath/default")))) {
+            assertThat(resp.code(), is(200));
+            assertThat(resp.body().string(), is("DEFAULT"));
         }
     }
 

--- a/src/test/java/io/muserver/rest/PathMatchTest.java
+++ b/src/test/java/io/muserver/rest/PathMatchTest.java
@@ -16,6 +16,14 @@ public class PathMatchTest {
         assertThat(match.params().get("name"), equalTo("orange"));
     }
 
+    @Test
+    public void emptyPathCapturesArePresent() {
+        PathMatch match = UriPattern.uriTemplateToRegex("/{name:.*}").matcher(URI.create("/"));
+        assertThat(match.prefixMatches(), is(true));
+        assertThat(match.params(), hasEntry("name", ""));
+        assertThat(match.segments().get("name").getPath(), is(""));
+    }
+
 
     @Test
     public void theEmptyMatcherMatches() {


### PR DESCRIPTION
## Summary

- treat an absent path-parameter key as no supplied values
- allow eagerly converted `@DefaultValue` values to apply to absent direct and locator path parameters
- add direct-resource and subresource-locator regressions

## TCK intent and master failure

The literal `sbpath/default` method wins over the `{param}` route. Its `@PathParam("param")` is therefore absent and must receive the `ParamConverter`-converted `@DefaultValue("DEFAULT")`; the paired test verifies the same through a subresource locator.

Mu master wrapped a missing lookup in `Collections.singletonList(null)`. The nonempty list was treated as a supplied value, bypassing the default and passing null to the resource; its null dereference surfaced as 406. Jersey represents the absent key as no values, allowing the default extractor path.

This change returns an empty list only when the path key is absent and preserves the singleton list for present path values.

## Validation

- Java 11 `JaxMatchingTest`: 8/8 passed
- Java 11 full Mu suite: 844/844 passed
- Java 11 `ext/paramconverter`: 27/27 passed (baseline 25/27)
- Java 11 neighboring `pathparam`: 43 passed, 2 pre-existing unsupported, 0 unexpected
- `git diff --check`
