### PR TITLE
Preserve repeated path parameter captures

### DIFF
--- a/src/main/java/io/muserver/rest/MuUriInfo.java
+++ b/src/main/java/io/muserver/rest/MuUriInfo.java
@@ -128,17 +128,16 @@ class MuUriInfo implements UriInfo {
     @Override
     public MultivaluedMap<String, String> getPathParameters(boolean decode) {
         if (matchedMethod == null) return ReadOnlyMultivaluedMap.empty();
-        Map<String, PathSegment> pp = matchedMethod.pathParams;
+        Map<String, List<PathSegment>> pp = matchedMethod.pathParamValues;
         if (pp.isEmpty()) return ReadOnlyMultivaluedMap.empty();
         MultivaluedMap<String, String> all = new MultivaluedHashMap<>(pp.size());
-        for (Map.Entry<String, PathSegment> entry : pp.entrySet()) {
+        for (Map.Entry<String, List<PathSegment>> entry : pp.entrySet()) {
             String param = entry.getKey();
-            String path = entry.getValue().getPath();
-            if (!all.containsKey(param)) {
-                all.put(param, new ArrayList<>());
+            for (PathSegment segment : entry.getValue()) {
+                String path = segment.getPath();
+                if (!decode) path = urlEncode(path);
+                all.add(param, path);
             }
-            if (!decode) path = urlEncode(path);
-            all.get(param).add(path);
         }
         return readOnly(all);
     }

--- a/src/main/java/io/muserver/rest/PathMatch.java
+++ b/src/main/java/io/muserver/rest/PathMatch.java
@@ -4,6 +4,7 @@ import jakarta.ws.rs.core.PathSegment;
 
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -19,15 +20,17 @@ public class PathMatch {
     /**
      * An empty match
      */
-    public static final PathMatch EMPTY_MATCH = new PathMatch(true, Collections.emptyMap(), Pattern.compile("").matcher(""));
+    public static final PathMatch EMPTY_MATCH = new PathMatch(true, Collections.emptyMap(), Collections.emptyMap(), Pattern.compile("").matcher(""));
 
     private final boolean matches;
     private final Map<String, PathSegment> params;
+    private final Map<String, List<PathSegment>> allParams;
     private final Matcher matcher;
 
-    PathMatch(boolean matches, Map<String, PathSegment> params, Matcher matcher) {
+    PathMatch(boolean matches, Map<String, PathSegment> params, Map<String, List<PathSegment>> allParams, Matcher matcher) {
         this.matches = matches;
         this.params = params;
+        this.allParams = allParams;
         this.matcher = matcher;
     }
 
@@ -68,6 +71,14 @@ public class PathMatch {
      */
     public Map<String, PathSegment> segments() {
         return params;
+    }
+
+    Map<String, List<PathSegment>> allSegments() {
+        return allParams;
+    }
+
+    PathMatch withParams(Map<String, PathSegment> combinedParams, Map<String, List<PathSegment>> combinedAllParams) {
+        return new PathMatch(matches, combinedParams, combinedAllParams, matcher);
     }
 
     /**

--- a/src/main/java/io/muserver/rest/RequestMatcher.java
+++ b/src/main/java/io/muserver/rest/RequestMatcher.java
@@ -72,7 +72,7 @@ class RequestMatcher {
                 }
                 if (c == 0) {
                     // " and the number of capturing groups with non-default regular expressions (i.e. not ‘([ˆ/]+?)’) as the tertiary key (descending order)"
-                    c = Integer.compare(countNonDefaultGroups(o2.resourceClass.pathTemplate), countNonDefaultGroups(o1.resourceClass.pathTemplate));
+                    c = Integer.compare(o2pp.nonDefaultCapturingGroupCount(), o1pp.nonDefaultCapturingGroupCount());
                 }
                 return c;
             })
@@ -138,7 +138,7 @@ class RequestMatcher {
             }
             if (c == 0) {
                 // " and the number of capturing groups with non-default regular expressions (i.e. not ‘([ˆ/]+?)’) as the tertiary key (descending order)"
-                c = Integer.compare(countNonDefaultGroups(rm2.pathTemplate), countNonDefaultGroups(rm1.pathTemplate));
+                c = Integer.compare(rm2.pathPattern.nonDefaultCapturingGroupCount(), rm1.pathPattern.nonDefaultCapturingGroupCount());
             }
             if (c == 0) {
                 // "and the source of each member as quaternary key sorting those derived from sub-resource methods ahead of those derived from sub-resource locators"
@@ -307,13 +307,4 @@ class RequestMatcher {
 
     }
 
-    private int countNonDefaultGroups(String pathTemplate) {
-        int count = 0;
-        for (String bit : pathTemplate.split("/")) {
-            if (bit.startsWith("{") && bit.endsWith("}") && bit.contains(":")) {
-                count++;
-            }
-        }
-        return count;
-    }
 }

--- a/src/main/java/io/muserver/rest/RequestMatcher.java
+++ b/src/main/java/io/muserver/rest/RequestMatcher.java
@@ -246,9 +246,11 @@ class RequestMatcher {
         }
 
         public List<String> getPathParams(String key) {
-            List<PathSegment> segments = pathParamValues.get(key);
-            if (segments == null) return Collections.emptyList();
-            return segments.stream().map(PathSegment::getPath).collect(toList());
+            return getPathSegments(key).stream().map(PathSegment::getPath).collect(toList());
+        }
+
+        public List<PathSegment> getPathSegments(String key) {
+            return pathParamValues.getOrDefault(key, Collections.emptyList());
         }
     }
 

--- a/src/main/java/io/muserver/rest/RequestMatcher.java
+++ b/src/main/java/io/muserver/rest/RequestMatcher.java
@@ -68,7 +68,7 @@ class RequestMatcher {
                 int c = Integer.compare(o2pp.numberOfLiterals, o1pp.numberOfLiterals);
                 if (c == 0) {
                     // "the number of capturing groups as a secondary key (descending order)"
-                    c = Integer.compare(o2pp.namedGroups().size(), o1pp.namedGroups().size());
+                    c = Integer.compare(o2pp.capturingGroupCount(), o1pp.capturingGroupCount());
                 }
                 if (c == 0) {
                     // " and the number of capturing groups with non-default regular expressions (i.e. not ‘([ˆ/]+?)’) as the tertiary key (descending order)"
@@ -134,7 +134,7 @@ class RequestMatcher {
             int c = Integer.compare(rm2.pathPattern.numberOfLiterals, rm1.pathPattern.numberOfLiterals);
             if (c == 0) {
                 // "the number of capturing groups as a secondary key (descending order)"
-                c = Integer.compare(rm2.pathPattern.namedGroups().size(), rm1.pathPattern.namedGroups().size());
+                c = Integer.compare(rm2.pathPattern.capturingGroupCount(), rm1.pathPattern.capturingGroupCount());
             }
             if (c == 0) {
                 // " and the number of capturing groups with non-default regular expressions (i.e. not ‘([ˆ/]+?)’) as the tertiary key (descending order)"

--- a/src/main/java/io/muserver/rest/RequestMatcher.java
+++ b/src/main/java/io/muserver/rest/RequestMatcher.java
@@ -112,7 +112,9 @@ class RequestMatcher {
                         if (matcher.fullyMatches() || (resourceMethod.isSubResourceLocator() && matcher.prefixMatches())) {
                             Map<String, PathSegment> combinedParams = new HashMap<>(candidateClass.pathMatch.segments());
                             combinedParams.putAll(matcher.segments());
-                            candidates.add(new MatchedMethod(candidateClass, resourceMethod, combinedParams, matcher));
+                            Map<String, List<PathSegment>> combinedAllParams = copyPathParams(candidateClass.pathMatch.allSegments());
+                            mergePathParams(combinedAllParams, matcher.allSegments());
+                            candidates.add(new MatchedMethod(candidateClass, resourceMethod, combinedParams, combinedAllParams, matcher));
                         }
                     }
                 }
@@ -167,7 +169,7 @@ class RequestMatcher {
         if (l.size() == 1) {
             MatchedMethod mm = l.stream().findFirst().get();
 
-            MatchedClass mc = new MatchedClass(subResourceLocator.apply(mm), mm.pathMatch);
+            MatchedClass mc = new MatchedClass(subResourceLocator.apply(mm), mm.pathMatch.withParams(mm.pathParams, mm.pathParamValues));
 
             String remainingUrl = mm.pathMatch.lastGroup();
             //Set U to be the value of the final capturing group of R(TL) when matched against U, and set C0 to be the
@@ -186,12 +188,22 @@ class RequestMatcher {
         for (MatchedClass mc : candidateClasses) {
             for (ResourceMethod resourceMethod : mc.resourceClass.resourceMethods) {
                 if (resourceMethod.isSubResource() == isSubResource && !resourceMethod.isSubResourceLocator()) {
-                    MatchedMethod matchedMethod = new MatchedMethod(mc, resourceMethod, mc.pathMatch.segments(), mc.pathMatch);
+                    MatchedMethod matchedMethod = new MatchedMethod(mc, resourceMethod, mc.pathMatch.segments(), mc.pathMatch.allSegments(), mc.pathMatch);
                     candidates.add(matchedMethod);
                 }
             }
         }
         return candidates;
+    }
+
+    private static Map<String, List<PathSegment>> copyPathParams(Map<String, List<PathSegment>> source) {
+        Map<String, List<PathSegment>> copy = new LinkedHashMap<>();
+        mergePathParams(copy, source);
+        return copy;
+    }
+
+    private static void mergePathParams(Map<String, List<PathSegment>> target, Map<String, List<PathSegment>> source) {
+        source.forEach((name, values) -> target.computeIfAbsent(name, ignored -> new ArrayList<>()).addAll(values));
     }
 
     static class MatchedClass {
@@ -208,12 +220,15 @@ class RequestMatcher {
         final MatchedClass matchedClass;
         final ResourceMethod resourceMethod;
         final Map<String, PathSegment> pathParams;
+        final Map<String, List<PathSegment>> pathParamValues;
         final PathMatch pathMatch;
 
-        MatchedMethod(MatchedClass matchedClass, ResourceMethod resourceMethod, Map<String, PathSegment> pathParams, PathMatch pathMatch) {
+        MatchedMethod(MatchedClass matchedClass, ResourceMethod resourceMethod, Map<String, PathSegment> pathParams,
+                      Map<String, List<PathSegment>> pathParamValues, PathMatch pathMatch) {
             this.matchedClass = matchedClass;
             this.resourceMethod = resourceMethod;
             this.pathParams = pathParams;
+            this.pathParamValues = pathParamValues;
             this.pathMatch = pathMatch;
         }
 
@@ -228,6 +243,12 @@ class RequestMatcher {
         public String getPathParam(String key) {
             PathSegment segment = pathParams.get(key);
             return segment == null ? null : segment.getPath();
+        }
+
+        public List<String> getPathParams(String key) {
+            List<PathSegment> segments = pathParamValues.get(key);
+            if (segments == null) return Collections.emptyList();
+            return segments.stream().map(PathSegment::getPath).collect(toList());
         }
     }
 

--- a/src/main/java/io/muserver/rest/ResourceMethodParam.java
+++ b/src/main/java/io/muserver/rest/ResourceMethodParam.java
@@ -243,7 +243,9 @@ abstract class ResourceMethodParam {
             Collection<Object> collection = createCollection(paramClass);
             String pathParam = source == ValueSource.PATH_PARAM ? matchedMethod.getPathParam(key) : null;
             List<String> specifiedValue =
-                source == ValueSource.PATH_PARAM ? (pathParam == null ? emptyList() : Collections.singletonList(pathParam))
+                source == ValueSource.PATH_PARAM ? (collection == null
+                    ? (pathParam == null ? emptyList() : Collections.singletonList(pathParam))
+                    : matchedMethod.getPathParams(key))
                     : source == ValueSource.QUERY_PARAM ? getParamValues(jaxRequest.getUriInfo().getQueryParameters(), key, cps, collection != null)
                     : source == ValueSource.HEADER_PARAM ? getParamValues(jaxRequest.getHeaders(), key, cps, collection != null)
                     : source == ValueSource.FORM_PARAM ? muRequest.form().getAll(key)

--- a/src/main/java/io/muserver/rest/ResourceMethodParam.java
+++ b/src/main/java/io/muserver/rest/ResourceMethodParam.java
@@ -241,6 +241,12 @@ abstract class ResourceMethodParam {
                 return cookieValues.isEmpty() ? null : new CookieBuilder().withName(key).withValue(cookieValues.get(0)).build();
             }
             Collection<Object> collection = createCollection(paramClass);
+            if (collection != null && source == ValueSource.PATH_PARAM && isPathSegmentCollection()) {
+                for (PathSegment segment : matchedMethod.getPathSegments(key)) {
+                    collection.add(encodedRequested ? ((MuPathSegment) segment).toEncoded() : segment);
+                }
+                return readOnly(collection);
+            }
             String pathParam = source == ValueSource.PATH_PARAM ? matchedMethod.getPathParam(key) : null;
             List<String> specifiedValue =
                 source == ValueSource.PATH_PARAM ? (collection == null
@@ -266,13 +272,27 @@ abstract class ResourceMethodParam {
                 } else if (hasExplicitDefault()) {
                     collection.add(defaultValue());
                 }
-                return (collection instanceof List) ? Collections.unmodifiableList((List) collection)
-                    : (collection instanceof SortedSet) ? Collections.unmodifiableSortedSet((SortedSet) collection)
-                    : (collection instanceof Set) ? Collections.unmodifiableSet((Set) collection)
-                    : Collections.unmodifiableCollection(collection);
+                return readOnly(collection);
             } else {
                 return isSpecified ? ResourceMethodParam.convertValue(parameterHandle, type, paramConverter, false, specifiedValue.get(0), source, key) : defaultValue();
             }
+        }
+
+        private boolean isPathSegmentCollection() {
+            if (!(genericType instanceof ParameterizedType)) return false;
+            Type elementType = ((ParameterizedType) genericType).getActualTypeArguments()[0];
+            if (elementType instanceof WildcardType) {
+                Type[] upperBounds = ((WildcardType) elementType).getUpperBounds();
+                elementType = upperBounds.length == 0 ? elementType : upperBounds[0];
+            }
+            return elementType instanceof Class && PathSegment.class.isAssignableFrom((Class<?>) elementType);
+        }
+
+        private static Collection<?> readOnly(Collection<?> collection) {
+            return (collection instanceof List) ? Collections.unmodifiableList((List) collection)
+                : (collection instanceof SortedSet) ? Collections.unmodifiableSortedSet((SortedSet) collection)
+                : (collection instanceof Set) ? Collections.unmodifiableSet((Set) collection)
+                : Collections.unmodifiableCollection(collection);
         }
 
         private List<String> getParamValues(MultivaluedMap<String, String> queryParameters, String key, CollectionParameterStrategy cps, boolean isCollectionType) {

--- a/src/main/java/io/muserver/rest/ResourceMethodParam.java
+++ b/src/main/java/io/muserver/rest/ResourceMethodParam.java
@@ -290,7 +290,7 @@ abstract class ResourceMethodParam {
                 Type[] upperBounds = ((WildcardType) elementType).getUpperBounds();
                 elementType = upperBounds.length == 0 ? elementType : upperBounds[0];
             }
-            return elementType instanceof Class && PathSegment.class.isAssignableFrom((Class<?>) elementType);
+            return PathSegment.class.equals(elementType);
         }
 
         private static Collection<?> readOnly(Collection<?> collection) {

--- a/src/main/java/io/muserver/rest/ResourceMethodParam.java
+++ b/src/main/java/io/muserver/rest/ResourceMethodParam.java
@@ -242,8 +242,13 @@ abstract class ResourceMethodParam {
             }
             Collection<Object> collection = createCollection(paramClass);
             if (collection != null && source == ValueSource.PATH_PARAM && isPathSegmentCollection()) {
-                for (PathSegment segment : matchedMethod.getPathSegments(key)) {
-                    collection.add(encodedRequested ? ((MuPathSegment) segment).toEncoded() : segment);
+                List<PathSegment> pathSegments = matchedMethod.getPathSegments(key);
+                if (pathSegments.isEmpty() && hasExplicitDefault()) {
+                    collection.add(defaultValue());
+                } else {
+                    for (PathSegment segment : pathSegments) {
+                        collection.add(encodedRequested ? ((MuPathSegment) segment).toEncoded() : segment);
+                    }
                 }
                 return readOnly(collection);
             }

--- a/src/main/java/io/muserver/rest/UriPattern.java
+++ b/src/main/java/io/muserver/rest/UriPattern.java
@@ -22,18 +22,20 @@ public class UriPattern {
     private final List<String> namedGroupRegexes;
     private final List<String> capturedParameterNames;
     private final List<String> captureGroupNames;
+    private final int nonDefaultCapturingGroupCount;
     final int numberOfLiterals;
     final String pathWithoutRegex;
 
     private UriPattern(Pattern pattern, List<String> namedGroups, List<String> namedGroupRegexes,
                        List<String> capturedParameterNames, List<String> captureGroupNames,
-                       int numberOfLiterals, String pathWithoutRegex) {
+                       int numberOfLiterals, int nonDefaultCapturingGroupCount, String pathWithoutRegex) {
         this.pattern = pattern;
         this.namedGroups = Collections.unmodifiableList(namedGroups);
         this.namedGroupRegexes = namedGroupRegexes;
         this.capturedParameterNames = capturedParameterNames;
         this.captureGroupNames = captureGroupNames;
         this.numberOfLiterals = numberOfLiterals;
+        this.nonDefaultCapturingGroupCount = nonDefaultCapturingGroupCount;
         this.pathWithoutRegex = pathWithoutRegex;
     }
 
@@ -59,6 +61,10 @@ public class UriPattern {
 
     int capturingGroupCount() {
         return captureGroupNames.size();
+    }
+
+    int nonDefaultCapturingGroupCount() {
+        return nonDefaultCapturingGroupCount;
     }
 
     /**
@@ -131,6 +137,7 @@ public class UriPattern {
 
         StringBuilder regex = new StringBuilder();
         int numberOfLiterals = 0;
+        int nonDefaultCapturingGroupCount = 0;
         int curIndex = 0;
         int loop = 0;
         while (curIndex < template.length()) {
@@ -174,6 +181,9 @@ public class UriPattern {
                 } else {
                     groupRegex = DEFAULT_CAPTURING_GROUP_PATTERN;
                 }
+                if (!DEFAULT_CAPTURING_GROUP_PATTERN.equals(groupRegex)) {
+                    nonDefaultCapturingGroupCount++;
+                }
                 String captureGroupName = groupName;
                 if (!groupNames.contains(groupName)) {
                     groupNames.add(groupName);
@@ -203,7 +213,8 @@ public class UriPattern {
         // 5. Append '(/.*)?' to the result.
         regex.append("(/.*)?");
         return new UriPattern(Pattern.compile(regex.toString()), groupNames, namedGroupRegexes,
-            capturedParameterNames, captureGroupNames, numberOfLiterals, simplePath.toString());
+            capturedParameterNames, captureGroupNames, numberOfLiterals, nonDefaultCapturingGroupCount,
+            simplePath.toString());
     }
 
     private static Set<String> declaredParameterNames(String template) {

--- a/src/main/java/io/muserver/rest/UriPattern.java
+++ b/src/main/java/io/muserver/rest/UriPattern.java
@@ -20,13 +20,19 @@ public class UriPattern {
     private final Pattern pattern;
     private final List<String> namedGroups;
     private final List<String> namedGroupRegexes;
+    private final List<String> capturedParameterNames;
+    private final List<String> captureGroupNames;
     final int numberOfLiterals;
     final String pathWithoutRegex;
 
-    private UriPattern(Pattern pattern, List<String> namedGroups, List<String> namedGroupRegexes, int numberOfLiterals, String pathWithoutRegex) {
+    private UriPattern(Pattern pattern, List<String> namedGroups, List<String> namedGroupRegexes,
+                       List<String> capturedParameterNames, List<String> captureGroupNames,
+                       int numberOfLiterals, String pathWithoutRegex) {
         this.pattern = pattern;
         this.namedGroups = Collections.unmodifiableList(namedGroups);
         this.namedGroupRegexes = namedGroupRegexes;
+        this.capturedParameterNames = capturedParameterNames;
+        this.captureGroupNames = captureGroupNames;
         this.numberOfLiterals = numberOfLiterals;
         this.pathWithoutRegex = pathWithoutRegex;
     }
@@ -74,18 +80,21 @@ public class UriPattern {
         Matcher matcher = pattern.matcher(rawPath);
         if (matcher.matches()) {
             HashMap<String, PathSegment> params = new HashMap<>();
-            for (String namedGroup : namedGroups) {
-                String capturedValue = matcher.group(namedGroup);
+            Map<String, List<PathSegment>> allParams = new LinkedHashMap<>();
+            for (int i = 0; i < captureGroupNames.size(); i++) {
+                String parameterName = capturedParameterNames.get(i);
+                String capturedValue = matcher.group(captureGroupNames.get(i));
                 MuPathSegment segment = capturedValue.isEmpty()
                     ? new MuPathSegment("", ReadOnlyMultivaluedMap.empty())
                     : MuUriInfo.pathStringToSegments(capturedValue, true, true).findFirst().orElse(null);
                 if (segment != null) {
-                    params.put(namedGroup, segment);
+                    params.put(parameterName, segment);
+                    allParams.computeIfAbsent(parameterName, ignored -> new ArrayList<>()).add(segment);
                 }
             }
-            return new PathMatch(true, params, matcher);
+            return new PathMatch(true, params, allParams, matcher);
         } else {
-            return new PathMatch(false, Collections.emptyMap(), matcher);
+            return new PathMatch(false, Collections.emptyMap(), Collections.emptyMap(), matcher);
         }
     }
 
@@ -110,6 +119,9 @@ public class UriPattern {
         // Numbered comments are direct from the spec
         List<String> groupNames = new ArrayList<>();
         List<String> namedGroupRegexes = new ArrayList<>();
+        List<String> capturedParameterNames = new ArrayList<>();
+        List<String> captureGroupNames = new ArrayList<>();
+        Set<String> declaredParameterNames = declaredParameterNames(template);
 
         StringBuilder simplePath = new StringBuilder("/");
 
@@ -158,13 +170,19 @@ public class UriPattern {
                 } else {
                     groupRegex = DEFAULT_CAPTURING_GROUP_PATTERN;
                 }
+                String captureGroupName = groupName;
                 if (!groupNames.contains(groupName)) {
                     groupNames.add(groupName);
                     namedGroupRegexes.add(groupRegex);
-                    regex.append("(?<").append(groupName).append(">").append(groupRegex).append(MATRIX_PARAMETERS_PATTERN).append(')');
                 } else {
-                    regex.append("\\k<").append(groupName).append('>');
+                    int suffix = captureGroupNames.size();
+                    do {
+                        captureGroupName = "muServerRepeatedPathParam" + suffix++;
+                    } while (declaredParameterNames.contains(captureGroupName) || captureGroupNames.contains(captureGroupName));
                 }
+                capturedParameterNames.add(groupName);
+                captureGroupNames.add(captureGroupName);
+                regex.append("(?<").append(captureGroupName).append(">").append(groupRegex).append(MATRIX_PARAMETERS_PATTERN).append(')');
                 simplePath.append('{').append(groupName).append('}');
                 curIndex = endOfRegex;
             }
@@ -180,7 +198,17 @@ public class UriPattern {
 
         // 5. Append '(/.*)?' to the result.
         regex.append("(/.*)?");
-        return new UriPattern(Pattern.compile(regex.toString()), groupNames, namedGroupRegexes, numberOfLiterals, simplePath.toString());
+        return new UriPattern(Pattern.compile(regex.toString()), groupNames, namedGroupRegexes,
+            capturedParameterNames, captureGroupNames, numberOfLiterals, simplePath.toString());
+    }
+
+    private static Set<String> declaredParameterNames(String template) {
+        Set<String> names = new HashSet<>();
+        Matcher matcher = Pattern.compile("\\{\\s*([^\\s}:]+)").matcher(template);
+        while (matcher.find()) {
+            names.add(matcher.group(1));
+        }
+        return names;
     }
 
     private static String escapeRegex(String literal) {

--- a/src/main/java/io/muserver/rest/UriPattern.java
+++ b/src/main/java/io/muserver/rest/UriPattern.java
@@ -57,6 +57,10 @@ public class UriPattern {
         return namedGroups;
     }
 
+    int capturingGroupCount() {
+        return captureGroupNames.size();
+    }
+
     /**
      * Matches the given URI against this pattern.
      * @param input The URI to check against.

--- a/src/test/java/io/muserver/rest/FilterTest.java
+++ b/src/test/java/io/muserver/rest/FilterTest.java
@@ -246,11 +246,11 @@ public class FilterTest {
             )
             .start();
         try (Response resp = call(request(server.uri().resolve("/something/class%20param/repeat%20value/and/method%20param/repeat%20value?decode=decode%20it")))) {
-            assertThat(resp.body().string(), is("something/class param/repeat value/and/method param/repeat value class param repeat value method param "));
+            assertThat(resp.body().string(), is("something/class param/repeat value/and/method param/repeat value class param repeat value,repeat value method param "));
         }
 
         try (Response resp = call(request(server.uri().resolve("/something/class%20param/repeat%20value/and/method%20param/repeat%20value?decode=no%20decode")))) {
-            assertThat(resp.body().string(), is("something/class%20param/repeat%20value/and/method%20param/repeat%20value class%20param repeat%20value method%20param "));
+            assertThat(resp.body().string(), is("something/class%20param/repeat%20value/and/method%20param/repeat%20value class%20param repeat%20value,repeat%20value method%20param "));
         }
 
 

--- a/src/test/java/io/muserver/rest/JaxMatchingTest.java
+++ b/src/test/java/io/muserver/rest/JaxMatchingTest.java
@@ -126,6 +126,31 @@ public class JaxMatchingTest {
     }
 
     @Test
+    public void repeatedNonDefaultCapturesWinPathMatchingTies() throws IOException {
+        @Path("/regex-rank")
+        class RankedResource {
+            @GET
+            @Path("x/{id:\\d+}{id}")
+            public String oneRegex() {
+                return "one regex";
+            }
+
+            @GET
+            @Path("x/{id:\\d+}{id:\\d+}")
+            public String twoRegexes() {
+                return "two regexes";
+            }
+        }
+        server = ServerUtils.httpsServerForTest()
+            .addHandler(restHandler(new RankedResource()).build())
+            .start();
+        try (Response resp = call(request(server.uri().resolve("/regex-rank/x/12")))) {
+            assertThat(resp.code(), is(200));
+            assertThat(resp.body().string(), is("two regexes"));
+        }
+    }
+
+    @Test
     public void differentMethodsCanHaveDifferentRegexes() throws IOException {
         @Path("/api")
         class Thing {

--- a/src/test/java/io/muserver/rest/JaxMatchingTest.java
+++ b/src/test/java/io/muserver/rest/JaxMatchingTest.java
@@ -7,6 +7,7 @@ import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.core.PathSegment;
+import jakarta.ws.rs.ext.ParamConverter;
 import okhttp3.Response;
 import org.hamcrest.Matchers;
 import org.junit.After;
@@ -136,6 +137,52 @@ public class JaxMatchingTest {
         try (Response resp = call(request(server.uri().resolve("/default-segments")))) {
             assertThat(resp.code(), is(200));
             assertThat(resp.body().string(), is("DEFAULT:red"));
+        }
+    }
+
+    @Test
+    public void pathSegmentSubtypeCollectionsUseCustomConverters() throws IOException {
+        class CustomSegment implements PathSegment {
+            private final String path;
+
+            CustomSegment(String path) {
+                this.path = path;
+            }
+
+            @Override
+            public String getPath() {
+                return path;
+            }
+
+            @Override
+            public jakarta.ws.rs.core.MultivaluedMap<String, String> getMatrixParameters() {
+                return ReadOnlyMultivaluedMap.empty();
+            }
+        }
+        @Path("/custom-segments/{id}/{id}")
+        class CustomPathResource {
+            @GET
+            public String get(@PathParam("id") List<CustomSegment> segments) {
+                return segments.get(0).getPath() + "," + segments.get(1).getPath();
+            }
+        }
+        ParamConverter<CustomSegment> converter = new ParamConverter<CustomSegment>() {
+            @Override
+            public CustomSegment fromString(String value) {
+                return new CustomSegment("converted-" + value);
+            }
+
+            @Override
+            public String toString(CustomSegment value) {
+                return value.getPath();
+            }
+        };
+        server = ServerUtils.httpsServerForTest()
+            .addHandler(restHandler(new CustomPathResource()).addCustomParamConverter(CustomSegment.class, converter).build())
+            .start();
+        try (Response resp = call(request(server.uri().resolve("/custom-segments/a/b")))) {
+            assertThat(resp.code(), is(200));
+            assertThat(resp.body().string(), is("converted-a,converted-b"));
         }
     }
 

--- a/src/test/java/io/muserver/rest/JaxMatchingTest.java
+++ b/src/test/java/io/muserver/rest/JaxMatchingTest.java
@@ -101,6 +101,31 @@ public class JaxMatchingTest {
     }
 
     @Test
+    public void repeatedCapturesWinPathMatchingTies() throws IOException {
+        @Path("/rank")
+        class RankedResource {
+            @GET
+            @Path("x/{id}")
+            public String oneCapture() {
+                return "one capture";
+            }
+
+            @GET
+            @Path("x/{id}{id}")
+            public String twoCaptures() {
+                return "two captures";
+            }
+        }
+        server = ServerUtils.httpsServerForTest()
+            .addHandler(restHandler(new RankedResource()).build())
+            .start();
+        try (Response resp = call(request(server.uri().resolve("/rank/x/aa")))) {
+            assertThat(resp.code(), is(200));
+            assertThat(resp.body().string(), is("two captures"));
+        }
+    }
+
+    @Test
     public void differentMethodsCanHaveDifferentRegexes() throws IOException {
         @Path("/api")
         class Thing {

--- a/src/test/java/io/muserver/rest/JaxMatchingTest.java
+++ b/src/test/java/io/muserver/rest/JaxMatchingTest.java
@@ -15,6 +15,7 @@ import scaffolding.ServerUtils;
 
 import java.io.IOException;
 import java.net.URI;
+import java.util.List;
 
 import static io.muserver.rest.RestHandlerBuilder.restHandler;
 import static org.hamcrest.CoreMatchers.is;
@@ -68,13 +69,34 @@ public class JaxMatchingTest {
             assertThat(resp.code(), is(404));
         }
         try (Response resp = call(request(server.uri().resolve("/tiger/TIGER/TIGER/TIGER")))) {
-            assertThat(resp.code(), is(404));
+            assertThat(resp.code(), is(200));
+            assertThat(resp.body().string(), is("TIGER"));
         }
         try (Response resp = call(request(server.uri().resolve("/dog/tiger/tiger/tiger")))) {
-            assertThat(resp.code(), is(404));
+            assertThat(resp.code(), is(200));
+            assertThat(resp.body().string(), is("tiger"));
         }
         try (Response resp = call(request(server.uri().resolve("/tiger/tiger/tiger/dog")))) {
-            assertThat(resp.code(), is(404));
+            assertThat(resp.code(), is(200));
+            assertThat(resp.body().string(), is("dog"));
+        }
+    }
+
+    @Test
+    public void repeatedPathParamsAreInjectedAsAList() throws IOException {
+        @Path("/repeated/{id}/{id}/{id}")
+        class RepeatedPathResource {
+            @GET
+            public String get(@PathParam("id") List<String> ids) {
+                return String.join(",", ids);
+            }
+        }
+        server = ServerUtils.httpsServerForTest()
+            .addHandler(restHandler(new RepeatedPathResource()).build())
+            .start();
+        try (Response resp = call(request(server.uri().resolve("/repeated/one/two/three")))) {
+            assertThat(resp.code(), is(200));
+            assertThat(resp.body().string(), is("one,two,three"));
         }
     }
 

--- a/src/test/java/io/muserver/rest/JaxMatchingTest.java
+++ b/src/test/java/io/muserver/rest/JaxMatchingTest.java
@@ -6,6 +6,7 @@ import jakarta.ws.rs.DefaultValue;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.core.PathSegment;
 import okhttp3.Response;
 import org.hamcrest.Matchers;
 import org.junit.After;
@@ -97,6 +98,25 @@ public class JaxMatchingTest {
         try (Response resp = call(request(server.uri().resolve("/repeated/one/two/three")))) {
             assertThat(resp.code(), is(200));
             assertThat(resp.body().string(), is("one,two,three"));
+        }
+    }
+
+    @Test
+    public void repeatedPathSegmentsRetainMatrixParameters() throws IOException {
+        @Path("/segments/{id}/{id}")
+        class RepeatedPathResource {
+            @GET
+            public String get(@PathParam("id") List<PathSegment> ids) {
+                return ids.get(0).getPath() + ":" + ids.get(0).getMatrixParameters().getFirst("color") + ","
+                    + ids.get(1).getPath() + ":" + ids.get(1).getMatrixParameters().getFirst("color");
+            }
+        }
+        server = ServerUtils.httpsServerForTest()
+            .addHandler(restHandler(new RepeatedPathResource()).build())
+            .start();
+        try (Response resp = call(request(server.uri().resolve("/segments/a;color=red/b;color=blue")))) {
+            assertThat(resp.code(), is(200));
+            assertThat(resp.body().string(), is("a:red,b:blue"));
         }
     }
 

--- a/src/test/java/io/muserver/rest/JaxMatchingTest.java
+++ b/src/test/java/io/muserver/rest/JaxMatchingTest.java
@@ -121,6 +121,25 @@ public class JaxMatchingTest {
     }
 
     @Test
+    public void absentPathSegmentCollectionsUseDefaultValues() throws IOException {
+        @Path("/default-segments")
+        class DefaultPathResource {
+            @GET
+            public String get(@DefaultValue("DEFAULT;color=red") @PathParam("missing") List<PathSegment> segments) {
+                PathSegment segment = segments.get(0);
+                return segment.getPath() + ":" + segment.getMatrixParameters().getFirst("color");
+            }
+        }
+        server = ServerUtils.httpsServerForTest()
+            .addHandler(restHandler(new DefaultPathResource()).build())
+            .start();
+        try (Response resp = call(request(server.uri().resolve("/default-segments")))) {
+            assertThat(resp.code(), is(200));
+            assertThat(resp.body().string(), is("DEFAULT:red"));
+        }
+    }
+
+    @Test
     public void repeatedCapturesWinPathMatchingTies() throws IOException {
         @Path("/rank")
         class RankedResource {

--- a/src/test/java/io/muserver/rest/SubResourceLocatorTest.java
+++ b/src/test/java/io/muserver/rest/SubResourceLocatorTest.java
@@ -7,6 +7,8 @@ import org.junit.After;
 import org.junit.Test;
 import scaffolding.MuAssert;
 
+import java.util.List;
+
 import static io.muserver.rest.RestHandlerBuilder.restHandler;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
@@ -90,6 +92,31 @@ public class SubResourceLocatorTest {
             assertThat(resp.code(), is(200));
             assertThat(resp.header("content-type"), is("text/strange;charset=utf-8"));
             assertThat(resp.body().string(), is("Widget xxx in cat sheep"));
+        }
+    }
+
+    @Test
+    public void repeatedPathParamsAreInjectedThroughSubResourceLocator() throws Exception {
+        class ChildResource {
+            @GET
+            @Path("{id}/{id}/{id}")
+            public String get(@PathParam("id") List<String> ids) {
+                return String.join(",", ids);
+            }
+        }
+        @Path("root")
+        class RootResource {
+            @Path("child")
+            public ChildResource child() {
+                return new ChildResource();
+            }
+        }
+        server = httpsServerForTest()
+            .addHandler(restHandler(new RootResource()).build())
+            .start();
+        try (Response resp = call(request(server.uri().resolve("/root/child/one/two/three")))) {
+            assertThat(resp.code(), is(200));
+            assertThat(resp.body().string(), is("one,two,three"));
         }
     }
 

--- a/src/test/java/io/muserver/rest/UriPatternTest.java
+++ b/src/test/java/io/muserver/rest/UriPatternTest.java
@@ -87,7 +87,10 @@ public class UriPatternTest {
         assertThat(matcher.prefixMatches(), is(true));
         assertThat(matcher.params().get("user"), is("dan"));
         matcher = uriPattern.matcher(URI.create("/user/dan/umm/notdan"));
-        assertThat(matcher.prefixMatches(), is(false));
+        assertThat(matcher.prefixMatches(), is(true));
+        assertThat(matcher.params().get("user"), is("notdan"));
+        assertThat(matcher.allSegments().get("user").get(0).getPath(), is("dan"));
+        assertThat(matcher.allSegments().get("user").get(1).getPath(), is("notdan"));
     }
 
     @Test


### PR DESCRIPTION
## Summary

- compile repeated URI-template variables as independent captures instead of regex backreferences
- retain all captures in declaration order for collection injection and `UriInfo#getPathParameters`
- carry captures through sub-resource locators while preserving last-value scalar injection

## Verification

- `mise exec java@temurin-11 -- mvn test` (892 tests passed)
- focused Jakarta REST TCK `pathparam` suite (45 passed, 0 failed/unsupported/unexpected)

This covers both repeated-path-parameter items in the TCK workbench todo: the direct resource and sub-resource variants.