### PR TITLE
Validate JAX-RS SameSite cookie values

### DIFF
--- a/src/main/java/io/muserver/rest/NewCookieHeaderDelegate.java
+++ b/src/main/java/io/muserver/rest/NewCookieHeaderDelegate.java
@@ -6,7 +6,14 @@ import jakarta.ws.rs.core.NewCookie;
 import jakarta.ws.rs.ext.RuntimeDelegate;
 import org.jspecify.annotations.Nullable;
 
+import java.util.Locale;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 class NewCookieHeaderDelegate implements RuntimeDelegate.HeaderDelegate<NewCookie> {
+    private static final Pattern SAME_SITE_ATTRIBUTE =
+        Pattern.compile("(?:^|;)\\s*SameSite\\s*=\\s*([^;]*)", Pattern.CASE_INSENSITIVE);
+
     static {
         MuRuntimeDelegate.ensureSet();
     }
@@ -20,7 +27,10 @@ class NewCookieHeaderDelegate implements RuntimeDelegate.HeaderDelegate<NewCooki
         if (cookie == null) {
             throw new IllegalArgumentException("Could not parse cookie header value: " + value);
         }
-        var sameSite = cookie instanceof DefaultCookie ? fromNetty(((DefaultCookie) cookie).sameSite()) : null;
+        NewCookie.SameSite sameSite = sameSiteFromHeader(value);
+        if (sameSite == null && cookie instanceof DefaultCookie) {
+            sameSite = fromNetty(((DefaultCookie) cookie).sameSite());
+        }
 
         int maxAge = cookie.maxAge() == DefaultCookie.UNDEFINED_MAX_AGE ? NewCookie.DEFAULT_MAX_AGE : (int) cookie.maxAge();
         return new NewCookie.Builder(cookie.name())
@@ -32,6 +42,19 @@ class NewCookieHeaderDelegate implements RuntimeDelegate.HeaderDelegate<NewCooki
             .httpOnly(cookie.isHttpOnly())
             .sameSite(sameSite)
             .build();
+    }
+
+    private static NewCookie.@Nullable SameSite sameSiteFromHeader(String value) {
+        Matcher matcher = SAME_SITE_ATTRIBUTE.matcher(value);
+        if (!matcher.find()) {
+            return null;
+        }
+        String sameSite = matcher.group(1).trim();
+        try {
+            return NewCookie.SameSite.valueOf(sameSite.toUpperCase(Locale.ROOT));
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("Invalid SameSite value: " + sameSite, e);
+        }
     }
 
     private static NewCookie.@Nullable SameSite fromNetty(CookieHeaderNames.@Nullable SameSite nettySameSite) {

--- a/src/main/java/io/muserver/rest/NewCookieHeaderDelegate.java
+++ b/src/main/java/io/muserver/rest/NewCookieHeaderDelegate.java
@@ -12,7 +12,7 @@ import java.util.regex.Pattern;
 
 class NewCookieHeaderDelegate implements RuntimeDelegate.HeaderDelegate<NewCookie> {
     private static final Pattern SAME_SITE_ATTRIBUTE =
-        Pattern.compile("(?:^|;)\\s*SameSite\\s*=\\s*([^;]*)", Pattern.CASE_INSENSITIVE);
+        Pattern.compile(";\\s*SameSite\\s*=\\s*([^;]*)", Pattern.CASE_INSENSITIVE);
 
     static {
         MuRuntimeDelegate.ensureSet();

--- a/src/main/java/io/muserver/rest/NewCookieHeaderDelegate.java
+++ b/src/main/java/io/muserver/rest/NewCookieHeaderDelegate.java
@@ -46,15 +46,16 @@ class NewCookieHeaderDelegate implements RuntimeDelegate.HeaderDelegate<NewCooki
 
     private static NewCookie.@Nullable SameSite sameSiteFromHeader(String value) {
         Matcher matcher = SAME_SITE_ATTRIBUTE.matcher(value);
-        if (!matcher.find()) {
-            return null;
+        NewCookie.SameSite result = null;
+        while (matcher.find()) {
+            String sameSite = matcher.group(1).trim();
+            try {
+                result = NewCookie.SameSite.valueOf(sameSite.toUpperCase(Locale.ROOT));
+            } catch (IllegalArgumentException e) {
+                throw new IllegalArgumentException("Invalid SameSite value: " + sameSite, e);
+            }
         }
-        String sameSite = matcher.group(1).trim();
-        try {
-            return NewCookie.SameSite.valueOf(sameSite.toUpperCase(Locale.ROOT));
-        } catch (IllegalArgumentException e) {
-            throw new IllegalArgumentException("Invalid SameSite value: " + sameSite, e);
-        }
+        return result;
     }
 
     private static NewCookie.@Nullable SameSite fromNetty(CookieHeaderNames.@Nullable SameSite nettySameSite) {

--- a/src/test/java/io/muserver/rest/NewCookieHeaderDelegateTest.java
+++ b/src/test/java/io/muserver/rest/NewCookieHeaderDelegateTest.java
@@ -62,6 +62,14 @@ public class NewCookieHeaderDelegateTest {
     }
 
     @Test
+    public void lastDuplicateSameSiteAttributeWins() {
+        NewCookie parsed = delegate.fromString(
+            "session=abc; SameSite=Lax; SameSite=None");
+
+        assertThat(parsed.getSameSite(), is(NewCookie.SameSite.NONE));
+    }
+
+    @Test
     public void invalidSameSiteValuesAreRejected() {
         assertThrows(IllegalArgumentException.class,
             () -> delegate.fromString("session=abc; SameSite=somewhere"));

--- a/src/test/java/io/muserver/rest/NewCookieHeaderDelegateTest.java
+++ b/src/test/java/io/muserver/rest/NewCookieHeaderDelegateTest.java
@@ -68,6 +68,16 @@ public class NewCookieHeaderDelegateTest {
     }
 
     @Test
+    public void cookieNamedSameSiteIsNotMistakenForAnAttribute() {
+        NewCookie parsed = delegate.fromString("SameSite=abc; Path=/");
+
+        assertThat(parsed.getName(), is("SameSite"));
+        assertThat(parsed.getValue(), is("abc"));
+        assertThat(parsed.getPath(), is("/"));
+        assertThat(parsed.getSameSite(), is(nullValue()));
+    }
+
+    @Test
     public void sessionCookieOmitsExpiryAttributes() {
         NewCookie cookie = new NewCookie.Builder("session")
             .value("abc")

--- a/src/test/java/io/muserver/rest/NewCookieHeaderDelegateTest.java
+++ b/src/test/java/io/muserver/rest/NewCookieHeaderDelegateTest.java
@@ -40,6 +40,34 @@ public class NewCookieHeaderDelegateTest {
     }
 
     @Test
+    public void allSameSiteValuesRoundTrip() {
+        for (NewCookie.SameSite sameSite : NewCookie.SameSite.values()) {
+            NewCookie cookie = new NewCookie.Builder("session")
+                .value("abc")
+                .sameSite(sameSite)
+                .build();
+
+            String serialized = delegate.toString(cookie);
+            NewCookie parsed = delegate.fromString(serialized);
+
+            assertThat(serialized, containsString("SameSite="));
+            assertThat(parsed.getSameSite(), is(sameSite));
+        }
+    }
+
+    @Test
+    public void sameSiteParsingIsCaseInsensitive() {
+        assertThat(delegate.fromString("session=abc; SameSite=sTrIcT").getSameSite(),
+            is(NewCookie.SameSite.STRICT));
+    }
+
+    @Test
+    public void invalidSameSiteValuesAreRejected() {
+        assertThrows(IllegalArgumentException.class,
+            () -> delegate.fromString("session=abc; SameSite=somewhere"));
+    }
+
+    @Test
     public void sessionCookieOmitsExpiryAttributes() {
         NewCookie cookie = new NewCookie.Builder("session")
             .value("abc")


### PR DESCRIPTION
## What changed

Expanded Jakarta REST 3.1 SameSite coverage across `STRICT`, `LAX`, and `NONE`, including case-insensitive parsing. Explicit but unknown SameSite values are now rejected with `IllegalArgumentException` instead of being silently discarded by Netty's decoder.

## Why

Jakarta's header delegate contract requires invalid header syntax to be rejected. Netty accepts an unknown SameSite token but returns no SameSite value, which made malformed cookies appear valid and lose data.

## Impact

Valid SameSite cookies continue to round-trip, while invalid values fail visibly.

## Validation

- Demonstrated the invalid-SameSite test failing before the implementation change
- `mvn -q -Dtest=NewCookieHeaderDelegateTest test`
- `git diff --check`