### PR TITLE
Prefer application message body writers

### DIFF
--- a/src/main/java/io/muserver/rest/EntityProviders.java
+++ b/src/main/java/io/muserver/rest/EntityProviders.java
@@ -65,6 +65,12 @@ class EntityProviders {
         // 3. SelectthesetofMessageBodyWriterprovidersthatsupport(seeSection4.2.3)theobjectandmedia type of the message entity body.
         Optional<ProviderWrapper<MessageBodyWriter<?>>> best = writers.stream().filter(w -> w.supports(responseMediaType))
             .sorted((o1, o2) -> {
+                // Application-provided providers take precedence over built-in providers.
+                int providerCompare = o1.compareTo(o2);
+                if (providerCompare != 0) {
+                    return providerCompare;
+                }
+
                 // 4. Sort the selected MessageBodyWriter providers with a primary key of generic type where providers whose generic
                 // type is the nearest superclass of the object class are sorted first
 
@@ -81,8 +87,7 @@ class EntityProviders {
                     return mtCompare;
                 }
 
-                // Natural order is to prefer user-supplied
-                return o1.compareTo(o2);
+                return 0;
             })
             .filter(w -> w.provider.isWriteable(type, genericType, annotations, responseMediaType))
             .findFirst();

--- a/src/test/java/io/muserver/rest/EntityProvidersTest.java
+++ b/src/test/java/io/muserver/rest/EntityProvidersTest.java
@@ -13,6 +13,7 @@ import okhttp3.RequestBody;
 import okhttp3.Response;
 import okio.BufferedSink;
 import org.example.MyStringReaderWriter;
+import org.example.NumberWriter;
 import org.example.RuntimeTypeOnlyStringWriter;
 import org.hamcrest.Matchers;
 import org.junit.After;
@@ -82,6 +83,26 @@ public class EntityProvidersTest {
             assertThat(resp.code(), equalTo(200));
             assertThat(resp.header("Content-Type"), equalTo("text/plain;charset=utf-8"));
             assertThat(resp.body().string(), equalTo("--HELLO WORLD--"));
+        }
+    }
+
+    @Test
+    public void customWriterOverridesMoreSpecificBuiltInWriter() throws Exception {
+        @Path("numbers")
+        class Sample {
+            @GET
+            public Integer number() {
+                return 1;
+            }
+        }
+
+        this.server = httpsServerForTest().addHandler(
+            restHandler(new Sample())
+                .addCustomWriter(new NumberWriter())
+                .build()).start();
+        try (Response response = call(request(server.uri().resolve("/numbers")))) {
+            assertThat(response.code(), equalTo(200));
+            assertThat(response.body().string(), equalTo("custom-number"));
         }
     }
 

--- a/src/test/java/org/example/NumberWriter.java
+++ b/src/test/java/org/example/NumberWriter.java
@@ -1,0 +1,22 @@
+package org.example;
+
+import jakarta.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.ext.MessageBodyWriter;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+
+public class NumberWriter implements MessageBodyWriter<Number> {
+    @Override
+    public boolean isWriteable(Class<?> type, Type genericType, Annotation[] annotations, jakarta.ws.rs.core.MediaType mediaType) {
+        return Number.class.isAssignableFrom(type);
+    }
+
+    @Override
+    public void writeTo(Number number, Class<?> type, Type genericType, Annotation[] annotations, jakarta.ws.rs.core.MediaType mediaType,
+                        MultivaluedMap<String, Object> httpHeaders, OutputStream entityStream) throws IOException {
+        entityStream.write("custom-number".getBytes());
+    }
+}


### PR DESCRIPTION
## Summary
- Prefer application MessageBodyWriters over built-in writers.
- Retain generic and media-type ranking within the same provider class.
- Add a regression covering a Number writer overriding the built-in Integer writer.

## Validation
- `mvn -Dtest=EntityProvidersTest test`
- Focused Jakarta REST TCK spec/provider/overridestandard: 13 passed.