### PR TITLE
Cover blocked reader and writer interceptor semantics

### DIFF
--- a/src/main/java/io/muserver/rest/RestHandler.java
+++ b/src/main/java/io/muserver/rest/RestHandler.java
@@ -267,6 +267,7 @@ public class RestHandler implements MuHandler {
                             System.arraycopy(jaxRSResponse.getAnnotations(), 0, writerAnnontations, annotations.length, jaxRSResponse.getAnnotations().length);
                         }
                     }
+                    jaxRSResponse.setAnnotations(writerAnnontations);
 
                     if (obj.entity != null) {
                         MediaType responseMediaType = MediaTypeDeterminer.determine(obj, produces, directlyProduces, entityProviders.writers, acceptHeaders, writerAnnontations);
@@ -279,6 +280,7 @@ public class RestHandler implements MuHandler {
                     if (jaxRSResponse.hasEntity()) {
                         jaxRSResponse.executeInterceptors(writerInterceptors); // run the interceptors
                     }
+                    writerAnnontations = jaxRSResponse.getAnnotations();
                     Object entity = jaxRSResponse.getEntity();
                     if (entity instanceof Exception) {
                         throw (Exception) entity;

--- a/src/test/java/io/muserver/rest/ReaderInterceptorTest.java
+++ b/src/test/java/io/muserver/rest/ReaderInterceptorTest.java
@@ -5,6 +5,8 @@ import io.muserver.MuServer;
 import jakarta.annotation.Priority;
 import jakarta.ws.rs.*;
 import jakarta.ws.rs.container.ResourceInfo;
+import jakarta.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.ext.MessageBodyReader;
 import jakarta.ws.rs.ext.ReaderInterceptor;
 import jakarta.ws.rs.ext.ReaderInterceptorContext;
 import okhttp3.MediaType;
@@ -15,17 +17,23 @@ import org.junit.Test;
 import scaffolding.ServerUtils;
 
 import java.io.ByteArrayInputStream;
+import java.io.File;
 import java.io.FilterInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.Reader;
+import java.lang.annotation.Annotation;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import java.lang.reflect.Type;
 import java.nio.ByteBuffer;
+import java.nio.file.Files;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static io.muserver.rest.RestHandlerBuilder.restHandler;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -179,6 +187,126 @@ public class ReaderInterceptorTest {
         )) {
             assertThat(resp.code(), is(200));
             assertThat(resp.body().string(), equalTo("hello"));
+        }
+    }
+
+    @Test
+    public void interceptorsRunForEverySupportedBlockedTckReaderType() throws Exception {
+        AtomicInteger interceptorCalls = new AtomicInteger();
+        @Path("/reader-types")
+        class Resource {
+            @POST
+            @Path("bytes")
+            public String bytes(byte[] body) {
+                return new String(body, StandardCharsets.UTF_8);
+            }
+
+            @POST
+            @Path("file")
+            public String file(File body) throws IOException {
+                return Files.readString(body.toPath());
+            }
+
+            @POST
+            @Path("stream")
+            public String stream(InputStream body) throws IOException {
+                return new String(body.readAllBytes(), StandardCharsets.UTF_8);
+            }
+
+            @POST
+            @Path("reader")
+            public String reader(Reader body) throws IOException {
+                StringBuilder value = new StringBuilder();
+                char[] buffer = new char[32];
+                int read;
+                while ((read = body.read(buffer)) >= 0) {
+                    value.append(buffer, 0, read);
+                }
+                return value.toString();
+            }
+        }
+        server = ServerUtils.httpsServerForTest()
+            .addHandler(restHandler(new Resource())
+                .addReaderInterceptor(context -> {
+                    interceptorCalls.incrementAndGet();
+                    return context.proceed();
+                }))
+            .start();
+
+        for (String path : List.of("bytes", "file", "stream", "reader")) {
+            try (Response response = call(request(server.uri().resolve("/reader-types/" + path))
+                .post(requestBody(path)))) {
+                assertThat(response.body().string(), is(path));
+            }
+        }
+        assertThat(interceptorCalls.get(), is(4));
+    }
+
+    @Test
+    public void lastReaderInterceptorValuesControlProviderSelection() throws Exception {
+        @Priority(200)
+        class ExpectedValuesReader implements MessageBodyReader<ArrayList<String>> {
+            @Override
+            public boolean isReadable(Class<?> type, Type genericType, Annotation[] annotations,
+                                      jakarta.ws.rs.core.MediaType mediaType) {
+                return type == ArrayList.class
+                    && genericType.getTypeName().equals("java.util.List<java.lang.String>")
+                    && mediaType.equals(jakarta.ws.rs.core.MediaType.TEXT_PLAIN_TYPE)
+                    && annotations.length == 1
+                    && annotations[0] instanceof Priority
+                    && ((Priority) annotations[0]).value() == 200;
+            }
+
+            @Override
+            public ArrayList<String> readFrom(Class<ArrayList<String>> type, Type genericType,
+                                              Annotation[] annotations,
+                                              jakarta.ws.rs.core.MediaType mediaType,
+                                              MultivaluedMap<String, String> httpHeaders,
+                                              InputStream entityStream) throws IOException {
+                return new ArrayList<>(List.of(
+                    new String(entityStream.readAllBytes(), StandardCharsets.UTF_8)));
+            }
+        }
+        @Path("/last-reader-values")
+        class Resource {
+            @POST
+            public String post(List<String> value) {
+                return value.get(0);
+            }
+        }
+        @Priority(100)
+        class First implements ReaderInterceptor {
+            @Override
+            public Object aroundReadFrom(ReaderInterceptorContext context) throws IOException {
+                context.setType(java.util.LinkedList.class);
+                context.setMediaType(jakarta.ws.rs.core.MediaType.TEXT_HTML_TYPE);
+                context.setAnnotations(getClass().getAnnotations());
+                context.setInputStream(new ByteArrayInputStream("first".getBytes(StandardCharsets.UTF_8)));
+                return context.proceed();
+            }
+        }
+        @Priority(200)
+        class Second implements ReaderInterceptor {
+            @Override
+            public Object aroundReadFrom(ReaderInterceptorContext context) throws IOException {
+                context.setType(ArrayList.class);
+                context.setMediaType(jakarta.ws.rs.core.MediaType.TEXT_PLAIN_TYPE);
+                context.setAnnotations(getClass().getAnnotations());
+                context.setInputStream(new ByteArrayInputStream("second".getBytes(StandardCharsets.UTF_8)));
+                return context.proceed();
+            }
+        }
+        server = ServerUtils.httpsServerForTest()
+            .addHandler(restHandler(new Resource())
+                .addCustomReader(new ExpectedValuesReader())
+                .addReaderInterceptor(new Second())
+                .addReaderInterceptor(new First()))
+            .start();
+
+        try (Response response = call(request(server.uri().resolve("/last-reader-values"))
+            .post(requestBody("original")))) {
+            assertThat(response.code(), is(200));
+            assertThat(response.body().string(), is("second"));
         }
     }
 

--- a/src/test/java/io/muserver/rest/WriterInterceptorTest.java
+++ b/src/test/java/io/muserver/rest/WriterInterceptorTest.java
@@ -5,6 +5,9 @@ import io.muserver.MuServer;
 import jakarta.annotation.Priority;
 import jakarta.ws.rs.*;
 import jakarta.ws.rs.container.ResourceInfo;
+import jakarta.ws.rs.core.GenericEntity;
+import jakarta.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.ext.MessageBodyWriter;
 import jakarta.ws.rs.ext.WriterInterceptor;
 import jakarta.ws.rs.ext.WriterInterceptorContext;
 import okhttp3.Response;
@@ -12,16 +15,26 @@ import org.junit.After;
 import org.junit.Test;
 import scaffolding.ServerUtils;
 
+import java.io.ByteArrayInputStream;
+import java.io.File;
 import java.io.FilterOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.OutputStream;
+import java.io.Reader;
+import java.io.StringReader;
+import java.lang.annotation.Annotation;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import java.lang.reflect.Type;
+import java.nio.file.Files;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.LinkedList;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static io.muserver.rest.RestHandlerBuilder.restHandler;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -140,6 +153,123 @@ public class WriterInterceptorTest {
             assertThat(resp.code(), is(200));
             assertThat(resp.header("content-type"), is("text/plain;charset=utf-8"));
             assertThat(resp.body().string(), equalTo("HELLO"));
+        }
+    }
+
+    @Test
+    public void interceptorsRunForEverySupportedBlockedTckWriterType() throws Exception {
+        AtomicInteger interceptorCalls = new AtomicInteger();
+        File file = File.createTempFile("mu-writer-interceptor", ".txt");
+        Files.writeString(file.toPath(), "file");
+        @Path("/writer-types")
+        class Resource {
+            @GET
+            @Path("bytes")
+            public byte[] bytes() {
+                return "bytes".getBytes(StandardCharsets.UTF_8);
+            }
+
+            @GET
+            @Path("file")
+            public File file() {
+                return file;
+            }
+
+            @GET
+            @Path("stream")
+            public InputStream stream() {
+                return new ByteArrayInputStream("stream".getBytes(StandardCharsets.UTF_8));
+            }
+
+            @GET
+            @Path("reader")
+            public Reader reader() {
+                return new StringReader("reader");
+            }
+        }
+        server = ServerUtils.httpsServerForTest()
+            .addHandler(restHandler(new Resource())
+                .addWriterInterceptor(context -> {
+                    interceptorCalls.incrementAndGet();
+                    context.proceed();
+                }))
+            .start();
+
+        for (String path : List.of("bytes", "file", "stream", "reader")) {
+            try (Response response = call(request(server.uri().resolve("/writer-types/" + path)))) {
+                assertThat(response.body().string(), is(path));
+            }
+        }
+        assertThat(interceptorCalls.get(), is(4));
+    }
+
+    @Test
+    public void lastWriterInterceptorValuesControlProviderSelectionAndWriting() throws Exception {
+        @Priority(200)
+        class ExpectedValuesWriter implements MessageBodyWriter<ArrayList<String>> {
+            @Override
+            public boolean isWriteable(Class<?> type, Type genericType, Annotation[] annotations,
+                                       jakarta.ws.rs.core.MediaType mediaType) {
+                return type == ArrayList.class
+                    && genericType == String.class
+                    && mediaType.equals(jakarta.ws.rs.core.MediaType.TEXT_PLAIN_TYPE)
+                    && annotations.length == 1
+                    && annotations[0] instanceof Priority
+                    && ((Priority) annotations[0]).value() == 200;
+            }
+
+            @Override
+            public void writeTo(ArrayList<String> value, Class<?> type, Type genericType,
+                                Annotation[] annotations, jakarta.ws.rs.core.MediaType mediaType,
+                                MultivaluedMap<String, Object> httpHeaders,
+                                OutputStream entityStream) throws IOException {
+                entityStream.write(value.get(0).getBytes(StandardCharsets.UTF_8));
+            }
+        }
+        @Path("/last-writer-values")
+        class Resource {
+            @GET
+            public jakarta.ws.rs.core.Response get() {
+                ArrayList<String> original = new ArrayList<>(List.of("original"));
+                return jakarta.ws.rs.core.Response.ok(
+                    new GenericEntity<ArrayList<String>>(original) { }).build();
+            }
+        }
+        @Priority(100)
+        class First implements WriterInterceptor {
+            @Override
+            public void aroundWriteTo(WriterInterceptorContext context) throws IOException {
+                context.setEntity(new LinkedList<>(List.of("first")));
+                context.setType(LinkedList.class);
+                context.setGenericType(LinkedList.class);
+                context.setMediaType(jakarta.ws.rs.core.MediaType.TEXT_HTML_TYPE);
+                context.setAnnotations(getClass().getAnnotations());
+                context.proceed();
+            }
+        }
+        @Priority(200)
+        class Second implements WriterInterceptor {
+            @Override
+            public void aroundWriteTo(WriterInterceptorContext context) throws IOException {
+                context.setEntity(new ArrayList<>(List.of("second")));
+                context.setType(ArrayList.class);
+                context.setGenericType(String.class);
+                context.setMediaType(jakarta.ws.rs.core.MediaType.TEXT_PLAIN_TYPE);
+                context.setAnnotations(getClass().getAnnotations());
+                context.proceed();
+            }
+        }
+        server = ServerUtils.httpsServerForTest()
+            .addHandler(restHandler(new Resource())
+                .addCustomWriter(new ExpectedValuesWriter())
+                .addWriterInterceptor(new Second())
+                .addWriterInterceptor(new First()))
+            .start();
+
+        try (Response response = call(request(server.uri().resolve("/last-writer-values")))) {
+            assertThat(response.code(), is(200));
+            assertThat(response.body().string(), is("second"));
+            assertThat(response.header("content-type"), is("text/plain;charset=utf-8"));
         }
     }
 


### PR DESCRIPTION
Adds direct coverage for supported entity types used by Jakarta REST 3.1 TCK interceptor tests that are blocked by per-request field injection. It also verifies that the final interceptor values control provider selection and writing.

The writer test failed first because interceptor annotations were not propagated to message-body-writer selection; the implementation now carries the final annotations through.

Tested with:
- `mvn -q -Dtest=ReaderInterceptorTest,WriterInterceptorTest,EntityProvidersTest test`