### PR TITLE
Align JAX-RS request property semantics

### DIFF
--- a/src/main/java/io/muserver/rest/JaxRSRequest.java
+++ b/src/main/java/io/muserver/rest/JaxRSRequest.java
@@ -106,12 +106,16 @@ class JaxRSRequest implements Request, ContainerRequestContext, ReaderIntercepto
 
     @Override
     public void setProperty(String name, Object object) {
-        muRequest.attribute(name, object);
+        if (object == null) {
+            removeProperty(name);
+        } else {
+            muRequest.attribute(name, object);
+        }
     }
 
     @Override
     public void removeProperty(String name) {
-        muRequest.attribute(name, null);
+        muRequest.attributes().remove(name);
     }
 
     @Override

--- a/src/test/java/io/muserver/rest/FilterTest.java
+++ b/src/test/java/io/muserver/rest/FilterTest.java
@@ -185,8 +185,15 @@ public class FilterTest {
                                 // expected
                             }
                             assertThat(requestContext.getPropertyNames(), containsInAnyOrder("murequest", "hello", "hello2", MU_REQUEST_PROPERTY, RESOURCE_INFO_PROPERTY));
+                            assertThat(requestContext.hasProperty("hello"), is(true));
+                            assertThat(requestContext.hasProperty("missing"), is(false));
+                            assertThat(requestContext.hasProperty(MU_REQUEST_PROPERTY), is(true));
+                            assertThat(requestContext.hasProperty(RESOURCE_INFO_PROPERTY), is(true));
                             requestContext.removeProperty("hello");
                             requestContext.setProperty("hello2", null);
+                            assertThat(requestContext.hasProperty("hello"), is(false));
+                            assertThat(requestContext.hasProperty("hello2"), is(false));
+                            assertThat(requestContext.getPropertyNames(), containsInAnyOrder("murequest", MU_REQUEST_PROPERTY, RESOURCE_INFO_PROPERTY));
                             requestContext.setProperty("hello3", "temp");
                             requestContext.setProperty("hello3", "hello3");
                         } catch (Throwable e) {


### PR DESCRIPTION
## What changed

Added coverage for Jakarta REST 3.1 `hasProperty`, including Mu's synthetic request/resource properties, ordinary properties, missing properties, removal, and null assignment. `setProperty(name, null)` and `removeProperty(name)` now actually remove the backing request attribute.

## Why

The Jakarta contracts say assigning `null` is equivalent to removing a property. The existing Mu attribute setter retained the key with a null value, so `hasProperty()` and `getPropertyNames()` incorrectly continued to report removed properties.

## Impact

Request filters and reader interceptors now observe consistent `getProperty`, `hasProperty`, and `getPropertyNames` results.

## Validation

- Demonstrated the new removal assertions failing before the implementation change
- `mvn -q -Dtest=FilterTest test`
- `git diff --check`