### PR TITLE
Throw when sending to a closed SSE sink

### DIFF
--- a/src/main/java/io/muserver/rest/JaxSseEventSinkImpl.java
+++ b/src/main/java/io/muserver/rest/JaxSseEventSinkImpl.java
@@ -42,6 +42,9 @@ class JaxSseEventSinkImpl implements SseEventSink {
 
     @Override
     public CompletionStage<?> send(OutboundSseEvent event) {
+        if (isClosed()) {
+            throw new IllegalStateException("The SSE stream was already closed");
+        }
 
         CompletionStage<?> stage = null;
 

--- a/src/main/java/io/muserver/rest/SseBroadcasterImpl.java
+++ b/src/main/java/io/muserver/rest/SseBroadcasterImpl.java
@@ -86,7 +86,8 @@ class SseBroadcasterImpl implements SseBroadcaster {
                         sendComplete(completableFuture, count);
                     });
                 } catch (IllegalStateException e) {
-                    onSinkErrored(sink, e);
+                    sinks.remove(sink);
+                    sendOnCloseEvent(sink);
                     sendComplete(completableFuture, count);
                 }
             }

--- a/src/main/java/io/muserver/rest/SseBroadcasterImpl.java
+++ b/src/main/java/io/muserver/rest/SseBroadcasterImpl.java
@@ -86,8 +86,9 @@ class SseBroadcasterImpl implements SseBroadcaster {
                         sendComplete(completableFuture, count);
                     });
                 } catch (IllegalStateException e) {
-                    sinks.remove(sink);
-                    sendOnCloseEvent(sink);
+                    if (sinks.remove(sink)) {
+                        sendOnCloseEvent(sink);
+                    }
                     sendComplete(completableFuture, count);
                 }
             }

--- a/src/main/java/io/muserver/rest/SseBroadcasterImpl.java
+++ b/src/main/java/io/muserver/rest/SseBroadcasterImpl.java
@@ -78,12 +78,17 @@ class SseBroadcasterImpl implements SseBroadcaster {
                 sendOnCloseEvent(sink);
                 sendComplete(completableFuture, count);
             } else {
-                sink.send(event).whenComplete((o, throwable) -> {
-                    if (throwable != null) {
-                        onSinkErrored(sink, throwable);
-                    }
+                try {
+                    sink.send(event).whenComplete((o, throwable) -> {
+                        if (throwable != null) {
+                            onSinkErrored(sink, throwable);
+                        }
+                        sendComplete(completableFuture, count);
+                    });
+                } catch (IllegalStateException e) {
+                    onSinkErrored(sink, e);
                     sendComplete(completableFuture, count);
-                });
+                }
             }
         }
 

--- a/src/test/java/io/muserver/rest/SseBroadcasterImplTest.java
+++ b/src/test/java/io/muserver/rest/SseBroadcasterImplTest.java
@@ -27,6 +27,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.CompletionStage;
 import java.util.concurrent.TimeUnit;
 
 import static io.muserver.rest.RestHandlerBuilder.restHandler;
@@ -288,6 +289,37 @@ public class SseBroadcasterImplTest {
 
         assertThat(MuRuntimeDelegate.connectedSinksCount(broadcaster), is(0));
 
+    }
+
+    @Test
+    public void synchronousSendFailureRemovesSinkAndCompletesBroadcast() throws Exception {
+        IllegalStateException sendFailure = new IllegalStateException("closed during broadcast");
+        List<Throwable> errors = new ArrayList<>();
+        SseBroadcasterImpl broadcaster = new SseBroadcasterImpl();
+        broadcaster.onError((sink, throwable) -> errors.add(throwable));
+
+        SseEventSink sink = new SseEventSink() {
+            @Override
+            public boolean isClosed() {
+                return false;
+            }
+
+            @Override
+            public CompletionStage<?> send(jakarta.ws.rs.sse.OutboundSseEvent event) {
+                throw sendFailure;
+            }
+
+            @Override
+            public void close() {
+            }
+        };
+        broadcaster.register(sink);
+
+        CompletionStage<?> broadcast = broadcaster.broadcast(MuRuntimeDelegate.createSseFactory().newEvent("Hello"));
+        broadcast.toCompletableFuture().get(1, TimeUnit.SECONDS);
+
+        assertThat(errors, contains(sendFailure));
+        assertThat(broadcaster.connectedSinksCount(), is(0));
     }
 
     @After

--- a/src/test/java/io/muserver/rest/SseBroadcasterImplTest.java
+++ b/src/test/java/io/muserver/rest/SseBroadcasterImplTest.java
@@ -12,6 +12,7 @@ import jakarta.ws.rs.ext.MessageBodyWriter;
 import jakarta.ws.rs.sse.Sse;
 import jakarta.ws.rs.sse.SseBroadcaster;
 import jakarta.ws.rs.sse.SseEventSink;
+import jakarta.ws.rs.sse.OutboundSseEvent;
 import okhttp3.Dispatcher;
 import org.junit.After;
 import org.junit.Before;
@@ -28,6 +29,7 @@ import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.CompletionStage;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
 import static io.muserver.rest.RestHandlerBuilder.restHandler;
@@ -299,6 +301,8 @@ public class SseBroadcasterImplTest {
         SseBroadcasterImpl broadcaster = new SseBroadcasterImpl();
         broadcaster.onError((sink, throwable) -> errors.add(throwable));
         broadcaster.onClose(closedSinks::add);
+        CountDownLatch sendsStarted = new CountDownLatch(2);
+        CountDownLatch releaseSends = new CountDownLatch(1);
 
         SseEventSink sink = new SseEventSink() {
             @Override
@@ -308,6 +312,13 @@ public class SseBroadcasterImplTest {
 
             @Override
             public CompletionStage<?> send(jakarta.ws.rs.sse.OutboundSseEvent event) {
+                sendsStarted.countDown();
+                try {
+                    releaseSends.await(1, TimeUnit.SECONDS);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    throw new IllegalStateException(e);
+                }
                 throw sendFailure;
             }
 
@@ -317,8 +328,12 @@ public class SseBroadcasterImplTest {
         };
         broadcaster.register(sink);
 
-        CompletionStage<?> broadcast = broadcaster.broadcast(MuRuntimeDelegate.createSseFactory().newEvent("Hello"));
-        broadcast.toCompletableFuture().get(1, TimeUnit.SECONDS);
+        OutboundSseEvent event = MuRuntimeDelegate.createSseFactory().newEvent("Hello");
+        CompletableFuture<?> first = CompletableFuture.runAsync(() -> broadcaster.broadcast(event).toCompletableFuture().join());
+        CompletableFuture<?> second = CompletableFuture.runAsync(() -> broadcaster.broadcast(event).toCompletableFuture().join());
+        assertThat(sendsStarted.await(1, TimeUnit.SECONDS), is(true));
+        releaseSends.countDown();
+        CompletableFuture.allOf(first, second).get(1, TimeUnit.SECONDS);
 
         assertThat(errors, empty());
         assertThat(closedSinks, contains(sink));

--- a/src/test/java/io/muserver/rest/SseBroadcasterImplTest.java
+++ b/src/test/java/io/muserver/rest/SseBroadcasterImplTest.java
@@ -295,8 +295,10 @@ public class SseBroadcasterImplTest {
     public void synchronousSendFailureRemovesSinkAndCompletesBroadcast() throws Exception {
         IllegalStateException sendFailure = new IllegalStateException("closed during broadcast");
         List<Throwable> errors = new ArrayList<>();
+        List<SseEventSink> closedSinks = new ArrayList<>();
         SseBroadcasterImpl broadcaster = new SseBroadcasterImpl();
         broadcaster.onError((sink, throwable) -> errors.add(throwable));
+        broadcaster.onClose(closedSinks::add);
 
         SseEventSink sink = new SseEventSink() {
             @Override
@@ -318,7 +320,8 @@ public class SseBroadcasterImplTest {
         CompletionStage<?> broadcast = broadcaster.broadcast(MuRuntimeDelegate.createSseFactory().newEvent("Hello"));
         broadcast.toCompletableFuture().get(1, TimeUnit.SECONDS);
 
-        assertThat(errors, contains(sendFailure));
+        assertThat(errors, empty());
+        assertThat(closedSinks, contains(sink));
         assertThat(broadcaster.connectedSinksCount(), is(0));
     }
 

--- a/src/test/java/io/muserver/rest/SseEventSinkTest.java
+++ b/src/test/java/io/muserver/rest/SseEventSinkTest.java
@@ -38,6 +38,35 @@ public class SseEventSinkTest {
     private TestSseClient listener = new TestSseClient();
 
     @Test
+    public void sendingAfterCloseThrowsImmediatelyAndRepeatedCloseIsIgnored() throws InterruptedException {
+        AtomicReference<IllegalStateException> sendFailure = new AtomicReference<>();
+
+        @Path("/streamer")
+        class Streamer {
+            @GET
+            @Produces(MediaType.SERVER_SENT_EVENTS)
+            public void eventStream(@Context SseEventSink eventSink, @Context Sse sse) {
+                eventSink.send(sse.newEvent("hello"));
+                eventSink.close();
+                eventSink.close();
+                try {
+                    eventSink.send(sse.newEvent("too late"));
+                } catch (IllegalStateException e) {
+                    sendFailure.set(e);
+                }
+            }
+        }
+
+        server = ServerUtils.httpsServerForTest().addHandler(restHandler(new Streamer())).start();
+
+        try (SseClient.ServerSentEvent ignored = sseClient.newServerSentEvent(
+            request().url(server.uri().resolve("/streamer").toString()).build(), listener)) {
+            listener.assertListenerIsClosed();
+        }
+        assertThat(sendFailure.get(), instanceOf(IllegalStateException.class));
+    }
+
+    @Test
     public void canPublishMessagesAndCustomDataWritersAreUsed() throws InterruptedException {
 
         class Dog {
@@ -173,16 +202,20 @@ public class SseEventSinkTest {
         class Streamer {
 
             private void sendStuff(SseEventSink sink, Sse sse) {
-                sink.send(sse.newEvent("Hello"))
-                    .whenCompleteAsync((o, throwable) -> {
-                        if (throwable == null) {
-                            oneSentLatch.countDown();
-                            MuAssert.assertNotTimedOut("Waiting for response to close", responseClosedLatch);
-                            sendStuff(sink, sse);
-                        } else {
-                            failureLatch.countDown();
-                        }
-                    });
+                try {
+                    sink.send(sse.newEvent("Hello"))
+                        .whenCompleteAsync((o, throwable) -> {
+                            if (throwable == null) {
+                                oneSentLatch.countDown();
+                                MuAssert.assertNotTimedOut("Waiting for response to close", responseClosedLatch);
+                                sendStuff(sink, sse);
+                            } else {
+                                failureLatch.countDown();
+                            }
+                        });
+                } catch (IllegalStateException e) {
+                    failureLatch.countDown();
+                }
             }
 
             @GET


### PR DESCRIPTION
## Summary

- throw `IllegalStateException` synchronously when sending to a closed SSE sink
- retain idempotent repeated `close()` behavior
- add an integration regression and adapt disconnect coverage to the synchronous contract

## TCK intent and master failure

`SseEventSink.send()` must throw `IllegalStateException` when the sink is already closed. Mu master instead returned an exceptionally completed stage, so callers did not receive the required synchronous exception.

The Jakarta TCK's `closeTest` masks this behavior behind an earlier case-sensitive `Content-Type` field-name assertion; Mu correctly normalizes header names to lowercase for HTTP/2 compatibility, so that remaining TCK result is handled separately in the harness.

## Validation

- Java 11 `SseEventSinkTest`: 5/5 passed
- Java 11 full Mu suite: 844/844 passed
- Java 11 neighboring `ssebroadcaster`: 1/1 passed
- charset/header experiment fully reverted; production change is limited to closed-sink behavior
- `git diff --check`
