### PR TITLE
Add JAX-RS Application support

### DIFF
--- a/src/main/java/io/muserver/rest/ApplicationRegistrar.java
+++ b/src/main/java/io/muserver/rest/ApplicationRegistrar.java
@@ -1,6 +1,7 @@
 package io.muserver.rest;
 
 import jakarta.ws.rs.ConstrainedTo;
+import jakarta.ws.rs.ApplicationPath;
 import jakarta.ws.rs.NameBinding;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.RuntimeType;
@@ -39,7 +40,17 @@ final class ApplicationRegistrar {
 
     @SuppressWarnings("deprecation") // Jakarta REST 3.1 deprecates registration, but still requires it to be honored.
     static RestHandlerBuilder from(Application application) {
+        return from(application, false);
+    }
+
+    @SuppressWarnings("deprecation") // Jakarta REST 3.1 deprecates registration, but still requires it to be honored.
+    static RestHandlerBuilder from(Application application, boolean applicationPathHandledExternally) {
         Objects.requireNonNull(application, "application");
+        if (!applicationPathHandledExternally
+            && application.getClass().isAnnotationPresent(ApplicationPath.class)) {
+            throw new UnsupportedOperationException("@ApplicationPath cannot be applied by a RestHandlerBuilder. "
+                + "Mount the handler with ContextHandlerBuilder or start the application with SeBootstrap.");
+        }
         rejectProperties(application.getProperties());
 
         Set<Object> singletons = copyOf(application.getSingletons());

--- a/src/main/java/io/muserver/rest/ApplicationRegistrar.java
+++ b/src/main/java/io/muserver/rest/ApplicationRegistrar.java
@@ -1,0 +1,376 @@
+package io.muserver.rest;
+
+import jakarta.ws.rs.ConstrainedTo;
+import jakarta.ws.rs.NameBinding;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.RuntimeType;
+import jakarta.ws.rs.container.ContainerRequestContext;
+import jakarta.ws.rs.container.ContainerRequestFilter;
+import jakarta.ws.rs.container.ContainerResponseContext;
+import jakarta.ws.rs.container.ContainerResponseFilter;
+import jakarta.ws.rs.container.PreMatching;
+import jakarta.ws.rs.container.ResourceInfo;
+import jakarta.ws.rs.core.Application;
+import jakarta.ws.rs.ext.ExceptionMapper;
+import jakarta.ws.rs.ext.MessageBodyReader;
+import jakarta.ws.rs.ext.MessageBodyWriter;
+import jakarta.ws.rs.ext.ParamConverterProvider;
+import jakarta.ws.rs.ext.ReaderInterceptor;
+import jakarta.ws.rs.ext.ReaderInterceptorContext;
+import jakarta.ws.rs.ext.WriterInterceptor;
+import jakarta.ws.rs.ext.WriterInterceptorContext;
+
+import java.io.IOException;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+final class ApplicationRegistrar {
+
+    private ApplicationRegistrar() {
+    }
+
+    @SuppressWarnings("deprecation") // Jakarta REST 3.1 deprecates registration, but still requires it to be honored.
+    static RestHandlerBuilder from(Application application) {
+        Objects.requireNonNull(application, "application");
+        rejectProperties(application.getProperties());
+
+        Set<Object> singletons = copyOf(application.getSingletons());
+        validateUniqueSingletonClasses(singletons);
+        Set<Class<?>> classes = copyOf(application.getClasses());
+
+        List<Object> components = new ArrayList<>(singletons);
+        for (Class<?> componentClass : classes) {
+            if (containsInstanceOf(singletons, componentClass) || isClientOnly(componentClass)) {
+                continue;
+            }
+            if (isRootResource(componentClass)) {
+                throw new UnsupportedOperationException("The Application class " + componentClass.getName()
+                    + " is a per-request resource, but Mu Server only supports singleton resource instances. "
+                    + "Return an instance from Application.getSingletons() instead.");
+            }
+            if (!isSupportedComponentType(componentClass)) {
+                throw unsupported(componentClass);
+            }
+            components.add(instantiate(componentClass));
+        }
+
+        RestHandlerBuilder builder = new RestHandlerBuilder();
+        List<Object> serverComponents = new ArrayList<>();
+        for (Object component : components) {
+            Objects.requireNonNull(component, "Application components must not contain null");
+            if (!isClientOnly(component.getClass())) {
+                register(builder, component);
+                serverComponents.add(component);
+            }
+        }
+        registerFiltersAndInterceptors(builder, application, serverComponents);
+        return builder;
+    }
+
+    private static void rejectProperties(Map<String, Object> properties) {
+        if (properties != null && !properties.isEmpty()) {
+            throw new UnsupportedOperationException("Application properties are not supported by Mu Server");
+        }
+    }
+
+    private static <T> Set<T> copyOf(Set<T> source) {
+        return source == null ? new LinkedHashSet<>() : new LinkedHashSet<>(source);
+    }
+
+    private static void validateUniqueSingletonClasses(Set<Object> singletons) {
+        Set<Class<?>> classes = new HashSet<>();
+        for (Object singleton : singletons) {
+            Objects.requireNonNull(singleton, "Application.getSingletons() must not contain null");
+            if (!classes.add(singleton.getClass())) {
+                throw new IllegalArgumentException("Application.getSingletons() returned more than one singleton of "
+                    + singleton.getClass().getName());
+            }
+        }
+    }
+
+    private static boolean containsInstanceOf(Set<Object> singletons, Class<?> componentClass) {
+        for (Object singleton : singletons) {
+            if (singleton.getClass().equals(componentClass)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static Object instantiate(Class<?> componentClass) {
+        try {
+            return componentClass.getConstructor().newInstance();
+        } catch (ReflectiveOperationException e) {
+            throw new IllegalArgumentException("Could not instantiate Application provider " + componentClass.getName()
+                + " using a public no-argument constructor", e);
+        }
+    }
+
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    private static void register(RestHandlerBuilder builder, Object component) {
+        boolean registered = false;
+        if (isRootResource(component.getClass())) {
+            builder.addResource(component);
+            registered = true;
+        }
+        if (component instanceof MessageBodyReader) {
+            builder.addCustomReader((MessageBodyReader) component);
+            registered = true;
+        }
+        if (component instanceof MessageBodyWriter) {
+            builder.addCustomWriter((MessageBodyWriter) component);
+            registered = true;
+        }
+        if (component instanceof ParamConverterProvider) {
+            builder.addCustomParamConverterProvider((ParamConverterProvider) component);
+            registered = true;
+        }
+        if (component instanceof ExceptionMapper) {
+            Type exceptionType = GenericTypeResolver.resolveTypeArgument(component.getClass(), ExceptionMapper.class, 0);
+            if (!(exceptionType instanceof Class) || !Throwable.class.isAssignableFrom((Class<?>) exceptionType)) {
+                throw new IllegalArgumentException("Could not infer the exception type handled by "
+                    + component.getClass().getName());
+            }
+            builder.addExceptionMapper((Class<? extends Throwable>) exceptionType, (ExceptionMapper) component);
+            registered = true;
+        }
+        if (component instanceof SchemaObjectCustomizer) {
+            builder.addSchemaObjectCustomizer((SchemaObjectCustomizer) component);
+            registered = true;
+        }
+        if (component instanceof ContainerRequestFilter
+            || component instanceof ContainerResponseFilter
+            || component instanceof ReaderInterceptor
+            || component instanceof WriterInterceptor) {
+            registered = true;
+        }
+        if (!registered) {
+            throw unsupported(component.getClass());
+        }
+    }
+
+    private static void registerFiltersAndInterceptors(RestHandlerBuilder builder, Application application,
+                                                       List<Object> components) {
+        for (Object component : components) {
+            if (component instanceof ContainerRequestFilter) {
+                ContainerRequestFilter filter = (ContainerRequestFilter) component;
+                builder.addRequestFilter(component.getClass().isAnnotationPresent(PreMatching.class)
+                    ? filter
+                    : new BoundRequestFilter(filter, remainingBindings(application, component)));
+            }
+        }
+        for (Object component : components) {
+            if (component instanceof ContainerResponseFilter) {
+                builder.addResponseFilter(new BoundResponseFilter((ContainerResponseFilter) component,
+                    remainingBindings(application, component)));
+            }
+        }
+        for (Object component : components) {
+            if (component instanceof ReaderInterceptor) {
+                builder.addReaderInterceptor(new BoundReaderInterceptor((ReaderInterceptor) component,
+                    remainingBindings(application, component)));
+            }
+        }
+        for (Object component : components) {
+            if (component instanceof WriterInterceptor) {
+                builder.addWriterInterceptor(new BoundWriterInterceptor((WriterInterceptor) component,
+                    remainingBindings(application, component)));
+            }
+        }
+    }
+
+    private static Set<Class<? extends Annotation>> remainingBindings(Application application, Object component) {
+        Set<Class<? extends Annotation>> remaining = nameBindings(component.getClass());
+        remaining.removeAll(nameBindings(application.getClass()));
+        return remaining;
+    }
+
+    private static Set<Class<? extends Annotation>> nameBindings(Class<?> type) {
+        Set<Class<? extends Annotation>> result = new LinkedHashSet<>();
+        for (Annotation annotation : type.getAnnotations()) {
+            if (annotation.annotationType().isAnnotationPresent(NameBinding.class)) {
+                result.add(annotation.annotationType());
+            }
+        }
+        return result;
+    }
+
+    private static ResourceInfo resourceInfo(Object value) {
+        return value instanceof ResourceInfo ? (ResourceInfo) value : null;
+    }
+
+    private static boolean hasBindings(ResourceInfo resourceInfo, Set<Class<? extends Annotation>> requiredBindings) {
+        if (requiredBindings.isEmpty()) {
+            return true;
+        }
+        if (resourceInfo == null || resourceInfo.getResourceMethod() == null || resourceInfo.getResourceClass() == null) {
+            return false;
+        }
+        Method concreteMethod = resourceInfo.getResourceMethod();
+        Class<?> concreteClass = resourceInfo.getResourceClass();
+        for (Class<? extends Annotation> binding : requiredBindings) {
+            if (!concreteMethod.isAnnotationPresent(binding)
+                && !methodAnnotationSource(concreteMethod).isAnnotationPresent(binding)
+                && !concreteClass.isAnnotationPresent(binding)
+                && !classAnnotationSource(concreteClass).isAnnotationPresent(binding)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static Method methodAnnotationSource(Method start) {
+        Class<?> type = start.getDeclaringClass();
+        while (type != null && type != Object.class) {
+            Method candidate = declaredMethod(start, type);
+            if (candidate != null && JaxClassLocator.hasAtLeastOneJaxRSAnnotation(candidate.getDeclaredAnnotations())) {
+                return candidate;
+            }
+            type = type.getSuperclass();
+        }
+        type = start.getDeclaringClass();
+        while (type != null && type != Object.class) {
+            for (Class<?> interfaceType : type.getInterfaces()) {
+                Method candidate = declaredMethod(start, interfaceType);
+                if (candidate != null && JaxClassLocator.hasAtLeastOneJaxRSAnnotation(candidate.getDeclaredAnnotations())) {
+                    return candidate;
+                }
+            }
+            type = type.getSuperclass();
+        }
+        return start;
+    }
+
+    private static Method declaredMethod(Method start, Class<?> type) {
+        try {
+            return type.getDeclaredMethod(start.getName(), start.getParameterTypes());
+        } catch (NoSuchMethodException ignored) {
+            return null;
+        }
+    }
+
+    private static Class<?> classAnnotationSource(Class<?> start) {
+        Class<?> source = JaxClassLocator.getClassWithJaxRSAnnotations(start);
+        return source == null ? start : source;
+    }
+
+    private static boolean isRootResource(Class<?> componentClass) {
+        Class<?> annotationSource = JaxClassLocator.getClassWithJaxRSAnnotations(componentClass);
+        return annotationSource != null && annotationSource.isAnnotationPresent(Path.class);
+    }
+
+    private static boolean isSupportedComponentType(Class<?> componentClass) {
+        return MessageBodyReader.class.isAssignableFrom(componentClass)
+            || MessageBodyWriter.class.isAssignableFrom(componentClass)
+            || ParamConverterProvider.class.isAssignableFrom(componentClass)
+            || ExceptionMapper.class.isAssignableFrom(componentClass)
+            || ContainerRequestFilter.class.isAssignableFrom(componentClass)
+            || ContainerResponseFilter.class.isAssignableFrom(componentClass)
+            || ReaderInterceptor.class.isAssignableFrom(componentClass)
+            || WriterInterceptor.class.isAssignableFrom(componentClass)
+            || SchemaObjectCustomizer.class.isAssignableFrom(componentClass);
+    }
+
+    private static boolean isClientOnly(Class<?> componentClass) {
+        ConstrainedTo constrainedTo = componentClass.getAnnotation(ConstrainedTo.class);
+        return constrainedTo != null && constrainedTo.value() == RuntimeType.CLIENT;
+    }
+
+    private static IllegalArgumentException unsupported(Class<?> componentClass) {
+        return new IllegalArgumentException("Unsupported Application component " + componentClass.getName());
+    }
+
+    private abstract static class BoundComponent implements PrioritizedComponent {
+        private final Set<Class<? extends Annotation>> bindings;
+        private final int priority;
+
+        BoundComponent(Object delegate, Set<Class<? extends Annotation>> bindings) {
+            this.bindings = bindings;
+            this.priority = PrioritizedComponent.priorityOf(delegate);
+        }
+
+        final boolean matches(Object resourceInfo) {
+            return hasBindings(ApplicationRegistrar.resourceInfo(resourceInfo), bindings);
+        }
+
+        @Override
+        public int priority() {
+            return priority;
+        }
+    }
+
+    private static final class BoundRequestFilter extends BoundComponent implements ContainerRequestFilter {
+        private final ContainerRequestFilter delegate;
+
+        BoundRequestFilter(ContainerRequestFilter delegate, Set<Class<? extends Annotation>> bindings) {
+            super(delegate, bindings);
+            this.delegate = delegate;
+        }
+
+        @Override
+        public void filter(ContainerRequestContext context) throws IOException {
+            if (matches(context.getProperty(MuRuntimeDelegate.RESOURCE_INFO_PROPERTY))) {
+                delegate.filter(context);
+            }
+        }
+    }
+
+    private static final class BoundResponseFilter extends BoundComponent implements ContainerResponseFilter {
+        private final ContainerResponseFilter delegate;
+
+        BoundResponseFilter(ContainerResponseFilter delegate, Set<Class<? extends Annotation>> bindings) {
+            super(delegate, bindings);
+            this.delegate = delegate;
+        }
+
+        @Override
+        public void filter(ContainerRequestContext requestContext,
+                           ContainerResponseContext responseContext) throws IOException {
+            if (matches(requestContext.getProperty(MuRuntimeDelegate.RESOURCE_INFO_PROPERTY))) {
+                delegate.filter(requestContext, responseContext);
+            }
+        }
+    }
+
+    private static final class BoundReaderInterceptor extends BoundComponent implements ReaderInterceptor {
+        private final ReaderInterceptor delegate;
+
+        BoundReaderInterceptor(ReaderInterceptor delegate, Set<Class<? extends Annotation>> bindings) {
+            super(delegate, bindings);
+            this.delegate = delegate;
+        }
+
+        @Override
+        public Object aroundReadFrom(ReaderInterceptorContext context) throws IOException {
+            return matches(context.getProperty(MuRuntimeDelegate.RESOURCE_INFO_PROPERTY))
+                ? delegate.aroundReadFrom(context)
+                : context.proceed();
+        }
+    }
+
+    private static final class BoundWriterInterceptor extends BoundComponent implements WriterInterceptor {
+        private final WriterInterceptor delegate;
+
+        BoundWriterInterceptor(WriterInterceptor delegate, Set<Class<? extends Annotation>> bindings) {
+            super(delegate, bindings);
+            this.delegate = delegate;
+        }
+
+        @Override
+        public void aroundWriteTo(WriterInterceptorContext context) throws IOException {
+            if (matches(context.getProperty(MuRuntimeDelegate.RESOURCE_INFO_PROPERTY))) {
+                delegate.aroundWriteTo(context);
+            } else {
+                context.proceed();
+            }
+        }
+    }
+}

--- a/src/main/java/io/muserver/rest/ApplicationRegistrar.java
+++ b/src/main/java/io/muserver/rest/ApplicationRegistrar.java
@@ -218,43 +218,14 @@ final class ApplicationRegistrar {
         Class<?> concreteClass = resourceInfo.getResourceClass();
         for (Class<? extends Annotation> binding : requiredBindings) {
             if (!concreteMethod.isAnnotationPresent(binding)
-                && !methodAnnotationSource(concreteMethod).isAnnotationPresent(binding)
+                && !JaxMethodLocator.getMethodThatHasJaxRSAnnotations(concreteMethod, concreteClass)
+                    .isAnnotationPresent(binding)
                 && !concreteClass.isAnnotationPresent(binding)
                 && !classAnnotationSource(concreteClass).isAnnotationPresent(binding)) {
                 return false;
             }
         }
         return true;
-    }
-
-    private static Method methodAnnotationSource(Method start) {
-        Class<?> type = start.getDeclaringClass();
-        while (type != null && type != Object.class) {
-            Method candidate = declaredMethod(start, type);
-            if (candidate != null && JaxClassLocator.hasAtLeastOneJaxRSAnnotation(candidate.getDeclaredAnnotations())) {
-                return candidate;
-            }
-            type = type.getSuperclass();
-        }
-        type = start.getDeclaringClass();
-        while (type != null && type != Object.class) {
-            for (Class<?> interfaceType : type.getInterfaces()) {
-                Method candidate = declaredMethod(start, interfaceType);
-                if (candidate != null && JaxClassLocator.hasAtLeastOneJaxRSAnnotation(candidate.getDeclaredAnnotations())) {
-                    return candidate;
-                }
-            }
-            type = type.getSuperclass();
-        }
-        return start;
-    }
-
-    private static Method declaredMethod(Method start, Class<?> type) {
-        try {
-            return type.getDeclaredMethod(start.getName(), start.getParameterTypes());
-        } catch (NoSuchMethodException ignored) {
-            return null;
-        }
     }
 
     private static Class<?> classAnnotationSource(Class<?> start) {

--- a/src/main/java/io/muserver/rest/FilterManagerThing.java
+++ b/src/main/java/io/muserver/rest/FilterManagerThing.java
@@ -1,7 +1,5 @@
 package io.muserver.rest;
 
-import jakarta.annotation.Priority;
-import jakarta.ws.rs.Priorities;
 import jakarta.ws.rs.container.ContainerRequestFilter;
 import jakarta.ws.rs.container.ContainerResponseContext;
 import jakarta.ws.rs.container.ContainerResponseFilter;
@@ -31,8 +29,7 @@ class FilterManagerThing {
     }
 
     private static int priority(Object filter) {
-        Priority priority = filter.getClass().getAnnotation(Priority.class);
-        return priority == null ? Priorities.USER : priority.value();
+        return PrioritizedComponent.priorityOf(filter);
     }
 
     void onPreMatch(JaxRSRequest requestContext) throws IOException {

--- a/src/main/java/io/muserver/rest/PrioritizedComponent.java
+++ b/src/main/java/io/muserver/rest/PrioritizedComponent.java
@@ -1,0 +1,17 @@
+package io.muserver.rest;
+
+import jakarta.annotation.Priority;
+import jakarta.ws.rs.Priorities;
+
+interface PrioritizedComponent {
+
+    int priority();
+
+    static int priorityOf(Object component) {
+        if (component instanceof PrioritizedComponent) {
+            return ((PrioritizedComponent) component).priority();
+        }
+        Priority priority = component.getClass().getAnnotation(Priority.class);
+        return priority == null ? Priorities.USER : priority.value();
+    }
+}

--- a/src/main/java/io/muserver/rest/README.md
+++ b/src/main/java/io/muserver/rest/README.md
@@ -9,9 +9,15 @@ provided by Oracle.
 
 ## 2 Applications
 
-The Mu Jax-RS implementation does not support classpath scanning or definition of Resource classes, and as
-such the `jakarta.ws.rs.core.Application` class is not supported. All resources and optional providers are 
-registered programmatically using the `io.muserver.rest.RestHandlerBuilder` class.
+Applications can be registered with `RestHandlerBuilder.fromApplication(application)`. Resource and provider
+instances returned by `Application.getSingletons()` are registered as application singletons. Provider classes
+returned by `Application.getClasses()` are instantiated once with a public no-argument constructor. Singleton
+components must be safe to use concurrently.
+
+Resource classes returned by `Application.getClasses()` are rejected because their default lifecycle is per-request,
+which Mu Server does not support. Application properties, features, dynamic features, context resolvers, classpath
+scanning, and `@ApplicationPath` mounting are also not supported. All supported components can alternatively be
+registered programmatically using `RestHandlerBuilder`.
 
 ## 3 Resources
 

--- a/src/main/java/io/muserver/rest/RestHandlerBuilder.java
+++ b/src/main/java/io/muserver/rest/RestHandlerBuilder.java
@@ -12,6 +12,7 @@ import jakarta.ws.rs.Priorities;
 import jakarta.ws.rs.container.ContainerRequestFilter;
 import jakarta.ws.rs.container.ContainerResponseFilter;
 import jakarta.ws.rs.container.PreMatching;
+import jakarta.ws.rs.core.Application;
 import jakarta.ws.rs.ext.*;
 
 import java.io.InputStream;
@@ -263,6 +264,22 @@ public class RestHandlerBuilder implements MuHandlerBuilder<RestHandler> {
     }
 
     /**
+     * Creates a handler builder from the singleton resources and supported server-side providers declared by a
+     * JAX-RS {@link Application}.
+     * <p>Mu Server supports resource instances returned by {@link Application#getSingletons()}, but not resource
+     * classes returned by {@link Application#getClasses()} because those have a per-request lifecycle by default.
+     * Singleton resources must therefore be safe to use concurrently. Provider classes are instantiated once using a
+     * public no-argument constructor. Application properties, features, dynamic features, context resolvers, automatic
+     * discovery, and {@link jakarta.ws.rs.ApplicationPath} mounting are not supported.</p>
+     *
+     * @param application The application configuration to adapt.
+     * @return A builder containing the application's supported singleton components.
+     */
+    public static RestHandlerBuilder fromApplication(Application application) {
+        return ApplicationRegistrar.from(application);
+    }
+
+    /**
      * <p>Specifies the CORS config for the REST services. Defaults to {@link CORSConfigBuilder#disabled()}</p>
      * <p>Note: an alternative to adding CORS config to the Rest Handler Builder is to add a handler with
      * {@link CORSHandlerBuilder#corsHandler()} which can apply the headers to all handlers (not just JAX-RS endpoints).</p>
@@ -410,8 +427,7 @@ public class RestHandlerBuilder implements MuHandlerBuilder<RestHandler> {
     }
 
     private static int priority(Object interceptor) {
-        Priority priority = interceptor.getClass().getAnnotation(Priority.class);
-        return priority == null ? Priorities.USER : priority.value();
+        return PrioritizedComponent.priorityOf(interceptor);
     }
 
     /**

--- a/src/test/java/io/muserver/rest/ApplicationTest.java
+++ b/src/test/java/io/muserver/rest/ApplicationTest.java
@@ -1,0 +1,470 @@
+package io.muserver.rest;
+
+import io.muserver.MuServer;
+import jakarta.annotation.Priority;
+import jakarta.ws.rs.ConstrainedTo;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.HeaderParam;
+import jakarta.ws.rs.NameBinding;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.RuntimeType;
+import jakarta.ws.rs.container.ContainerRequestContext;
+import jakarta.ws.rs.container.ContainerRequestFilter;
+import jakarta.ws.rs.container.ContainerResponseContext;
+import jakarta.ws.rs.container.ContainerResponseFilter;
+import jakarta.ws.rs.core.Application;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.ext.ExceptionMapper;
+import jakarta.ws.rs.ext.MessageBodyReader;
+import jakarta.ws.rs.ext.MessageBodyWriter;
+import jakarta.ws.rs.ext.ParamConverter;
+import jakarta.ws.rs.ext.ParamConverterProvider;
+import jakarta.ws.rs.ext.ReaderInterceptor;
+import jakarta.ws.rs.ext.ReaderInterceptorContext;
+import jakarta.ws.rs.ext.WriterInterceptor;
+import jakarta.ws.rs.ext.WriterInterceptorContext;
+import okhttp3.RequestBody;
+import okhttp3.Response;
+import org.junit.After;
+import org.junit.Test;
+import scaffolding.ServerUtils;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.lang.annotation.Annotation;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.lang.reflect.Type;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThrows;
+import static scaffolding.ClientUtils.call;
+import static scaffolding.ClientUtils.request;
+import static scaffolding.MuAssert.stopAndCheck;
+
+public class ApplicationTest {
+
+    private MuServer server;
+
+    @After
+    public void stop() {
+        stopAndCheck(server);
+    }
+
+    @Test
+    public void singletonResourcesAndProvidersAreRegistered() {
+        SampleResource resource = new SampleResource();
+        SupportedProvider provider = new SupportedProvider();
+        Application application = singletonApplication(resource, provider);
+
+        RestHandlerBuilder builder = RestHandlerBuilder.fromApplication(application);
+
+        assertThat(builder.resources(), contains(resource));
+        assertThat(builder.customReaders(), contains(provider));
+        assertThat(builder.customWriters(), contains(provider));
+        assertThat(builder.customParamConverterProviders(), contains(provider));
+        assertThat(builder.exceptionMappers(), hasEntry(SampleException.class, provider));
+        assertThat(builder.requestFilters(), hasSize(1));
+        assertThat(builder.responseFilters(), hasSize(1));
+        assertThat(builder.readerInterceptors(), hasSize(1));
+        assertThat(builder.writerInterceptors(), hasSize(1));
+    }
+
+    @Test
+    public void providerClassesAreCreatedAsApplicationSingletons() {
+        Application application = new Application() {
+            @Override
+            public Set<Class<?>> getClasses() {
+                return Set.of(SupportedProvider.class);
+            }
+        };
+
+        RestHandlerBuilder builder = RestHandlerBuilder.fromApplication(application);
+
+        assertThat(builder.customReaders(), hasSize(1));
+        SupportedProvider provider = (SupportedProvider) builder.customReaders().get(0);
+        assertThat(builder.customWriters(), contains(provider));
+        assertThat(builder.customParamConverterProviders(), contains(provider));
+        assertThat(builder.exceptionMappers(), hasEntry(SampleException.class, provider));
+    }
+
+    @Test
+    public void singletonTakesPrecedenceOverClassRegistration() {
+        SupportedProvider singleton = new SupportedProvider();
+        Application application = new Application() {
+            @Override
+            public Set<Class<?>> getClasses() {
+                return Set.of(SupportedProvider.class);
+            }
+
+            @Override
+            public Set<Object> getSingletons() {
+                return Set.of(singleton);
+            }
+        };
+
+        RestHandlerBuilder builder = RestHandlerBuilder.fromApplication(application);
+
+        assertThat(builder.customReaders(), contains(singleton));
+    }
+
+    @Test
+    public void resourceClassesAreRejectedBecauseMuDoesNotSupportPerRequestResources() {
+        Application application = new Application() {
+            @Override
+            public Set<Class<?>> getClasses() {
+                return Set.of(SampleResource.class);
+            }
+        };
+
+        UnsupportedOperationException error = assertThrows(UnsupportedOperationException.class,
+            () -> RestHandlerBuilder.fromApplication(application));
+
+        assertThat(error.getMessage(), containsString("per-request"));
+        assertThat(error.getMessage(), containsString(SampleResource.class.getName()));
+    }
+
+    @Test
+    public void unsupportedComponentsAndPropertiesAreRejected() {
+        Application unsupportedComponent = singletonApplication(new Object());
+        IllegalArgumentException componentError = assertThrows(IllegalArgumentException.class,
+            () -> RestHandlerBuilder.fromApplication(unsupportedComponent));
+        assertThat(componentError.getMessage(), containsString(Object.class.getName()));
+
+        Application properties = new Application() {
+            @Override
+            public Map<String, Object> getProperties() {
+                return Map.of("example", true);
+            }
+        };
+        UnsupportedOperationException propertyError = assertThrows(UnsupportedOperationException.class,
+            () -> RestHandlerBuilder.fromApplication(properties));
+        assertThat(propertyError.getMessage(), containsString("properties"));
+    }
+
+    @Test
+    public void duplicateSingletonClassesAreRejected() {
+        Application application = singletonApplication(new SupportedProvider(), new SupportedProvider());
+
+        IllegalArgumentException error = assertThrows(IllegalArgumentException.class,
+            () -> RestHandlerBuilder.fromApplication(application));
+
+        assertThat(error.getMessage(), containsString("more than one singleton"));
+        assertThat(error.getMessage(), containsString(SupportedProvider.class.getName()));
+    }
+
+    @Test
+    public void clientOnlyComponentsAreIgnoredAndNullCollectionsAreEmpty() {
+        Application application = new Application() {
+            @Override
+            public Set<Class<?>> getClasses() {
+                return null;
+            }
+
+            @Override
+            public Set<Object> getSingletons() {
+                return Set.of(new ClientOnlyFilter());
+            }
+
+            @Override
+            public Map<String, Object> getProperties() {
+                return null;
+            }
+        };
+
+        RestHandlerBuilder builder = RestHandlerBuilder.fromApplication(application);
+
+        assertThat(builder.resources(), is(empty()));
+        assertThat(builder.requestFilters(), is(empty()));
+    }
+
+    @Test
+    public void applicationComponentsParticipateInRequestProcessing() throws IOException {
+        Application application = singletonApplication(new SampleResource(), new SupportedProvider());
+        server = ServerUtils.httpsServerForTest()
+            .addHandler(RestHandlerBuilder.fromApplication(application))
+            .start();
+
+        RequestBody body = RequestBody.create(okhttp3.MediaType.get("application/example"), "body");
+        try (Response response = call(request(server.uri().resolve("/sample/echo?value=query")).post(body))) {
+            assertThat(response.code(), is(200));
+            assertThat(response.body().string(),
+                is("query-converted:filtered:body-read-reader-interceptor-response-filter-writer-interceptor"));
+        }
+
+        try (Response response = call(request(server.uri().resolve("/sample/fail")))) {
+            assertThat(response.code(), is(409));
+            assertThat(response.body().string(), is("mapped"));
+        }
+    }
+
+    @Test
+    public void nameBindingOnApplicationMakesMatchingProviderGlobal() throws IOException {
+        BoundResponseFilter filter = new BoundResponseFilter();
+        server = ServerUtils.httpsServerForTest()
+            .addHandler(RestHandlerBuilder.fromApplication(new GloballyBoundApplication(filter)))
+            .start();
+
+        try (Response response = call(request(server.uri().resolve("/binding/unbound")))) {
+            assertThat(response.code(), is(200));
+            assertThat(response.header("X-Application-Binding"), is("applied"));
+        }
+    }
+
+    @Test
+    public void applicationComponentPriorityIsRetainedWhenBuilderIsCustomized() throws IOException {
+        List<String> calls = new ArrayList<>();
+        server = ServerUtils.httpsServerForTest()
+            .addHandler(RestHandlerBuilder.fromApplication(new PrioritizedApplication(calls))
+                .addRequestFilter(new LaterRequestFilter(calls)))
+            .start();
+
+        try (Response response = call(request(server.uri().resolve("/binding/unbound")))) {
+            assertThat(response.code(), is(200));
+            assertThat(calls, contains("application", "builder"));
+        }
+    }
+
+    private static Application singletonApplication(Object... components) {
+        return new Application() {
+            @Override
+            public Set<Object> getSingletons() {
+                Set<Object> result = new LinkedHashSet<>();
+                for (Object component : components) {
+                    result.add(component);
+                }
+                return result;
+            }
+        };
+    }
+
+    @NameBinding
+    @Target({ElementType.TYPE, ElementType.METHOD})
+    @Retention(RetentionPolicy.RUNTIME)
+    private @interface ApplicationBinding {
+    }
+
+    @ApplicationBinding
+    private static class GloballyBoundApplication extends Application {
+        private final BoundResponseFilter filter;
+
+        private GloballyBoundApplication(BoundResponseFilter filter) {
+            this.filter = filter;
+        }
+
+        @Override
+        public Set<Object> getSingletons() {
+            return Set.of(new BindingResource(), filter);
+        }
+    }
+
+    @Path("binding")
+    public static class BindingResource {
+        @GET
+        @Path("unbound")
+        public String unbound() {
+            return "response";
+        }
+    }
+
+    @ApplicationBinding
+    private static class BoundResponseFilter implements ContainerResponseFilter {
+        @Override
+        public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext) {
+            responseContext.getHeaders().putSingle("X-Application-Binding", "applied");
+        }
+    }
+
+    @ApplicationBinding
+    private static class PrioritizedApplication extends Application {
+        private final List<String> calls;
+
+        private PrioritizedApplication(List<String> calls) {
+            this.calls = calls;
+        }
+
+        @Override
+        public Set<Object> getSingletons() {
+            return Set.of(new BindingResource(), new EarlyApplicationRequestFilter(calls));
+        }
+    }
+
+    @Priority(100)
+    @ApplicationBinding
+    private static class EarlyApplicationRequestFilter implements ContainerRequestFilter {
+        private final List<String> calls;
+
+        private EarlyApplicationRequestFilter(List<String> calls) {
+            this.calls = calls;
+        }
+
+        @Override
+        public void filter(ContainerRequestContext requestContext) {
+            calls.add("application");
+        }
+    }
+
+    @Priority(200)
+    private static class LaterRequestFilter implements ContainerRequestFilter {
+        private final List<String> calls;
+
+        private LaterRequestFilter(List<String> calls) {
+            this.calls = calls;
+        }
+
+        @Override
+        public void filter(ContainerRequestContext requestContext) {
+            calls.add("builder");
+        }
+    }
+
+    @Path("sample")
+    public static class SampleResource {
+        @POST
+        @Path("echo")
+        @Consumes("application/example")
+        @Produces("application/example")
+        public Payload echo(@QueryParam("value") Converted converted, @HeaderParam("X-Application") String filtered,
+                            Payload payload) {
+            return new Payload(converted.value + ":" + filtered + ":" + payload.value);
+        }
+
+        @GET
+        @Path("fail")
+        public String fail() {
+            throw new SampleException();
+        }
+    }
+
+    public static class SampleException extends RuntimeException {
+    }
+
+    private static class Converted {
+        private final String value;
+
+        private Converted(String value) {
+            this.value = value;
+        }
+    }
+
+    private static class Payload {
+        private final String value;
+
+        private Payload(String value) {
+            this.value = value;
+        }
+    }
+
+    public static class SupportedProvider implements MessageBodyReader<Payload>, MessageBodyWriter<Payload>,
+        ParamConverterProvider, ExceptionMapper<SampleException>, ContainerRequestFilter, ContainerResponseFilter,
+        ReaderInterceptor, WriterInterceptor {
+
+        @Override
+        public boolean isReadable(Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType) {
+            return type == Payload.class;
+        }
+
+        @Override
+        public Payload readFrom(Class<Payload> type, Type genericType, Annotation[] annotations, MediaType mediaType,
+                                MultivaluedMap<String, String> httpHeaders, InputStream entityStream) throws IOException {
+            return new Payload(new String(entityStream.readAllBytes(), StandardCharsets.UTF_8) + "-read");
+        }
+
+        @Override
+        public boolean isWriteable(Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType) {
+            return type == Payload.class;
+        }
+
+        @Override
+        public long getSize(Payload value, Class<?> type, Type genericType, Annotation[] annotations,
+                            MediaType mediaType) {
+            return value.value.length();
+        }
+
+        @Override
+        public void writeTo(Payload value, Class<?> type, Type genericType, Annotation[] annotations,
+                            MediaType mediaType, MultivaluedMap<String, Object> httpHeaders,
+                            OutputStream entityStream) throws IOException {
+            entityStream.write(value.value.getBytes(StandardCharsets.UTF_8));
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public <T> ParamConverter<T> getConverter(Class<T> rawType, Type genericType, Annotation[] annotations) {
+            if (rawType != Converted.class) {
+                return null;
+            }
+            return (ParamConverter<T>) new ParamConverter<Converted>() {
+                @Override
+                public Converted fromString(String value) {
+                    return new Converted(value + "-converted");
+                }
+
+                @Override
+                public String toString(Converted value) {
+                    return value.value;
+                }
+            };
+        }
+
+        @Override
+        public jakarta.ws.rs.core.Response toResponse(SampleException exception) {
+            return jakarta.ws.rs.core.Response.status(409).entity("mapped").build();
+        }
+
+        @Override
+        public void filter(ContainerRequestContext requestContext) {
+            requestContext.getHeaders().putSingle("X-Application", "filtered");
+        }
+
+        @Override
+        public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext) {
+            if (responseContext.getEntity() instanceof Payload) {
+                Payload payload = (Payload) responseContext.getEntity();
+                responseContext.setEntity(new Payload(payload.value + "-response-filter"));
+            }
+        }
+
+        @Override
+        public Object aroundReadFrom(ReaderInterceptorContext context) throws IOException {
+            Payload payload = (Payload) context.proceed();
+            return new Payload(payload.value + "-reader-interceptor");
+        }
+
+        @Override
+        public void aroundWriteTo(WriterInterceptorContext context) throws IOException {
+            if (context.getEntity() instanceof Payload) {
+                Payload payload = (Payload) context.getEntity();
+                context.setEntity(new Payload(payload.value + "-writer-interceptor"));
+            }
+            context.proceed();
+        }
+    }
+
+    @ConstrainedTo(RuntimeType.CLIENT)
+    private static class ClientOnlyFilter implements ContainerRequestFilter {
+        @Override
+        public void filter(ContainerRequestContext requestContext) {
+        }
+    }
+}

--- a/src/test/java/io/muserver/rest/ApplicationTest.java
+++ b/src/test/java/io/muserver/rest/ApplicationTest.java
@@ -2,6 +2,7 @@ package io.muserver.rest;
 
 import io.muserver.MuServer;
 import jakarta.annotation.Priority;
+import jakarta.ws.rs.ApplicationPath;
 import jakarta.ws.rs.ConstrainedTo;
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.GET;
@@ -145,6 +146,15 @@ public class ApplicationTest {
     }
 
     @Test
+    public void applicationPathIsRejectedBecauseAHandlerBuilderCannotMountItself() {
+        UnsupportedOperationException error = assertThrows(UnsupportedOperationException.class,
+            () -> RestHandlerBuilder.fromApplication(new PathAnnotatedApplication()));
+
+        assertThat(error.getMessage(), containsString("@ApplicationPath"));
+        assertThat(error.getMessage(), containsString("ContextHandlerBuilder"));
+    }
+
+    @Test
     public void unsupportedComponentsAndPropertiesAreRejected() {
         Application unsupportedComponent = singletonApplication(new Object());
         IllegalArgumentException componentError = assertThrows(IllegalArgumentException.class,
@@ -270,6 +280,10 @@ public class ApplicationTest {
                 return result;
             }
         };
+    }
+
+    @ApplicationPath("api")
+    private static class PathAnnotatedApplication extends Application {
     }
 
     @NameBinding

--- a/src/test/java/io/muserver/rest/ApplicationTest.java
+++ b/src/test/java/io/muserver/rest/ApplicationTest.java
@@ -232,6 +232,20 @@ public class ApplicationTest {
     }
 
     @Test
+    public void nameBindingIsInheritedFromGenericParentInterface() throws IOException {
+        server = ServerUtils.httpsServerForTest()
+            .addHandler(RestHandlerBuilder.fromApplication(singletonApplication(
+                new GenericBindingResource(), new GenericBindingResponseFilter())))
+            .start();
+
+        try (Response response = call(request(server.uri().resolve("/generic-binding/value?value=hello")))) {
+            assertThat(response.code(), is(200));
+            assertThat(response.body().string(), is("hello"));
+            assertThat(response.header("X-Generic-Binding"), is("applied"));
+        }
+    }
+
+    @Test
     public void applicationComponentPriorityIsRetainedWhenBuilderIsCustomized() throws IOException {
         List<String> calls = new ArrayList<>();
         server = ServerUtils.httpsServerForTest()
@@ -292,6 +306,38 @@ public class ApplicationTest {
         @Override
         public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext) {
             responseContext.getHeaders().putSingle("X-Application-Binding", "applied");
+        }
+    }
+
+    @NameBinding
+    @Target({ElementType.TYPE, ElementType.METHOD})
+    @Retention(RetentionPolicy.RUNTIME)
+    private @interface GenericBinding {
+    }
+
+    private interface GenericBindingParent<T> {
+        @GET
+        @Path("value")
+        @GenericBinding
+        String value(@QueryParam("value") T value);
+    }
+
+    private interface GenericBindingChild<T> extends GenericBindingParent<T> {
+    }
+
+    @Path("generic-binding")
+    public static class GenericBindingResource implements GenericBindingChild<String> {
+        @Override
+        public String value(String value) {
+            return value;
+        }
+    }
+
+    @GenericBinding
+    private static class GenericBindingResponseFilter implements ContainerResponseFilter {
+        @Override
+        public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext) {
+            responseContext.getHeaders().putSingle("X-Generic-Binding", "applied");
         }
     }
 


### PR DESCRIPTION
## Summary

- add `RestHandlerBuilder.fromApplication(Application)` for singleton-based application configuration
- register singleton resources plus supported readers, writers, parameter converter providers, exception mappers, request/response filters, and reader/writer interceptors
- instantiate provider classes from `getClasses()` while rejecting per-request resource classes and unsupported application features/properties
- preserve name binding, `@Priority`, client/server constraints, duplicate detection, and singleton-over-class precedence
- document the supported `Application` subset and concurrency expectations

## Why

Mu already supports these components through `RestHandlerBuilder`, but could not consume the standard JAX-RS `Application` configuration type. This adds an explicit compatibility boundary without taking ownership of per-request resource lifecycles.

The implementation continues to honor the deprecated `getSingletons()` method on Jakarta REST 3.1 because it remains the standard mechanism for passing preconstructed singleton instances.

## Validation

Developed test-first: the new application tests initially failed because `fromApplication` did not exist, then drove the component mappings and lifecycle validation. A second failing regression test drove priority preservation when the returned builder is customized.

- `mise shell java@temurin-11 && mvn -Dtest=ApplicationTest test` — 10 tests passed against Jakarta REST 3.1
- `mise shell java@temurin-11 && mvn test` — 908 tests passed
- `git diff --check`