### PR TITLE
Complete JAX-RS SSE close semantics

### DIFF
--- a/src/main/java/io/muserver/rest/JaxSseEventSinkImpl.java
+++ b/src/main/java/io/muserver/rest/JaxSseEventSinkImpl.java
@@ -1,6 +1,7 @@
 package io.muserver.rest;
 
 import io.muserver.AsyncSsePublisher;
+import io.muserver.Mutils;
 import io.muserver.MuResponse;
 import io.muserver.ResponseCompleteListener;
 import jakarta.ws.rs.ServerErrorException;
@@ -11,8 +12,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.ByteArrayOutputStream;
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.TimeUnit;
 
 import static io.muserver.rest.JaxRSResponse.muHeadersToJaxObj;
@@ -24,15 +27,29 @@ class JaxSseEventSinkImpl implements SseEventSink {
     private final AsyncSsePublisher ssePublisher;
     private final MuResponse response;
     private final EntityProviders entityProviders;
+    private final List<ResponseCompleteListener> responseCompleteListeners = new CopyOnWriteArrayList<>();
 
     public JaxSseEventSinkImpl(AsyncSsePublisher ssePublisher, MuResponse response, EntityProviders entityProviders) {
         this.ssePublisher = ssePublisher;
         this.response = response;
         this.entityProviders = entityProviders;
+        if (ssePublisher != null) {
+            ssePublisher.setResponseCompleteHandler(info -> {
+                for (ResponseCompleteListener listener : responseCompleteListeners) {
+                    try {
+                        listener.onComplete(info);
+                    } catch (Throwable e) {
+                        log.warn("Unhandled exception from SSE response completion listener", e);
+                    }
+                }
+            });
+        }
     }
 
-    void setResponseCompleteHandler(ResponseCompleteListener listener) {
-        ssePublisher.setResponseCompleteHandler(listener);
+    Runnable addResponseCompleteHandler(ResponseCompleteListener listener) {
+        Mutils.notNull("listener", listener);
+        responseCompleteListeners.add(listener);
+        return () -> responseCompleteListeners.remove(listener);
     }
 
     @Override

--- a/src/main/java/io/muserver/rest/SseBroadcasterImpl.java
+++ b/src/main/java/io/muserver/rest/SseBroadcasterImpl.java
@@ -123,8 +123,9 @@ class SseBroadcasterImpl implements SseBroadcaster {
     }
 
     @Override
-    public void close(boolean cascading) {
+    public synchronized void close(boolean cascading) {
         if (!isClosed) {
+            isClosed = true;
             if (cascading) {
                 for (SseEventSink sink : sinks) {
                     try {
@@ -136,7 +137,6 @@ class SseBroadcasterImpl implements SseBroadcaster {
                 }
             }
             sinks.clear();
-            isClosed = true;
         }
     }
 

--- a/src/main/java/io/muserver/rest/SseBroadcasterImpl.java
+++ b/src/main/java/io/muserver/rest/SseBroadcasterImpl.java
@@ -8,8 +8,10 @@ import jakarta.ws.rs.sse.SseBroadcaster;
 import jakarta.ws.rs.sse.SseEventSink;
 
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -22,6 +24,7 @@ class SseBroadcasterImpl implements SseBroadcaster {
     private final List<BiConsumer<SseEventSink, Throwable>> errorListeners = new CopyOnWriteArrayList<>();
     private final List<Consumer<SseEventSink>> closeListeners = new CopyOnWriteArrayList<>();
     private final List<SseEventSink> sinks = new CopyOnWriteArrayList<>();
+    private final Set<SseEventSink> closeNotifications = ConcurrentHashMap.newKeySet();
 
     @Override
     public synchronized void onError(BiConsumer<SseEventSink, Throwable> onError) {
@@ -81,9 +84,8 @@ class SseBroadcasterImpl implements SseBroadcaster {
         }
         for (SseEventSink sink : currentSinks) {
             if (sink.isClosed()) {
-                if (sinks.remove(sink)) {
-                    sendOnCloseEvent(sink);
-                }
+                sinks.remove(sink);
+                sendOnCloseEvent(sink);
                 sendComplete(completableFuture, count);
             } else {
                 try {
@@ -94,9 +96,8 @@ class SseBroadcasterImpl implements SseBroadcaster {
                         sendComplete(completableFuture, count);
                     });
                 } catch (IllegalStateException e) {
-                    if (sinks.remove(sink)) {
-                        sendOnCloseEvent(sink);
-                    }
+                    sinks.remove(sink);
+                    sendOnCloseEvent(sink);
                     sendComplete(completableFuture, count);
                 }
             }
@@ -152,8 +153,10 @@ class SseBroadcasterImpl implements SseBroadcaster {
     }
 
     private void sendOnCloseEvent(SseEventSink sink) {
-        for (Consumer<SseEventSink> closeListener : closeListeners) {
-            closeListener.accept(sink);
+        if (closeNotifications.add(sink)) {
+            for (Consumer<SseEventSink> closeListener : closeListeners) {
+                closeListener.accept(sink);
+            }
         }
     }
 

--- a/src/main/java/io/muserver/rest/SseBroadcasterImpl.java
+++ b/src/main/java/io/muserver/rest/SseBroadcasterImpl.java
@@ -107,8 +107,8 @@ class SseBroadcasterImpl implements SseBroadcaster {
     }
 
     private void onSinkErrored(SinkRegistration registration, Throwable throwable) {
-        boolean wasInList = sinks.remove(registration);
-        if (wasInList) {
+        sinks.remove(registration);
+        if (registration.errorNotified.compareAndSet(false, true)) {
             try {
                 registration.sink.close();
             } catch (Exception ignored) {
@@ -173,6 +173,7 @@ class SseBroadcasterImpl implements SseBroadcaster {
     private static class SinkRegistration {
         private final SseEventSink sink;
         private final AtomicBoolean closeNotified = new AtomicBoolean();
+        private final AtomicBoolean errorNotified = new AtomicBoolean();
 
         private SinkRegistration(SseEventSink sink) {
             this.sink = sink;

--- a/src/main/java/io/muserver/rest/SseBroadcasterImpl.java
+++ b/src/main/java/io/muserver/rest/SseBroadcasterImpl.java
@@ -24,21 +24,21 @@ class SseBroadcasterImpl implements SseBroadcaster {
     private final List<SseEventSink> sinks = new CopyOnWriteArrayList<>();
 
     @Override
-    public void onError(BiConsumer<SseEventSink, Throwable> onError) {
+    public synchronized void onError(BiConsumer<SseEventSink, Throwable> onError) {
         Mutils.notNull("onError", onError);
         throwIfClosed();
         this.errorListeners.add(onError);
     }
 
     @Override
-    public void onClose(Consumer<SseEventSink> onClose) {
+    public synchronized void onClose(Consumer<SseEventSink> onClose) {
         Mutils.notNull("onClose", onClose);
         throwIfClosed();
         this.closeListeners.add(onClose);
     }
 
     @Override
-    public void register(SseEventSink sseEventSink) {
+    public synchronized void register(SseEventSink sseEventSink) {
         Mutils.notNull("sseEventSink", sseEventSink);
         throwIfClosed();
         this.sinks.add(sseEventSink);
@@ -66,13 +66,20 @@ class SseBroadcasterImpl implements SseBroadcaster {
     @Override
     public CompletionStage<?> broadcast(OutboundSseEvent event) {
         Mutils.notNull("event", event);
-        throwIfClosed();
-
+        List<SseEventSink> currentSinks;
+        synchronized (this) {
+            throwIfClosed();
+            currentSinks = List.copyOf(sinks);
+        }
 
         CompletableFuture<?> completableFuture = new CompletableFuture<>();
 
-        AtomicInteger count = new AtomicInteger(sinks.size());
-        for (SseEventSink sink : sinks) {
+        AtomicInteger count = new AtomicInteger(currentSinks.size());
+        if (currentSinks.isEmpty()) {
+            completableFuture.complete(null);
+            return completableFuture;
+        }
+        for (SseEventSink sink : currentSinks) {
             if (sink.isClosed()) {
                 sinks.remove(sink);
                 sendOnCloseEvent(sink);

--- a/src/main/java/io/muserver/rest/SseBroadcasterImpl.java
+++ b/src/main/java/io/muserver/rest/SseBroadcasterImpl.java
@@ -8,12 +8,11 @@ import jakarta.ws.rs.sse.SseBroadcaster;
 import jakarta.ws.rs.sse.SseEventSink;
 
 import java.util.List;
-import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
@@ -23,8 +22,7 @@ class SseBroadcasterImpl implements SseBroadcaster {
     private volatile boolean isClosed = false;
     private final List<BiConsumer<SseEventSink, Throwable>> errorListeners = new CopyOnWriteArrayList<>();
     private final List<Consumer<SseEventSink>> closeListeners = new CopyOnWriteArrayList<>();
-    private final List<SseEventSink> sinks = new CopyOnWriteArrayList<>();
-    private final Set<SseEventSink> closeNotifications = ConcurrentHashMap.newKeySet();
+    private final List<SinkRegistration> sinks = new CopyOnWriteArrayList<>();
 
     @Override
     public synchronized void onError(BiConsumer<SseEventSink, Throwable> onError) {
@@ -44,7 +42,8 @@ class SseBroadcasterImpl implements SseBroadcaster {
     public synchronized void register(SseEventSink sseEventSink) {
         Mutils.notNull("sseEventSink", sseEventSink);
         throwIfClosed();
-        this.sinks.add(sseEventSink);
+        SinkRegistration registration = new SinkRegistration(sseEventSink);
+        this.sinks.add(registration);
         if (sseEventSink instanceof JaxSseEventSinkImpl) {
             ((JaxSseEventSinkImpl) sseEventSink).setResponseCompleteHandler(info -> {
                 if (!info.completedSuccessfully()) {
@@ -60,7 +59,7 @@ class SseBroadcasterImpl implements SseBroadcaster {
                         case ERRORED:
                             ex = new MuException("Generic error");
                     }
-                    onSinkErrored(sseEventSink, ex);
+                    onSinkErrored(registration, ex);
                 }
             });
         }
@@ -69,7 +68,7 @@ class SseBroadcasterImpl implements SseBroadcaster {
     @Override
     public CompletionStage<?> broadcast(OutboundSseEvent event) {
         Mutils.notNull("event", event);
-        List<SseEventSink> currentSinks;
+        List<SinkRegistration> currentSinks;
         synchronized (this) {
             throwIfClosed();
             currentSinks = List.copyOf(sinks);
@@ -82,22 +81,23 @@ class SseBroadcasterImpl implements SseBroadcaster {
             completableFuture.complete(null);
             return completableFuture;
         }
-        for (SseEventSink sink : currentSinks) {
+        for (SinkRegistration registration : currentSinks) {
+            SseEventSink sink = registration.sink;
             if (sink.isClosed()) {
-                sinks.remove(sink);
-                sendOnCloseEvent(sink);
+                sinks.remove(registration);
+                sendOnCloseEvent(registration);
                 sendComplete(completableFuture, count);
             } else {
                 try {
                     sink.send(event).whenComplete((o, throwable) -> {
                         if (throwable != null) {
-                            onSinkErrored(sink, throwable);
+                            onSinkErrored(registration, throwable);
                         }
                         sendComplete(completableFuture, count);
                     });
                 } catch (IllegalStateException e) {
-                    sinks.remove(sink);
-                    sendOnCloseEvent(sink);
+                    sinks.remove(registration);
+                    sendOnCloseEvent(registration);
                     sendComplete(completableFuture, count);
                 }
             }
@@ -106,15 +106,15 @@ class SseBroadcasterImpl implements SseBroadcaster {
         return completableFuture;
     }
 
-    private void onSinkErrored(SseEventSink sink, Throwable throwable) {
-        boolean wasInList = sinks.remove(sink);
+    private void onSinkErrored(SinkRegistration registration, Throwable throwable) {
+        boolean wasInList = sinks.remove(registration);
         if (wasInList) {
             try {
-                sink.close();
+                registration.sink.close();
             } catch (Exception ignored) {
             }
             for (BiConsumer<SseEventSink, Throwable> errorListener : errorListeners) {
-                errorListener.accept(sink, throwable);
+                errorListener.accept(registration.sink, throwable);
             }
         }
     }
@@ -133,7 +133,7 @@ class SseBroadcasterImpl implements SseBroadcaster {
 
     @Override
     public void close(boolean cascading) {
-        List<SseEventSink> sinksToClose;
+        List<SinkRegistration> sinksToClose;
         synchronized (this) {
             if (isClosed) {
                 return;
@@ -142,20 +142,20 @@ class SseBroadcasterImpl implements SseBroadcaster {
             sinksToClose = cascading ? List.copyOf(sinks) : List.of();
             sinks.clear();
         }
-        for (SseEventSink sink : sinksToClose) {
+        for (SinkRegistration registration : sinksToClose) {
             try {
-                sink.close();
-                sendOnCloseEvent(sink);
+                registration.sink.close();
+                sendOnCloseEvent(registration);
             } catch (Exception e) {
                 // ignore
             }
         }
     }
 
-    private void sendOnCloseEvent(SseEventSink sink) {
-        if (closeNotifications.add(sink)) {
+    private void sendOnCloseEvent(SinkRegistration registration) {
+        if (registration.closeNotified.compareAndSet(false, true)) {
             for (Consumer<SseEventSink> closeListener : closeListeners) {
-                closeListener.accept(sink);
+                closeListener.accept(registration.sink);
             }
         }
     }
@@ -168,5 +168,14 @@ class SseBroadcasterImpl implements SseBroadcaster {
 
     public int connectedSinksCount() {
         return sinks.size();
+    }
+
+    private static class SinkRegistration {
+        private final SseEventSink sink;
+        private final AtomicBoolean closeNotified = new AtomicBoolean();
+
+        private SinkRegistration(SseEventSink sink) {
+            this.sink = sink;
+        }
     }
 }

--- a/src/main/java/io/muserver/rest/SseBroadcasterImpl.java
+++ b/src/main/java/io/muserver/rest/SseBroadcasterImpl.java
@@ -131,20 +131,23 @@ class SseBroadcasterImpl implements SseBroadcaster {
     }
 
     @Override
-    public synchronized void close(boolean cascading) {
-        if (!isClosed) {
-            isClosed = true;
-            if (cascading) {
-                for (SseEventSink sink : sinks) {
-                    try {
-                        sink.close();
-                        sendOnCloseEvent(sink);
-                    } catch (Exception e) {
-                        // ignore
-                    }
-                }
+    public void close(boolean cascading) {
+        List<SseEventSink> sinksToClose;
+        synchronized (this) {
+            if (isClosed) {
+                return;
             }
+            isClosed = true;
+            sinksToClose = cascading ? List.copyOf(sinks) : List.of();
             sinks.clear();
+        }
+        for (SseEventSink sink : sinksToClose) {
+            try {
+                sink.close();
+                sendOnCloseEvent(sink);
+            } catch (Exception e) {
+                // ignore
+            }
         }
     }
 

--- a/src/main/java/io/muserver/rest/SseBroadcasterImpl.java
+++ b/src/main/java/io/muserver/rest/SseBroadcasterImpl.java
@@ -59,7 +59,7 @@ class SseBroadcasterImpl implements SseBroadcaster {
                         case ERRORED:
                             ex = new MuException("Generic error");
                     }
-                    onSinkErrored(registration, ex);
+                    onSinkErrored(registration, ex, true);
                 }
             });
         }
@@ -91,7 +91,7 @@ class SseBroadcasterImpl implements SseBroadcaster {
                 try {
                     sink.send(event).whenComplete((o, throwable) -> {
                         if (throwable != null) {
-                            onSinkErrored(registration, throwable);
+                            onSinkErrored(registration, throwable, false);
                         }
                         sendComplete(completableFuture, count);
                     });
@@ -106,9 +106,10 @@ class SseBroadcasterImpl implements SseBroadcaster {
         return completableFuture;
     }
 
-    private void onSinkErrored(SinkRegistration registration, Throwable throwable) {
-        sinks.remove(registration);
-        if (registration.errorNotified.compareAndSet(false, true)) {
+    private void onSinkErrored(SinkRegistration registration, Throwable throwable, boolean requireCurrentRegistration) {
+        boolean wasRegistered = sinks.remove(registration);
+        if ((!requireCurrentRegistration || wasRegistered)
+            && registration.errorNotified.compareAndSet(false, true)) {
             try {
                 registration.sink.close();
             } catch (Exception ignored) {

--- a/src/main/java/io/muserver/rest/SseBroadcasterImpl.java
+++ b/src/main/java/io/muserver/rest/SseBroadcasterImpl.java
@@ -81,8 +81,9 @@ class SseBroadcasterImpl implements SseBroadcaster {
         }
         for (SseEventSink sink : currentSinks) {
             if (sink.isClosed()) {
-                sinks.remove(sink);
-                sendOnCloseEvent(sink);
+                if (sinks.remove(sink)) {
+                    sendOnCloseEvent(sink);
+                }
                 sendComplete(completableFuture, count);
             } else {
                 try {

--- a/src/main/java/io/muserver/rest/SseBroadcasterImpl.java
+++ b/src/main/java/io/muserver/rest/SseBroadcasterImpl.java
@@ -14,6 +14,7 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 
@@ -23,45 +24,61 @@ class SseBroadcasterImpl implements SseBroadcaster {
     private final List<BiConsumer<SseEventSink, Throwable>> errorListeners = new CopyOnWriteArrayList<>();
     private final List<Consumer<SseEventSink>> closeListeners = new CopyOnWriteArrayList<>();
     private final List<SinkRegistration> sinks = new CopyOnWriteArrayList<>();
+    private final ReentrantLock stateLock = new ReentrantLock();
 
     @Override
-    public synchronized void onError(BiConsumer<SseEventSink, Throwable> onError) {
+    public void onError(BiConsumer<SseEventSink, Throwable> onError) {
         Mutils.notNull("onError", onError);
-        throwIfClosed();
-        this.errorListeners.add(onError);
+        stateLock.lock();
+        try {
+            throwIfClosed();
+            this.errorListeners.add(onError);
+        } finally {
+            stateLock.unlock();
+        }
     }
 
     @Override
-    public synchronized void onClose(Consumer<SseEventSink> onClose) {
+    public void onClose(Consumer<SseEventSink> onClose) {
         Mutils.notNull("onClose", onClose);
-        throwIfClosed();
-        this.closeListeners.add(onClose);
+        stateLock.lock();
+        try {
+            throwIfClosed();
+            this.closeListeners.add(onClose);
+        } finally {
+            stateLock.unlock();
+        }
     }
 
     @Override
-    public synchronized void register(SseEventSink sseEventSink) {
+    public void register(SseEventSink sseEventSink) {
         Mutils.notNull("sseEventSink", sseEventSink);
-        throwIfClosed();
-        SinkRegistration registration = new SinkRegistration(sseEventSink);
-        this.sinks.add(registration);
-        if (sseEventSink instanceof JaxSseEventSinkImpl) {
-            ((JaxSseEventSinkImpl) sseEventSink).setResponseCompleteHandler(info -> {
-                if (!info.completedSuccessfully()) {
-                    Exception ex;
-                    switch (info.response().responseState()) {
-                        case CLIENT_DISCONNECTED:
-                            ex = new ClientDisconnectedException();
-                            break;
-                        case TIMED_OUT:
-                            ex = new TimeoutException();
-                            break;
-                        default:
-                        case ERRORED:
-                            ex = new MuException("Generic error");
+        stateLock.lock();
+        try {
+            throwIfClosed();
+            SinkRegistration registration = new SinkRegistration(sseEventSink);
+            this.sinks.add(registration);
+            if (sseEventSink instanceof JaxSseEventSinkImpl) {
+                ((JaxSseEventSinkImpl) sseEventSink).setResponseCompleteHandler(info -> {
+                    if (!info.completedSuccessfully()) {
+                        Exception ex;
+                        switch (info.response().responseState()) {
+                            case CLIENT_DISCONNECTED:
+                                ex = new ClientDisconnectedException();
+                                break;
+                            case TIMED_OUT:
+                                ex = new TimeoutException();
+                                break;
+                            default:
+                            case ERRORED:
+                                ex = new MuException("Generic error");
+                        }
+                        onSinkErrored(registration, ex, true);
                     }
-                    onSinkErrored(registration, ex, true);
-                }
-            });
+                });
+            }
+        } finally {
+            stateLock.unlock();
         }
     }
 
@@ -69,9 +86,12 @@ class SseBroadcasterImpl implements SseBroadcaster {
     public CompletionStage<?> broadcast(OutboundSseEvent event) {
         Mutils.notNull("event", event);
         List<SinkRegistration> currentSinks;
-        synchronized (this) {
+        stateLock.lock();
+        try {
             throwIfClosed();
             currentSinks = List.copyOf(sinks);
+        } finally {
+            stateLock.unlock();
         }
 
         CompletableFuture<?> completableFuture = new CompletableFuture<>();
@@ -135,13 +155,16 @@ class SseBroadcasterImpl implements SseBroadcaster {
     @Override
     public void close(boolean cascading) {
         List<SinkRegistration> sinksToClose;
-        synchronized (this) {
+        stateLock.lock();
+        try {
             if (isClosed) {
                 return;
             }
             isClosed = true;
             sinksToClose = cascading ? List.copyOf(sinks) : List.of();
             sinks.clear();
+        } finally {
+            stateLock.unlock();
         }
         for (SinkRegistration registration : sinksToClose) {
             try {

--- a/src/main/java/io/muserver/rest/SseBroadcasterImpl.java
+++ b/src/main/java/io/muserver/rest/SseBroadcasterImpl.java
@@ -127,16 +127,25 @@ class SseBroadcasterImpl implements SseBroadcaster {
     }
 
     private void onSinkErrored(SinkRegistration registration, Throwable throwable, boolean requireCurrentRegistration) {
-        boolean wasRegistered = sinks.remove(registration);
-        if ((!requireCurrentRegistration || wasRegistered)
-            && registration.errorNotified.compareAndSet(false, true)) {
-            try {
-                registration.sink.close();
-            } catch (Exception ignored) {
-            }
-            for (BiConsumer<SseEventSink, Throwable> errorListener : errorListeners) {
-                errorListener.accept(registration.sink, throwable);
-            }
+        boolean notify;
+        stateLock.lock();
+        try {
+            boolean wasRegistered = sinks.remove(registration);
+            notify = (wasRegistered
+                || (!requireCurrentRegistration && registration.acceptInFlightErrors))
+                && registration.errorNotified.compareAndSet(false, true);
+        } finally {
+            stateLock.unlock();
+        }
+        if (!notify) {
+            return;
+        }
+        try {
+            registration.sink.close();
+        } catch (Exception ignored) {
+        }
+        for (BiConsumer<SseEventSink, Throwable> errorListener : errorListeners) {
+            errorListener.accept(registration.sink, throwable);
         }
     }
 
@@ -161,6 +170,11 @@ class SseBroadcasterImpl implements SseBroadcaster {
                 return;
             }
             isClosed = true;
+            if (!cascading) {
+                for (SinkRegistration registration : sinks) {
+                    registration.acceptInFlightErrors = false;
+                }
+            }
             sinksToClose = cascading ? List.copyOf(sinks) : List.of();
             sinks.clear();
         } finally {
@@ -198,6 +212,7 @@ class SseBroadcasterImpl implements SseBroadcaster {
         private final SseEventSink sink;
         private final AtomicBoolean closeNotified = new AtomicBoolean();
         private final AtomicBoolean errorNotified = new AtomicBoolean();
+        private boolean acceptInFlightErrors = true;
 
         private SinkRegistration(SseEventSink sink) {
             this.sink = sink;

--- a/src/main/java/io/muserver/rest/SseBroadcasterImpl.java
+++ b/src/main/java/io/muserver/rest/SseBroadcasterImpl.java
@@ -6,13 +6,16 @@ import io.muserver.Mutils;
 import jakarta.ws.rs.sse.OutboundSseEvent;
 import jakarta.ws.rs.sse.SseBroadcaster;
 import jakarta.ws.rs.sse.SseEventSink;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.TimeoutException;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.BiConsumer;
@@ -20,11 +23,14 @@ import java.util.function.Consumer;
 
 class SseBroadcasterImpl implements SseBroadcaster {
 
-    private volatile boolean isClosed = false;
+    private static final Logger log = LoggerFactory.getLogger(SseBroadcasterImpl.class);
+    private static final Runnable NO_OP = () -> { };
+
     private final List<BiConsumer<SseEventSink, Throwable>> errorListeners = new CopyOnWriteArrayList<>();
     private final List<Consumer<SseEventSink>> closeListeners = new CopyOnWriteArrayList<>();
-    private final List<SinkRegistration> sinks = new CopyOnWriteArrayList<>();
+    private final Set<SinkRegistration> sinks = new HashSet<>();
     private final ReentrantLock stateLock = new ReentrantLock();
+    private CloseMode closeMode = CloseMode.OPEN;
 
     @Override
     public void onError(BiConsumer<SseEventSink, Throwable> onError) {
@@ -59,23 +65,29 @@ class SseBroadcasterImpl implements SseBroadcaster {
             SinkRegistration registration = new SinkRegistration(sseEventSink);
             this.sinks.add(registration);
             if (sseEventSink instanceof JaxSseEventSinkImpl) {
-                ((JaxSseEventSinkImpl) sseEventSink).setResponseCompleteHandler(info -> {
-                    if (!info.completedSuccessfully()) {
-                        Exception ex;
-                        switch (info.response().responseState()) {
-                            case CLIENT_DISCONNECTED:
-                                ex = new ClientDisconnectedException();
-                                break;
-                            case TIMED_OUT:
-                                ex = new TimeoutException();
-                                break;
-                            default:
-                            case ERRORED:
-                                ex = new MuException("Generic error");
-                        }
-                        onSinkErrored(registration, ex, true);
-                    }
-                });
+                try {
+                    registration.responseCompleteHandlerRemoval =
+                        ((JaxSseEventSinkImpl) sseEventSink).addResponseCompleteHandler(info -> {
+                            if (!info.completedSuccessfully()) {
+                                Exception ex;
+                                switch (info.response().responseState()) {
+                                    case CLIENT_DISCONNECTED:
+                                        ex = new ClientDisconnectedException();
+                                        break;
+                                    case TIMED_OUT:
+                                        ex = new TimeoutException();
+                                        break;
+                                    default:
+                                    case ERRORED:
+                                        ex = new MuException("Generic error");
+                                }
+                                onSinkErrored(registration, ex, FailureSource.RESPONSE_COMPLETION);
+                            }
+                        });
+                } catch (RuntimeException | Error e) {
+                    sinks.remove(registration);
+                    throw e;
+                }
             }
         } finally {
             stateLock.unlock();
@@ -102,22 +114,32 @@ class SseBroadcasterImpl implements SseBroadcaster {
             return completableFuture;
         }
         for (SinkRegistration registration : currentSinks) {
-            SseEventSink sink = registration.sink;
-            if (sink.isClosed()) {
-                sinks.remove(registration);
-                sendOnCloseEvent(registration);
-                sendComplete(completableFuture, count);
-            } else {
-                try {
+            try {
+                SseEventSink sink = registration.sink;
+                if (sink.isClosed()) {
+                    onSinkClosed(registration);
+                    sendComplete(completableFuture, count);
+                } else {
                     sink.send(event).whenComplete((o, throwable) -> {
-                        if (throwable != null) {
-                            onSinkErrored(registration, throwable, false);
+                        try {
+                            if (throwable != null) {
+                                onSinkErrored(registration, throwable, FailureSource.BROADCAST);
+                            }
+                        } finally {
+                            sendComplete(completableFuture, count);
                         }
-                        sendComplete(completableFuture, count);
                     });
-                } catch (IllegalStateException e) {
-                    sinks.remove(registration);
-                    sendOnCloseEvent(registration);
+                }
+            } catch (IllegalStateException e) {
+                try {
+                    onSinkClosed(registration);
+                } finally {
+                    sendComplete(completableFuture, count);
+                }
+            } catch (Throwable e) {
+                try {
+                    onSinkErrored(registration, e, FailureSource.BROADCAST);
+                } finally {
                     sendComplete(completableFuture, count);
                 }
             }
@@ -126,26 +148,33 @@ class SseBroadcasterImpl implements SseBroadcaster {
         return completableFuture;
     }
 
-    private void onSinkErrored(SinkRegistration registration, Throwable throwable, boolean requireCurrentRegistration) {
+    private void onSinkErrored(SinkRegistration registration, Throwable throwable, FailureSource failureSource) {
         boolean notify;
         stateLock.lock();
         try {
             boolean wasRegistered = sinks.remove(registration);
             notify = (wasRegistered
-                || (!requireCurrentRegistration && registration.acceptInFlightErrors))
-                && registration.errorNotified.compareAndSet(false, true);
+                || (failureSource == FailureSource.BROADCAST && closeMode != CloseMode.CLOSED_NON_CASCADING))
+                && !registration.errorNotified;
+            if (notify) {
+                registration.errorNotified = true;
+            }
         } finally {
             stateLock.unlock();
         }
+        removeResponseCompleteHandler(registration);
         if (!notify) {
             return;
         }
+        Throwable closeFailure = null;
         try {
             registration.sink.close();
-        } catch (Exception ignored) {
+        } catch (Throwable e) {
+            closeFailure = e;
         }
-        for (BiConsumer<SseEventSink, Throwable> errorListener : errorListeners) {
-            errorListener.accept(registration.sink, throwable);
+        sendOnErrorEvent(registration.sink, throwable);
+        if (closeFailure != null) {
+            sendOnErrorEvent(registration.sink, closeFailure);
         }
     }
 
@@ -163,56 +192,104 @@ class SseBroadcasterImpl implements SseBroadcaster {
 
     @Override
     public void close(boolean cascading) {
+        List<SinkRegistration> currentSinks;
         List<SinkRegistration> sinksToClose;
         stateLock.lock();
         try {
-            if (isClosed) {
+            if (closeMode != CloseMode.OPEN) {
                 return;
             }
-            isClosed = true;
-            if (!cascading) {
-                for (SinkRegistration registration : sinks) {
-                    registration.acceptInFlightErrors = false;
-                }
-            }
-            sinksToClose = cascading ? List.copyOf(sinks) : List.of();
+            closeMode = cascading ? CloseMode.CLOSED_CASCADING : CloseMode.CLOSED_NON_CASCADING;
+            currentSinks = List.copyOf(sinks);
+            sinksToClose = cascading ? currentSinks : List.of();
             sinks.clear();
         } finally {
             stateLock.unlock();
         }
+        for (SinkRegistration registration : currentSinks) {
+            removeResponseCompleteHandler(registration);
+        }
         for (SinkRegistration registration : sinksToClose) {
             try {
                 registration.sink.close();
-                sendOnCloseEvent(registration);
-            } catch (Exception e) {
-                // ignore
+                onSinkClosed(registration);
+            } catch (Throwable e) {
+                sendOnErrorEvent(registration.sink, e);
             }
         }
     }
 
-    private void sendOnCloseEvent(SinkRegistration registration) {
-        if (registration.closeNotified.compareAndSet(false, true)) {
+    private void onSinkClosed(SinkRegistration registration) {
+        boolean notify;
+        stateLock.lock();
+        try {
+            sinks.remove(registration);
+            notify = !registration.closeNotified;
+            registration.closeNotified = true;
+        } finally {
+            stateLock.unlock();
+        }
+        removeResponseCompleteHandler(registration);
+        if (notify) {
             for (Consumer<SseEventSink> closeListener : closeListeners) {
-                closeListener.accept(registration.sink);
+                try {
+                    closeListener.accept(registration.sink);
+                } catch (Throwable e) {
+                    log.warn("Unhandled exception from SSE close listener", e);
+                }
+            }
+        }
+    }
+
+    private static void removeResponseCompleteHandler(SinkRegistration registration) {
+        try {
+            registration.responseCompleteHandlerRemoval.run();
+        } catch (Throwable e) {
+            log.warn("Unable to remove SSE response completion listener", e);
+        }
+    }
+
+    private void sendOnErrorEvent(SseEventSink sink, Throwable throwable) {
+        for (BiConsumer<SseEventSink, Throwable> errorListener : errorListeners) {
+            try {
+                errorListener.accept(sink, throwable);
+            } catch (Throwable e) {
+                log.warn("Unhandled exception from SSE error listener", e);
             }
         }
     }
 
     private void throwIfClosed() {
-        if (isClosed) {
+        if (closeMode != CloseMode.OPEN) {
             throw new IllegalStateException("This broadcaster has already been closed");
         }
     }
 
     public int connectedSinksCount() {
-        return sinks.size();
+        stateLock.lock();
+        try {
+            return sinks.size();
+        } finally {
+            stateLock.unlock();
+        }
+    }
+
+    private enum CloseMode {
+        OPEN,
+        CLOSED_CASCADING,
+        CLOSED_NON_CASCADING
+    }
+
+    private enum FailureSource {
+        BROADCAST,
+        RESPONSE_COMPLETION
     }
 
     private static class SinkRegistration {
         private final SseEventSink sink;
-        private final AtomicBoolean closeNotified = new AtomicBoolean();
-        private final AtomicBoolean errorNotified = new AtomicBoolean();
-        private boolean acceptInFlightErrors = true;
+        private boolean closeNotified;
+        private boolean errorNotified;
+        private Runnable responseCompleteHandlerRemoval = NO_OP;
 
         private SinkRegistration(SseEventSink sink) {
             this.sink = sink;

--- a/src/test/java/io/muserver/rest/SseBroadcasterImplTest.java
+++ b/src/test/java/io/muserver/rest/SseBroadcasterImplTest.java
@@ -535,6 +535,51 @@ public class SseBroadcasterImplTest {
         assertThat(notifications.get(), is(1));
     }
 
+    @Test
+    public void cascadingCloseDoesNotSuppressInFlightSendError() throws Exception {
+        SseBroadcasterImpl broadcaster = new SseBroadcasterImpl();
+        CompletableFuture<Void> sendResult = new CompletableFuture<>();
+        CountDownLatch closeStarted = new CountDownLatch(1);
+        CountDownLatch releaseClose = new CountDownLatch(1);
+        AtomicInteger closeCalls = new AtomicInteger();
+        AtomicInteger errorNotifications = new AtomicInteger();
+        SseEventSink sink = new SseEventSink() {
+            @Override
+            public boolean isClosed() {
+                return false;
+            }
+
+            @Override
+            public CompletionStage<?> send(OutboundSseEvent event) {
+                return sendResult;
+            }
+
+            @Override
+            public void close() {
+                if (closeCalls.incrementAndGet() == 1) {
+                    closeStarted.countDown();
+                    try {
+                        assertThat(releaseClose.await(1, TimeUnit.SECONDS), is(true));
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                        throw new IllegalStateException(e);
+                    }
+                }
+            }
+        };
+        broadcaster.onError((failedSink, error) -> errorNotifications.incrementAndGet());
+        broadcaster.register(sink);
+        broadcaster.broadcast(new JaxOutboundSseEventBuilder().data("event").build());
+
+        CompletableFuture<?> close = CompletableFuture.runAsync(broadcaster::close);
+        assertThat(closeStarted.await(1, TimeUnit.SECONDS), is(true));
+        sendResult.completeExceptionally(new IOException("send failed"));
+
+        assertThat(errorNotifications.get(), is(1));
+        releaseClose.countDown();
+        close.get(1, TimeUnit.SECONDS);
+    }
+
     private static SseEventSink sink(AtomicBoolean closed) {
         return new SseEventSink() {
             @Override

--- a/src/test/java/io/muserver/rest/SseBroadcasterImplTest.java
+++ b/src/test/java/io/muserver/rest/SseBroadcasterImplTest.java
@@ -368,6 +368,37 @@ public class SseBroadcasterImplTest {
     }
 
     @Test
+    public void closeDoesNotInvokeApplicationCallbacksWhileHoldingBroadcasterLock() {
+        SseBroadcasterImpl broadcaster = new SseBroadcasterImpl();
+        AtomicBoolean sinkCloseHeldLock = new AtomicBoolean();
+        AtomicBoolean closeListenerHeldLock = new AtomicBoolean();
+        SseEventSink sink = new SseEventSink() {
+            @Override
+            public boolean isClosed() {
+                return false;
+            }
+
+            @Override
+            public CompletionStage<?> send(OutboundSseEvent event) {
+                return CompletableFuture.completedFuture(null);
+            }
+
+            @Override
+            public void close() {
+                sinkCloseHeldLock.set(Thread.holdsLock(broadcaster));
+            }
+        };
+        broadcaster.onClose(closedSink ->
+            closeListenerHeldLock.set(Thread.holdsLock(broadcaster)));
+        broadcaster.register(sink);
+
+        broadcaster.close();
+
+        assertThat(sinkCloseHeldLock.get(), is(false));
+        assertThat(closeListenerHeldLock.get(), is(false));
+    }
+
+    @Test
     public void nonCascadingCloseLeavesSinksOpen() {
         SseBroadcasterImpl broadcaster = new SseBroadcasterImpl();
         AtomicBoolean sinkClosed = new AtomicBoolean();

--- a/src/test/java/io/muserver/rest/SseBroadcasterImplTest.java
+++ b/src/test/java/io/muserver/rest/SseBroadcasterImplTest.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.lang.annotation.Annotation;
+import java.lang.reflect.Modifier;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.List;
@@ -36,6 +37,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import static io.muserver.rest.RestHandlerBuilder.restHandler;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.assertThrows;
 import static scaffolding.ClientUtils.request;
 import static scaffolding.MuAssert.assertEventually;
 
@@ -377,6 +379,39 @@ public class SseBroadcasterImplTest {
         assertThat(sinkClosed.get(), is(false));
         assertThat(closeListenerCalled.get(), is(false));
         assertThat(broadcaster.connectedSinksCount(), is(0));
+    }
+
+    @Test
+    public void stateChangingOperationsAreSerializedWithClose() throws Exception {
+        assertThat(Modifier.isSynchronized(SseBroadcasterImpl.class
+            .getMethod("register", SseEventSink.class).getModifiers()), is(true));
+        assertThat(Modifier.isSynchronized(SseBroadcasterImpl.class
+            .getMethod("onClose", java.util.function.Consumer.class).getModifiers()), is(true));
+        assertThat(Modifier.isSynchronized(SseBroadcasterImpl.class
+            .getMethod("onError", java.util.function.BiConsumer.class).getModifiers()), is(true));
+    }
+
+    @Test
+    public void everyOperationOtherThanCloseIsRejectedAfterClose() {
+        SseBroadcasterImpl broadcaster = new SseBroadcasterImpl();
+        broadcaster.close(false);
+
+        assertThrows(IllegalStateException.class,
+            () -> broadcaster.register(sink(new AtomicBoolean())));
+        assertThrows(IllegalStateException.class,
+            () -> broadcaster.broadcast(new JaxOutboundSseEventBuilder().data("event").build()));
+        assertThrows(IllegalStateException.class,
+            () -> broadcaster.onClose(closedSink -> { }));
+        assertThrows(IllegalStateException.class,
+            () -> broadcaster.onError((closedSink, error) -> { }));
+    }
+
+    @Test
+    public void broadcastingWithNoSinksCompletesImmediately() throws Exception {
+        SseBroadcasterImpl broadcaster = new SseBroadcasterImpl();
+
+        broadcaster.broadcast(new JaxOutboundSseEventBuilder().data("event").build())
+            .toCompletableFuture().get(1, TimeUnit.SECONDS);
     }
 
     private static SseEventSink sink(AtomicBoolean closed) {

--- a/src/test/java/io/muserver/rest/SseBroadcasterImplTest.java
+++ b/src/test/java/io/muserver/rest/SseBroadcasterImplTest.java
@@ -490,6 +490,51 @@ public class SseBroadcasterImplTest {
         assertThat(notifications.get(), is(1));
     }
 
+    @Test
+    public void nonCascadingCloseDoesNotSuppressInFlightClosedSinkNotification() throws Exception {
+        SseBroadcasterImpl broadcaster = new SseBroadcasterImpl();
+        AtomicBoolean closed = new AtomicBoolean();
+        AtomicInteger notifications = new AtomicInteger();
+        CountDownLatch checkingClosed = new CountDownLatch(1);
+        CountDownLatch releaseClosedCheck = new CountDownLatch(1);
+        SseEventSink sink = new SseEventSink() {
+            @Override
+            public boolean isClosed() {
+                checkingClosed.countDown();
+                try {
+                    assertThat(releaseClosedCheck.await(1, TimeUnit.SECONDS), is(true));
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    throw new IllegalStateException(e);
+                }
+                return closed.get();
+            }
+
+            @Override
+            public CompletionStage<?> send(OutboundSseEvent event) {
+                return CompletableFuture.completedFuture(null);
+            }
+
+            @Override
+            public void close() {
+                closed.set(true);
+            }
+        };
+        broadcaster.onClose(closedSink -> notifications.incrementAndGet());
+        broadcaster.register(sink);
+
+        CompletableFuture<?> broadcast = CompletableFuture.runAsync(() ->
+            broadcaster.broadcast(new JaxOutboundSseEventBuilder().data("event").build())
+                .toCompletableFuture().join());
+        assertThat(checkingClosed.await(1, TimeUnit.SECONDS), is(true));
+        broadcaster.close(false);
+        closed.set(true);
+        releaseClosedCheck.countDown();
+        broadcast.get(1, TimeUnit.SECONDS);
+
+        assertThat(notifications.get(), is(1));
+    }
+
     private static SseEventSink sink(AtomicBoolean closed) {
         return new SseEventSink() {
             @Override

--- a/src/test/java/io/muserver/rest/SseBroadcasterImplTest.java
+++ b/src/test/java/io/muserver/rest/SseBroadcasterImplTest.java
@@ -31,6 +31,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import static io.muserver.rest.RestHandlerBuilder.restHandler;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -338,6 +339,63 @@ public class SseBroadcasterImplTest {
         assertThat(errors, empty());
         assertThat(closedSinks, contains(sink));
         assertThat(broadcaster.connectedSinksCount(), is(0));
+    }
+
+    @Test
+    public void closeMarksTheBroadcasterClosedBeforeClosingSinks() {
+        SseBroadcasterImpl broadcaster = new SseBroadcasterImpl();
+        AtomicBoolean sinkClosed = new AtomicBoolean();
+        AtomicBoolean reentrantRegistrationRejected = new AtomicBoolean();
+        SseEventSink sink = sink(sinkClosed);
+
+        broadcaster.onClose(closedSink -> {
+            try {
+                broadcaster.register(sink(new AtomicBoolean()));
+            } catch (IllegalStateException expected) {
+                reentrantRegistrationRejected.set(true);
+            }
+        });
+        broadcaster.register(sink);
+
+        broadcaster.close();
+
+        assertThat(sinkClosed.get(), is(true));
+        assertThat(reentrantRegistrationRejected.get(), is(true));
+        assertThat(broadcaster.connectedSinksCount(), is(0));
+    }
+
+    @Test
+    public void nonCascadingCloseLeavesSinksOpen() {
+        SseBroadcasterImpl broadcaster = new SseBroadcasterImpl();
+        AtomicBoolean sinkClosed = new AtomicBoolean();
+        AtomicBoolean closeListenerCalled = new AtomicBoolean();
+        broadcaster.onClose(closedSink -> closeListenerCalled.set(true));
+        broadcaster.register(sink(sinkClosed));
+
+        broadcaster.close(false);
+
+        assertThat(sinkClosed.get(), is(false));
+        assertThat(closeListenerCalled.get(), is(false));
+        assertThat(broadcaster.connectedSinksCount(), is(0));
+    }
+
+    private static SseEventSink sink(AtomicBoolean closed) {
+        return new SseEventSink() {
+            @Override
+            public boolean isClosed() {
+                return closed.get();
+            }
+
+            @Override
+            public CompletionStage<?> send(OutboundSseEvent event) {
+                return CompletableFuture.completedFuture(null);
+            }
+
+            @Override
+            public void close() {
+                closed.set(true);
+            }
+        };
     }
 
     @After

--- a/src/test/java/io/muserver/rest/SseBroadcasterImplTest.java
+++ b/src/test/java/io/muserver/rest/SseBroadcasterImplTest.java
@@ -33,6 +33,7 @@ import java.util.concurrent.CompletionStage;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static io.muserver.rest.RestHandlerBuilder.restHandler;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -412,6 +413,50 @@ public class SseBroadcasterImplTest {
 
         broadcaster.broadcast(new JaxOutboundSseEventBuilder().data("event").build())
             .toCompletableFuture().get(1, TimeUnit.SECONDS);
+    }
+
+    @Test
+    public void concurrentCloseAndBroadcastNotifySinkCloseOnlyOnce() throws Exception {
+        SseBroadcasterImpl broadcaster = new SseBroadcasterImpl();
+        AtomicBoolean closed = new AtomicBoolean();
+        AtomicInteger notifications = new AtomicInteger();
+        CountDownLatch checkingClosed = new CountDownLatch(1);
+        CountDownLatch releaseClosedCheck = new CountDownLatch(1);
+        SseEventSink sink = new SseEventSink() {
+            @Override
+            public boolean isClosed() {
+                checkingClosed.countDown();
+                try {
+                    assertThat(releaseClosedCheck.await(1, TimeUnit.SECONDS), is(true));
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    throw new IllegalStateException(e);
+                }
+                return closed.get();
+            }
+
+            @Override
+            public CompletionStage<?> send(OutboundSseEvent event) {
+                return CompletableFuture.completedFuture(null);
+            }
+
+            @Override
+            public void close() {
+                closed.set(true);
+            }
+        };
+        broadcaster.onClose(closedSink -> notifications.incrementAndGet());
+        broadcaster.register(sink);
+
+        CompletableFuture<?> broadcast = CompletableFuture.runAsync(() ->
+            broadcaster.broadcast(new JaxOutboundSseEventBuilder().data("event").build())
+                .toCompletableFuture().join());
+        assertThat(checkingClosed.await(1, TimeUnit.SECONDS), is(true));
+        broadcaster.close();
+        releaseClosedCheck.countDown();
+        broadcast.get(1, TimeUnit.SECONDS);
+
+        assertThat(notifications.get(), is(1));
     }
 
     private static SseEventSink sink(AtomicBoolean closed) {

--- a/src/test/java/io/muserver/rest/SseBroadcasterImplTest.java
+++ b/src/test/java/io/muserver/rest/SseBroadcasterImplTest.java
@@ -1,6 +1,11 @@
 package io.muserver.rest;
 
+import io.muserver.MuRequest;
+import io.muserver.MuResponse;
 import io.muserver.MuServer;
+import io.muserver.ResponseCompleteListener;
+import io.muserver.ResponseInfo;
+import io.muserver.ResponseState;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
@@ -24,6 +29,7 @@ import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Modifier;
+import java.lang.reflect.Proxy;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.List;
@@ -578,6 +584,78 @@ public class SseBroadcasterImplTest {
         assertThat(errorNotifications.get(), is(1));
         releaseClose.countDown();
         close.get(1, TimeUnit.SECONDS);
+    }
+
+    @Test
+    public void nonCascadingCloseIgnoresLaterResponseCompletionErrors() {
+        SseBroadcasterImpl broadcaster = new SseBroadcasterImpl();
+        AtomicInteger closeCalls = new AtomicInteger();
+        AtomicInteger errorNotifications = new AtomicInteger();
+        class CapturingSink extends JaxSseEventSinkImpl {
+            private ResponseCompleteListener responseCompleteListener;
+
+            private CapturingSink() {
+                super(null, null, null);
+            }
+
+            @Override
+            void setResponseCompleteHandler(ResponseCompleteListener listener) {
+                responseCompleteListener = listener;
+            }
+
+            @Override
+            public boolean isClosed() {
+                return false;
+            }
+
+            @Override
+            public CompletionStage<?> send(OutboundSseEvent event) {
+                return CompletableFuture.completedFuture(null);
+            }
+
+            @Override
+            public void close() {
+                closeCalls.incrementAndGet();
+            }
+        }
+        CapturingSink sink = new CapturingSink();
+        broadcaster.onError((failedSink, error) -> errorNotifications.incrementAndGet());
+        broadcaster.register(sink);
+        broadcaster.close(false);
+
+        MuResponse response = (MuResponse) Proxy.newProxyInstance(
+            MuResponse.class.getClassLoader(),
+            new Class<?>[]{MuResponse.class},
+            (proxy, method, args) -> {
+                if (method.getName().equals("responseState")) {
+                    return ResponseState.CLIENT_DISCONNECTED;
+                }
+                throw new UnsupportedOperationException(method.getName());
+            });
+        sink.responseCompleteListener.onComplete(new ResponseInfo() {
+            @Override
+            public long duration() {
+                return 0;
+            }
+
+            @Override
+            public boolean completedSuccessfully() {
+                return false;
+            }
+
+            @Override
+            public MuRequest request() {
+                return null;
+            }
+
+            @Override
+            public MuResponse response() {
+                return response;
+            }
+        });
+
+        assertThat(errorNotifications.get(), is(0));
+        assertThat(closeCalls.get(), is(0));
     }
 
     private static SseEventSink sink(AtomicBoolean closed) {

--- a/src/test/java/io/muserver/rest/SseBroadcasterImplTest.java
+++ b/src/test/java/io/muserver/rest/SseBroadcasterImplTest.java
@@ -1,5 +1,6 @@
 package io.muserver.rest;
 
+import io.muserver.AsyncSsePublisher;
 import io.muserver.MuRequest;
 import io.muserver.MuResponse;
 import io.muserver.MuServer;
@@ -40,6 +41,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static io.muserver.rest.RestHandlerBuilder.restHandler;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -438,7 +440,7 @@ public class SseBroadcasterImplTest {
             }
 
             @Override
-            void setResponseCompleteHandler(ResponseCompleteListener listener) {
+            Runnable addResponseCompleteHandler(ResponseCompleteListener listener) {
                 registrationStarted.countDown();
                 try {
                     assertThat(allowRegistrationToComplete.await(1, TimeUnit.SECONDS), is(true));
@@ -446,6 +448,7 @@ public class SseBroadcasterImplTest {
                     Thread.currentThread().interrupt();
                     throw new IllegalStateException(e);
                 }
+                return () -> { };
             }
         }
 
@@ -664,10 +667,152 @@ public class SseBroadcasterImplTest {
     }
 
     @Test
-    public void nonCascadingCloseIgnoresLaterResponseCompletionErrors() {
+    public void nonCascadingCloseSuppressesFailureFromAlreadyRemovedRegistration() throws Exception {
+        SseBroadcasterImpl broadcaster = new SseBroadcasterImpl();
+        CompletableFuture<Void> firstSend = new CompletableFuture<>();
+        AtomicInteger closedChecks = new AtomicInteger();
+        AtomicInteger closeCalls = new AtomicInteger();
+        AtomicInteger errorNotifications = new AtomicInteger();
+        SseEventSink sink = new SseEventSink() {
+            @Override
+            public boolean isClosed() {
+                return closedChecks.incrementAndGet() > 1;
+            }
+
+            @Override
+            public CompletionStage<?> send(OutboundSseEvent event) {
+                return firstSend;
+            }
+
+            @Override
+            public void close() {
+                closeCalls.incrementAndGet();
+            }
+        };
+        broadcaster.onError((failedSink, error) -> errorNotifications.incrementAndGet());
+        broadcaster.register(sink);
+
+        CompletionStage<?> pendingBroadcast =
+            broadcaster.broadcast(new JaxOutboundSseEventBuilder().data("first").build());
+        broadcaster.broadcast(new JaxOutboundSseEventBuilder().data("second").build())
+            .toCompletableFuture().get(1, TimeUnit.SECONDS);
+        broadcaster.close(false);
+        firstSend.completeExceptionally(new IOException("send failed"));
+        pendingBroadcast.toCompletableFuture().get(1, TimeUnit.SECONDS);
+
+        assertThat(errorNotifications.get(), is(0));
+        assertThat(closeCalls.get(), is(0));
+    }
+
+    @Test
+    public void throwingErrorListenerDoesNotStrandBroadcastOrSkipLaterListeners() throws Exception {
+        SseBroadcasterImpl broadcaster = new SseBroadcasterImpl();
+        CompletableFuture<Void> sendResult = new CompletableFuture<>();
+        AtomicInteger laterListenerCalls = new AtomicInteger();
+        broadcaster.onError((failedSink, error) -> {
+            throw new IllegalStateException("listener failed");
+        });
+        broadcaster.onError((failedSink, error) -> laterListenerCalls.incrementAndGet());
+        broadcaster.register(new SseEventSink() {
+            @Override
+            public boolean isClosed() {
+                return false;
+            }
+
+            @Override
+            public CompletionStage<?> send(OutboundSseEvent event) {
+                return sendResult;
+            }
+
+            @Override
+            public void close() {
+            }
+        });
+
+        CompletionStage<?> broadcast =
+            broadcaster.broadcast(new JaxOutboundSseEventBuilder().data("event").build());
+        sendResult.completeExceptionally(new IOException("send failed"));
+
+        broadcast.toCompletableFuture().get(1, TimeUnit.SECONDS);
+        assertThat(laterListenerCalls.get(), is(1));
+    }
+
+    @Test
+    public void throwingCloseListenerDoesNotStrandBroadcastOrSkipLaterListeners() throws Exception {
+        SseBroadcasterImpl broadcaster = new SseBroadcasterImpl();
+        AtomicBoolean closed = new AtomicBoolean(true);
+        AtomicInteger laterListenerCalls = new AtomicInteger();
+        broadcaster.onClose(closedSink -> {
+            throw new IllegalStateException("listener failed");
+        });
+        broadcaster.onClose(closedSink -> laterListenerCalls.incrementAndGet());
+        broadcaster.register(sink(closed));
+
+        broadcaster.broadcast(new JaxOutboundSseEventBuilder().data("event").build())
+            .toCompletableFuture().get(1, TimeUnit.SECONDS);
+
+        assertThat(laterListenerCalls.get(), is(1));
+    }
+
+    @Test
+    public void cascadingCloseReportsSinkCloseFailure() {
+        SseBroadcasterImpl broadcaster = new SseBroadcasterImpl();
+        IllegalStateException closeFailure = new IllegalStateException("close failed");
+        List<Throwable> errors = new CopyOnWriteArrayList<>();
+        broadcaster.onError((failedSink, error) -> errors.add(error));
+        broadcaster.register(new SseEventSink() {
+            @Override
+            public boolean isClosed() {
+                return false;
+            }
+
+            @Override
+            public CompletionStage<?> send(OutboundSseEvent event) {
+                return CompletableFuture.completedFuture(null);
+            }
+
+            @Override
+            public void close() {
+                throw closeFailure;
+            }
+        });
+
+        broadcaster.close();
+
+        assertThat(errors, contains(closeFailure));
+    }
+
+    @Test
+    public void responseCompleteHandlersCanBeRemovedFromJaxSink() {
+        AtomicReference<ResponseCompleteListener> upstreamHandler = new AtomicReference<>();
+        AsyncSsePublisher publisher = (AsyncSsePublisher) Proxy.newProxyInstance(
+            AsyncSsePublisher.class.getClassLoader(),
+            new Class<?>[]{AsyncSsePublisher.class},
+            (proxy, method, args) -> {
+                if (method.getName().equals("setResponseCompleteHandler")) {
+                    upstreamHandler.set((ResponseCompleteListener) args[0]);
+                    return null;
+                }
+                throw new UnsupportedOperationException(method.getName());
+            });
+        JaxSseEventSinkImpl sink = new JaxSseEventSinkImpl(publisher, null, null);
+        AtomicInteger handlerCalls = new AtomicInteger();
+        Runnable removeHandler = sink.addResponseCompleteHandler(info -> handlerCalls.incrementAndGet());
+
+        upstreamHandler.get().onComplete(null);
+        removeHandler.run();
+        removeHandler.run();
+        upstreamHandler.get().onComplete(null);
+
+        assertThat(handlerCalls.get(), is(1));
+    }
+
+    @Test
+    public void nonCascadingCloseRemovesResponseHandlerAndIgnoresRacingCompletion() {
         SseBroadcasterImpl broadcaster = new SseBroadcasterImpl();
         AtomicInteger closeCalls = new AtomicInteger();
         AtomicInteger errorNotifications = new AtomicInteger();
+        AtomicBoolean responseCompleteHandlerRemoved = new AtomicBoolean();
         class CapturingSink extends JaxSseEventSinkImpl {
             private ResponseCompleteListener responseCompleteListener;
 
@@ -676,8 +821,9 @@ public class SseBroadcasterImplTest {
             }
 
             @Override
-            void setResponseCompleteHandler(ResponseCompleteListener listener) {
+            Runnable addResponseCompleteHandler(ResponseCompleteListener listener) {
                 responseCompleteListener = listener;
+                return () -> responseCompleteHandlerRemoved.set(true);
             }
 
             @Override
@@ -699,6 +845,7 @@ public class SseBroadcasterImplTest {
         broadcaster.onError((failedSink, error) -> errorNotifications.incrementAndGet());
         broadcaster.register(sink);
         broadcaster.close(false);
+        assertThat(responseCompleteHandlerRemoved.get(), is(true));
 
         MuResponse response = (MuResponse) Proxy.newProxyInstance(
             MuResponse.class.getClassLoader(),

--- a/src/test/java/io/muserver/rest/SseBroadcasterImplTest.java
+++ b/src/test/java/io/muserver/rest/SseBroadcasterImplTest.java
@@ -28,7 +28,6 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.lang.annotation.Annotation;
-import java.lang.reflect.Modifier;
 import java.lang.reflect.Proxy;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
@@ -38,6 +37,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -420,13 +420,49 @@ public class SseBroadcasterImplTest {
     }
 
     @Test
-    public void stateChangingOperationsAreSerializedWithClose() throws Exception {
-        assertThat(Modifier.isSynchronized(SseBroadcasterImpl.class
-            .getMethod("register", SseEventSink.class).getModifiers()), is(true));
-        assertThat(Modifier.isSynchronized(SseBroadcasterImpl.class
-            .getMethod("onClose", java.util.function.Consumer.class).getModifiers()), is(true));
-        assertThat(Modifier.isSynchronized(SseBroadcasterImpl.class
-            .getMethod("onError", java.util.function.BiConsumer.class).getModifiers()), is(true));
+    public void registerAndCloseAreSerialized() throws Exception {
+        SseBroadcasterImpl broadcaster = new SseBroadcasterImpl();
+        CountDownLatch registrationStarted = new CountDownLatch(1);
+        CountDownLatch allowRegistrationToComplete = new CountDownLatch(1);
+        class BlockingSink extends JaxSseEventSinkImpl {
+            private BlockingSink() {
+                super(null, null, null);
+            }
+
+            @Override
+            void setResponseCompleteHandler(ResponseCompleteListener listener) {
+                registrationStarted.countDown();
+                try {
+                    assertThat(allowRegistrationToComplete.await(1, TimeUnit.SECONDS), is(true));
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    throw new IllegalStateException(e);
+                }
+            }
+        }
+
+        CompletableFuture<?> registration = CompletableFuture.runAsync(() ->
+            broadcaster.register(new BlockingSink()));
+        assertThat(registrationStarted.await(1, TimeUnit.SECONDS), is(true));
+
+        CountDownLatch closeStarted = new CountDownLatch(1);
+        CompletableFuture<?> close = CompletableFuture.runAsync(() -> {
+            closeStarted.countDown();
+            broadcaster.close(false);
+        });
+        assertThat(closeStarted.await(1, TimeUnit.SECONDS), is(true));
+
+        try {
+            assertThrows(TimeoutException.class, () -> close.get(100, TimeUnit.MILLISECONDS));
+        } finally {
+            allowRegistrationToComplete.countDown();
+        }
+        registration.get(1, TimeUnit.SECONDS);
+        close.get(1, TimeUnit.SECONDS);
+
+        assertThat(broadcaster.connectedSinksCount(), is(0));
+        assertThrows(IllegalStateException.class,
+            () -> broadcaster.register(sink(new AtomicBoolean())));
     }
 
     @Test

--- a/src/test/java/io/muserver/rest/SseBroadcasterImplTest.java
+++ b/src/test/java/io/muserver/rest/SseBroadcasterImplTest.java
@@ -376,8 +376,18 @@ public class SseBroadcasterImplTest {
     @Test
     public void closeDoesNotInvokeApplicationCallbacksWhileHoldingBroadcasterLock() {
         SseBroadcasterImpl broadcaster = new SseBroadcasterImpl();
-        AtomicBoolean sinkCloseHeldLock = new AtomicBoolean();
-        AtomicBoolean closeListenerHeldLock = new AtomicBoolean();
+        AtomicInteger crossThreadProbes = new AtomicInteger();
+        Runnable probeBroadcasterFromAnotherThread = () -> {
+            CompletableFuture<?> probe = CompletableFuture.runAsync(() ->
+                assertThrows(IllegalStateException.class,
+                    () -> broadcaster.register(sink(new AtomicBoolean()))));
+            try {
+                probe.get(1, TimeUnit.SECONDS);
+                crossThreadProbes.incrementAndGet();
+            } catch (Exception e) {
+                throw new AssertionError("Broadcaster lock was held while invoking a callback", e);
+            }
+        };
         SseEventSink sink = new SseEventSink() {
             @Override
             public boolean isClosed() {
@@ -391,17 +401,15 @@ public class SseBroadcasterImplTest {
 
             @Override
             public void close() {
-                sinkCloseHeldLock.set(Thread.holdsLock(broadcaster));
+                probeBroadcasterFromAnotherThread.run();
             }
         };
-        broadcaster.onClose(closedSink ->
-            closeListenerHeldLock.set(Thread.holdsLock(broadcaster)));
+        broadcaster.onClose(closedSink -> probeBroadcasterFromAnotherThread.run());
         broadcaster.register(sink);
 
         broadcaster.close();
 
-        assertThat(sinkCloseHeldLock.get(), is(false));
-        assertThat(closeListenerHeldLock.get(), is(false));
+        assertThat(crossThreadProbes.get(), is(2));
     }
 
     @Test
@@ -620,6 +628,39 @@ public class SseBroadcasterImplTest {
         assertThat(errorNotifications.get(), is(1));
         releaseClose.countDown();
         close.get(1, TimeUnit.SECONDS);
+    }
+
+    @Test
+    public void nonCascadingCloseSuppressesInFlightSendError() {
+        SseBroadcasterImpl broadcaster = new SseBroadcasterImpl();
+        CompletableFuture<Void> sendResult = new CompletableFuture<>();
+        AtomicInteger closeCalls = new AtomicInteger();
+        AtomicInteger errorNotifications = new AtomicInteger();
+        SseEventSink sink = new SseEventSink() {
+            @Override
+            public boolean isClosed() {
+                return false;
+            }
+
+            @Override
+            public CompletionStage<?> send(OutboundSseEvent event) {
+                return sendResult;
+            }
+
+            @Override
+            public void close() {
+                closeCalls.incrementAndGet();
+            }
+        };
+        broadcaster.onError((failedSink, error) -> errorNotifications.incrementAndGet());
+        broadcaster.register(sink);
+        broadcaster.broadcast(new JaxOutboundSseEventBuilder().data("event").build());
+
+        broadcaster.close(false);
+        sendResult.completeExceptionally(new IOException("send failed"));
+
+        assertThat(errorNotifications.get(), is(0));
+        assertThat(closeCalls.get(), is(0));
     }
 
     @Test


### PR DESCRIPTION
## What changed

Added Jakarta REST 3.1 coverage for cascading and non-cascading broadcaster shutdown. Broadcaster state-changing operations are serialized with close, while broadcast takes an atomic sink snapshot so independent sends remain concurrent.

## Why

`SseBroadcaster.close(boolean)` is new in 3.1. During a cascading close, the previous implementation did not mark the broadcaster closed until after sink callbacks. A close listener could therefore re-enter and register another sink even though shutdown had begun. Concurrent registration/listener updates also raced with close.

## Impact

- `close()` / `close(true)` close registered sinks
- `close(false)` releases the broadcaster without closing sinks
- Reentrant and concurrent state changes during shutdown are rejected atomically
- Concurrent/repeated close calls perform shutdown once
- Broadcasting with no registered sinks completes immediately
- Sends to independent sinks remain concurrent

## Validation

- Demonstrated the reentrant-registration and close-race tests failing before the implementation changes
- `mvn -q -Dtest=SseBroadcasterImplTest test`
- CI passes on Java 11, 17, 21, and 25
- `git diff --check`