### PR TITLE
Validate HTTP/2 content length before EOF

### DIFF
--- a/src/main/java/io/muserver/Http2Stream.java
+++ b/src/main/java/io/muserver/Http2Stream.java
@@ -145,10 +145,10 @@ class Http2Stream implements ResponseInfo {
                 throw new Http2Exception(Http2ErrorCode.PROTOCOL_ERROR, "invalid trailer field", id);
             }
         }
+        validateRequestBodyLengthAtEnd();
         if (bodyInputStream instanceof Http2BodyInputStream) {
             ((Http2BodyInputStream) bodyInputStream).onTrailers(headersFrame.headers());
         }
-        validateRequestBodyLengthAtEnd();
         switch (state) {
             case OPEN:
                 state = State.HALF_CLOSED_REMOTE;

--- a/src/main/java/io/muserver/Http2Stream.java
+++ b/src/main/java/io/muserver/Http2Stream.java
@@ -177,9 +177,13 @@ class Http2Stream implements ResponseInfo {
             if (declaredRequestBodyLength != null && receivedRequestBodyLength > declaredRequestBodyLength) {
                 throw new Http2Exception(Http2ErrorCode.PROTOCOL_ERROR, "content-length does not match received DATA", id);
             }
+            if (dataFrame.endStream()) {
+                // Validate before making the terminal frame visible to the handler. Otherwise the
+                // handler can observe EOF and send a response before this stream error is raised.
+                validateRequestBodyLengthAtEnd();
+            }
             ((Http2BodyInputStream)bodyInputStream).onData(dataFrame, flowControlSize);
             if (dataFrame.endStream()) {
-                validateRequestBodyLengthAtEnd();
                 switch (state) {
                     case OPEN:
                         state = State.HALF_CLOSED_REMOTE;

--- a/src/test/java/io/muserver/RFC9113_8_1_HttpMessageFramingTest.java
+++ b/src/test/java/io/muserver/RFC9113_8_1_HttpMessageFramingTest.java
@@ -237,6 +237,36 @@ class RFC9113_8_1_HttpMessageFramingTest {
         }
     }
 
+    @Test
+    void contentLengthMustMatchWhenRequestEndsWithTrailers() throws Exception {
+        server = httpsServer()
+            .withHttp2Config(Http2ConfigBuilder.http2Enabled())
+            .addHandler(Method.POST, "/hello", (request, response, pathParams) -> {
+                request.readBodyAsString();
+                response.status(200);
+            })
+            .start();
+
+        try (var client = new H2Client();
+             var con = client.connect(server)) {
+
+            var headers = postHelloHeaders(getPort());
+            headers.add("content-length", "5");
+            var trailers = new FieldBlock();
+            trailers.add("checksum", "abc123");
+
+            con.handshake()
+                .writeFrame(new Http2HeadersFrame(1, false, headers))
+                .writeFrame(utf8DataFrame(1, false, "1234"))
+                .writeFrame(new Http2HeadersFrame(1, true, trailers))
+                .flush();
+
+            var reset = readIgnoringWindowUpdates(con, Http2ResetStreamFrame.class);
+            assertThat(reset.streamId(), equalTo(1));
+            assertThat(reset.errorCodeEnum(), equalTo(Http2ErrorCode.PROTOCOL_ERROR));
+        }
+    }
+
     private int getPort() {
         return server.uri().getPort();
     }


### PR DESCRIPTION
## Summary

- validate the accumulated HTTP/2 request body length before exposing a terminal DATA frame to the request handler
- prevent a handler from observing EOF and sending a successful response before the required `RST_STREAM` is queued
- preserve the existing behavior for valid terminal DATA frames

## Root cause

`Http2Stream.onData()` previously published an end-of-stream DATA frame to `Http2BodyInputStream` before checking whether the accumulated payload matched the declared `content-length`. This created a scheduling race where the handler could consume EOF and send a `200` response before the connection raised `PROTOCOL_ERROR`.

## Validation

- `mise exec java@temurin-11 -- mvn -Dtest=io.muserver.RFC9113_8_1_HttpMessageFramingTest test` — 7 tests passed
- previously failing multi-frame test run 20 times in fresh Maven/JVM invocations — 20 passed
- `mise exec java@temurin-11 -- mvn test` — 1,403 tests passed, 0 failures, 0 errors, 5 skipped