### PR TITLE
Support JAX-RS entity parts

### DIFF
--- a/src/main/java/io/muserver/openapi/SchemaObjectBuilder.java
+++ b/src/main/java/io/muserver/openapi/SchemaObjectBuilder.java
@@ -1,6 +1,7 @@
 package io.muserver.openapi;
 
 import io.muserver.UploadedFile;
+import jakarta.ws.rs.core.EntityPart;
 
 import java.io.File;
 import java.io.InputStream;
@@ -897,7 +898,7 @@ public class SchemaObjectBuilder {
     }
 
     private static boolean isBinaryClass(Class<?> type) {
-        return UploadedFile.class.isAssignableFrom(type) || File.class.isAssignableFrom(type)
+        return UploadedFile.class.isAssignableFrom(type) || EntityPart.class.isAssignableFrom(type) || File.class.isAssignableFrom(type)
             || InputStream.class.isAssignableFrom(type) || (type.isArray() && type.getComponentType().equals(byte.class));
     }
 

--- a/src/main/java/io/muserver/rest/BuiltInParamConverterProvider.java
+++ b/src/main/java/io/muserver/rest/BuiltInParamConverterProvider.java
@@ -3,6 +3,7 @@ package io.muserver.rest;
 import io.muserver.Cookie;
 import io.muserver.Mutils;
 import io.muserver.UploadedFile;
+import jakarta.ws.rs.core.EntityPart;
 import jakarta.ws.rs.core.PathSegment;
 import jakarta.ws.rs.ext.ParamConverter;
 import jakarta.ws.rs.ext.ParamConverterProvider;
@@ -71,6 +72,9 @@ class BuiltInParamConverterProvider implements ParamConverterProvider {
         if (UploadedFile.class.isAssignableFrom(rawType)) {
             return new UploadedFileConverter();
         }
+        if (EntityPart.class.isAssignableFrom(rawType)) {
+            return new EntityPartConverter();
+        }
         if (PathSegment.class.isAssignableFrom(rawType)) {
             return new PathSegmentConverter();
         }
@@ -98,6 +102,18 @@ class BuiltInParamConverterProvider implements ParamConverterProvider {
         @Override
         public String toString(UploadedFile value) {
             return value.filename();
+        }
+    }
+
+    private static class EntityPartConverter implements ParamConverter<EntityPart> {
+        @Override
+        public EntityPart fromString(String value) {
+            return null;
+        }
+
+        @Override
+        public String toString(EntityPart value) {
+            return value.getName();
         }
     }
 

--- a/src/main/java/io/muserver/rest/EntityProviders.java
+++ b/src/main/java/io/muserver/rest/EntityProviders.java
@@ -22,8 +22,15 @@ class EntityProviders {
     final List<ProviderWrapper<MessageBodyWriter<?>>> writers;
 
     public EntityProviders(List<MessageBodyReader> readers, List<MessageBodyWriter> writers) {
-        this.readers = readers.stream().map(ProviderWrapper::reader).sorted().collect(Collectors.toList());
-        this.writers = writers.stream().map(ProviderWrapper::writer).sorted().collect(Collectors.toList());
+        List<ProviderWrapper<MessageBodyReader<?>>> wrappedReaders =
+            readers.stream().map(ProviderWrapper::reader).collect(Collectors.toList());
+        List<ProviderWrapper<MessageBodyWriter<?>>> wrappedWriters =
+            writers.stream().map(ProviderWrapper::writer).collect(Collectors.toList());
+        MultipartEntityProvider multipartProvider = new MultipartEntityProvider(this);
+        wrappedReaders.add(ProviderWrapper.reader(multipartProvider));
+        wrappedWriters.add(ProviderWrapper.writer(multipartProvider));
+        this.readers = wrappedReaders.stream().sorted().collect(Collectors.toList());
+        this.writers = wrappedWriters.stream().sorted().collect(Collectors.toList());
     }
     public MessageBodyReader<?> selectReader(Class<?> type, Type genericType, Annotation[] annotations, MediaType requestBodyMediaType) {
         Optional<ProviderWrapper<MessageBodyReader<?>>> best = readers.stream()

--- a/src/main/java/io/muserver/rest/JaxRSRequest.java
+++ b/src/main/java/io/muserver/rest/JaxRSRequest.java
@@ -40,6 +40,7 @@ class JaxRSRequest implements Request, ContainerRequestContext, ReaderIntercepto
     private boolean requestFilterChainRunning;
     private boolean responseFilterChainStarted;
     private boolean exceptionMapperUsed;
+    private List<EntityPart> multipartEntityParts;
 
     JaxRSRequest(MuRequest muRequest, MuResponse muResponse, InputStream inputStream, String relativePath, SecurityContext securityContext, List<ReaderInterceptor> readerInterceptors, EntityProviders entityProviders) {
         this.muRequest = muRequest;
@@ -512,6 +513,44 @@ class JaxRSRequest implements Request, ContainerRequestContext, ReaderIntercepto
 
     EntityProviders entityProviders() {
         return entityProviders;
+    }
+
+    void prepareMultipartEntityParts() throws IOException {
+        if (multipartEntityParts != null) {
+            return;
+        }
+        MediaType mediaType = getMediaType();
+        if (mediaType == null || !"multipart".equalsIgnoreCase(mediaType.getType())) {
+            multipartEntityParts = Collections.emptyList();
+            return;
+        }
+        multipartEntityParts = new MultipartEntityProvider(entityProviders).readFrom(
+            null, null, JaxRSResponse.Builder.EMPTY_ANNOTATIONS, mediaType, getHeaders(), getInputStream());
+    }
+
+    EntityPart multipartEntityPart(String name) {
+        if (multipartEntityParts == null) {
+            throw new IllegalStateException("Multipart entity parts have not been prepared");
+        }
+        for (EntityPart part : multipartEntityParts) {
+            if (part.getName().equals(name)) {
+                return part;
+            }
+        }
+        return null;
+    }
+
+    List<String> formValues(String name) throws IOException {
+        if (multipartEntityParts == null) {
+            return muRequest.form().getAll(name);
+        }
+        List<String> values = new ArrayList<>();
+        for (EntityPart part : multipartEntityParts) {
+            if (part.getName().equals(name)) {
+                values.add(part.getContent(String.class));
+            }
+        }
+        return values;
     }
 
     /**

--- a/src/main/java/io/muserver/rest/JaxRSRequest.java
+++ b/src/main/java/io/muserver/rest/JaxRSRequest.java
@@ -510,6 +510,10 @@ class JaxRSRequest implements Request, ContainerRequestContext, ReaderIntercepto
         return getUriInfo().getPath(false);
     }
 
+    EntityProviders entityProviders() {
+        return entityProviders;
+    }
+
     /**
      * This special exception preserves the immediate abort behavior when the request context is used outside a
      * request-filter callback.

--- a/src/main/java/io/muserver/rest/MuEntityPart.java
+++ b/src/main/java/io/muserver/rest/MuEntityPart.java
@@ -78,6 +78,9 @@ final class MuEntityPart implements EntityPart {
     private synchronized <T> T readContent(Class<?> rawType, Type genericType) throws IOException, WebApplicationException {
         Objects.requireNonNull(rawType, "type");
         claimContent();
+        if (rawType == InputStream.class) {
+            return (T) content;
+        }
         MediaType mediaType = getMediaType();
         try {
             MessageBodyReader<T> reader = (MessageBodyReader<T>) entityProviders.selectReader(

--- a/src/main/java/io/muserver/rest/MuEntityPart.java
+++ b/src/main/java/io/muserver/rest/MuEntityPart.java
@@ -1,0 +1,253 @@
+package io.muserver.rest;
+
+import jakarta.ws.rs.NotSupportedException;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.EntityPart;
+import jakarta.ws.rs.core.GenericType;
+import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.MultivaluedHashMap;
+import jakarta.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.ext.MessageBodyReader;
+import jakarta.ws.rs.ext.MessageBodyWriter;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.ArrayList;
+import java.util.Collections;
+
+final class MuEntityPart implements EntityPart {
+
+    private static final Annotation[] NO_ANNOTATIONS = new Annotation[0];
+
+    private final String name;
+    private final String fileName;
+    private final MultivaluedMap<String, String> headers;
+    private final InputStream content;
+    private final EntityProviders entityProviders;
+    private boolean contentClaimed;
+
+    MuEntityPart(String name, String fileName, MultivaluedMap<String, String> headers, InputStream content,
+                 EntityProviders entityProviders) {
+        this.name = Objects.requireNonNull(name, "name");
+        this.fileName = fileName;
+        MultivaluedMap<String, String> copy = new LowercasedMultivaluedHashMap<>();
+        headers.forEach((key, values) ->
+            copy.put(key, Collections.unmodifiableList(new ArrayList<>(values))));
+        this.headers = ReadOnlyMultivaluedMap.readOnly(copy);
+        this.content = Objects.requireNonNull(content, "content");
+        this.entityProviders = entityProviders;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public Optional<String> getFileName() {
+        return Optional.ofNullable(fileName);
+    }
+
+    @Override
+    public synchronized InputStream getContent() {
+        claimContent();
+        return content;
+    }
+
+    @Override
+    public <T> T getContent(Class<T> type) throws IOException, WebApplicationException {
+        return readContent(type, type);
+    }
+
+    @Override
+    public <T> T getContent(GenericType<T> type) throws IOException, WebApplicationException {
+        Objects.requireNonNull(type, "type");
+        return readContent(type.getRawType(), type.getType());
+    }
+
+    @SuppressWarnings("unchecked")
+    private synchronized <T> T readContent(Class<?> rawType, Type genericType) throws IOException, WebApplicationException {
+        Objects.requireNonNull(rawType, "type");
+        claimContent();
+        MediaType mediaType = getMediaType();
+        try {
+            MessageBodyReader<T> reader = (MessageBodyReader<T>) entityProviders.selectReader(
+                rawType, genericType, NO_ANNOTATIONS, mediaType);
+            try (InputStream in = content) {
+                return reader.readFrom((Class<T>) rawType, genericType, NO_ANNOTATIONS, mediaType, headers, in);
+            }
+        } catch (NotSupportedException e) {
+            throw new IllegalArgumentException("No entity provider can read " + genericType + " as " + mediaType, e);
+        }
+    }
+
+    private void claimContent() {
+        if (contentClaimed) {
+            throw new IllegalStateException("The entity part content has already been accessed");
+        }
+        contentClaimed = true;
+    }
+
+    @Override
+    public MultivaluedMap<String, String> getHeaders() {
+        return headers;
+    }
+
+    @Override
+    public MediaType getMediaType() {
+        return MediaType.valueOf(headers.getFirst(HttpHeaders.CONTENT_TYPE));
+    }
+
+    static final class Builder implements EntityPart.Builder {
+
+        private final String name;
+        private final EntityProviders entityProviders;
+        private final MultivaluedMap<String, String> headers = new LowercasedMultivaluedHashMap<>();
+        private String fileName;
+        private InputStream streamContent;
+        private Object objectContent;
+        private Class<?> rawContentType;
+        private Type genericContentType;
+
+        Builder(String name, EntityProviders entityProviders) {
+            if (name == null) {
+                throw new IllegalArgumentException("The entity part name must not be null");
+            }
+            this.name = name;
+            this.entityProviders = entityProviders;
+        }
+
+        @Override
+        public EntityPart.Builder mediaType(MediaType mediaType) {
+            if (mediaType == null) {
+                throw new IllegalArgumentException("The media type must not be null");
+            }
+            headers.putSingle(HttpHeaders.CONTENT_TYPE, mediaType.toString());
+            return this;
+        }
+
+        @Override
+        public EntityPart.Builder mediaType(String mediaTypeString) {
+            if (mediaTypeString == null) {
+                throw new IllegalArgumentException("The media type must not be null");
+            }
+            return mediaType(MediaType.valueOf(mediaTypeString));
+        }
+
+        @Override
+        public EntityPart.Builder header(String headerName, String... headerValues) {
+            if (headerName == null) {
+                throw new IllegalArgumentException("The header name must not be null");
+            }
+            headers.remove(headerName);
+            if (headerValues != null) {
+                headers.addAll(headerName, headerValues);
+            }
+            return this;
+        }
+
+        @Override
+        public EntityPart.Builder headers(MultivaluedMap<String, String> newHeaders) {
+            if (newHeaders == null) {
+                throw new IllegalArgumentException("The headers must not be null");
+            }
+            newHeaders.forEach((name, values) -> header(name, values.toArray(new String[0])));
+            return this;
+        }
+
+        @Override
+        public EntityPart.Builder fileName(String fileName) {
+            if (fileName == null) {
+                throw new IllegalArgumentException("The file name must not be null");
+            }
+            this.fileName = fileName;
+            return this;
+        }
+
+        @Override
+        public EntityPart.Builder content(InputStream content) {
+            if (content == null) {
+                throw new IllegalArgumentException("The content must not be null");
+            }
+            this.streamContent = content;
+            this.objectContent = null;
+            this.rawContentType = InputStream.class;
+            this.genericContentType = InputStream.class;
+            return this;
+        }
+
+        @Override
+        public <T> EntityPart.Builder content(T content, Class<? extends T> type) {
+            if (content == null || type == null) {
+                throw new IllegalArgumentException("The content and type must not be null");
+            }
+            this.objectContent = content;
+            this.streamContent = null;
+            this.rawContentType = type;
+            this.genericContentType = type;
+            return this;
+        }
+
+        @Override
+        public EntityPart.Builder content(Object content) {
+            if (content == null) {
+                throw new IllegalArgumentException("The content must not be null");
+            }
+            return content(content, content.getClass());
+        }
+
+        @Override
+        public <T> EntityPart.Builder content(T content, GenericType<T> type) {
+            if (content == null || type == null) {
+                throw new IllegalArgumentException("The content and type must not be null");
+            }
+            this.objectContent = content;
+            this.streamContent = null;
+            this.rawContentType = type.getRawType();
+            this.genericContentType = type.getType();
+            return this;
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public EntityPart build() throws IOException, WebApplicationException {
+            if (streamContent == null && objectContent == null) {
+                throw new IllegalStateException("Entity part content must be specified");
+            }
+            if (!headers.containsKey(HttpHeaders.CONTENT_TYPE)) {
+                mediaType(fileName == null ? MediaType.TEXT_PLAIN_TYPE : MediaType.APPLICATION_OCTET_STREAM_TYPE);
+            }
+            headers.putSingle(HttpHeaders.CONTENT_DISPOSITION, MultipartEntityProvider.contentDisposition(name, fileName));
+
+            InputStream content = streamContent;
+            if (content == null) {
+                MediaType mediaType = MediaType.valueOf(headers.getFirst(HttpHeaders.CONTENT_TYPE));
+                MessageBodyWriter<Object> writer;
+                try {
+                    writer = (MessageBodyWriter<Object>) entityProviders.selectWriter(
+                        rawContentType, genericContentType, NO_ANNOTATIONS, mediaType);
+                } catch (WebApplicationException e) {
+                    throw new IllegalStateException("No entity provider can write " + genericContentType + " as " + mediaType, e);
+                }
+                ByteArrayOutputStream output = new ByteArrayOutputStream();
+                MultivaluedHashMap<String, Object> objectHeaders = new MultivaluedHashMap<>();
+                for (Map.Entry<String, List<String>> entry : headers.entrySet()) {
+                    objectHeaders.addAll(entry.getKey(), entry.getValue().toArray());
+                }
+                writer.writeTo(objectContent, rawContentType, genericContentType, NO_ANNOTATIONS,
+                    mediaType, objectHeaders, output);
+                content = new ByteArrayInputStream(output.toByteArray());
+            }
+            return new MuEntityPart(name, fileName, headers, content, entityProviders);
+        }
+    }
+}

--- a/src/main/java/io/muserver/rest/MuRuntimeDelegate.java
+++ b/src/main/java/io/muserver/rest/MuRuntimeDelegate.java
@@ -23,6 +23,10 @@ import java.util.concurrent.CompletionStage;
  */
 public class MuRuntimeDelegate extends RuntimeDelegate {
 
+    private static final EntityProviders ENTITY_PART_PROVIDERS =
+        new EntityProviders(EntityProviders.builtInReaders(), EntityProviders.builtInWriters());
+    private static final ThreadLocal<EntityProviders> currentEntityProviders = new ThreadLocal<>();
+
     private static MuRuntimeDelegate singleton;
 
     /**
@@ -154,7 +158,22 @@ public class MuRuntimeDelegate extends RuntimeDelegate {
 
     @Override
     public EntityPart.Builder createEntityPartBuilder(String partName) throws IllegalArgumentException {
-        throw new NotImplementedException("MuServer does not support entity parts");
+        EntityProviders entityProviders = currentEntityProviders.get();
+        return new MuEntityPart.Builder(partName, entityProviders == null ? ENTITY_PART_PROVIDERS : entityProviders);
+    }
+
+    static EntityProviders setCurrentEntityProviders(EntityProviders entityProviders) {
+        EntityProviders previous = currentEntityProviders.get();
+        currentEntityProviders.set(entityProviders);
+        return previous;
+    }
+
+    static void restoreCurrentEntityProviders(EntityProviders previous) {
+        if (previous == null) {
+            currentEntityProviders.remove();
+        } else {
+            currentEntityProviders.set(previous);
+        }
     }
 
     /**

--- a/src/main/java/io/muserver/rest/MultipartEntityProvider.java
+++ b/src/main/java/io/muserver/rest/MultipartEntityProvider.java
@@ -31,7 +31,7 @@ import java.util.UUID;
 
 @Consumes("multipart/*")
 @Produces("multipart/*")
-final class MultipartEntityProvider implements MessageBodyReader<List<EntityPart>>, MessageBodyWriter<List<EntityPart>> {
+final class MultipartEntityProvider implements MessageBodyReader<List<EntityPart>>, MessageBodyWriter<Collection<EntityPart>> {
 
     private static final String CRLF = "\r\n";
     private final EntityProviders entityProviders;
@@ -136,7 +136,7 @@ final class MultipartEntityProvider implements MessageBodyReader<List<EntityPart
     }
 
     @Override
-    public void writeTo(List<EntityPart> parts, Class<?> type, Type genericType, Annotation[] annotations,
+    public void writeTo(Collection<EntityPart> parts, Class<?> type, Type genericType, Annotation[] annotations,
                         MediaType mediaType, MultivaluedMap<String, Object> httpHeaders,
                         OutputStream entityStream) throws IOException, WebApplicationException {
         String boundary = "mu-" + UUID.randomUUID().toString().replace("-", "");

--- a/src/main/java/io/muserver/rest/MultipartEntityProvider.java
+++ b/src/main/java/io/muserver/rest/MultipartEntityProvider.java
@@ -1,0 +1,206 @@
+package io.muserver.rest;
+
+import io.muserver.Mutils;
+import io.muserver.ParameterizedHeaderWithValue;
+import jakarta.ws.rs.BadRequestException;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.EntityPart;
+import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.MultivaluedHashMap;
+import jakarta.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.ext.MessageBodyReader;
+import jakarta.ws.rs.ext.MessageBodyWriter;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+@Consumes("multipart/*")
+@Produces("multipart/*")
+final class MultipartEntityProvider implements MessageBodyReader<List<EntityPart>>, MessageBodyWriter<List<EntityPart>> {
+
+    private static final String CRLF = "\r\n";
+    private final EntityProviders entityProviders;
+
+    MultipartEntityProvider(EntityProviders entityProviders) {
+        this.entityProviders = entityProviders;
+    }
+
+    @Override
+    public boolean isReadable(Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType) {
+        return (List.class.equals(type) || Collection.class.equals(type)) && containsEntityParts(genericType);
+    }
+
+    @Override
+    public List<EntityPart> readFrom(Class<List<EntityPart>> type, Type genericType, Annotation[] annotations,
+                                     MediaType mediaType, MultivaluedMap<String, String> httpHeaders,
+                                     InputStream entityStream) throws IOException, WebApplicationException {
+        String boundary = mediaType.getParameters().get("boundary");
+        if (boundary == null || boundary.isEmpty()) {
+            throw new BadRequestException("A multipart request must include a boundary parameter");
+        }
+        byte[] bytes = Mutils.toByteArray(entityStream, 8192);
+        String body = new String(bytes, StandardCharsets.ISO_8859_1);
+        String delimiter = "--" + boundary;
+        int position = findBoundary(body, delimiter, 0);
+        if (position < 0) {
+            throw new BadRequestException("The multipart boundary was not found in the request body");
+        }
+
+        List<EntityPart> parts = new ArrayList<>();
+        while (position >= 0) {
+            int afterDelimiter = position + delimiter.length();
+            if (body.startsWith("--", afterDelimiter)) {
+                break;
+            }
+            if (!body.startsWith(CRLF, afterDelimiter)) {
+                throw new BadRequestException("Invalid multipart boundary delimiter");
+            }
+            int headersStart = afterDelimiter + CRLF.length();
+            int headersEnd = body.indexOf(CRLF + CRLF, headersStart);
+            if (headersEnd < 0) {
+                throw new BadRequestException("Invalid multipart part headers");
+            }
+            MultivaluedMap<String, String> partHeaders = parseHeaders(body.substring(headersStart, headersEnd));
+            int contentStart = headersEnd + (CRLF + CRLF).length();
+            int nextBoundary = findBoundary(body, CRLF + delimiter, contentStart);
+            if (nextBoundary < 0) {
+                throw new BadRequestException("The closing multipart boundary was not found");
+            }
+
+            String dispositionValue = partHeaders.getFirst(HttpHeaders.CONTENT_DISPOSITION);
+            List<ParameterizedHeaderWithValue> dispositions = ParameterizedHeaderWithValue.fromString(dispositionValue);
+            if (dispositions.isEmpty() || !"form-data".equalsIgnoreCase(dispositions.get(0).value())) {
+                throw new BadRequestException("Each entity part must have a form-data Content-Disposition header");
+            }
+            String name = dispositions.get(0).parameter("name");
+            if (name == null) {
+                throw new BadRequestException("Each entity part must have a name");
+            }
+            String fileName = dispositions.get(0).parameter("filename");
+            if (!partHeaders.containsKey(HttpHeaders.CONTENT_TYPE)) {
+                partHeaders.putSingle(HttpHeaders.CONTENT_TYPE,
+                    fileName == null ? MediaType.TEXT_PLAIN : MediaType.APPLICATION_OCTET_STREAM);
+            }
+            byte[] content = body.substring(contentStart, nextBoundary).getBytes(StandardCharsets.ISO_8859_1);
+            parts.add(new MuEntityPart(name, fileName, partHeaders, new ByteArrayInputStream(content), entityProviders));
+            position = nextBoundary + CRLF.length();
+        }
+        return parts;
+    }
+
+    private static int findBoundary(String body, String marker, int fromIndex) {
+        int candidate = body.indexOf(marker, fromIndex);
+        while (candidate >= 0) {
+            int afterMarker = candidate + marker.length();
+            if (body.startsWith("--", afterMarker) || body.startsWith(CRLF, afterMarker)) {
+                return candidate;
+            }
+            candidate = body.indexOf(marker, candidate + 1);
+        }
+        return -1;
+    }
+
+    private static MultivaluedMap<String, String> parseHeaders(String headerBlock) {
+        MultivaluedMap<String, String> headers = new LowercasedMultivaluedHashMap<>();
+        if (headerBlock.isEmpty()) {
+            return headers;
+        }
+        for (String line : headerBlock.split(CRLF)) {
+            int colon = line.indexOf(':');
+            if (colon <= 0) {
+                throw new BadRequestException("Invalid multipart header: " + line);
+            }
+            headers.add(line.substring(0, colon).trim(), line.substring(colon + 1).trim());
+        }
+        return headers;
+    }
+
+    @Override
+    public boolean isWriteable(Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType) {
+        return Collection.class.isAssignableFrom(type) && containsEntityParts(genericType);
+    }
+
+    @Override
+    public void writeTo(List<EntityPart> parts, Class<?> type, Type genericType, Annotation[] annotations,
+                        MediaType mediaType, MultivaluedMap<String, Object> httpHeaders,
+                        OutputStream entityStream) throws IOException, WebApplicationException {
+        String boundary = "mu-" + UUID.randomUUID().toString().replace("-", "");
+        Map<String, String> parameters = new LinkedHashMap<>(mediaType.getParameters());
+        parameters.put("boundary", boundary);
+        MediaType multipartType = new MediaType(mediaType.getType(), mediaType.getSubtype(), parameters);
+        httpHeaders.putSingle(HttpHeaders.CONTENT_TYPE, multipartType.toString());
+
+        for (EntityPart part : parts) {
+            writeAscii(entityStream, "--" + boundary + CRLF);
+            for (Map.Entry<String, List<String>> header : part.getHeaders().entrySet()) {
+                validateHeader(header.getKey());
+                for (String value : header.getValue()) {
+                    validateHeader(value);
+                    writeAscii(entityStream, displayHeaderName(header.getKey()) + ": " + value + CRLF);
+                }
+            }
+            writeAscii(entityStream, CRLF);
+            try (InputStream content = part.getContent()) {
+                Mutils.copy(content, entityStream, 8192);
+            }
+            writeAscii(entityStream, CRLF);
+        }
+        writeAscii(entityStream, "--" + boundary + "--" + CRLF);
+    }
+
+    private static void writeAscii(OutputStream output, String value) throws IOException {
+        output.write(value.getBytes(StandardCharsets.ISO_8859_1));
+    }
+
+    private static void validateHeader(String value) {
+        if (value == null || value.indexOf('\r') >= 0 || value.indexOf('\n') >= 0) {
+            throw new IllegalArgumentException("Invalid multipart header value");
+        }
+    }
+
+    private static String displayHeaderName(String name) {
+        if (HttpHeaders.CONTENT_DISPOSITION.equalsIgnoreCase(name)) {
+            return HttpHeaders.CONTENT_DISPOSITION;
+        }
+        if (HttpHeaders.CONTENT_TYPE.equalsIgnoreCase(name)) {
+            return HttpHeaders.CONTENT_TYPE;
+        }
+        return name;
+    }
+
+    static String contentDisposition(String name, String fileName) {
+        StringBuilder result = new StringBuilder("form-data; name=\"").append(quote(name)).append('"');
+        if (fileName != null) {
+            result.append("; filename=\"").append(quote(fileName)).append('"');
+        }
+        return result.toString();
+    }
+
+    private static String quote(String value) {
+        validateHeader(value);
+        return value.replace("\\", "\\\\").replace("\"", "\\\"");
+    }
+
+    private static boolean containsEntityParts(Type genericType) {
+        if (!(genericType instanceof ParameterizedType)) {
+            return false;
+        }
+        Type[] arguments = ((ParameterizedType) genericType).getActualTypeArguments();
+        return arguments.length == 1 && arguments[0] == EntityPart.class;
+    }
+}

--- a/src/main/java/io/muserver/rest/MultipartEntityProvider.java
+++ b/src/main/java/io/muserver/rest/MultipartEntityProvider.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.lang.annotation.Annotation;
+import java.lang.ref.Cleaner;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.nio.charset.StandardCharsets;
@@ -296,11 +297,12 @@ final class MultipartEntityProvider implements MessageBodyReader<List<EntityPart
     }
 
     private static final class DeletingFileInputStream extends FileInputStream {
-        private final File file;
+        private static final Cleaner CLEANER = Cleaner.create();
+        private final Cleaner.Cleanable cleanable;
 
         private DeletingFileInputStream(File file) throws IOException {
             super(file);
-            this.file = file;
+            this.cleanable = CLEANER.register(this, file::delete);
         }
 
         @Override
@@ -308,7 +310,7 @@ final class MultipartEntityProvider implements MessageBodyReader<List<EntityPart
             try {
                 super.close();
             } finally {
-                file.delete();
+                cleanable.clean();
             }
         }
     }

--- a/src/main/java/io/muserver/rest/MultipartEntityProvider.java
+++ b/src/main/java/io/muserver/rest/MultipartEntityProvider.java
@@ -14,7 +14,11 @@ import jakarta.ws.rs.core.MultivaluedMap;
 import jakarta.ws.rs.ext.MessageBodyReader;
 import jakarta.ws.rs.ext.MessageBodyWriter;
 
-import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.BufferedInputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -53,66 +57,148 @@ final class MultipartEntityProvider implements MessageBodyReader<List<EntityPart
         if (boundary == null || boundary.isEmpty()) {
             throw new BadRequestException("A multipart request must include a boundary parameter");
         }
-        byte[] bytes = Mutils.toByteArray(entityStream, 8192);
-        String body = new String(bytes, StandardCharsets.ISO_8859_1);
+        InputStream input = new BufferedInputStream(entityStream, 8192);
         String delimiter = "--" + boundary;
-        int position = findBoundary(body, delimiter, 0);
-        if (position < 0) {
+        String firstBoundary;
+        do {
+            firstBoundary = readLine(input);
+        } while (firstBoundary != null
+            && !delimiter.equals(firstBoundary)
+            && !(delimiter + "--").equals(firstBoundary));
+        if (firstBoundary == null) {
             throw new BadRequestException("The multipart boundary was not found in the request body");
+        }
+        if ((delimiter + "--").equals(firstBoundary)) {
+            return new ArrayList<>();
         }
 
         List<EntityPart> parts = new ArrayList<>();
-        while (position >= 0) {
-            int afterDelimiter = position + delimiter.length();
-            if (body.startsWith("--", afterDelimiter)) {
-                break;
-            }
-            if (!body.startsWith(CRLF, afterDelimiter)) {
-                throw new BadRequestException("Invalid multipart boundary delimiter");
-            }
-            int headersStart = afterDelimiter + CRLF.length();
-            int headersEnd = body.indexOf(CRLF + CRLF, headersStart);
-            if (headersEnd < 0) {
-                throw new BadRequestException("Invalid multipart part headers");
-            }
-            MultivaluedMap<String, String> partHeaders = parseHeaders(body.substring(headersStart, headersEnd));
-            int contentStart = headersEnd + (CRLF + CRLF).length();
-            int nextBoundary = findBoundary(body, CRLF + delimiter, contentStart);
-            if (nextBoundary < 0) {
-                throw new BadRequestException("The closing multipart boundary was not found");
-            }
+        List<DeletingFileInputStream> openedStreams = new ArrayList<>();
+        try {
+            boolean finished = false;
+            while (!finished) {
+                MultivaluedMap<String, String> partHeaders = readHeaders(input);
+                File spoolFile = File.createTempFile("mu-entity-part-", ".tmp");
+                spoolFile.deleteOnExit();
+                BoundaryResult boundaryResult;
+                try (OutputStream spool = new FileOutputStream(spoolFile)) {
+                    boundaryResult = copyUntilBoundary(input,
+                        (CRLF + delimiter).getBytes(StandardCharsets.ISO_8859_1), spool);
+                } catch (IOException | RuntimeException | Error failure) {
+                    spoolFile.delete();
+                    throw failure;
+                }
 
-            String dispositionValue = partHeaders.getFirst(HttpHeaders.CONTENT_DISPOSITION);
-            List<ParameterizedHeaderWithValue> dispositions = ParameterizedHeaderWithValue.fromString(dispositionValue);
-            if (dispositions.isEmpty() || !"form-data".equalsIgnoreCase(dispositions.get(0).value())) {
-                throw new BadRequestException("Each entity part must have a form-data Content-Disposition header");
+                String dispositionValue = partHeaders.getFirst(HttpHeaders.CONTENT_DISPOSITION);
+                List<ParameterizedHeaderWithValue> dispositions =
+                    ParameterizedHeaderWithValue.fromString(dispositionValue);
+                if (dispositions.isEmpty() || !"form-data".equalsIgnoreCase(dispositions.get(0).value())) {
+                    spoolFile.delete();
+                    throw new BadRequestException(
+                        "Each entity part must have a form-data Content-Disposition header");
+                }
+                String name = dispositions.get(0).parameter("name");
+                if (name == null) {
+                    spoolFile.delete();
+                    throw new BadRequestException("Each entity part must have a name");
+                }
+                String fileName = dispositions.get(0).parameter("filename");
+                if (!partHeaders.containsKey(HttpHeaders.CONTENT_TYPE)) {
+                    partHeaders.putSingle(HttpHeaders.CONTENT_TYPE,
+                        fileName == null ? MediaType.TEXT_PLAIN : MediaType.APPLICATION_OCTET_STREAM);
+                }
+                DeletingFileInputStream content = new DeletingFileInputStream(spoolFile);
+                openedStreams.add(content);
+                parts.add(new MuEntityPart(name, fileName, partHeaders, content, entityProviders));
+                finished = boundaryResult == BoundaryResult.CLOSING;
             }
-            String name = dispositions.get(0).parameter("name");
-            if (name == null) {
-                throw new BadRequestException("Each entity part must have a name");
+            return parts;
+        } catch (IOException | RuntimeException | Error failure) {
+            for (DeletingFileInputStream stream : openedStreams) {
+                try {
+                    stream.close();
+                } catch (IOException ignored) {
+                }
             }
-            String fileName = dispositions.get(0).parameter("filename");
-            if (!partHeaders.containsKey(HttpHeaders.CONTENT_TYPE)) {
-                partHeaders.putSingle(HttpHeaders.CONTENT_TYPE,
-                    fileName == null ? MediaType.TEXT_PLAIN : MediaType.APPLICATION_OCTET_STREAM);
-            }
-            byte[] content = body.substring(contentStart, nextBoundary).getBytes(StandardCharsets.ISO_8859_1);
-            parts.add(new MuEntityPart(name, fileName, partHeaders, new ByteArrayInputStream(content), entityProviders));
-            position = nextBoundary + CRLF.length();
+            throw failure;
         }
-        return parts;
     }
 
-    private static int findBoundary(String body, String marker, int fromIndex) {
-        int candidate = body.indexOf(marker, fromIndex);
-        while (candidate >= 0) {
-            int afterMarker = candidate + marker.length();
-            if (body.startsWith("--", afterMarker) || body.startsWith(CRLF, afterMarker)) {
-                return candidate;
+    private static MultivaluedMap<String, String> readHeaders(InputStream input) throws IOException {
+        StringBuilder block = new StringBuilder();
+        while (true) {
+            String line = readLine(input);
+            if (line == null) {
+                throw new BadRequestException("Invalid multipart part headers");
             }
-            candidate = body.indexOf(marker, candidate + 1);
+            if (line.isEmpty()) {
+                return parseHeaders(block.toString());
+            }
+            if (block.length() > 0) {
+                block.append(CRLF);
+            }
+            block.append(line);
         }
-        return -1;
+    }
+
+    private static String readLine(InputStream input) throws IOException {
+        ByteArrayOutputStream line = new ByteArrayOutputStream();
+        int previous = -1;
+        int current;
+        while ((current = input.read()) >= 0) {
+            if (previous == '\r' && current == '\n') {
+                byte[] bytes = line.toByteArray();
+                return new String(bytes, 0, bytes.length - 1, StandardCharsets.ISO_8859_1);
+            }
+            line.write(current);
+            previous = current;
+            if (line.size() > 64 * 1024) {
+                throw new BadRequestException("Multipart header line is too long");
+            }
+        }
+        return line.size() == 0 ? null : new String(line.toByteArray(), StandardCharsets.ISO_8859_1);
+    }
+
+    private static BoundaryResult copyUntilBoundary(InputStream input, byte[] marker, OutputStream output)
+        throws IOException {
+        int matched = 0;
+        int current;
+        while ((current = input.read()) >= 0) {
+            if (current == (marker[matched] & 0xff)) {
+                matched++;
+                if (matched == marker.length) {
+                    int suffixOne = input.read();
+                    int suffixTwo = input.read();
+                    if (suffixOne == '-' && suffixTwo == '-') {
+                        return BoundaryResult.CLOSING;
+                    }
+                    if (suffixOne == '\r' && suffixTwo == '\n') {
+                        return BoundaryResult.NEXT;
+                    }
+                    output.write(marker);
+                    if (suffixOne >= 0) {
+                        output.write(suffixOne);
+                    }
+                    if (suffixTwo >= 0) {
+                        output.write(suffixTwo);
+                    }
+                    matched = 0;
+                }
+            } else {
+                if (matched > 0) {
+                    output.write(marker, 0, matched);
+                    matched = 0;
+                    if (current == (marker[0] & 0xff)) {
+                        matched = 1;
+                    } else {
+                        output.write(current);
+                    }
+                } else {
+                    output.write(current);
+                }
+            }
+        }
+        throw new BadRequestException("The closing multipart boundary was not found");
     }
 
     private static MultivaluedMap<String, String> parseHeaders(String headerBlock) {
@@ -202,5 +288,28 @@ final class MultipartEntityProvider implements MessageBodyReader<List<EntityPart
         }
         Type[] arguments = ((ParameterizedType) genericType).getActualTypeArguments();
         return arguments.length == 1 && arguments[0] == EntityPart.class;
+    }
+
+    private enum BoundaryResult {
+        NEXT,
+        CLOSING
+    }
+
+    private static final class DeletingFileInputStream extends FileInputStream {
+        private final File file;
+
+        private DeletingFileInputStream(File file) throws IOException {
+            super(file);
+            this.file = file;
+        }
+
+        @Override
+        public void close() throws IOException {
+            try {
+                super.close();
+            } finally {
+                file.delete();
+            }
+        }
     }
 }

--- a/src/main/java/io/muserver/rest/README.md
+++ b/src/main/java/io/muserver/rest/README.md
@@ -162,6 +162,7 @@ No plan to implement as it would add another dependency.
 - [ ] `javax.xml.transform.Source` XML types (text/xml, application/xml and media types of the form application/*+xml)
 - [ ] `javax.xml.bind.JAXBElement` and application-supplied JAXB classes XML types (text/xml and application/xml and media types of the form application/*+xml)
 - [x] `MultivaluedMap<String,String>` Form content (application/x-www-form-urlencoded)
+- [x] `List<EntityPart>` Multipart content (multipart/*), including `@FormParam EntityPart`
 - [x] `StreamingOutput` All media types (*/*), MessageBodyWriter only
 - [x] `java.lang.Boolean`, `java.lang.Character`, `java.lang.Number` Only for text/plain
 - [x] Corresponding primitive types supported via boxing/unboxing conversion.
@@ -385,3 +386,4 @@ The following are not described by the spec but are interfaces defined in the ja
 - [x] `Link`
 - [x] `VariantListBuilder`
 - [x] `ResourceInfo` (this is available in a filter by calling `ResourceInfo resourceInfo = (ResourceInfo) requestContext.getProperty(MuRuntimeDelegate.RESOURCE_INFO_PROPERTY);`)
+- [x] `EntityPart` and `EntityPart.Builder`

--- a/src/main/java/io/muserver/rest/ReadOnlyMultivaluedMap.java
+++ b/src/main/java/io/muserver/rest/ReadOnlyMultivaluedMap.java
@@ -5,9 +5,13 @@ import jakarta.ws.rs.core.MultivaluedMap;
 
 import java.io.Serializable;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.AbstractMap.SimpleImmutableEntry;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * A read only version of the multi-valued map
@@ -33,20 +37,20 @@ class ReadOnlyMultivaluedMap<K, V> implements MultivaluedMap<K, V>, Serializable
 
 
     public void putSingle(K key, V value) {
-        throw new NotImplementedException("Invalid access for readonly map");
+        throw new UnsupportedOperationException("This map is read only");
     }
 
     public void add(K key, V value) {
-        throw new NotImplementedException("Invalid access for readonly map");
+        throw new UnsupportedOperationException("This map is read only");
     }
 
     @SafeVarargs
     public final void addAll(K key, V... newValues) {
-        throw new NotImplementedException("Invalid access for readonly map");
+        throw new UnsupportedOperationException("This map is read only");
     }
 
     public void addAll(K key, List<V> valueList) {
-        throw new NotImplementedException("Invalid access for readonly map");
+        throw new UnsupportedOperationException("This map is read only");
     }
 
     public V getFirst(K key) {
@@ -54,7 +58,7 @@ class ReadOnlyMultivaluedMap<K, V> implements MultivaluedMap<K, V>, Serializable
     }
 
     public void addFirst(K key, V value) {
-        actual.addFirst(key, value);
+        throw new UnsupportedOperationException("This map is read only");
     }
 
     public String toString() {
@@ -70,7 +74,9 @@ class ReadOnlyMultivaluedMap<K, V> implements MultivaluedMap<K, V>, Serializable
     }
 
     public Collection<List<V>> values() {
-        return actual.values();
+        return Collections.unmodifiableList(actual.values().stream()
+            .map(Collections::unmodifiableList)
+            .collect(Collectors.toList()));
     }
 
     public int size() {
@@ -78,19 +84,19 @@ class ReadOnlyMultivaluedMap<K, V> implements MultivaluedMap<K, V>, Serializable
     }
 
     public List<V> remove(Object key) {
-        throw new NotImplementedException("Invalid access for readonly map");
+        throw new UnsupportedOperationException("This map is read only");
     }
 
     public void putAll(Map<? extends K, ? extends List<V>> m) {
-        throw new NotImplementedException("Invalid access for readonly map");
+        throw new UnsupportedOperationException("This map is read only");
     }
 
     public List<V> put(K key, List<V> value) {
-        throw new NotImplementedException("Invalid access for readonly map");
+        throw new UnsupportedOperationException("This map is read only");
     }
 
     public Set<K> keySet() {
-        return actual.keySet();
+        return Collections.unmodifiableSet(actual.keySet());
     }
 
     public boolean isEmpty() {
@@ -98,11 +104,15 @@ class ReadOnlyMultivaluedMap<K, V> implements MultivaluedMap<K, V>, Serializable
     }
 
     public List<V> get(Object key) {
-        return actual.get(key);
+        List<V> values = actual.get(key);
+        return values == null ? null : Collections.unmodifiableList(values);
     }
 
     public Set<Entry<K, List<V>>> entrySet() {
-        return actual.entrySet();
+        Set<Entry<K, List<V>>> entries = actual.entrySet().stream()
+            .map(entry -> new SimpleImmutableEntry<>(entry.getKey(), Collections.unmodifiableList(entry.getValue())))
+            .collect(Collectors.toCollection(LinkedHashSet::new));
+        return Collections.unmodifiableSet(entries);
     }
 
     public boolean containsValue(Object value) {
@@ -114,7 +124,7 @@ class ReadOnlyMultivaluedMap<K, V> implements MultivaluedMap<K, V>, Serializable
     }
 
     public void clear() {
-        throw new NotImplementedException("Invalid access for readonly map");
+        throw new UnsupportedOperationException("This map is read only");
     }
 
     public boolean equalsIgnoreValueOrder(MultivaluedMap<K, V> omap) {

--- a/src/main/java/io/muserver/rest/ResourceMethodParam.java
+++ b/src/main/java/io/muserver/rest/ResourceMethodParam.java
@@ -201,24 +201,7 @@ abstract class ResourceMethodParam {
             MuRequest muRequest = jaxRequest.muRequest;
             Class<?> paramClass = type;
             if (EntityPart.class.isAssignableFrom(paramClass)) {
-                UploadedFile uploadedFile = muRequest.uploadedFile(key);
-                MultivaluedHashMap<String, String> headers = new MultivaluedHashMap<>();
-                if (uploadedFile != null) {
-                    headers.putSingle(HttpHeaders.CONTENT_TYPE,
-                        Mutils.nullOrEmpty(uploadedFile.contentType()) ? MediaType.APPLICATION_OCTET_STREAM : uploadedFile.contentType());
-                    headers.putSingle(HttpHeaders.CONTENT_DISPOSITION,
-                        MultipartEntityProvider.contentDisposition(key, uploadedFile.filename()));
-                    return new MuEntityPart(key, uploadedFile.filename(), headers, uploadedFile.asStream(), jaxRequest.entityProviders());
-                }
-                String value = muRequest.form().get(key);
-                if (value == null) {
-                    return null;
-                }
-                headers.putSingle(HttpHeaders.CONTENT_TYPE, MediaType.TEXT_PLAIN);
-                headers.putSingle(HttpHeaders.CONTENT_DISPOSITION, MultipartEntityProvider.contentDisposition(key, null));
-                return new MuEntityPart(key, null, headers,
-                    new java.io.ByteArrayInputStream(value.getBytes(java.nio.charset.StandardCharsets.UTF_8)),
-                    jaxRequest.entityProviders());
+                return jaxRequest.multipartEntityPart(key);
             } else if (UploadedFile.class.isAssignableFrom(paramClass)) {
                 return muRequest.uploadedFile(key);
             } else if (File.class.isAssignableFrom(paramClass)) {
@@ -283,7 +266,7 @@ abstract class ResourceMethodParam {
                     : matchedMethod.getPathParams(key))
                     : source == ValueSource.QUERY_PARAM ? getParamValues(jaxRequest.getUriInfo().getQueryParameters(), key, cps, collection != null)
                     : source == ValueSource.HEADER_PARAM ? getParamValues(jaxRequest.getHeaders(), key, cps, collection != null)
-                    : source == ValueSource.FORM_PARAM ? muRequest.form().getAll(key)
+                    : source == ValueSource.FORM_PARAM ? jaxRequest.formValues(key)
                     : source == ValueSource.COOKIE_PARAM ? cookieValue(muRequest, key)
                     : source == ValueSource.MATRIX_PARAM ? matrixParamValue(key, jaxRequest.relativePath())
                     : emptyList();

--- a/src/main/java/io/muserver/rest/ResourceMethodParam.java
+++ b/src/main/java/io/muserver/rest/ResourceMethodParam.java
@@ -7,6 +7,10 @@ import jakarta.ws.rs.*;
 import jakarta.ws.rs.container.Suspended;
 import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.Cookie;
+import jakarta.ws.rs.core.EntityPart;
+import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.MultivaluedHashMap;
 import jakarta.ws.rs.core.MultivaluedMap;
 import jakarta.ws.rs.core.PathSegment;
 import jakarta.ws.rs.ext.ParamConverter;
@@ -196,7 +200,26 @@ abstract class ResourceMethodParam {
         public @Nullable Object getValue(JaxRSRequest jaxRequest, RequestMatcher.MatchedMethod matchedMethod, CollectionParameterStrategy cps) throws IOException {
             MuRequest muRequest = jaxRequest.muRequest;
             Class<?> paramClass = type;
-            if (UploadedFile.class.isAssignableFrom(paramClass)) {
+            if (EntityPart.class.isAssignableFrom(paramClass)) {
+                UploadedFile uploadedFile = muRequest.uploadedFile(key);
+                MultivaluedHashMap<String, String> headers = new MultivaluedHashMap<>();
+                if (uploadedFile != null) {
+                    headers.putSingle(HttpHeaders.CONTENT_TYPE,
+                        Mutils.nullOrEmpty(uploadedFile.contentType()) ? MediaType.APPLICATION_OCTET_STREAM : uploadedFile.contentType());
+                    headers.putSingle(HttpHeaders.CONTENT_DISPOSITION,
+                        MultipartEntityProvider.contentDisposition(key, uploadedFile.filename()));
+                    return new MuEntityPart(key, uploadedFile.filename(), headers, uploadedFile.asStream(), jaxRequest.entityProviders());
+                }
+                String value = muRequest.form().get(key);
+                if (value == null) {
+                    return null;
+                }
+                headers.putSingle(HttpHeaders.CONTENT_TYPE, MediaType.TEXT_PLAIN);
+                headers.putSingle(HttpHeaders.CONTENT_DISPOSITION, MultipartEntityProvider.contentDisposition(key, null));
+                return new MuEntityPart(key, null, headers,
+                    new java.io.ByteArrayInputStream(value.getBytes(java.nio.charset.StandardCharsets.UTF_8)),
+                    jaxRequest.entityProviders());
+            } else if (UploadedFile.class.isAssignableFrom(paramClass)) {
                 return muRequest.uploadedFile(key);
             } else if (File.class.isAssignableFrom(paramClass)) {
                 UploadedFile uf = muRequest.uploadedFile(key);

--- a/src/main/java/io/muserver/rest/RestHandler.java
+++ b/src/main/java/io/muserver/rest/RestHandler.java
@@ -178,23 +178,28 @@ public class RestHandler implements MuHandler {
     }
 
     static Object invokeResourceMethod(JaxRSRequest requestContext, MuResponse muResponse, RequestMatcher.MatchedMethod mm, Function<ResourceMethod, Object> suspendedParamCallback, EntityProviders entityProviders, CollectionParameterStrategy collectionParameterStrategy) throws Exception {
-        ResourceMethod rm = mm.resourceMethod;
-        Object[] params = new Object[rm.methodHandle.getParameterCount()];
-        for (ResourceMethodParam param : rm.params) {
-            Object paramValue;
-            if (param.source == ResourceMethodParam.ValueSource.MESSAGE_BODY) {
-                paramValue = readRequestEntity(requestContext, param);
-            } else if (param.source == ResourceMethodParam.ValueSource.CONTEXT) {
-                paramValue = getContextParam(requestContext, muResponse, mm, param, entityProviders);
-            } else if (param.source == ResourceMethodParam.ValueSource.SUSPENDED) {
-                paramValue = suspendedParamCallback.apply(rm);
-            } else {
-                ResourceMethodParam.RequestBasedParam rbp = (ResourceMethodParam.RequestBasedParam) param;
-                paramValue = rbp.getValue(requestContext, mm, collectionParameterStrategy);
+        EntityProviders previous = MuRuntimeDelegate.setCurrentEntityProviders(entityProviders);
+        try {
+            ResourceMethod rm = mm.resourceMethod;
+            Object[] params = new Object[rm.methodHandle.getParameterCount()];
+            for (ResourceMethodParam param : rm.params) {
+                Object paramValue;
+                if (param.source == ResourceMethodParam.ValueSource.MESSAGE_BODY) {
+                    paramValue = readRequestEntity(requestContext, param);
+                } else if (param.source == ResourceMethodParam.ValueSource.CONTEXT) {
+                    paramValue = getContextParam(requestContext, muResponse, mm, param, entityProviders);
+                } else if (param.source == ResourceMethodParam.ValueSource.SUSPENDED) {
+                    paramValue = suspendedParamCallback.apply(rm);
+                } else {
+                    ResourceMethodParam.RequestBasedParam rbp = (ResourceMethodParam.RequestBasedParam) param;
+                    paramValue = rbp.getValue(requestContext, mm, collectionParameterStrategy);
+                }
+                params[param.index] = paramValue;
             }
-            params[param.index] = paramValue;
+            return rm.invoke(params);
+        } finally {
+            MuRuntimeDelegate.restoreCurrentEntityProviders(previous);
         }
-        return rm.invoke(params);
     }
 
     private void dealWithUnhandledException(int nestingLevel, JaxRSRequest request, MuResponse muResponse, Exception ex, List<MediaType> acceptHeaders, List<MediaType> producesRef, List<MediaType> directlyProducesRef) throws Exception {

--- a/src/main/java/io/muserver/rest/RestHandler.java
+++ b/src/main/java/io/muserver/rest/RestHandler.java
@@ -181,6 +181,11 @@ public class RestHandler implements MuHandler {
         EntityProviders previous = MuRuntimeDelegate.setCurrentEntityProviders(entityProviders);
         try {
             ResourceMethod rm = mm.resourceMethod;
+            if (rm.params.stream().anyMatch(param ->
+                param.source == ResourceMethodParam.ValueSource.FORM_PARAM
+                    && EntityPart.class.isAssignableFrom(param.type))) {
+                requestContext.prepareMultipartEntityParts();
+            }
             Object[] params = new Object[rm.methodHandle.getParameterCount()];
             for (ResourceMethodParam param : rm.params) {
                 Object paramValue;

--- a/src/test/java/io/muserver/rest/EntityPartTest.java
+++ b/src/test/java/io/muserver/rest/EntityPartTest.java
@@ -29,6 +29,8 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
+import java.util.Collection;
+import java.util.LinkedHashSet;
 import java.util.List;
 
 import static io.muserver.rest.RestHandlerBuilder.restHandler;
@@ -169,6 +171,31 @@ public class EntityPartTest {
             assertThat(body, containsString("hello"));
             assertThat(body, containsString("Content-Disposition: form-data; name=\"hello.txt\"; filename=\"hello.txt\""));
             assertThat(body, containsString("file contents"));
+        }
+    }
+
+    @Test
+    public void writesAnyEntityPartCollectionAsMultipartBodies() throws Exception {
+        @Path("/parts")
+        class PartsResource {
+            @GET
+            @Produces(MediaType.MULTIPART_FORM_DATA)
+            public GenericEntity<Collection<EntityPart>> get() throws Exception {
+                Collection<EntityPart> parts = new LinkedHashSet<>();
+                parts.add(EntityPart.withName("description").content("hello").build());
+                return new GenericEntity<Collection<EntityPart>>(parts) {
+                };
+            }
+        }
+
+        server = ServerUtils.httpsServerForTest()
+            .addHandler(restHandler(new PartsResource()))
+            .start();
+
+        try (Response response = call(request(server.uri().resolve("/parts")))) {
+            assertThat(response.code(), is(200));
+            assertThat(response.header("content-type"), startsWith("multipart/form-data;boundary="));
+            assertThat(response.body().string(), containsString("hello"));
         }
     }
 

--- a/src/test/java/io/muserver/rest/EntityPartTest.java
+++ b/src/test/java/io/muserver/rest/EntityPartTest.java
@@ -22,6 +22,7 @@ import scaffolding.MuAssert;
 import scaffolding.ServerUtils;
 
 import java.io.ByteArrayInputStream;
+import java.io.FilterInputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.InputStream;
@@ -67,6 +68,35 @@ public class EntityPartTest {
             () -> part.getHeaders().put("Other", Arrays.asList("value")));
         assertThrows(UnsupportedOperationException.class,
             () -> part.getHeaders().get("X-Test").add("three"));
+    }
+
+    @Test
+    public void typedInputStreamContentRemainsOpenForTheCaller() throws Exception {
+        InputStream source = new FilterInputStream(
+            new ByteArrayInputStream("hello".getBytes(StandardCharsets.UTF_8))) {
+            private boolean closed;
+
+            @Override
+            public int read(byte[] bytes, int offset, int length) throws IOException {
+                if (closed) {
+                    throw new IOException("closed");
+                }
+                return super.read(bytes, offset, length);
+            }
+
+            @Override
+            public void close() throws IOException {
+                closed = true;
+                super.close();
+            }
+        };
+        EntityPart part = EntityPart.withName("content")
+            .content(source)
+            .build();
+
+        InputStream content = part.getContent(InputStream.class);
+
+        assertThat(new String(content.readAllBytes(), StandardCharsets.UTF_8), is("hello"));
     }
 
     @Test
@@ -137,6 +167,34 @@ public class EntityPartTest {
         try (Response response = call(request(server.uri().resolve("/parts")).post(body))) {
             assertThat(response.code(), is(200));
             assertThat(response.body().string(), is("hello; hello.txt:file contents"));
+        }
+    }
+
+    @Test
+    public void entityPartFormParamsCanBeMixedWithStringFormParams() throws Exception {
+        @Path("/parts")
+        class PartsResource {
+            @POST
+            @Consumes(MediaType.MULTIPART_FORM_DATA)
+            public String post(@FormParam("description") String description,
+                               @FormParam("attachment") EntityPart attachment) throws Exception {
+                return description + ":" + attachment.getContent(String.class);
+            }
+        }
+
+        server = ServerUtils.httpsServerForTest()
+            .addHandler(restHandler(new PartsResource()))
+            .start();
+
+        MultipartBody body = new MultipartBody.Builder()
+            .setType(MultipartBody.FORM)
+            .addFormDataPart("description", "hello")
+            .addFormDataPart("attachment", null,
+                RequestBody.create("contents", okhttp3.MediaType.parse("text/plain")))
+            .build();
+        try (Response response = call(request(server.uri().resolve("/parts")).post(body))) {
+            assertThat(response.code(), is(200));
+            assertThat(response.body().string(), is("hello:contents"));
         }
     }
 
@@ -288,6 +346,52 @@ public class EntityPartTest {
         try (Response response = call(request(server.uri().resolve("/parts")).post(body))) {
             assertThat(response.code(), is(200));
             assertThat(response.body().string(), is("custom:hello"));
+        }
+    }
+
+    @Test
+    public void formParamEntityPartsPreserveTheirMediaType() throws Exception {
+        class Greeting {
+            final String value;
+
+            Greeting(String value) {
+                this.value = value;
+            }
+        }
+        MessageBodyReader<Greeting> reader = new MessageBodyReader<Greeting>() {
+            @Override
+            public boolean isReadable(Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType) {
+                return type == Greeting.class && mediaType.isCompatible(new MediaType("application", "x-greeting"));
+            }
+
+            @Override
+            public Greeting readFrom(Class<Greeting> type, Type genericType, Annotation[] annotations,
+                                     MediaType mediaType, MultivaluedMap<String, String> httpHeaders,
+                                     InputStream entityStream) throws IOException {
+                return new Greeting(new String(entityStream.readAllBytes(), StandardCharsets.UTF_8));
+            }
+        };
+        @Path("/parts")
+        class PartsResource {
+            @POST
+            @Consumes(MediaType.MULTIPART_FORM_DATA)
+            public String post(@FormParam("greeting") EntityPart greeting) throws Exception {
+                return greeting.getMediaType() + ":" + greeting.getContent(Greeting.class).value;
+            }
+        }
+
+        server = ServerUtils.httpsServerForTest()
+            .addHandler(restHandler(new PartsResource()).addCustomReader(reader))
+            .start();
+
+        MultipartBody body = new MultipartBody.Builder()
+            .setType(MultipartBody.FORM)
+            .addFormDataPart("greeting", null,
+                RequestBody.create("hello", okhttp3.MediaType.parse("application/x-greeting")))
+            .build();
+        try (Response response = call(request(server.uri().resolve("/parts")).post(body))) {
+            assertThat(response.code(), is(200));
+            assertThat(response.body().string(), is("application/x-greeting;charset=utf-8:hello"));
         }
     }
 

--- a/src/test/java/io/muserver/rest/EntityPartTest.java
+++ b/src/test/java/io/muserver/rest/EntityPartTest.java
@@ -1,0 +1,271 @@
+package io.muserver.rest;
+
+import io.muserver.MuServer;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.FormParam;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.EntityPart;
+import jakarta.ws.rs.core.GenericEntity;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.ext.MessageBodyWriter;
+import jakarta.ws.rs.ext.MessageBodyReader;
+import okhttp3.MultipartBody;
+import okhttp3.RequestBody;
+import okhttp3.Response;
+import org.junit.After;
+import org.junit.Test;
+import scaffolding.MuAssert;
+import scaffolding.ServerUtils;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.InputStream;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.List;
+
+import static io.muserver.rest.RestHandlerBuilder.restHandler;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.assertThrows;
+import static scaffolding.ClientUtils.call;
+import static scaffolding.ClientUtils.request;
+
+public class EntityPartTest {
+
+    static {
+        MuRuntimeDelegate.ensureSet();
+    }
+
+    private MuServer server;
+
+    @Test
+    public void runtimeDelegateBuildsEntityParts() throws Exception {
+        EntityPart part = EntityPart.withName("message")
+            .fileName("hello.txt")
+            .mediaType(MediaType.TEXT_PLAIN_TYPE)
+            .header("X-Test", "one", "two")
+            .content(new ByteArrayInputStream("hello".getBytes(StandardCharsets.UTF_8)))
+            .build();
+
+        assertThat(part.getName(), is("message"));
+        assertThat(part.getFileName().orElse(null), is("hello.txt"));
+        assertThat(part.getMediaType(), is(MediaType.TEXT_PLAIN_TYPE));
+        assertThat(part.getHeaders().get("X-Test"), contains("one", "two"));
+        assertThat(new String(part.getContent().readAllBytes(), StandardCharsets.UTF_8), is("hello"));
+        assertThrows(IllegalStateException.class, () -> part.getContent(String.class));
+        assertThrows(UnsupportedOperationException.class,
+            () -> part.getHeaders().put("Other", Arrays.asList("value")));
+        assertThrows(UnsupportedOperationException.class,
+            () -> part.getHeaders().get("X-Test").add("three"));
+    }
+
+    @Test
+    public void entityPartBuildersRejectMissingAndInvalidValues() {
+        assertThrows(IllegalArgumentException.class, () -> EntityPart.withName(null));
+        assertThrows(IllegalArgumentException.class,
+            () -> EntityPart.withName("part").content((ByteArrayInputStream) null));
+        assertThrows(IllegalArgumentException.class,
+            () -> EntityPart.withName("part").content((Object) null));
+        assertThrows(IllegalStateException.class, () -> EntityPart.withName("part").build());
+    }
+
+    @Test
+    public void readsMultipartBodiesAsEntityPartLists() throws Exception {
+        @Path("/parts")
+        class PartsResource {
+            @POST
+            @Consumes(MediaType.MULTIPART_FORM_DATA)
+            public String post(List<EntityPart> parts) throws Exception {
+                EntityPart description = parts.get(0);
+                EntityPart attachment = parts.get(1);
+                return description.getName() + "=" + description.getContent(String.class)
+                    + "; " + attachment.getName() + "=" + attachment.getFileName().orElse(null)
+                    + ":" + new String(attachment.getContent().readAllBytes(), StandardCharsets.UTF_8);
+            }
+        }
+
+        server = ServerUtils.httpsServerForTest()
+            .addHandler(restHandler(new PartsResource()))
+            .start();
+
+        MultipartBody body = new MultipartBody.Builder()
+            .setType(MultipartBody.FORM)
+            .addFormDataPart("description", "hello")
+            .addFormDataPart("attachment", "hello.txt",
+                RequestBody.create("file contents", okhttp3.MediaType.parse("text/plain")))
+            .build();
+        try (Response response = call(request(server.uri().resolve("/parts")).post(body))) {
+            assertThat(response.code(), is(200));
+            assertThat(response.body().string(), is("description=hello; attachment=hello.txt:file contents"));
+        }
+    }
+
+    @Test
+    public void injectsNamedEntityPartsAsFormParams() throws Exception {
+        @Path("/parts")
+        class PartsResource {
+            @POST
+            @Consumes(MediaType.MULTIPART_FORM_DATA)
+            public String post(@FormParam("description") EntityPart description,
+                               @FormParam("attachment") EntityPart attachment) throws Exception {
+                return description.getContent(String.class)
+                    + "; " + attachment.getFileName().orElse(null)
+                    + ":" + new String(attachment.getContent().readAllBytes(), StandardCharsets.UTF_8);
+            }
+        }
+
+        server = ServerUtils.httpsServerForTest()
+            .addHandler(restHandler(new PartsResource()))
+            .start();
+
+        MultipartBody body = new MultipartBody.Builder()
+            .setType(MultipartBody.FORM)
+            .addFormDataPart("description", "hello")
+            .addFormDataPart("attachment", "hello.txt",
+                RequestBody.create("file contents", okhttp3.MediaType.parse("text/plain")))
+            .build();
+        try (Response response = call(request(server.uri().resolve("/parts")).post(body))) {
+            assertThat(response.code(), is(200));
+            assertThat(response.body().string(), is("hello; hello.txt:file contents"));
+        }
+    }
+
+    @Test
+    public void writesEntityPartListsAsMultipartBodies() throws Exception {
+        @Path("/parts")
+        class PartsResource {
+            @GET
+            @Produces(MediaType.MULTIPART_FORM_DATA)
+            public GenericEntity<List<EntityPart>> get() throws Exception {
+                List<EntityPart> parts = Arrays.asList(
+                    EntityPart.withName("description").content("hello").build(),
+                    EntityPart.withFileName("hello.txt")
+                        .mediaType(MediaType.TEXT_PLAIN_TYPE)
+                        .content(new ByteArrayInputStream("file contents".getBytes(StandardCharsets.UTF_8)))
+                        .build()
+                );
+                return new GenericEntity<List<EntityPart>>(parts) {
+                };
+            }
+        }
+
+        server = ServerUtils.httpsServerForTest()
+            .addHandler(restHandler(new PartsResource()))
+            .start();
+
+        try (Response response = call(request(server.uri().resolve("/parts")))) {
+            assertThat(response.code(), is(200));
+            assertThat(response.header("content-type"), startsWith("multipart/form-data;boundary="));
+            String body = response.body().string();
+            assertThat(body, containsString("Content-Disposition: form-data; name=\"description\""));
+            assertThat(body, containsString("hello"));
+            assertThat(body, containsString("Content-Disposition: form-data; name=\"hello.txt\"; filename=\"hello.txt\""));
+            assertThat(body, containsString("file contents"));
+        }
+    }
+
+    @Test
+    public void entityPartBuildersUseCustomMessageBodyWritersInResources() throws Exception {
+        class Greeting {
+            final String value;
+
+            Greeting(String value) {
+                this.value = value;
+            }
+        }
+        MessageBodyWriter<Greeting> writer = new MessageBodyWriter<Greeting>() {
+            @Override
+            public boolean isWriteable(Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType) {
+                return type == Greeting.class;
+            }
+
+            @Override
+            public void writeTo(Greeting greeting, Class<?> type, Type genericType, Annotation[] annotations,
+                                MediaType mediaType, MultivaluedMap<String, Object> httpHeaders,
+                                OutputStream entityStream) throws IOException {
+                entityStream.write(("custom:" + greeting.value).getBytes(StandardCharsets.UTF_8));
+            }
+        };
+        @Path("/parts")
+        class PartsResource {
+            @GET
+            @Produces(MediaType.MULTIPART_FORM_DATA)
+            public GenericEntity<List<EntityPart>> get() throws Exception {
+                EntityPart part = EntityPart.withName("greeting")
+                    .mediaType("application/x-greeting")
+                    .content(new Greeting("hello"))
+                    .build();
+                return new GenericEntity<List<EntityPart>>(Arrays.asList(part)) {
+                };
+            }
+        }
+
+        server = ServerUtils.httpsServerForTest()
+            .addHandler(restHandler(new PartsResource()).addCustomWriter(writer))
+            .start();
+
+        try (Response response = call(request(server.uri().resolve("/parts")))) {
+            assertThat(response.code(), is(200));
+            assertThat(response.body().string(), containsString("custom:hello"));
+        }
+    }
+
+    @Test
+    public void receivedEntityPartsUseCustomMessageBodyReaders() throws Exception {
+        class Greeting {
+            final String value;
+
+            Greeting(String value) {
+                this.value = value;
+            }
+        }
+        MessageBodyReader<Greeting> reader = new MessageBodyReader<Greeting>() {
+            @Override
+            public boolean isReadable(Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType) {
+                return type == Greeting.class;
+            }
+
+            @Override
+            public Greeting readFrom(Class<Greeting> type, Type genericType, Annotation[] annotations,
+                                     MediaType mediaType, MultivaluedMap<String, String> httpHeaders,
+                                     InputStream entityStream) throws IOException {
+                return new Greeting("custom:" + new String(entityStream.readAllBytes(), StandardCharsets.UTF_8));
+            }
+        };
+        @Path("/parts")
+        class PartsResource {
+            @POST
+            @Consumes(MediaType.MULTIPART_FORM_DATA)
+            public String post(List<EntityPart> parts) throws Exception {
+                return parts.get(0).getContent(Greeting.class).value;
+            }
+        }
+
+        server = ServerUtils.httpsServerForTest()
+            .addHandler(restHandler(new PartsResource()).addCustomReader(reader))
+            .start();
+
+        MultipartBody body = new MultipartBody.Builder()
+            .setType(MultipartBody.FORM)
+            .addFormDataPart("greeting", null,
+                RequestBody.create("hello", okhttp3.MediaType.parse("application/x-greeting")))
+            .build();
+        try (Response response = call(request(server.uri().resolve("/parts")).post(body))) {
+            assertThat(response.code(), is(200));
+            assertThat(response.body().string(), is("custom:hello"));
+        }
+    }
+
+    @After
+    public void stop() {
+        MuAssert.stopAndCheck(server);
+    }
+}

--- a/src/test/java/io/muserver/rest/EntityPartTest.java
+++ b/src/test/java/io/muserver/rest/EntityPartTest.java
@@ -23,6 +23,7 @@ import scaffolding.ServerUtils;
 
 import java.io.ByteArrayInputStream;
 import java.io.FilterInputStream;
+import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.InputStream;
@@ -137,6 +138,33 @@ public class EntityPartTest {
         try (Response response = call(request(server.uri().resolve("/parts")).post(body))) {
             assertThat(response.code(), is(200));
             assertThat(response.body().string(), is("description=hello; attachment=hello.txt:file contents"));
+        }
+    }
+
+    @Test
+    public void multipartEntityPartContentIsSpooledOutOfHeap() throws Exception {
+        @Path("/parts")
+        class PartsResource {
+            @POST
+            @Consumes(MediaType.MULTIPART_FORM_DATA)
+            public boolean post(List<EntityPart> parts) throws Exception {
+                try (InputStream content = parts.get(0).getContent()) {
+                    return content instanceof FileInputStream && content.read() == 'h';
+                }
+            }
+        }
+
+        server = ServerUtils.httpsServerForTest()
+            .addHandler(restHandler(new PartsResource()))
+            .start();
+
+        MultipartBody body = new MultipartBody.Builder()
+            .setType(MultipartBody.FORM)
+            .addFormDataPart("description", "hello")
+            .build();
+        try (Response response = call(request(server.uri().resolve("/parts")).post(body))) {
+            assertThat(response.code(), is(200));
+            assertThat(response.body().string(), is("true"));
         }
     }
 

--- a/src/test/java/io/muserver/rest/OpenApiDocumentorTest.java
+++ b/src/test/java/io/muserver/rest/OpenApiDocumentorTest.java
@@ -7,6 +7,7 @@ import io.muserver.openapi.InfoObjectBuilder;
 import io.muserver.openapi.LicenseObjectBuilder;
 import io.muserver.openapi.OpenAPIObjectBuilder;
 import jakarta.ws.rs.*;
+import jakarta.ws.rs.core.EntityPart;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import org.example.petstore.resource.PetResource;
@@ -182,6 +183,7 @@ public class OpenApiDocumentorTest {
                                @Description("The list of images")
                                @FormParam("images") List<UploadedFile> images,
                                @FormParam("oneThing") UploadedFile oneThing,
+                               @FormParam("entityPart") EntityPart entityPart,
                                @FormParam("requiredThing") @Required UploadedFile requiredThing) {
             }
         }
@@ -219,6 +221,10 @@ public class OpenApiDocumentorTest {
             assertThat(oneThing.getString("type"), is("string"));
             assertThat(oneThing.getString("format"), is("binary"));
             assertThat(oneThing.has("description"), is(false));
+
+            JSONObject entityPart = params.getJSONObject("entityPart");
+            assertThat(entityPart.getString("type"), is("string"));
+            assertThat(entityPart.getString("format"), is("binary"));
 
             JSONObject images = params.getJSONObject("images");
             assertThat(images.getString("type"), is("array"));


### PR DESCRIPTION
## What changed

Implements Jakarta REST 3.1 `EntityPart` support without adding Application or SEBootstrap support.

- Implements `EntityPart` and `EntityPart.Builder` through `MuRuntimeDelegate`
- Reads and writes `Collection<EntityPart>` for `multipart/*` message bodies
- Supports named `@FormParam EntityPart` values for text fields and uploaded files
- Resolves built-in and handler-registered message-body readers/writers for part content
- Preserves part names, filenames, media types, and headers
- Enforces one-shot content access and closes streams after multipart writes/conversion
- Makes read-only multivalued-map views genuinely immutable
- Documents EntityPart support and describes EntityPart form fields as binary in generated OpenAPI

## Why

Jakarta REST 3.1 added EntityPart and a required RuntimeDelegate builder hook. The initial dependency upgrade left that hook unsupported and had no multipart entity provider.

## Impact

Resources can consume multipart bodies as `List<EntityPart>`, produce multipart responses from any `Collection<EntityPart>`, or receive named form parts using standard Jakarta REST APIs. Application and Java SE bootstrap methods remain explicitly unsupported.

## Validation

- Demonstrated builder and multipart tests failing before implementation
- Added a regression test proving non-List collections no longer fail with a bridge-method cast
- `mvn -q -Dtest=EntityPartTest,OpenApiDocumentorTest test`
- Full suite: 905 tests, 0 failures, 0 errors
- CI passes on Java 11, 17, 21, and 25
- `mvn -q -DskipTests package`
- `git diff --check`