### PR TITLE
Reject request context mutation from response filters

### DIFF
--- a/src/main/java/io/muserver/rest/JaxRSRequest.java
+++ b/src/main/java/io/muserver/rest/JaxRSRequest.java
@@ -448,6 +448,7 @@ class JaxRSRequest implements Request, ContainerRequestContext, ReaderIntercepto
 
     @Override
     public void setEntityStream(InputStream input) {
+        ensureNotInResponseFilter("setEntityStream");
         this.inputStream = input;
     }
 
@@ -458,19 +459,24 @@ class JaxRSRequest implements Request, ContainerRequestContext, ReaderIntercepto
 
     @Override
     public void setSecurityContext(SecurityContext context) {
+        ensureNotInResponseFilter("setSecurityContext");
         this.securityContext = context;
     }
 
     @Override
     public void abortWith(Response response) {
-        if (responseFilterChainStarted) {
-            throw new IllegalStateException("abortWith cannot be called from a response filter");
-        }
+        ensureNotInResponseFilter("abortWith");
         response = Objects.requireNonNull(response, "response");
         if (!requestFilterChainRunning) {
             throw new FilterAbortedException(response);
         }
         this.abortResponse = response;
+    }
+
+    private void ensureNotInResponseFilter(String operation) {
+        if (responseFilterChainStarted) {
+            throw new IllegalStateException(operation + " cannot be called from a response filter");
+        }
     }
 
     Response getAbortResponse() {

--- a/src/test/java/io/muserver/rest/FilterTest.java
+++ b/src/test/java/io/muserver/rest/FilterTest.java
@@ -755,6 +755,41 @@ public class FilterTest {
     }
 
     @Test
+    public void requestContextCannotBeMutatedFromResponseFilter() throws IOException {
+        AtomicReference<Throwable> abortFailure = new AtomicReference<>();
+        AtomicReference<Throwable> entityStreamFailure = new AtomicReference<>();
+        AtomicReference<Throwable> securityContextFailure = new AtomicReference<>();
+
+        server = httpsServerForTest()
+            .addHandler(restHandler(new BrokenResource())
+                .addResponseFilter((requestContext, responseContext) -> {
+                    try {
+                        requestContext.abortWith(jakarta.ws.rs.core.Response.ok().build());
+                    } catch (Throwable failure) {
+                        abortFailure.set(failure);
+                    }
+                    try {
+                        requestContext.setEntityStream(new ByteArrayInputStream(new byte[0]));
+                    } catch (Throwable failure) {
+                        entityStreamFailure.set(failure);
+                    }
+                    try {
+                        requestContext.setSecurityContext(requestContext.getSecurityContext());
+                    } catch (Throwable failure) {
+                        securityContextFailure.set(failure);
+                    }
+                }))
+            .start();
+
+        try (Response response = call(request(server.uri().resolve("/broken")))) {
+            assertThat(response.code(), equalTo(200));
+        }
+        assertThat(abortFailure.get(), instanceOf(IllegalStateException.class));
+        assertThat(entityStreamFailure.get(), instanceOf(IllegalStateException.class));
+        assertThat(securityContextFailure.get(), instanceOf(IllegalStateException.class));
+    }
+
+    @Test
     public void globalResponseFiltersRunForAnExceptionMappedBeforeMatching() throws IOException {
         @PreMatching
         class ThrowingFilter implements ContainerRequestFilter {


### PR DESCRIPTION
## What changed

- reject `ContainerRequestContext.setEntityStream` from response filters
- reject `ContainerRequestContext.setSecurityContext` from response filters
- share the existing lifecycle guard used by `abortWith`
- add a direct response-filter regression covering all three operations

## Why

Jakarta REST permits these request-context mutations during request processing but requires `IllegalStateException` once response filtering has begun. Mu already enforced this for `abortWith`; the other two setters remained mutable.

This covers the three `container/requestcontext/illegalstate` todo rows. Inspection of the official TCK fixture also showed that those cases dereference a field-injected `UriInfo`, which Mu intentionally does not support. The direct regression proves the Mu behavior independently; the harness expectations will classify the fixture cases as blocked rather than relying on them as the implementation test.

## Validation

- new regression fails on `master` for `setEntityStream` and `setSecurityContext`, while proving `abortWith` already throws
- `mvn -Dtest=FilterTest test` — 22 passed
- `mvn test` under Java 11 — 891 passed