### PR TITLE
Continue past unmatched name-bound interceptors

### DIFF
--- a/src/main/java/io/muserver/rest/JaxRSRequest.java
+++ b/src/main/java/io/muserver/rest/JaxRSRequest.java
@@ -322,7 +322,7 @@ class JaxRSRequest implements Request, ContainerRequestContext, ReaderIntercepto
 
     @Override
     public Object proceed() throws IOException, WebApplicationException {
-        if (nextReader < readerInterceptors.size()) {
+        while (nextReader < readerInterceptors.size()) {
             nextReader++;
             ReaderInterceptor nextInterceptor = readerInterceptors.get(nextReader - 1);
             List<Class<? extends Annotation>> filterBindings = ResourceClass.getNameBindingAnnotations(nextInterceptor.getClass());

--- a/src/main/java/io/muserver/rest/JaxRSResponse.java
+++ b/src/main/java/io/muserver/rest/JaxRSResponse.java
@@ -427,12 +427,13 @@ class JaxRSResponse extends Response implements ContainerResponseContext, Writer
 
     @Override
     public void proceed() throws IOException, WebApplicationException {
-        if (nextWriter < writerInterceptors.size()) {
+        while (nextWriter < writerInterceptors.size()) {
             nextWriter++;
             WriterInterceptor nextInterceptor = writerInterceptors.get(nextWriter - 1);
             List<Class<? extends Annotation>> filterBindings = ResourceClass.getNameBindingAnnotations(nextInterceptor.getClass());
             if (requestContext.methodHasAnnotations(filterBindings)) {
                 nextInterceptor.aroundWriteTo(this);
+                return;
             }
         }
     }

--- a/src/test/java/io/muserver/rest/ReaderInterceptorTest.java
+++ b/src/test/java/io/muserver/rest/ReaderInterceptorTest.java
@@ -208,6 +208,50 @@ public class ReaderInterceptorTest {
     @Retention(value = RetentionPolicy.RUNTIME)
     public @interface UppercaseBinding { }
 
+    @NameBinding
+    @Target({ ElementType.TYPE, ElementType.METHOD })
+    @Retention(value = RetentionPolicy.RUNTIME)
+    public @interface UnusedBinding { }
+
+    @Test
+    public void nonMatchingNameBoundInterceptorDoesNotStopTheChain() throws IOException {
+        @UnusedBinding
+        class UnusedInterceptor implements ReaderInterceptor {
+            @Override
+            public Object aroundReadFrom(ReaderInterceptorContext context) {
+                throw new AssertionError("This interceptor should not run");
+            }
+        }
+
+        @UppercaseBinding
+        class Uppercaser implements ReaderInterceptor {
+            @Override
+            public Object aroundReadFrom(ReaderInterceptorContext context) throws IOException {
+                return ((String) context.proceed()).toUpperCase();
+            }
+        }
+
+        @Path("something")
+        class Resource {
+            @POST
+            @UppercaseBinding
+            public String post(String body) {
+                return body;
+            }
+        }
+
+        server = ServerUtils.httpsServerForTest()
+            .addHandler(restHandler(new Resource())
+                .addReaderInterceptor(new Uppercaser())
+                .addReaderInterceptor(new UnusedInterceptor()))
+            .start();
+
+        try (Response resp = call(request(server.uri().resolve("/something")).post(requestBody("hello")))) {
+            assertThat(resp.code(), is(200));
+            assertThat(resp.body().string(), is("HELLO"));
+        }
+    }
+
     @Test
     public void nameBindingIsCanBeUsedToTargetSpecificMethods() throws IOException {
 

--- a/src/test/java/io/muserver/rest/WriterInterceptorTest.java
+++ b/src/test/java/io/muserver/rest/WriterInterceptorTest.java
@@ -219,6 +219,51 @@ public class WriterInterceptorTest {
     @Retention(value = RetentionPolicy.RUNTIME)
     public @interface UppercaseBinding { }
 
+    @NameBinding
+    @Target({ ElementType.TYPE, ElementType.METHOD })
+    @Retention(value = RetentionPolicy.RUNTIME)
+    public @interface UnusedBinding { }
+
+    @Test
+    public void nonMatchingNameBoundInterceptorDoesNotStopTheChain() throws IOException {
+        @UnusedBinding
+        class UnusedInterceptor implements WriterInterceptor {
+            @Override
+            public void aroundWriteTo(WriterInterceptorContext context) {
+                throw new AssertionError("This interceptor should not run");
+            }
+        }
+
+        @UppercaseBinding
+        class Uppercaser implements WriterInterceptor {
+            @Override
+            public void aroundWriteTo(WriterInterceptorContext context) throws IOException {
+                context.setEntity(((String) context.getEntity()).toUpperCase());
+                context.proceed();
+            }
+        }
+
+        @Path("something")
+        class Resource {
+            @GET
+            @UppercaseBinding
+            public String get() {
+                return "hello";
+            }
+        }
+
+        server = ServerUtils.httpsServerForTest()
+            .addHandler(restHandler(new Resource())
+                .addWriterInterceptor(new UnusedInterceptor())
+                .addWriterInterceptor(new Uppercaser()))
+            .start();
+
+        try (Response resp = call(request(server.uri().resolve("/something")))) {
+            assertThat(resp.code(), is(200));
+            assertThat(resp.body().string(), is("HELLO"));
+        }
+    }
+
     @Test
     public void nameBindingIsCanBeUsedToTargetSpecificMethods() throws IOException {
 


### PR DESCRIPTION
## Summary

- continue reader and writer interceptor traversal past nonmatching name-bound interceptors
- preserve execution of later matching interceptors
- add symmetric reader and writer regression tests

## TCK intent and failure

`readerWriterInterceptorBoundTest` sends `1111` and expects the matching reader and writer interceptors to produce `1113`. Clean master returned `1112`: writer traversal encountered a nonmatching interceptor first and stopped, so it never reached the later matching interceptor. Reader registration order happened to hide the same defect.

PR #103's priority sorting is compatible but does not fix this selection bug.

## Validation

- clean-master baseline: `spec/filter/namebinding` 5/6; target returned `1112`
- fixed focused TCK leaf: 6/6
- full Mu suite: 845/845
- combined with PR #103: reader/writer focused tests 16/16 and TCK 6/6
- combined with PR #103 and harness PR #19: TCK 6/6
- `git diff --check`
