### PR TITLE
Implement Jakarta REST SEBootstrap

### DIFF
--- a/src/main/java/io/muserver/HttpsConfigBuilder.java
+++ b/src/main/java/io/muserver/HttpsConfigBuilder.java
@@ -93,7 +93,7 @@ public class HttpsConfigBuilder {
      * @param sslContext an SSL context
      * @return This builder
      */
-    HttpsConfigBuilder withSSLContext(SSLContext sslContext) {
+    public HttpsConfigBuilder withSSLContext(SSLContext sslContext) {
         keyManagerFactory = null;
         this.sslContext = sslContext;
         return this;

--- a/src/main/java/io/muserver/rest/MuRuntimeDelegate.java
+++ b/src/main/java/io/muserver/rest/MuRuntimeDelegate.java
@@ -39,7 +39,7 @@ public class MuRuntimeDelegate extends RuntimeDelegate {
 
     private final Map<Class<?>, HeaderDelegate> headerDelegates = new HashMap<>();
 
-    private MuRuntimeDelegate() {
+    public MuRuntimeDelegate() {
         headerDelegates.put(MediaType.class, new MediaTypeHeaderDelegate());
         headerDelegates.put(CacheControl.class, new CacheControlHeaderDelegate());
         headerDelegates.put(NewCookie.class, new NewCookieHeaderDelegate());
@@ -139,17 +139,17 @@ public class MuRuntimeDelegate extends RuntimeDelegate {
 
     @Override
     public SeBootstrap.Configuration.Builder createConfigurationBuilder() {
-        throw new NotImplementedException("MuServer does not support configuration");
+        return new MuSeBootstrap.ConfigurationBuilder();
     }
 
     @Override
     public CompletionStage<SeBootstrap.Instance> bootstrap(Application application, SeBootstrap.Configuration configuration) {
-        throw new NotImplementedException("MuServer does not support bootstraping");
+        return MuSeBootstrap.start(application, configuration);
     }
 
     @Override
     public CompletionStage<SeBootstrap.Instance> bootstrap(Class<? extends Application> clazz, SeBootstrap.Configuration configuration) {
-        throw new NotImplementedException("MuServer does not support bootstraping");
+        return MuSeBootstrap.start(clazz, configuration);
     }
 
     @Override

--- a/src/main/java/io/muserver/rest/MuRuntimeDelegate.java
+++ b/src/main/java/io/muserver/rest/MuRuntimeDelegate.java
@@ -11,6 +11,7 @@ import jakarta.ws.rs.core.*;
 import jakarta.ws.rs.ext.RuntimeDelegate;
 import jakarta.ws.rs.sse.Sse;
 import jakarta.ws.rs.sse.SseBroadcaster;
+import org.jspecify.annotations.Nullable;
 
 import java.net.URI;
 import java.util.*;
@@ -23,7 +24,7 @@ import java.util.concurrent.CompletionStage;
  */
 public class MuRuntimeDelegate extends RuntimeDelegate {
 
-    private static MuRuntimeDelegate singleton;
+    private static @Nullable MuRuntimeDelegate singleton;
 
     /**
      * Registers the mu RuntimeDelegate with jax-rs, if it was not already.
@@ -39,7 +40,7 @@ public class MuRuntimeDelegate extends RuntimeDelegate {
 
     private final Map<Class<?>, HeaderDelegate> headerDelegates = new HashMap<>();
 
-    public MuRuntimeDelegate() {
+    private MuRuntimeDelegate() {
         headerDelegates.put(MediaType.class, new MediaTypeHeaderDelegate());
         headerDelegates.put(CacheControl.class, new CacheControlHeaderDelegate());
         headerDelegates.put(NewCookie.class, new NewCookieHeaderDelegate());

--- a/src/main/java/io/muserver/rest/MuSeBootstrap.java
+++ b/src/main/java/io/muserver/rest/MuSeBootstrap.java
@@ -1,0 +1,228 @@
+package io.muserver.rest;
+
+import io.muserver.ContextHandlerBuilder;
+import io.muserver.HttpsConfigBuilder;
+import io.muserver.MuServer;
+import io.muserver.MuServerBuilder;
+import jakarta.ws.rs.ApplicationPath;
+import jakarta.ws.rs.SeBootstrap;
+import jakarta.ws.rs.core.Application;
+
+import javax.net.ssl.SSLContext;
+import java.lang.reflect.InvocationTargetException;
+import java.security.NoSuchAlgorithmException;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.BiFunction;
+
+final class MuSeBootstrap {
+    private static final Map<String, Class<?>> PROPERTY_TYPES = propertyTypes();
+
+    private MuSeBootstrap() {
+    }
+
+    static CompletionStage<SeBootstrap.Instance> start(Application application,
+                                                       SeBootstrap.Configuration requested) {
+        try {
+            Objects.requireNonNull(application, "application");
+            Objects.requireNonNull(requested, "configuration");
+
+            String protocol = requested.protocol();
+            String host = requested.host();
+            int requestedPort = requested.port();
+            String rootPath = requested.rootPath();
+            if (requestedPort < SeBootstrap.Configuration.DEFAULT_PORT || requestedPort > 65535) {
+                throw new IllegalArgumentException("Invalid port: " + requestedPort);
+            }
+
+            int port = requestedPort == SeBootstrap.Configuration.DEFAULT_PORT
+                ? SeBootstrap.Configuration.FREE_PORT
+                : requestedPort;
+            MuServerBuilder serverBuilder = MuServerBuilder.muServer().withInterface(host);
+            if ("HTTP".equalsIgnoreCase(protocol)) {
+                serverBuilder.withHttpPort(port);
+            } else if ("HTTPS".equalsIgnoreCase(protocol)) {
+                if (requested.sslClientAuthentication()
+                    != SeBootstrap.Configuration.SSLClientAuthentication.NONE) {
+                    throw new UnsupportedOperationException("SEBootstrap TLS client authentication is not supported");
+                }
+                serverBuilder.withHttpsPort(port)
+                    .withHttpsConfig(new HttpsConfigBuilder().withSSLContext(requested.sslContext()));
+            } else {
+                throw new IllegalArgumentException("Unsupported protocol: " + protocol);
+            }
+
+            String applicationPath = applicationPath(application.getClass());
+            String mountPath = joinPaths(rootPath, applicationPath);
+            serverBuilder.addHandler(ContextHandlerBuilder.context(mountPath)
+                .addHandler(ApplicationRegistrar.from(application, true)));
+            MuServer server = serverBuilder.start();
+            SeBootstrap.Configuration actual = new ConfigurationBuilder()
+                .protocol(protocol)
+                .host(host)
+                .port(server.uri().getPort())
+                .rootPath(rootPath)
+                .sslContext(requested.sslContext())
+                .sslClientAuthentication(requested.sslClientAuthentication())
+                .build();
+            return CompletableFuture.completedFuture(new Instance(server, actual));
+        } catch (Throwable failure) {
+            CompletableFuture<SeBootstrap.Instance> failed = new CompletableFuture<>();
+            failed.completeExceptionally(failure);
+            return failed;
+        }
+    }
+
+    static CompletionStage<SeBootstrap.Instance> start(Class<? extends Application> applicationClass,
+                                                       SeBootstrap.Configuration configuration) {
+        try {
+            Objects.requireNonNull(applicationClass, "applicationClass");
+            return start(applicationClass.getDeclaredConstructor().newInstance(), configuration);
+        } catch (InvocationTargetException e) {
+            CompletableFuture<SeBootstrap.Instance> failed = new CompletableFuture<>();
+            failed.completeExceptionally(e.getCause());
+            return failed;
+        } catch (Throwable failure) {
+            CompletableFuture<SeBootstrap.Instance> failed = new CompletableFuture<>();
+            failed.completeExceptionally(failure);
+            return failed;
+        }
+    }
+
+    private static String applicationPath(Class<?> applicationClass) {
+        ApplicationPath annotation = applicationClass.getAnnotation(ApplicationPath.class);
+        return annotation == null ? "" : annotation.value();
+    }
+
+    private static String joinPaths(String first, String second) {
+        String left = Objects.requireNonNull(first, "rootPath").trim();
+        String right = Objects.requireNonNull(second, "applicationPath").trim();
+        if (left.isEmpty() || "/".equals(left)) {
+            return right;
+        }
+        if (right.isEmpty() || "/".equals(right)) {
+            return left;
+        }
+        return left.replaceAll("/+$", "") + "/" + right.replaceAll("^/+", "");
+    }
+
+    private static Map<String, Class<?>> propertyTypes() {
+        Map<String, Class<?>> types = new LinkedHashMap<>();
+        types.put(SeBootstrap.Configuration.PROTOCOL, String.class);
+        types.put(SeBootstrap.Configuration.HOST, String.class);
+        types.put(SeBootstrap.Configuration.PORT, Integer.class);
+        types.put(SeBootstrap.Configuration.ROOT_PATH, String.class);
+        types.put(SeBootstrap.Configuration.SSL_CONTEXT, SSLContext.class);
+        types.put(SeBootstrap.Configuration.SSL_CLIENT_AUTHENTICATION,
+            SeBootstrap.Configuration.SSLClientAuthentication.class);
+        return types;
+    }
+
+    static final class ConfigurationBuilder implements SeBootstrap.Configuration.Builder {
+        private final Map<String, Object> properties = defaults();
+
+        @Override
+        public SeBootstrap.Configuration build() {
+            return new Configuration(properties);
+        }
+
+        @Override
+        public SeBootstrap.Configuration.Builder property(String name, Object value) {
+            Objects.requireNonNull(name, "name");
+            if (PROPERTY_TYPES.containsKey(name)) {
+                if (value == null) {
+                    properties.put(name, defaults().get(name));
+                } else {
+                    properties.put(name, value);
+                }
+            }
+            return this;
+        }
+
+        @Override
+        public <T> SeBootstrap.Configuration.Builder from(
+            BiFunction<String, Class<T>, Optional<T>> propertiesProvider) {
+            Objects.requireNonNull(propertiesProvider, "propertiesProvider");
+            for (Map.Entry<String, Class<?>> entry : PROPERTY_TYPES.entrySet()) {
+                load(propertiesProvider, entry.getKey(), entry.getValue());
+            }
+            return this;
+        }
+
+        @SuppressWarnings({"unchecked", "rawtypes"})
+        private <T> void load(BiFunction<String, Class<T>, Optional<T>> provider,
+                              String name, Class<?> type) {
+            Optional<?> value = Objects.requireNonNull(provider.apply(name, (Class) type),
+                "propertiesProvider result");
+            value.ifPresent(it -> properties.put(name, it));
+        }
+
+        private static Map<String, Object> defaults() {
+            Map<String, Object> defaults = new LinkedHashMap<>();
+            defaults.put(SeBootstrap.Configuration.PROTOCOL, "HTTP");
+            defaults.put(SeBootstrap.Configuration.HOST, "localhost");
+            defaults.put(SeBootstrap.Configuration.PORT, SeBootstrap.Configuration.DEFAULT_PORT);
+            defaults.put(SeBootstrap.Configuration.ROOT_PATH, "/");
+            try {
+                defaults.put(SeBootstrap.Configuration.SSL_CONTEXT, SSLContext.getDefault());
+            } catch (NoSuchAlgorithmException e) {
+                throw new IllegalStateException("No default SSLContext is available", e);
+            }
+            defaults.put(SeBootstrap.Configuration.SSL_CLIENT_AUTHENTICATION,
+                SeBootstrap.Configuration.SSLClientAuthentication.NONE);
+            return defaults;
+        }
+    }
+
+    private static final class Configuration implements SeBootstrap.Configuration {
+        private final Map<String, Object> properties;
+
+        private Configuration(Map<String, Object> properties) {
+            this.properties = new LinkedHashMap<>(properties);
+        }
+
+        @Override
+        public Object property(String name) {
+            return properties.get(name);
+        }
+    }
+
+    private static final class Instance implements SeBootstrap.Instance {
+        private final MuServer server;
+        private final SeBootstrap.Configuration configuration;
+        private final AtomicBoolean stopped = new AtomicBoolean();
+
+        private Instance(MuServer server, SeBootstrap.Configuration configuration) {
+            this.server = server;
+            this.configuration = configuration;
+        }
+
+        @Override
+        public SeBootstrap.Configuration configuration() {
+            return configuration;
+        }
+
+        @Override
+        public CompletionStage<StopResult> stop() {
+            if (stopped.compareAndSet(false, true)) {
+                server.stop();
+            }
+            return CompletableFuture.completedFuture(new StopResult() {
+                @Override
+                public <T> T unwrap(Class<T> nativeClass) {
+                    return null;
+                }
+            });
+        }
+
+        @Override
+        public <T> T unwrap(Class<T> nativeClass) {
+            return nativeClass.cast(server);
+        }
+    }
+}

--- a/src/main/java/io/muserver/rest/README.md
+++ b/src/main/java/io/muserver/rest/README.md
@@ -380,6 +380,9 @@ Will not implement. Configuration should be handled by the user.
 - [x] Java SE bootstrap with HTTP, HTTPS, root-path mounting, external configuration, dynamic ports, and shutdown.
 - [ ] TLS client authentication through `SeBootstrap` is not supported.
 
+Mu Server does not advertise its `RuntimeDelegate` globally merely by being present on an application's classpath.
+Call `MuRuntimeDelegate.ensureSet()` once before the first `SeBootstrap` call to select Mu explicitly.
+
 ## 12 Runtime Delegate
 
 - [x] Implemented, including Java SE configuration and bootstrap. `createEndpoint` is not supported.

--- a/src/main/java/io/muserver/rest/README.md
+++ b/src/main/java/io/muserver/rest/README.md
@@ -3,8 +3,7 @@
 
 This section goes into detail about which parts of the spec are implemented, which parts may be implemented
 later, and which parts will never be implemented. The numbers and headers are taken directly from the
-[jaxrs-2.1 final spec](https://jcp.org/aboutJava/communityprocess/final/jsr370/index.html)
-provided by Oracle.
+[Jakarta REST 3.1 specification](https://jakarta.ee/specifications/restful-ws/3.1/).
 
 
 ## 2 Applications
@@ -15,9 +14,10 @@ returned by `Application.getClasses()` are instantiated once with a public no-ar
 components must be safe to use concurrently.
 
 Resource classes returned by `Application.getClasses()` are rejected because their default lifecycle is per-request,
-which Mu Server does not support. Application properties, features, dynamic features, context resolvers, classpath
-scanning, and `@ApplicationPath` mounting are also not supported. All supported components can alternatively be
-registered programmatically using `RestHandlerBuilder`.
+which Mu Server does not support. Application properties, features, dynamic features, context resolvers, and classpath
+scanning are also not supported. `@ApplicationPath` is honored when starting an application with `SeBootstrap`; a
+handler created directly with `RestHandlerBuilder.fromApplication` can instead be mounted in a Mu context. All
+supported components can alternatively be registered programmatically using `RestHandlerBuilder`.
 
 ## 3 Resources
 
@@ -377,11 +377,12 @@ Will not implement. Configuration should be handled by the user.
 
 ## 11 Environment
 
-None of this section is applicable to MuServer as it does not manage your server's lifecycle.
+- [x] Java SE bootstrap with HTTP, HTTPS, root-path mounting, external configuration, dynamic ports, and shutdown.
+- [ ] TLS client authentication through `SeBootstrap` is not supported.
 
 ## 12 Runtime Delegate
 
-- [x] Implemented, although note that `createEndpoint` will never be supported.
+- [x] Implemented, including Java SE configuration and bootstrap. `createEndpoint` is not supported.
 
 ## Interface implementations
 

--- a/src/main/resources/META-INF/services/jakarta.ws.rs.ext.RuntimeDelegate
+++ b/src/main/resources/META-INF/services/jakarta.ws.rs.ext.RuntimeDelegate
@@ -1,0 +1,1 @@
+io.muserver.rest.MuRuntimeDelegate

--- a/src/main/resources/META-INF/services/jakarta.ws.rs.ext.RuntimeDelegate
+++ b/src/main/resources/META-INF/services/jakarta.ws.rs.ext.RuntimeDelegate
@@ -1,1 +1,0 @@
-io.muserver.rest.MuRuntimeDelegate

--- a/src/test/java/io/muserver/rest/MuSeBootstrapTest.java
+++ b/src/test/java/io/muserver/rest/MuSeBootstrapTest.java
@@ -1,0 +1,112 @@
+package io.muserver.rest;
+
+import io.muserver.MuServer;
+import jakarta.ws.rs.ApplicationPath;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.SeBootstrap;
+import jakarta.ws.rs.core.Application;
+import okhttp3.Response;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertNull;
+import static scaffolding.ClientUtils.call;
+import static scaffolding.ClientUtils.request;
+
+public class MuSeBootstrapTest {
+
+    @Test
+    public void bootsApplicationAtConfiguredRootAndApplicationPaths() throws Exception {
+        SeBootstrap.Configuration requested = SeBootstrap.Configuration.builder()
+            .protocol("HTTP")
+            .host("localhost")
+            .port(SeBootstrap.Configuration.FREE_PORT)
+            .rootPath("/root/path")
+            .build();
+
+        SeBootstrap.Instance instance = SeBootstrap.start(new TestApplication(), requested)
+            .toCompletableFuture().get(10, TimeUnit.SECONDS);
+        try {
+            SeBootstrap.Configuration actual = instance.configuration();
+            assertThat(actual.protocol(), is("HTTP"));
+            assertThat(actual.host(), is("localhost"));
+            assertThat(actual.port(), is(greaterThan(0)));
+            assertThat(actual.rootPath(), is("/root/path"));
+            try (Response response = call(request(actual.baseUriBuilder().path("application/resource").build()))) {
+                assertThat(response.code(), is(200));
+                assertThat(response.body().string(), is("booted"));
+            }
+            assertThat(instance.unwrap(MuServer.class).uri().getPort(), is(actual.port()));
+        } finally {
+            SeBootstrap.Instance.StopResult result = instance.stop().toCompletableFuture().get(10, TimeUnit.SECONDS);
+            assertNull(result.unwrap(Object.class));
+        }
+    }
+
+    @Test
+    public void configurationHasDefaultsAndLoadsKnownExternalProperties() {
+        SeBootstrap.Configuration defaults = SeBootstrap.Configuration.builder().build();
+        assertThat(defaults.protocol(), is("HTTP"));
+        assertThat(defaults.host(), is("localhost"));
+        assertThat(defaults.port(), is(SeBootstrap.Configuration.DEFAULT_PORT));
+        assertThat(defaults.rootPath(), is("/"));
+        assertThat(defaults.sslClientAuthentication(),
+            is(SeBootstrap.Configuration.SSLClientAuthentication.NONE));
+
+        SeBootstrap.Configuration loaded = SeBootstrap.Configuration.builder()
+            .from((name, type) -> {
+                if (SeBootstrap.Configuration.HOST.equals(name)) {
+                    return Optional.of(type.cast("127.0.0.1"));
+                }
+                if (SeBootstrap.Configuration.PORT.equals(name)) {
+                    return Optional.of(type.cast(12345));
+                }
+                return Optional.empty();
+            })
+            .property("unknown", "ignored")
+            .build();
+        assertThat(loaded.host(), is("127.0.0.1"));
+        assertThat(loaded.port(), is(12345));
+        assertThat(loaded.protocol(), is("HTTP"));
+        assertNull(loaded.property("unknown"));
+    }
+
+    @Test
+    public void applicationClassIsCreatedWithItsDefaultConstructor() throws Exception {
+        SeBootstrap.Instance instance = SeBootstrap.start(TestApplication.class)
+            .toCompletableFuture().get(10, TimeUnit.SECONDS);
+        try {
+            try (Response response = call(request(instance.configuration().baseUriBuilder()
+                .path("application/resource").build()))) {
+                assertThat(response.code(), is(200));
+                assertThat(response.body().string(), is("booted"));
+            }
+        } finally {
+            instance.stop().toCompletableFuture().get(10, TimeUnit.SECONDS);
+        }
+    }
+
+    @ApplicationPath("application")
+    public static class TestApplication extends Application {
+        @Override
+        public Set<Object> getSingletons() {
+            return Set.of(new TestResource());
+        }
+    }
+
+    @Path("resource")
+    public static class TestResource {
+        @GET
+        public String get() throws IOException {
+            return "booted";
+        }
+    }
+}

--- a/src/test/java/io/muserver/rest/MuSeBootstrapTest.java
+++ b/src/test/java/io/muserver/rest/MuSeBootstrapTest.java
@@ -8,6 +8,7 @@ import jakarta.ws.rs.SeBootstrap;
 import jakarta.ws.rs.core.Application;
 import okhttp3.Response;
 import org.junit.Test;
+import org.junit.BeforeClass;
 
 import java.io.IOException;
 import java.util.Optional;
@@ -22,6 +23,11 @@ import static scaffolding.ClientUtils.call;
 import static scaffolding.ClientUtils.request;
 
 public class MuSeBootstrapTest {
+
+    @BeforeClass
+    public static void registerRuntimeDelegate() {
+        MuRuntimeDelegate.ensureSet();
+    }
 
     @Test
     public void bootsApplicationAtConfiguredRootAndApplicationPaths() throws Exception {


### PR DESCRIPTION
## What changed

Implements Jakarta REST 3.1 Java SE bootstrap on top of the Application support in PR #113.

- Keeps `MuRuntimeDelegate` selection opt-in via `MuRuntimeDelegate.ensureSet()`
- Implements configuration defaults, explicit properties, and external property loading
- Supports instance- and class-based Application startup
- Honors bootstrap root paths and `@ApplicationPath`
- Supports dynamic/default ports and reports the actual bound port
- Supports HTTP and HTTPS with a supplied `SSLContext`
- Implements stop and native `MuServer` unwrapping
- Rejects unsupported TLS client-authentication modes explicitly
- Leaves `EntityPart` and multipart parsing intentionally unsupported in Mu 3

## Dependency

This is a stacked, independently developed branch targeting `agent/application-support` because SEBootstrap delegates component registration to PR #113. Once #113 merges, this PR can be retargeted to `master` without changing its SEBootstrap commits.

## TDD and validation

- Added a failing end-to-end bootstrap test before implementation
- `mvn -q -Dtest=MuSeBootstrapTest,ApplicationTest test`
- Full Mu test suite: passed
- Jakarta REST 3.1 TCK `sebootstrap` suite: all 7 tests pass with opt-in RuntimeDelegate selection
- CI passes on Java 11, 17, 21, and 25
- `git diff --check`