### PR TITLE
Cover blocked message-body reader selection

### DIFF
--- a/src/main/java/io/muserver/rest/EntityProviders.java
+++ b/src/main/java/io/muserver/rest/EntityProviders.java
@@ -29,8 +29,18 @@ class EntityProviders {
         Optional<ProviderWrapper<MessageBodyReader<?>>> best = readers.stream()
             .filter(reader -> reader.supports(requestBodyMediaType))
             .filter(reader -> !(reader.genericType instanceof Class) || ((Class<?>) reader.genericType).isAssignableFrom(box(type)))
+            .sorted((first, second) -> {
+                int typeCompare = ProviderWrapper.compareTo(first, second, type);
+                if (typeCompare != 0) {
+                    return typeCompare;
+                }
+                int mediaTypeCompare = Integer.compare(
+                    mediaTypeSpecificity(first, requestBodyMediaType),
+                    mediaTypeSpecificity(second, requestBodyMediaType));
+                return mediaTypeCompare != 0 ? mediaTypeCompare : first.compareTo(second);
+            })
             .filter(reader -> reader.provider.isReadable(type, genericType, annotations, requestBodyMediaType))
-            .min(Comparator.comparingInt(reader -> mediaTypeSpecificity(reader, requestBodyMediaType)));
+            .findFirst();
         if (best.isPresent()) {
             return best.get().provider;
         }

--- a/src/main/java/io/muserver/rest/EntityProviders.java
+++ b/src/main/java/io/muserver/rest/EntityProviders.java
@@ -30,14 +30,13 @@ class EntityProviders {
             .filter(reader -> reader.supports(requestBodyMediaType))
             .filter(reader -> !(reader.genericType instanceof Class) || ((Class<?>) reader.genericType).isAssignableFrom(box(type)))
             .sorted((first, second) -> {
-                int typeCompare = ProviderWrapper.compareTo(first, second, type);
-                if (typeCompare != 0) {
-                    return typeCompare;
-                }
                 int mediaTypeCompare = Integer.compare(
                     mediaTypeSpecificity(first, requestBodyMediaType),
                     mediaTypeSpecificity(second, requestBodyMediaType));
-                return mediaTypeCompare != 0 ? mediaTypeCompare : first.compareTo(second);
+                if (mediaTypeCompare != 0) {
+                    return mediaTypeCompare;
+                }
+                return first.compareTo(second);
             })
             .filter(reader -> reader.provider.isReadable(type, genericType, annotations, requestBodyMediaType))
             .findFirst();

--- a/src/main/java/io/muserver/rest/ProviderWrapper.java
+++ b/src/main/java/io/muserver/rest/ProviderWrapper.java
@@ -78,7 +78,7 @@ class ProviderWrapper<T> implements Comparable<ProviderWrapper<T>> {
     }
 
     @SuppressWarnings("unchecked")
-    public static int compareTo(ProviderWrapper<?> o1, ProviderWrapper<?> o2, Type genericType) {
+    public static int compareTo(ProviderWrapper<MessageBodyWriter<?>> o1, ProviderWrapper<MessageBodyWriter<?>> o2, Type genericType) {
         if (o1.genericType.equals(o2.genericType)) {
             return 0;
         }

--- a/src/main/java/io/muserver/rest/ProviderWrapper.java
+++ b/src/main/java/io/muserver/rest/ProviderWrapper.java
@@ -78,7 +78,7 @@ class ProviderWrapper<T> implements Comparable<ProviderWrapper<T>> {
     }
 
     @SuppressWarnings("unchecked")
-    public static int compareTo(ProviderWrapper<MessageBodyWriter<?>> o1, ProviderWrapper<MessageBodyWriter<?>> o2, Type genericType) {
+    public static int compareTo(ProviderWrapper<?> o1, ProviderWrapper<?> o2, Type genericType) {
         if (o1.genericType.equals(o2.genericType)) {
             return 0;
         }

--- a/src/test/java/io/muserver/rest/EntityProvidersTest.java
+++ b/src/test/java/io/muserver/rest/EntityProvidersTest.java
@@ -14,6 +14,7 @@ import okhttp3.Response;
 import okio.BufferedSink;
 import org.example.MyStringReaderWriter;
 import org.example.NumberWriter;
+import org.example.ObjectReader;
 import org.example.RuntimeTypeOnlyStringWriter;
 import org.hamcrest.Matchers;
 import org.junit.After;
@@ -85,6 +86,20 @@ public class EntityProvidersTest {
             assertThat(resp.header("Content-Type"), equalTo("text/plain;charset=utf-8"));
             assertThat(resp.body().string(), equalTo("--HELLO WORLD--"));
         }
+    }
+
+    @Test
+    public void broadApplicationReaderOverridesMoreSpecificBuiltInReader() {
+        ObjectReader applicationReader = new ObjectReader();
+        EntityProviders providers = new EntityProviders(
+            asList(applicationReader, StringEntityProviders.stringEntityReaders.get(0)),
+            Collections.emptyList());
+
+        assertThat(providers.selectReader(
+            String.class,
+            String.class,
+            new Annotation[0],
+            jakarta.ws.rs.core.MediaType.TEXT_PLAIN_TYPE), Matchers.sameInstance(applicationReader));
     }
 
     @Test

--- a/src/test/java/io/muserver/rest/EntityProvidersTest.java
+++ b/src/test/java/io/muserver/rest/EntityProvidersTest.java
@@ -27,6 +27,7 @@ import java.lang.reflect.Type;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
@@ -435,6 +436,121 @@ public class EntityProvidersTest {
             assertThat(resp.code(), equalTo(200));
             assertThat(resp.body().string(), equalTo("read by default reader"));
         }
+    }
+
+    @Test
+    public void readersReceiveTheRequestContentTypeOrOctetStreamByDefault() throws Exception {
+        class Payload {
+            private final String value;
+
+            private Payload(String value) {
+                this.value = value;
+            }
+        }
+        @Consumes("*/*")
+        class PayloadReader implements MessageBodyReader<Payload> {
+            @Override
+            public boolean isReadable(Class<?> type, Type genericType, Annotation[] annotations,
+                                      jakarta.ws.rs.core.MediaType mediaType) {
+                return type == Payload.class;
+            }
+
+            @Override
+            public Payload readFrom(Class<Payload> type, Type genericType, Annotation[] annotations,
+                                    jakarta.ws.rs.core.MediaType mediaType,
+                                    MultivaluedMap<String, String> httpHeaders,
+                                    InputStream entityStream) throws IOException {
+                return new Payload(mediaType + ":" + new String(entityStream.readAllBytes(), StandardCharsets.UTF_8));
+            }
+        }
+        @Path("reader-media-type")
+        class Resource {
+            @POST
+            public String post(Payload payload) {
+                return payload.value;
+            }
+        }
+        server = httpsServerForTest()
+            .addHandler(restHandler(new Resource()).addCustomReader(new PayloadReader()))
+            .start();
+
+        try (Response response = call(request(server.uri().resolve("/reader-media-type"))
+            .post(RequestBody.create("explicit", MediaType.get("text/html"))))) {
+            assertThat(response.body().string(), equalTo("text/html;charset=utf-8:explicit"));
+        }
+        try (Response response = call(request(server.uri().resolve("/reader-media-type"))
+            .post(new RequestBody() {
+                @Override
+                public MediaType contentType() {
+                    return null;
+                }
+
+                @Override
+                public void writeTo(BufferedSink sink) throws IOException {
+                    sink.writeUtf8("default");
+                }
+            }))) {
+            assertThat(response.body().string(), equalTo("application/octet-stream:default"));
+        }
+    }
+
+    @Test
+    public void readerSelectionStopsAtTheFirstReadableSortedCandidate() {
+        List<String> calls = new ArrayList<>();
+        @Consumes("application/java")
+        class ExactReader implements MessageBodyReader<String> {
+            private final boolean readable;
+
+            private ExactReader(boolean readable) {
+                this.readable = readable;
+            }
+
+            @Override
+            public boolean isReadable(Class<?> type, Type genericType, Annotation[] annotations,
+                                      jakarta.ws.rs.core.MediaType mediaType) {
+                calls.add("exact");
+                return readable;
+            }
+
+            @Override
+            public String readFrom(Class<String> type, Type genericType, Annotation[] annotations,
+                                   jakarta.ws.rs.core.MediaType mediaType,
+                                   MultivaluedMap<String, String> httpHeaders,
+                                   InputStream entityStream) {
+                return "exact";
+            }
+        }
+        @Consumes("*/*")
+        class WildcardReader implements MessageBodyReader<String> {
+            @Override
+            public boolean isReadable(Class<?> type, Type genericType, Annotation[] annotations,
+                                      jakarta.ws.rs.core.MediaType mediaType) {
+                calls.add("wildcard");
+                return true;
+            }
+
+            @Override
+            public String readFrom(Class<String> type, Type genericType, Annotation[] annotations,
+                                   jakarta.ws.rs.core.MediaType mediaType,
+                                   MultivaluedMap<String, String> httpHeaders,
+                                   InputStream entityStream) {
+                return "wildcard";
+            }
+        }
+        jakarta.ws.rs.core.MediaType mediaType = new jakarta.ws.rs.core.MediaType("application", "java");
+
+        EntityProviders firstReadable = new EntityProviders(
+            asList(new WildcardReader(), new ExactReader(true)), Collections.emptyList());
+        assertThat(firstReadable.selectReader(String.class, String.class, new Annotation[0], mediaType),
+            Matchers.instanceOf(ExactReader.class));
+        assertThat(calls, Matchers.contains("exact"));
+
+        calls.clear();
+        EntityProviders fallback = new EntityProviders(
+            asList(new WildcardReader(), new ExactReader(false)), Collections.emptyList());
+        assertThat(fallback.selectReader(String.class, String.class, new Annotation[0], mediaType),
+            Matchers.instanceOf(WildcardReader.class));
+        assertThat(calls, Matchers.contains("exact", "wildcard"));
     }
 
     @Test

--- a/src/test/java/org/example/ObjectReader.java
+++ b/src/test/java/org/example/ObjectReader.java
@@ -1,0 +1,25 @@
+package org.example;
+
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.ext.MessageBodyReader;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+
+@Consumes("text/plain")
+public class ObjectReader implements MessageBodyReader<Object> {
+    @Override
+    public boolean isReadable(Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType) {
+        return true;
+    }
+
+    @Override
+    public Object readFrom(Class<Object> type, Type genericType, Annotation[] annotations, MediaType mediaType,
+                           MultivaluedMap<String, String> httpHeaders, InputStream entityStream) throws IOException {
+        return "application-reader";
+    }
+}


### PR DESCRIPTION
Adds direct coverage for the intent of the Jakarta REST 3.1 TCK reader-provider tests that the harness cannot execute because their resources rely on per-request field injection.

The tests verify that readers receive the request content type (or application/octet-stream by default), and that candidates are sorted before isReadable is invoked. The latter test failed first and drove the provider-ordering fix.

Tested with:
- `mvn -q -Dtest=EntityProvidersTest test`