### PR TITLE
Report JAX-RS response closed state

### DIFF
--- a/src/main/java/io/muserver/rest/JaxRSResponse.java
+++ b/src/main/java/io/muserver/rest/JaxRSResponse.java
@@ -759,6 +759,6 @@ class JaxRSResponse extends Response implements ContainerResponseContext, Writer
 
     @Override
     public boolean isClosed() {
-        return super.isClosed();
+        return isClosed;
     }
 }

--- a/src/test/java/io/muserver/rest/JaxRSResponseTest.java
+++ b/src/test/java/io/muserver/rest/JaxRSResponseTest.java
@@ -33,6 +33,15 @@ public class JaxRSResponseTest {
     private MuServer server;
 
     @Test
+    public void reportsWhetherItIsClosed() {
+        Response response = JaxRSResponse.ok("hello").build();
+
+        assertThat(response.isClosed(), is(false));
+        response.close();
+        assertThat(response.isClosed(), is(true));
+    }
+
+    @Test
     public void relativeLocationsAreResolvedAgainstTheApplicationBaseUri() {
         @Path("/resource")
         class ResourceWithRelativeLocation {


### PR DESCRIPTION
## What changed

`JaxRSResponse.isClosed()` now returns the response's actual lifecycle state, with a regression test covering the transition before and after `close()`.

## Why

Jakarta REST 3.1 added `Response.isClosed()`. Its default heuristic calls `hasEntity()` and expects an `IllegalStateException` after closure, but Mu's response implementation does not use that behavior, so it always reported `false`.

## Impact

Applications can reliably query whether a Mu-backed JAX-RS response has been closed.

## Validation

- Demonstrated the new test failing before the implementation change
- `mvn -q -Dtest=JaxRSResponseTest test`
- `git diff --check`