### PR TITLE
Handle mapped filter errors once

### DIFF
--- a/src/main/java/io/muserver/rest/JaxRSRequest.java
+++ b/src/main/java/io/muserver/rest/JaxRSRequest.java
@@ -39,6 +39,7 @@ class JaxRSRequest implements Request, ContainerRequestContext, ReaderIntercepto
     private Response abortResponse;
     private boolean requestFilterChainRunning;
     private boolean responseFilterChainStarted;
+    private boolean exceptionMapperUsed;
 
     JaxRSRequest(MuRequest muRequest, MuResponse muResponse, InputStream inputStream, String relativePath, SecurityContext securityContext, List<ReaderInterceptor> readerInterceptors, EntityProviders entityProviders) {
         this.muRequest = muRequest;
@@ -58,10 +59,24 @@ class JaxRSRequest implements Request, ContainerRequestContext, ReaderIntercepto
     }
 
     boolean methodHasAnnotations(List<Class<? extends Annotation>> toCheck) {
+        if (toCheck.isEmpty()) {
+            return true;
+        }
         if (matchedMethod == null) {
             return false;
         }
         return matchedMethod.resourceMethod.hasAll(toCheck);
+    }
+
+    Response mapExceptionOnce(CustomExceptionMapper exceptionMapper, Exception exception) {
+        if (exceptionMapperUsed) {
+            return null;
+        }
+        Response response = exceptionMapper.toResponse(exception);
+        if (response != null) {
+            exceptionMapperUsed = true;
+        }
+        return response;
     }
 
     @Override

--- a/src/main/java/io/muserver/rest/RestHandler.java
+++ b/src/main/java/io/muserver/rest/RestHandler.java
@@ -217,7 +217,7 @@ public class RestHandler implements MuHandler {
         }
         Response response = ex instanceof WebApplicationException && ((WebApplicationException) ex).getResponse().hasEntity()
             ? null
-            : customExceptionMapper.toResponse(ex);
+            : request.mapExceptionOnce(customExceptionMapper, ex);
         if (response == null && ex instanceof WebApplicationException) {
             dealWithWebApplicationException(nestingLevel, request, muResponse, (WebApplicationException) ex, acceptHeaders, producesRef == null ? emptyList() : producesRef, directlyProducesRef == null ? emptyList() : directlyProducesRef);
         } else if (response == null) {

--- a/src/test/java/io/muserver/rest/FilterTest.java
+++ b/src/test/java/io/muserver/rest/FilterTest.java
@@ -756,14 +756,17 @@ public class FilterTest {
 
     @Test
     public void globalResponseFiltersRunForAnExceptionMappedBeforeMatching() throws IOException {
+        @PreMatching
+        class ThrowingFilter implements ContainerRequestFilter {
+            @Override
+            public void filter(ContainerRequestContext requestContext) {
+                throw new IllegalArgumentException("broken before matching");
+            }
+        }
+
         server = httpsServerForTest()
             .addHandler(restHandler(new BrokenResource())
-                .addRequestFilter(new ContainerRequestFilter() {
-                    @Override
-                    public void filter(ContainerRequestContext requestContext) {
-                        throw new IllegalArgumentException("broken before matching");
-                    }
-                })
+                .addRequestFilter(new ThrowingFilter())
                 .addExceptionMapper(IllegalArgumentException.class, exception -> jakarta.ws.rs.core.Response.ok("100").build())
                 .addResponseFilter((requestContext, responseContext) ->
                     responseContext.setEntity(responseContext.getEntity() + " filtered")))

--- a/src/test/java/io/muserver/rest/FilterTest.java
+++ b/src/test/java/io/muserver/rest/FilterTest.java
@@ -754,6 +754,54 @@ public class FilterTest {
         assertThat(responseFilterCalls.get(), equalTo(1));
     }
 
+    @Test
+    public void globalResponseFiltersRunForAnExceptionMappedBeforeMatching() throws IOException {
+        server = httpsServerForTest()
+            .addHandler(restHandler(new BrokenResource())
+                .addRequestFilter(new ContainerRequestFilter() {
+                    @Override
+                    public void filter(ContainerRequestContext requestContext) {
+                        throw new IllegalArgumentException("broken before matching");
+                    }
+                })
+                .addExceptionMapper(IllegalArgumentException.class, exception -> jakarta.ws.rs.core.Response.ok("100").build())
+                .addResponseFilter((requestContext, responseContext) ->
+                    responseContext.setEntity(responseContext.getEntity() + " filtered")))
+            .start();
+
+        try (Response response = call(request(server.uri().resolve("/broken")))) {
+            assertThat(response.code(), equalTo(200));
+            assertThat(response.body().string(), is("100 filtered"));
+        }
+    }
+
+    @Test
+    public void exceptionMapperIsNotUsedAgainWhenWritingItsResponseFails() throws IOException {
+        AtomicInteger mapperCalls = new AtomicInteger();
+
+        server = httpsServerForTest()
+            .addHandler(restHandler(new BrokenResource())
+                .addRequestFilter(new ContainerRequestFilter() {
+                    @Override
+                    public void filter(ContainerRequestContext requestContext) {
+                        throw new IllegalArgumentException("first exception");
+                    }
+                })
+                .addExceptionMapper(IllegalArgumentException.class, exception -> {
+                    mapperCalls.incrementAndGet();
+                    return jakarta.ws.rs.core.Response.ok("mapped").build();
+                })
+                .addResponseFilter((requestContext, responseContext) -> {
+                    throw new IllegalArgumentException("second exception");
+                }))
+            .start();
+
+        try (Response response = call(request(server.uri().resolve("/broken")))) {
+            assertThat(response.code(), equalTo(500));
+        }
+        assertThat(mapperCalls.get(), equalTo(1));
+    }
+
     @Path("/broken")
     public static class BrokenResource {
 


### PR DESCRIPTION
## Summary
- run unbound filters and interceptors even before resource matching
- prevent an exception mapper from producing a second response in one request
- add regression coverage for both error paths

## Validation
- `mvn -Dtest=FilterTest test`