### PR TITLE
Complete JSpecify nullability audit

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,5 +23,9 @@ jobs:
           java-version: ${{ matrix.java }}
           distribution: 'temurin'
           cache: 'maven'
+      - name: Build with Maven and NullAway on JDK 11 and ${{ matrix.netty-profile }}
+        if: matrix.java == 11
+        run: mvn --batch-mode --update-snapshots -P${{ matrix.netty-profile }},nullaway verify
       - name: Build with Maven on JDK ${{ matrix.java }} and ${{ matrix.netty-profile }}
+        if: matrix.java != 11
         run: mvn --batch-mode --update-snapshots -P${{ matrix.netty-profile }} verify

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,9 +23,9 @@ jobs:
           java-version: ${{ matrix.java }}
           distribution: 'temurin'
           cache: 'maven'
-      - name: Build with Maven and NullAway on JDK 11 and ${{ matrix.netty-profile }}
-        if: matrix.java == 11
+      - name: Build with Maven and NullAway on JDK 21 and ${{ matrix.netty-profile }}
+        if: matrix.java == 21
         run: mvn --batch-mode --update-snapshots -P${{ matrix.netty-profile }},nullaway verify
       - name: Build with Maven on JDK ${{ matrix.java }} and ${{ matrix.netty-profile }}
-        if: matrix.java != 11
+        if: matrix.java != 21
         run: mvn --batch-mode --update-snapshots -P${{ matrix.netty-profile }} verify

--- a/pom.xml
+++ b/pom.xml
@@ -14,12 +14,12 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <error-prone.version>2.31.0</error-prone.version>
+        <error-prone.version>2.50.0</error-prone.version>
         <netty.version.4.1>4.1.135.Final</netty.version.4.1>
         <netty.version.4.2>4.2.14.Final</netty.version.4.2>
         <netty.version>${netty.version.4.1}</netty.version>
         <netty.codec.artifactId>netty-codec</netty.codec.artifactId>
-        <nullaway.version>0.12.10</nullaway.version>
+        <nullaway.version>0.13.8</nullaway.version>
         <slf4j.version>2.0.18</slf4j.version>
         <jetty.version>9.4.58.v20250814</jetty.version>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -14,10 +14,12 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <error-prone.version>2.31.0</error-prone.version>
         <netty.version.4.1>4.1.135.Final</netty.version.4.1>
         <netty.version.4.2>4.2.14.Final</netty.version.4.2>
         <netty.version>${netty.version.4.1}</netty.version>
         <netty.codec.artifactId>netty-codec</netty.codec.artifactId>
+        <nullaway.version>0.12.10</nullaway.version>
         <slf4j.version>2.0.18</slf4j.version>
         <jetty.version>9.4.58.v20250814</jetty.version>
     </properties>
@@ -342,6 +344,59 @@
     </build>
 
     <profiles>
+        <profile>
+            <id>nullaway</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-compiler-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>default-testCompile</id>
+                                <configuration>
+                                    <!-- Keep NullAway on production code; tests intentionally exercise null contracts and lifecycle setup. -->
+                                    <compilerArgs combine.self="override">
+                                        <arg>-proc:none</arg>
+                                    </compilerArgs>
+                                </configuration>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <fork>true</fork>
+                            <annotationProcessorPaths>
+                                <path>
+                                    <groupId>com.google.errorprone</groupId>
+                                    <artifactId>error_prone_core</artifactId>
+                                    <version>${error-prone.version}</version>
+                                </path>
+                                <path>
+                                    <groupId>com.uber.nullaway</groupId>
+                                    <artifactId>nullaway</artifactId>
+                                    <version>${nullaway.version}</version>
+                                </path>
+                            </annotationProcessorPaths>
+                            <compilerArgs combine.self="override">
+                                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED</arg>
+                                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED</arg>
+                                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED</arg>
+                                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED</arg>
+                                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED</arg>
+                                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED</arg>
+                                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED</arg>
+                                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED</arg>
+                                <arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED</arg>
+                                <arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED</arg>
+                                <arg>-XDcompilePolicy=simple</arg>
+                                <arg>-XDaddTypeAnnotationsToSymbol=true</arg>
+                                <arg>--should-stop=ifError=FLOW</arg>
+                                <arg>-Xplugin:ErrorProne -XepDisableAllChecks -Xep:NullAway:ERROR -XepOpt:NullAway:OnlyNullMarked=true -XepOpt:NullAway:JSpecifyMode=true</arg>
+                            </compilerArgs>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
         <profile>
             <id>netty-4.1</id>
             <properties>

--- a/src/main/java/io/muserver/AsyncSsePublisher.java
+++ b/src/main/java/io/muserver/AsyncSsePublisher.java
@@ -138,12 +138,12 @@ class AsyncSsePublisherImpl implements AsyncSsePublisher {
     }
 
     @Override
-    public CompletionStage<?> send(String message, String event) {
+    public CompletionStage<?> send(String message, @Nullable String event) {
         return send(message, event, null);
     }
 
     @Override
-    public CompletionStage<?> send(String message, String event, String eventID) {
+    public CompletionStage<?> send(String message, @Nullable String event, @Nullable String eventID) {
         return write(SsePublisherImpl.dataText(message, event, eventID));
     }
 

--- a/src/main/java/io/muserver/BaseWebSocket.java
+++ b/src/main/java/io/muserver/BaseWebSocket.java
@@ -1,6 +1,7 @@
 package io.muserver;
 
 import io.netty.handler.codec.CorruptedFrameException;
+import org.jspecify.annotations.Nullable;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -14,7 +15,7 @@ import java.util.concurrent.TimeoutException;
  */
 @SuppressWarnings("RedundantThrows") // because implementing classes might throw exceptions
 public abstract class BaseWebSocket implements MuWebSocket {
-    private MuWebSocketSession session;
+    private @Nullable MuWebSocketSession session;
 
     /**
      * @return The state of the current session
@@ -40,9 +41,9 @@ public abstract class BaseWebSocket implements MuWebSocket {
     }
 
     @Override
-    public void onClientClosed(int statusCode, String reason) throws Exception {
+    public void onClientClosed(int statusCode, @Nullable String reason) throws Exception {
         try {
-            session.close(statusCode, reason);
+            session().close(statusCode, reason);
         } catch (IOException ignored) {
         }
     }

--- a/src/main/java/io/muserver/ChunkedHttpOutputStream.java
+++ b/src/main/java/io/muserver/ChunkedHttpOutputStream.java
@@ -24,7 +24,7 @@ class ChunkedHttpOutputStream extends OutputStream {
         if (isClosed) {
             throw new IOException("Cannot write to closed output stream");
         }
-        response.httpExchange.block(() -> response.writeAndFlush(Unpooled.wrappedBuffer(b, off, len)));
+        response.exchange().block(() -> response.writeAndFlush(Unpooled.wrappedBuffer(b, off, len)));
     }
 
     public void close() {

--- a/src/main/java/io/muserver/ContextHandler.java
+++ b/src/main/java/io/muserver/ContextHandler.java
@@ -4,6 +4,9 @@ import java.net.URI;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import org.jspecify.annotations.Nullable;
+
+import static java.util.Objects.requireNonNull;
 
 /**
  * A handler that wraps a list of other handlers and serves them at a certain path prefix (or context).
@@ -22,8 +25,8 @@ public class ContextHandler implements MuHandler {
      * @param contextPath The patch
      * @param muHandlers The handlers
      */
-    ContextHandler(String contextPath, List<MuHandler> muHandlers) {
-        String slashTrimmed = Mutils.trim(Mutils.coalesce(contextPath, "").trim(), "/");
+    ContextHandler(@Nullable String contextPath, List<MuHandler> muHandlers) {
+        String slashTrimmed = Mutils.trim(requireNonNull(Mutils.coalesce(contextPath, "")).trim(), "/");
         this.hasContext = !slashTrimmed.isEmpty();
         this.contextPath = Stream.of(slashTrimmed.split("/"))
             .map(Mutils::urlEncode)

--- a/src/main/java/io/muserver/ContextHandlerBuilder.java
+++ b/src/main/java/io/muserver/ContextHandlerBuilder.java
@@ -9,7 +9,7 @@ import org.jspecify.annotations.Nullable;
  * Use this to serve a list of handlers from a base path.
  */
 public class ContextHandlerBuilder implements MuHandlerBuilder<ContextHandler> {
-    private String path;
+    private @Nullable String path;
     private List<MuHandler> handlers = new ArrayList<>();
 
     /**

--- a/src/main/java/io/muserver/Cookie.java
+++ b/src/main/java/io/muserver/Cookie.java
@@ -1,5 +1,7 @@
 package io.muserver;
 
+import org.jspecify.annotations.Nullable;
+
 import io.netty.handler.codec.http.cookie.DefaultCookie;
 
 import java.util.List;
@@ -85,7 +87,7 @@ public class Cookie {
         return nettyCookie.hashCode();
     }
 
-    public boolean equals(Object o) {
+    public boolean equals(@Nullable Object o) {
         return (this == o) || ((o instanceof Cookie) && nettyCookie.equals(o));
     }
 

--- a/src/main/java/io/muserver/CookieBuilder.java
+++ b/src/main/java/io/muserver/CookieBuilder.java
@@ -13,10 +13,10 @@ import org.jspecify.annotations.Nullable;
  */
 public class CookieBuilder {
 
-    private String name;
-    private String value;
-    private String domain;
-    private String path;
+    private @Nullable String name;
+    private @Nullable String value;
+    private @Nullable String domain;
+    private @Nullable String path;
     private long maxAge = DefaultCookie.UNDEFINED_MAX_AGE;
     private boolean secure;
     private boolean httpOnly;
@@ -190,9 +190,10 @@ public class CookieBuilder {
      * @return Returns a newly created cookie.
      */
     public Cookie build() {
-        if (Mutils.nullOrEmpty(name)) throw new IllegalStateException("A cookie name must be specified");
+        String cookieName = name;
+        if (cookieName == null || cookieName.isEmpty()) throw new IllegalStateException("A cookie name must be specified");
         if (value == null) throw new IllegalStateException("A cookie value must be specified");
-        Cookie c = new Cookie(name, value);
+        Cookie c = new Cookie(cookieName, value);
         c.nettyCookie.setDomain(domain);
         c.nettyCookie.setPath(path);
         c.nettyCookie.setMaxAge(maxAge);

--- a/src/main/java/io/muserver/ForwardedHeader.java
+++ b/src/main/java/io/muserver/ForwardedHeader.java
@@ -266,7 +266,7 @@ public class ForwardedHeader {
     }
 
     @Override
-    public boolean equals(Object o) {
+    public boolean equals(@Nullable Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         ForwardedHeader that = (ForwardedHeader) o;

--- a/src/main/java/io/muserver/ForwardedHeader.java
+++ b/src/main/java/io/muserver/ForwardedHeader.java
@@ -12,10 +12,10 @@ import static java.util.Collections.emptyMap;
  */
 public class ForwardedHeader {
 
-    private final String by;
-    private final String forValue;
-    private final String host;
-    private final String proto;
+    private final @Nullable String by;
+    private final @Nullable String forValue;
+    private final @Nullable String host;
+    private final @Nullable String proto;
     private final Map<String,String> extensions;
 
     /**
@@ -85,7 +85,7 @@ public class ForwardedHeader {
      * @return A list of ForwardedHeader objects
      * @throws IllegalArgumentException The value cannot be parsed
      */
-    public static List<ForwardedHeader> fromString(String input) {
+    public static List<ForwardedHeader> fromString(@Nullable String input) {
         if (input == null || input.trim().isEmpty()) {
             return emptyList();
         }
@@ -149,7 +149,7 @@ public class ForwardedHeader {
                         } else {
                             if (c == ';') {
                                 String val = buffer.toString();
-                                switch (paramName.toLowerCase()) {
+                                switch (Objects.requireNonNull(paramName).toLowerCase()) {
                                     case "by":
                                         by = val;
                                         break;
@@ -190,7 +190,7 @@ public class ForwardedHeader {
             switch (state) {
                 case PARAM_VALUE:
                     String val = buffer.toString();
-                    switch (paramName.toLowerCase()) {
+                    switch (Objects.requireNonNull(paramName).toLowerCase()) {
                         case "by":
                             by = val;
                             break;
@@ -255,7 +255,7 @@ public class ForwardedHeader {
         return sb.toString();
     }
 
-    private static void appendString(StringBuilder sb, String key, String value) {
+    private static void appendString(StringBuilder sb, String key, @Nullable String value) {
         if (value == null) {
             return;
         }

--- a/src/main/java/io/muserver/Http1Connection.java
+++ b/src/main/java/io/muserver/Http1Connection.java
@@ -26,6 +26,7 @@ import java.util.Set;
 import static io.netty.buffer.Unpooled.copiedBuffer;
 import static io.netty.handler.codec.http.HttpVersion.HTTP_1_1;
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Objects.requireNonNull;
 
 class Http1Connection extends SimpleChannelInboundHandler<Object> implements HttpConnection {
     private static final Logger log = LoggerFactory.getLogger(Http1Connection.class);
@@ -36,9 +37,9 @@ class Http1Connection extends SimpleChannelInboundHandler<Object> implements Htt
     private final MuServerImpl server;
     private final String proto;
     private final Instant startTime = Instant.now();
-    private ChannelHandlerContext nettyCtx;
-    private InetSocketAddress remoteAddress;
-    private Exchange currentExchange = null;
+    private @Nullable ChannelHandlerContext nettyCtx;
+    private @Nullable InetSocketAddress remoteAddress;
+    private @Nullable Exchange currentExchange;
 
     Http1Connection(NettyHandlerAdapter nettyHandlerAdapter, MuServerImpl server, String proto) {
         this.nettyHandlerAdapter = nettyHandlerAdapter;
@@ -123,20 +124,22 @@ class Http1Connection extends SimpleChannelInboundHandler<Object> implements Htt
                 HttpRequest rejectedReq = (HttpRequest) msg;
                 String method = rejectedReq.method() == null ? null : rejectedReq.method().name();
                 String uri = rejectedReq.uri();
-                nettyHandlerAdapter.onRequestRejected(new RejectedRequestImpl(ihr.code, ihr.getMessage(), method, uri, this));
-                sendSimpleResponse(ctx, ihr.getMessage(), ihr.code);
+                String message = String.valueOf(ihr.getMessage());
+                nettyHandlerAdapter.onRequestRejected(new RejectedRequestImpl(ihr.code, message, method, uri, this));
+                sendSimpleResponse(ctx, message, ihr.code);
                 ctx.channel().read();
             } catch (RedirectException e) {
                 sendRedirect(ctx, e.location);
             }
         } else if (currentExchange != null) {
-            currentExchange.onMessage(ctx, msg, error -> {
+            Exchange exchange = currentExchange;
+            exchange.onMessage(ctx, msg, error -> {
                 if (error == null) {
                     if (!(msg instanceof LastHttpContent)) {
                         ctx.channel().read();
                     }
                 } else {
-                    ctx.fireUserEventTriggered(new MuExceptionFiredEvent(currentExchange, -1, error));
+                    ctx.fireUserEventTriggered(new MuExceptionFiredEvent(exchange, -1, error));
                 }
             });
         } else {
@@ -226,12 +229,12 @@ class Http1Connection extends SimpleChannelInboundHandler<Object> implements Htt
 
     @Override
     public @Nullable String httpsProtocol() {
-        return isHttps() ? getSslSession(nettyCtx).getProtocol() : null;
+        return isHttps() ? getSslSession(context()).getProtocol() : null;
     }
 
     @Override
     public @Nullable String cipher() {
-        return isHttps() ? getSslSession(nettyCtx).getCipherSuite() : null;
+        return isHttps() ? getSslSession(context()).getCipherSuite() : null;
     }
 
     @Override
@@ -241,7 +244,7 @@ class Http1Connection extends SimpleChannelInboundHandler<Object> implements Htt
 
     @Override
     public InetSocketAddress remoteAddress() {
-        return remoteAddress;
+        return requireNonNull(remoteAddress, "Channel handler has not been added");
     }
 
     @Override
@@ -282,17 +285,21 @@ class Http1Connection extends SimpleChannelInboundHandler<Object> implements Htt
 
     @Override
     public Optional<Certificate> clientCertificate() {
-        return fromContext(nettyCtx);
+        return fromContext(context());
     }
 
     @Override
     public Optional<ProxiedConnectionInfo> proxyInfo() {
-        return Optional.ofNullable(nettyCtx.channel().attr(HAProxyMessageHandler.HA_PROXY_INFO).get());
+        return Optional.ofNullable(context().channel().attr(HAProxyMessageHandler.HA_PROXY_INFO).get());
     }
 
     @Override
     public Optional<String> sniHostName() {
-        return Optional.ofNullable(nettyCtx.channel().attr(MuSniHandler.SNI_HOSTNAME).get());
+        return Optional.ofNullable(context().channel().attr(MuSniHandler.SNI_HOSTNAME).get());
+    }
+
+    private ChannelHandlerContext context() {
+        return requireNonNull(nettyCtx, "Channel handler has not been added");
     }
 
     static Optional<Certificate> fromContext(ChannelHandlerContext channelHandlerContext) {

--- a/src/main/java/io/muserver/Http1Headers.java
+++ b/src/main/java/io/muserver/Http1Headers.java
@@ -84,7 +84,7 @@ class Http1Headers implements Headers {
 
     @Override
     public boolean getBoolean(String name) {
-        String val = get(name, "").toLowerCase();
+        String val = Objects.requireNonNull(get(name, "")).toLowerCase();
         return isTruthy(val);
     }
 

--- a/src/main/java/io/muserver/Http1Headers.java
+++ b/src/main/java/io/muserver/Http1Headers.java
@@ -264,7 +264,7 @@ class Http1Headers implements Headers {
     }
 
     @Override
-    public boolean equals(Object o) {
+    public boolean equals(@Nullable Object o) {
         return entries.equals(o);
     }
 

--- a/src/main/java/io/muserver/Http2Connection.java
+++ b/src/main/java/io/muserver/Http2Connection.java
@@ -23,6 +23,7 @@ import org.jspecify.annotations.Nullable;
 import static io.netty.buffer.Unpooled.EMPTY_BUFFER;
 import static io.netty.buffer.Unpooled.copiedBuffer;
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Objects.requireNonNull;
 
 abstract class Http2ConnectionFlowControl extends Http2ConnectionHandler implements Http2FrameListener {
 
@@ -313,8 +314,9 @@ final class Http2Connection extends Http2ConnectionFlowControl implements HttpCo
             }
             String method = headers.method() == null ? null : headers.method().toString();
             String uri = headers.path() == null ? null : headers.path().toString();
-            nettyHandlerAdapter.onRequestRejected(new RejectedRequestImpl(ihr.code, ihr.getMessage(), method, uri, this));
-            sendSimpleResponse(ctx, streamId, ihr.getMessage(), ihr.code);
+            String message = String.valueOf(ihr.getMessage());
+            nettyHandlerAdapter.onRequestRejected(new RejectedRequestImpl(ihr.code, message, method, uri, this));
+            sendSimpleResponse(ctx, streamId, message, ihr.code);
         } catch (RedirectException e) {
             sendRedirect(ctx, streamId, e.location);
         }
@@ -404,7 +406,7 @@ final class Http2Connection extends Http2ConnectionFlowControl implements HttpCo
         }
     }
 
-    static CharSequence compressionToUse(Headers requestHeaders) {
+    static @Nullable CharSequence compressionToUse(Headers requestHeaders) {
         for (ParameterizedHeaderWithValue encVal : requestHeaders.acceptEncoding()) {
             String enc = encVal.value();
             if (HttpHeaderValues.GZIP.contentEqualsIgnoreCase(enc)) {
@@ -517,12 +519,12 @@ final class Http2Connection extends Http2ConnectionFlowControl implements HttpCo
 
     @Override
     public @Nullable String httpsProtocol() {
-        return Http1Connection.getSslSession(nettyContext).getProtocol();
+        return Http1Connection.getSslSession(context()).getProtocol();
     }
 
     @Override
     public @Nullable String cipher() {
-        return Http1Connection.getSslSession(nettyContext).getCipherSuite();
+        return Http1Connection.getSslSession(context()).getCipherSuite();
     }
 
     @Override
@@ -532,7 +534,7 @@ final class Http2Connection extends Http2ConnectionFlowControl implements HttpCo
 
     @Override
     public InetSocketAddress remoteAddress() {
-        return remoteAddress;
+        return requireNonNull(remoteAddress, "The connection has not been initialized");
     }
 
     @Override
@@ -567,17 +569,20 @@ final class Http2Connection extends Http2ConnectionFlowControl implements HttpCo
 
     @Override
     public Optional<Certificate> clientCertificate() {
-        return Http1Connection.fromContext(nettyContext);
+        return Http1Connection.fromContext(context());
     }
 
     @Override
     public Optional<ProxiedConnectionInfo> proxyInfo() {
-        return Optional.ofNullable(this.nettyContext.channel().attr(HAProxyMessageHandler.HA_PROXY_INFO).get());
+        return Optional.ofNullable(context().channel().attr(HAProxyMessageHandler.HA_PROXY_INFO).get());
     }
 
     @Override
     public Optional<String> sniHostName() {
-        return Optional.ofNullable(this.nettyContext.channel().attr(MuSniHandler.SNI_HOSTNAME).get());
+        return Optional.ofNullable(context().channel().attr(MuSniHandler.SNI_HOSTNAME).get());
     }
 
+    private ChannelHandlerContext context() {
+        return requireNonNull(nettyContext, "The connection has not been initialized");
+    }
 }

--- a/src/main/java/io/muserver/Http2Headers.java
+++ b/src/main/java/io/muserver/Http2Headers.java
@@ -97,7 +97,7 @@ class Http2Headers implements Headers {
 
     @Override
     public boolean getBoolean(String name) {
-        String val = get(name, "").toLowerCase();
+        String val = Objects.requireNonNull(get(name, "")).toLowerCase();
         return isTruthy(val);
     }
 

--- a/src/main/java/io/muserver/Http2Headers.java
+++ b/src/main/java/io/muserver/Http2Headers.java
@@ -288,7 +288,7 @@ class Http2Headers implements Headers {
     }
 
     @Override
-    public boolean equals(Object o) {
+    public boolean equals(@Nullable Object o) {
         return entries.equals(o);
     }
 

--- a/src/main/java/io/muserver/Http2To1RequestAdapter.java
+++ b/src/main/java/io/muserver/Http2To1RequestAdapter.java
@@ -5,13 +5,14 @@ import io.netty.handler.codec.http.*;
 import io.netty.handler.codec.http2.Http2Exception;
 import io.netty.handler.codec.http2.Http2Headers;
 import io.netty.handler.codec.http2.HttpConversionUtil;
+import org.jspecify.annotations.Nullable;
 
 class Http2To1RequestAdapter implements HttpRequest {
     private final HttpMethod nettyMeth;
     private final String uri;
     private final Http2Headers headers;
     private final int streamId;
-    private HttpHeaders http1Headers;
+    private @Nullable HttpHeaders http1Headers;
 
     Http2To1RequestAdapter(int streamId, HttpMethod nettyMeth, String uri, Http2Headers headers) {
         this.streamId = streamId;

--- a/src/main/java/io/muserver/HttpExchange.java
+++ b/src/main/java/io/muserver/HttpExchange.java
@@ -13,6 +13,7 @@ import jakarta.ws.rs.InternalServerErrorException;
 import jakarta.ws.rs.NotFoundException;
 import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.Response;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -26,6 +27,7 @@ import java.util.UUID;
 import java.util.concurrent.*;
 
 import static io.netty.handler.codec.http.HttpVersion.HTTP_1_1;
+import static java.util.Objects.requireNonNull;
 
 /**
  * A request and response exchange between a client and the server
@@ -52,7 +54,7 @@ class HttpExchange implements ResponseInfo, Exchange {
     private volatile long endTime;
     private volatile HttpExchangeState state = HttpExchangeState.IN_PROGRESS;
     private final List<HttpExchangeStateChangeListener> listeners = new CopyOnWriteArrayList<>();
-    private ScheduledFuture<?> readTimer;
+    private @Nullable ScheduledFuture<?> readTimer;
 
     boolean inLoop() {
         return ctx.executor().inEventLoop();
@@ -68,7 +70,7 @@ class HttpExchange implements ResponseInfo, Exchange {
             Thread.currentThread().interrupt();
             throw new UncheckedIOException(new InterruptedIOException("Interrupted while writing"));
         } catch (ExecutionException e) {
-            Throwable cause = e.getCause();
+            Throwable cause = requireNonNull(e.getCause(), "ExecutionException had no cause");
             if (cause instanceof RuntimeException) {
                 throw (RuntimeException) cause;
             } else {
@@ -86,7 +88,7 @@ class HttpExchange implements ResponseInfo, Exchange {
             Thread.currentThread().interrupt();
             throw new UncheckedIOException(new InterruptedIOException("Interrupted while writing"));
         } catch (ExecutionException e) {
-            Throwable cause = e.getCause();
+            Throwable cause = requireNonNull(e.getCause(), "ExecutionException had no cause");
             if (cause instanceof RuntimeException) {
                 throw (RuntimeException) cause;
             } else {
@@ -109,7 +111,7 @@ class HttpExchange implements ResponseInfo, Exchange {
         this.listeners.add(listener);
     }
 
-    private void onReqOrRespStateChange(RequestState requestChanged, ResponseState responseChanged) {
+    private void onReqOrRespStateChange(@Nullable RequestState requestChanged, @Nullable ResponseState responseChanged) {
         RequestState reqState = request.requestState();
         ResponseState respState = response.responseState();
         if (reqState.endState() && respState == ResponseState.UPGRADED) {
@@ -277,7 +279,7 @@ class HttpExchange implements ResponseInfo, Exchange {
         String relativeUri = getRelativeUrl(nettyRequest.uri());
 
         NettyRequestAdapter muRequest = new NettyRequestAdapter(ctx, nettyRequest, headers, method,
-            proto, relativeUri, headers.get(HeaderNames.HOST));
+            proto, relativeUri, requireNonNull(headers.get(HeaderNames.HOST), "Validated HTTP/1 request had no Host header"));
 
         MuStatsImpl serverStats = server.stats;
         Http1Response muResponse = new Http1Response(ctx, muRequest, new Http1Headers());
@@ -345,9 +347,10 @@ class HttpExchange implements ResponseInfo, Exchange {
         if (nettyRequest.decoderResult().isFailure()) {
             Throwable cause = nettyRequest.decoderResult().cause();
             if (cause instanceof TooLongFrameException) {
-                if (cause.getMessage().contains("header is larger")) {
+                String message = cause.getMessage();
+                if (message != null && message.contains("header is larger")) {
                     throw new InvalidHttpRequestException(431, "431 Request Header Fields Too Large");
-                } else if (cause.getMessage().contains("line is larger")) {
+                } else if (message != null && message.contains("line is larger")) {
                     throw new InvalidHttpRequestException(414, "414 Request-URI Too Long");
                 }
             }

--- a/src/main/java/io/muserver/HttpsConfigBuilder.java
+++ b/src/main/java/io/muserver/HttpsConfigBuilder.java
@@ -401,7 +401,11 @@ public class HttpsConfigBuilder {
     private String[] getHttpsProtocolsArray() throws NoSuchAlgorithmException {
         List<String> supportedProtocols = asList(SSLContext.getDefault().getSupportedSSLParameters().getProtocols());
         List<String> protocolsToUse = new ArrayList<>();
-        for (String protocol : Mutils.coalesce(this.protocols, new String[]{"TLSv1.2", "TLSv1.3"})) {
+        String[] requestedProtocols = this.protocols;
+        if (requestedProtocols == null) {
+            requestedProtocols = new String[]{"TLSv1.2", "TLSv1.3"};
+        }
+        for (String protocol : requestedProtocols) {
             if (supportedProtocols.contains(protocol)) {
                 protocolsToUse.add(protocol);
             } else {

--- a/src/main/java/io/muserver/MuGzipHttp2ConnectionEncoder.java
+++ b/src/main/java/io/muserver/MuGzipHttp2ConnectionEncoder.java
@@ -7,6 +7,7 @@ import io.netty.channel.ChannelPromise;
 import io.netty.handler.codec.http2.Http2Connection;
 import io.netty.handler.codec.http2.Http2Headers;
 import io.netty.handler.codec.http2.*;
+import org.jspecify.annotations.Nullable;
 
 class MuGzipHttp2ConnectionEncoder implements Http2ConnectionEncoder {
     private final Http2ConnectionEncoder encoder;
@@ -65,7 +66,7 @@ class MuGzipHttp2ConnectionEncoder implements Http2ConnectionEncoder {
         }
     }
 
-    static CharSequence actualEncodingIfHasMuPrefix(CharSequence seq) {
+    static @Nullable CharSequence actualEncodingIfHasMuPrefix(@Nullable CharSequence seq) {
         if (seq != null) {
             int len = seq.length();
             if (len > 3 && seq.charAt(0) == 'm' && seq.charAt(1) == 'u' && seq.charAt(2) == '-') {

--- a/src/main/java/io/muserver/MuServerBuilder.java
+++ b/src/main/java/io/muserver/MuServerBuilder.java
@@ -28,6 +28,7 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.*;
 import java.util.function.Function;
@@ -58,19 +59,19 @@ public class MuServerBuilder {
     private boolean gzipEnabled = true;
     private Set<String> mimeTypesToGzip = ResourceType.gzippableMimeTypes(ResourceType.getResourceTypes());
     private boolean addShutdownHook = false;
-    private String host;
-    private HttpsConfigBuilder sslContextBuilder;
-    private Http2Config http2Config;
+    private @Nullable String host;
+    private @Nullable HttpsConfigBuilder sslContextBuilder;
+    private @Nullable Http2Config http2Config;
     private long requestReadTimeoutMillis = TimeUnit.MINUTES.toMillis(2);
     private long idleTimeoutMills = TimeUnit.MINUTES.toMillis(10);
-    private ExecutorService executor;
+    private @Nullable ExecutorService executor;
     private long maxRequestSize = 24 * 1024 * 1024;
-    private List<ResponseCompleteListener> responseCompleteListeners;
-    private List<RequestRejectListener> requestRejectListeners;
-    private HashedWheelTimer wheelTimer;
-    private List<RateLimiterImpl> rateLimiters;
+    private @Nullable List<ResponseCompleteListener> responseCompleteListeners;
+    private @Nullable List<RequestRejectListener> requestRejectListeners;
+    private @Nullable HashedWheelTimer wheelTimer;
+    private @Nullable List<RateLimiterImpl> rateLimiters;
     private WriteBufferWaterMark writeBufferWaterMark = WriteBufferWaterMark.DEFAULT;
-    private UnhandledExceptionHandler unhandledExceptionHandler;
+    private @Nullable UnhandledExceptionHandler unhandledExceptionHandler;
     private boolean haProxyProtocolEnabled = false;
 
     /**
@@ -90,7 +91,7 @@ public class MuServerBuilder {
      *             only, or <code>"0.0.0.0"</code> to allow connections from the local network.
      * @return The current Mu Server Builder
      */
-    public MuServerBuilder withInterface(String host) {
+    public MuServerBuilder withInterface(@Nullable String host) {
         this.host = host;
         return this;
     }
@@ -412,7 +413,11 @@ public class MuServerBuilder {
             rateLimiters = new ArrayList<>();
         }
         RateLimiterImpl rateLimiter = new RateLimiterImpl(selector, wheelTimer);
-        this.rateLimiters.add(rateLimiter);
+        List<RateLimiterImpl> limiters = this.rateLimiters;
+        if (limiters == null) {
+            throw new IllegalStateException("Rate limiter storage was not initialized");
+        }
+        limiters.add(rateLimiter);
         return this;
     }
 
@@ -513,14 +518,14 @@ public class MuServerBuilder {
     /**
      * @return The current value of this property
      */
-    public String interfaceHost() {
+    public @Nullable String interfaceHost() {
         return host;
     }
 
     /**
      * @return The current value of this property
      */
-    public HttpsConfigBuilder httpsConfigBuilder() {
+    public @Nullable HttpsConfigBuilder httpsConfigBuilder() {
         if (sslContextBuilder != null && !(sslContextBuilder instanceof HttpsConfigBuilder)) {
             throw new IllegalStateException("Please switch to using HttpsConfigBuilder to set HTTPS config");
         }
@@ -530,7 +535,7 @@ public class MuServerBuilder {
     /**
      * @return The current value of this property
      */
-    public Http2Config http2Config() {
+    public @Nullable Http2Config http2Config() {
         return http2Config;
     }
 
@@ -551,7 +556,7 @@ public class MuServerBuilder {
     /**
      * @return The current value of this property
      */
-    public ExecutorService executor() {
+    public @Nullable ExecutorService executor() {
         return executor;
     }
 
@@ -573,27 +578,30 @@ public class MuServerBuilder {
      * @return The current value of this property
      */
     public List<ResponseCompleteListener> responseCompleteListeners() {
-        return Collections.unmodifiableList(responseCompleteListeners);
+        return responseCompleteListeners == null ? Collections.emptyList() : Collections.unmodifiableList(responseCompleteListeners);
     }
 
     /**
      * @return The current value of this property
      */
     public List<RequestRejectListener> requestRejectListeners() {
-        return Collections.unmodifiableList(requestRejectListeners);
+        return requestRejectListeners == null ? Collections.emptyList() : Collections.unmodifiableList(requestRejectListeners);
     }
 
     /**
      * @return The current value of this property
      */
     public List<RateLimiter> rateLimiters() {
-        return rateLimiters.stream().map(RateLimiter.class::cast).collect(Collectors.toList());
+        List<RateLimiterImpl> limiters = rateLimiters;
+        return limiters == null
+            ? Collections.emptyList()
+            : limiters.stream().map(RateLimiter.class::cast).collect(Collectors.toList());
     }
 
     /**
      * @return The current value of this property
      */
-    public UnhandledExceptionHandler unhandledExceptionHandler() {
+    public @Nullable UnhandledExceptionHandler unhandledExceptionHandler() {
         return unhandledExceptionHandler;
     }
 
@@ -718,7 +726,7 @@ public class MuServerBuilder {
             if (httpsChannel != null) {
                 channels.add(httpsChannel);
                 httpsUri = getUriFromChannel(httpsChannel, "https", host);
-                ((SSLInfoImpl) sslContextProvider.sslInfo()).setHttpsUri(httpsUri);
+                ((SSLInfoImpl) Objects.requireNonNull(sslContextProvider).sslInfo()).setHttpsUri(httpsUri);
             }
 
             InetSocketAddress serverAddress = (InetSocketAddress) channels.get(0).localAddress();
@@ -743,13 +751,19 @@ private  boolean gracefulWait(Duration gracefulDuration, MuStatsImpl stats) thro
     return !stats.activeRequests().isEmpty();
 }
 
-    private static URI getUriFromChannel(Channel httpChannel, String protocol, String host) {
+    private static URI getUriFromChannel(Channel httpChannel, String protocol, @Nullable String host) {
         host = host == null ? "localhost" : host;
         InetSocketAddress a = (InetSocketAddress) httpChannel.localAddress();
         return URI.create(protocol + "://" + host.toLowerCase() + ":" + a.getPort());
     }
 
-    private static Channel createChannel(NioEventLoopGroup bossGroup, NioEventLoopGroup workerGroup, NettyHandlerAdapter nettyHandlerAdapter, String host, int port, SslContextProvider sslContextProvider, GlobalTrafficShapingHandler trafficShapingHandler, MuServerImpl server, final boolean http2, long idleTimeoutMills, WriteBufferWaterMark writeBufferWaterMark, boolean haProxyProtocolEnabled) throws InterruptedException {
+    private static Channel createChannel(NioEventLoopGroup bossGroup, NioEventLoopGroup workerGroup,
+                                         NettyHandlerAdapter nettyHandlerAdapter, @Nullable String host, int port,
+                                         @Nullable SslContextProvider sslContextProvider,
+                                         GlobalTrafficShapingHandler trafficShapingHandler, MuServerImpl server,
+                                         final boolean http2, long idleTimeoutMills,
+                                         WriteBufferWaterMark writeBufferWaterMark,
+                                         boolean haProxyProtocolEnabled) throws InterruptedException {
         boolean usesSsl = sslContextProvider != null;
         String proto = usesSsl ? "https" : "http";
         ServerBootstrap b = new ServerBootstrap();
@@ -767,7 +781,7 @@ private  boolean gracefulWait(Duration gracefulDuration, MuStatsImpl stats) thro
                         p.addLast("HAProxyMessageHandler", new HAProxyMessageHandler());
                     }
                     if (usesSsl) {
-                        p.addLast("sni", new MuSniHandler(() -> new DomainWildcardMappingBuilder<>(sslContextProvider.get()).build()));
+                        p.addLast("sni", new MuSniHandler(() -> new DomainWildcardMappingBuilder<>(Objects.requireNonNull(sslContextProvider).get()).build()));
                     }
                     boolean addAlpn = http2 && usesSsl;
                     if (addAlpn) {

--- a/src/main/java/io/muserver/MuServerImpl.java
+++ b/src/main/java/io/muserver/MuServerImpl.java
@@ -1,6 +1,7 @@
 package io.muserver;
 
 import io.netty.handler.ssl.SslContext;
+import org.jspecify.annotations.Nullable;
 
 import java.net.InetSocketAddress;
 import java.net.URI;
@@ -13,20 +14,23 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import static java.util.Objects.requireNonNull;
+
 class MuServerImpl implements MuServer {
 
-    private URI httpUri;
-    private URI httpsUri;
-    private Function<Duration, Boolean> shutdown;
+    private @Nullable URI httpUri;
+    private @Nullable URI httpsUri;
+    private @Nullable Function<Duration, Boolean> shutdown;
     final MuStatsImpl stats;
-    private InetSocketAddress address;
-    private SslContextProvider sslContextProvider;
+    private @Nullable InetSocketAddress address;
+    private @Nullable SslContextProvider sslContextProvider;
     private final Http2Config http2Config;
     private final ServerSettings settings;
     private final Set<HttpConnection> connections = ConcurrentHashMap.newKeySet();
-    final UnhandledExceptionHandler unhandledExceptionHandler;
+    final @Nullable UnhandledExceptionHandler unhandledExceptionHandler;
 
-    void onStarted(URI httpUri, URI httpsUri, Function<Duration, Boolean> shutdown, InetSocketAddress address, SslContextProvider sslContextProvider) {
+    void onStarted(@Nullable URI httpUri, @Nullable URI httpsUri, Function<Duration, Boolean> shutdown,
+                   InetSocketAddress address, @Nullable SslContextProvider sslContextProvider) {
         this.address = address;
         this.sslContextProvider = sslContextProvider;
         if (httpUri == null && httpsUri == null) {
@@ -37,7 +41,8 @@ class MuServerImpl implements MuServer {
         this.shutdown = shutdown;
     }
 
-    MuServerImpl(MuStatsImpl stats, Http2Config http2Config, ServerSettings settings, UnhandledExceptionHandler unhandledExceptionHandler) {
+    MuServerImpl(MuStatsImpl stats, @Nullable Http2Config http2Config, ServerSettings settings,
+                 @Nullable UnhandledExceptionHandler unhandledExceptionHandler) {
         this.stats = stats;
         this.http2Config = http2Config == null ? Http2ConfigBuilder.http2Config().build() : http2Config;
         this.settings = settings;
@@ -51,21 +56,21 @@ class MuServerImpl implements MuServer {
 
     @Override
     public boolean stop(long duration, TimeUnit unit) {
-        return shutdown.apply(Duration.ofMillis(unit.toMillis(duration)));
+        return requireNonNull(shutdown, "Server has not started").apply(Duration.ofMillis(unit.toMillis(duration)));
     }
 
     @Override
     public URI uri() {
-        return httpsUri != null ? httpsUri : httpUri;
+        return requireNonNull(httpsUri != null ? httpsUri : httpUri, "Server has not started");
     }
 
     @Override
-    public URI httpUri() {
+    public @Nullable URI httpUri() {
         return httpUri;
     }
 
     @Override
-    public URI httpsUri() {
+    public @Nullable URI httpsUri() {
         return httpsUri;
     }
 
@@ -81,7 +86,7 @@ class MuServerImpl implements MuServer {
 
     @Override
     public InetSocketAddress address() {
-        return address;
+        return requireNonNull(address, "Server has not started");
     }
 
     @Override
@@ -125,15 +130,16 @@ class MuServerImpl implements MuServer {
         Mutils.notNull("newSSLContext", newHttpsConfig);
         try {
             SslContext nettySslContext = newHttpsConfig.toNettySslContext(http2Config.enabled);
-            sslContextProvider.set(nettySslContext);
-            ((SSLInfoImpl) sslContextProvider.sslInfo()).setHttpsUri(httpsUri);
+            SslContextProvider provider = requireNonNull(sslContextProvider, "Server does not have an HTTPS connector");
+            provider.set(nettySslContext);
+            ((SSLInfoImpl) provider.sslInfo()).setHttpsUri(httpsUri);
         } catch (Exception e) {
             throw new MuException("Error while changing SSL Certificate. The old one will still be used.", e);
         }
     }
 
     @Override
-    public SSLInfo sslInfo() {
+    public @Nullable SSLInfo sslInfo() {
         return sslContextProvider == null ? null : sslContextProvider.sslInfo();
     }
 

--- a/src/main/java/io/muserver/MuStatsImpl.java
+++ b/src/main/java/io/muserver/MuStatsImpl.java
@@ -1,6 +1,7 @@
 package io.muserver;
 
 import io.netty.handler.traffic.TrafficCounter;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -9,8 +10,10 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
 
+import static java.util.Objects.requireNonNull;
+
 class MuStatsImpl implements MuStats {
-    private final TrafficCounter trafficCounter;
+    private final @Nullable TrafficCounter trafficCounter;
     private final AtomicLong activeConnections = new AtomicLong(0);
     private final AtomicLong totalConnections = new AtomicLong(0);
     private final AtomicLong completedRequests = new AtomicLong(0);
@@ -19,7 +22,7 @@ class MuStatsImpl implements MuStats {
     private final AtomicLong failedToConnect = new AtomicLong(0);
     private final Set<MuRequest> activeRequests = ConcurrentHashMap.newKeySet();
 
-    MuStatsImpl(TrafficCounter trafficCounter) {
+    MuStatsImpl(@Nullable TrafficCounter trafficCounter) {
         this.trafficCounter = trafficCounter;
     }
 
@@ -45,12 +48,12 @@ class MuStatsImpl implements MuStats {
 
     @Override
     public long bytesSent() {
-        return trafficCounter.cumulativeWrittenBytes();
+        return requireNonNull(trafficCounter, "Traffic statistics are not available for this counter").cumulativeWrittenBytes();
     }
 
     @Override
     public long bytesRead() {
-        return trafficCounter.cumulativeReadBytes();
+        return requireNonNull(trafficCounter, "Traffic statistics are not available for this counter").cumulativeReadBytes();
     }
 
     @Override

--- a/src/main/java/io/muserver/MuWebSocket.java
+++ b/src/main/java/io/muserver/MuWebSocket.java
@@ -1,5 +1,7 @@
 package io.muserver;
 
+import org.jspecify.annotations.Nullable;
+
 import java.nio.ByteBuffer;
 import java.util.concurrent.TimeUnit;
 
@@ -76,7 +78,7 @@ public interface MuWebSocket {
      * @param reason     An optional reason for the closure.
      * @throws Exception Any exceptions thrown will result in the onError method being called with the thrown exception being used as the <code>cause</code> parameter.
      */
-    void onClientClosed(int statusCode, String reason) throws Exception;
+    void onClientClosed(int statusCode, @Nullable String reason) throws Exception;
 
     /**
      * Called when a ping message is sent from a client.

--- a/src/main/java/io/muserver/MuWebSocketSession.java
+++ b/src/main/java/io/muserver/MuWebSocketSession.java
@@ -1,5 +1,7 @@
 package io.muserver;
 
+import org.jspecify.annotations.Nullable;
+
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.nio.ByteBuffer;
@@ -78,7 +80,7 @@ public interface MuWebSocketSession {
      * @param reason An optional reason for closing.
      * @throws IOException Thrown if there is an error writing to the client, for example if the user has closed their browser.
      */
-    void close(int statusCode, String reason) throws IOException;
+    void close(int statusCode, @Nullable String reason) throws IOException;
 
     /**
      * @return The client's address

--- a/src/main/java/io/muserver/MuWebSocketSessionImpl.java
+++ b/src/main/java/io/muserver/MuWebSocketSessionImpl.java
@@ -8,6 +8,7 @@ import io.netty.handler.codec.http.HttpContent;
 import io.netty.handler.codec.http.websocketx.*;
 import io.netty.handler.timeout.IdleState;
 import io.netty.handler.timeout.IdleStateEvent;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -105,7 +106,7 @@ class MuWebSocketSessionImpl implements MuWebSocketSession, Exchange {
     }
 
     @Override
-    public void close(int statusCode, String reason) {
+    public void close(int statusCode, @Nullable String reason) {
         if (state.endState()) {
             throw new IllegalArgumentException("Cannot close a websocket when the state is " + state);
         }
@@ -310,4 +311,3 @@ class MuWebSocketSessionImpl implements MuWebSocketSession, Exchange {
         }
     }
 }
-

--- a/src/main/java/io/muserver/Mutils.java
+++ b/src/main/java/io/muserver/Mutils.java
@@ -108,7 +108,7 @@ public class Mutils {
      * @param val The value to check
      * @return True if the string is 1 or more characters.
      */
-    public static boolean hasValue(String val) {
+    public static boolean hasValue(@Nullable String val) {
         return !nullOrEmpty(val);
     }
 

--- a/src/main/java/io/muserver/Mutils.java
+++ b/src/main/java/io/muserver/Mutils.java
@@ -98,7 +98,7 @@ public class Mutils {
      * @param val The value to check
      * @return True if the value is null or a zero-length string.
      */
-    public static boolean nullOrEmpty(String val) {
+    public static boolean nullOrEmpty(@Nullable String val) {
         return val == null || val.length() == 0;
     }
 
@@ -124,7 +124,7 @@ public class Mutils {
      * @param two The suffix
      * @return The joined strings
      */
-    public static String join(String one, String sep, String two) {
+    public static String join(@Nullable String one, String sep, @Nullable String two) {
         one = one == null ? "" : one;
         two = two == null ? "" : two;
         boolean oneEnds = one.endsWith(sep);
@@ -247,7 +247,7 @@ public class Mutils {
         return Stream.of(values).filter(Objects::nonNull).findFirst().orElse(null);
     }
 
-    static void closeSilently(Closeable closeable) {
+    static void closeSilently(@Nullable Closeable closeable) {
         if (closeable != null) {
             try {
                 closeable.close();

--- a/src/main/java/io/muserver/NettyHandlerAdapter.java
+++ b/src/main/java/io/muserver/NettyHandlerAdapter.java
@@ -2,6 +2,7 @@ package io.muserver;
 
 import jakarta.ws.rs.NotFoundException;
 import jakarta.ws.rs.RedirectionException;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -14,10 +15,12 @@ class NettyHandlerAdapter {
     private static final Logger log = LoggerFactory.getLogger(NettyHandlerAdapter.class);
     private final List<MuHandler> muHandlers;
     private final ExecutorService executor;
-    private final List<ResponseCompleteListener> completeListeners;
-    private final List<RequestRejectListener> rejectListeners;
+    private final @Nullable List<ResponseCompleteListener> completeListeners;
+    private final @Nullable List<RequestRejectListener> rejectListeners;
 
-    NettyHandlerAdapter(ExecutorService executor, List<MuHandler> muHandlers, List<ResponseCompleteListener> completeListeners, List<RequestRejectListener> rejectListeners) {
+    NettyHandlerAdapter(ExecutorService executor, List<MuHandler> muHandlers,
+                        @Nullable List<ResponseCompleteListener> completeListeners,
+                        @Nullable List<RequestRejectListener> rejectListeners) {
         this.executor = executor;
         this.muHandlers = muHandlers;
         this.completeListeners = completeListeners;

--- a/src/main/java/io/muserver/NettyRequestAdapter.java
+++ b/src/main/java/io/muserver/NettyRequestAdapter.java
@@ -40,15 +40,15 @@ class NettyRequestAdapter implements MuRequest {
     private final URI uri;
     private final Method method;
     private final Headers headers;
-    private volatile RequestBodyReader requestBodyReader;
+    private volatile @Nullable RequestBodyReader requestBodyReader;
     private final RequestParameters query;
 
-    private List<Cookie> cookies;
+    private @Nullable List<Cookie> cookies;
     private String contextPath = "";
     private String relativePath;
-    private Map<String, Object> attributes;
-    private volatile AsyncHandleImpl asyncHandle;
-    private HttpExchange httpExchange;
+    private @Nullable Map<String, Object> attributes;
+    private volatile @Nullable AsyncHandleImpl asyncHandle;
+    private @Nullable HttpExchange httpExchange;
     private final List<RequestStateChangeListener> listeners = new CopyOnWriteArrayList<>();
 
     NettyRequestAdapter(ChannelHandlerContext ctx, HttpRequest nettyRequest, Headers headers, Method method, String proto, String uri, String host) {
@@ -73,7 +73,7 @@ class NettyRequestAdapter implements MuRequest {
 
     @Override
     public HttpConnection connection() {
-        return this.httpExchange.connection();
+        return exchange().connection();
     }
 
     private static URI getUri(Headers h, String scheme, String hostHeader, String requestUri, URI serverUri) {
@@ -106,7 +106,7 @@ class NettyRequestAdapter implements MuRequest {
 
     @Override
     public long startTime() {
-        return httpExchange.startTime();
+        return exchange().startTime();
     }
 
     public Method method() {
@@ -148,7 +148,7 @@ class NettyRequestAdapter implements MuRequest {
                 Throwable cause = e.getCause();
                 if (cause instanceof Error) throw (Error) cause;
                 if (cause instanceof RuntimeException) throw (RuntimeException) cause;
-                throw new MuException("Error while getting input stream", cause);
+                throw new MuException("Error while getting input stream", Objects.requireNonNull(cause));
             }
             return Optional.of(inputStreamReader.inputStream());
         } else if (rbr instanceof RequestBodyReaderInputStreamAdapter) {
@@ -179,7 +179,7 @@ class NettyRequestAdapter implements MuRequest {
         Charset bodyCharset = UTF_8;
         if (mediaType != null) {
             String charset = mediaType.getParameters().get("charset");
-            if (!Mutils.nullOrEmpty(charset)) {
+            if (charset != null && !charset.isEmpty()) {
                 try {
                     bodyCharset = Charset.forName(charset);
                 } catch (IllegalCharsetNameException | UnsupportedCharsetException e) {
@@ -205,7 +205,7 @@ class NettyRequestAdapter implements MuRequest {
         if (!state.endState()) {
             requestBodyReader = reader;
             setState(RequestState.RECEIVING_BODY);
-            httpExchange.scheduleReadTimeout();
+            exchange().scheduleReadTimeout();
             return ctx.newSucceededFuture();
         } else {
             log.warn("Request body reader set after state is " + state);
@@ -222,11 +222,11 @@ class NettyRequestAdapter implements MuRequest {
     @Override
     public List<UploadedFile> uploadedFiles(String name) throws IOException {
         ensureFormDataLoaded();
-        return ((RequestBodyReader.MultipartFormReader) requestBodyReader).uploads(name);
+        return ((RequestBodyReader.MultipartFormReader) Objects.requireNonNull(requestBodyReader)).uploads(name);
     }
 
     @Override
-    public UploadedFile uploadedFile(String name) throws IOException {
+    public @Nullable UploadedFile uploadedFile(String name) throws IOException {
         List<UploadedFile> uploadedFiles = uploadedFiles(name);
         return uploadedFiles.isEmpty() ? null : uploadedFiles.get(0);
     }
@@ -240,7 +240,7 @@ class NettyRequestAdapter implements MuRequest {
     @Override
     public RequestParameters form() throws IOException {
         ensureFormDataLoaded();
-        return ((FormRequestBodyReader) requestBodyReader).params();
+        return ((FormRequestBodyReader) Objects.requireNonNull(requestBodyReader)).params();
     }
 
     @Override
@@ -282,7 +282,7 @@ class NettyRequestAdapter implements MuRequest {
     }
 
     @Override
-    public Object attribute(String key) {
+    public @Nullable Object attribute(String key) {
         Mutils.notNull("key", key);
         if (attributes == null) {
             return null;
@@ -291,7 +291,7 @@ class NettyRequestAdapter implements MuRequest {
     }
 
     @Override
-    public void attribute(String key, Object value) {
+    public void attribute(String key, @Nullable Object value) {
         Mutils.notNull("key", key);
         if (attributes == null) {
             attributes = new HashMap<>();
@@ -309,11 +309,13 @@ class NettyRequestAdapter implements MuRequest {
 
     @Override
     public AsyncHandle handleAsync() {
-        if (isAsync()) {
-            return asyncHandle;
+        AsyncHandleImpl handle = asyncHandle;
+        if (handle != null) {
+            return handle;
         }
-        asyncHandle = new AsyncHandleImpl(this, httpExchange);
-        return asyncHandle;
+        handle = new AsyncHandleImpl(this, exchange());
+        asyncHandle = handle;
+        return handle;
     }
 
     @Override
@@ -341,10 +343,10 @@ class NettyRequestAdapter implements MuRequest {
         if (requestBodyReader == null) {
             String ct = contentType();
             RequestBodyReader reader;
-            if (ct.startsWith("multipart/")) {
+            if (ct != null && ct.startsWith("multipart/")) {
                 reader = new RequestBodyReader.MultipartFormReader(maxRequestBytes(), nettyRequest, bodyCharset(headers, true));
                 claimingBodyRead(reader);
-            } else if (ct.equals("application/x-www-form-urlencoded")) {
+            } else if ("application/x-www-form-urlencoded".equals(ct)) {
                 reader = new RequestBodyReader.UrlEncodedBodyReader(createStringRequestBodyReader(maxRequestBytes(), headers()));
                 claimingBodyRead(reader);
             } else {
@@ -408,7 +410,7 @@ class NettyRequestAdapter implements MuRequest {
                 if (future.isSuccess()) {
                     ctx.pipeline().fireUserEventTriggered(new ExchangeUpgradeEvent(session));
                 } else {
-                    ctx.pipeline().fireUserEventTriggered(new MuExceptionFiredEvent(httpExchange, 0, future.cause()));
+                    ctx.pipeline().fireUserEventTriggered(new MuExceptionFiredEvent(exchange(), 0, future.cause()));
                 }
             });
 
@@ -427,14 +429,15 @@ class NettyRequestAdapter implements MuRequest {
     }
 
     void setState(RequestState status) {
-        assert httpExchange.inLoop() : "Not in event loop";
+        HttpExchange exchange = exchange();
+        assert exchange.inLoop() : "Not in event loop";
         RequestState oldState = this.state;
         if (oldState.endState()) {
             throw new IllegalStateException("Didn't expect to get a status update to " + status + " when the current status is " + oldState);
         }
         this.state = status;
         for (RequestStateChangeListener listener : listeners) {
-            listener.onChange(httpExchange, status);
+            listener.onChange(exchange, status);
         }
     }
 
@@ -465,7 +468,7 @@ class NettyRequestAdapter implements MuRequest {
     }
 
     public HttpExchange exchange() {
-        return httpExchange;
+        return Objects.requireNonNull(httpExchange, "Exchange has not been set");
     }
 
     static class AsyncHandleImpl implements AsyncHandle {
@@ -499,7 +502,7 @@ class NettyRequestAdapter implements MuRequest {
         }
 
         @Override
-        public void complete(Throwable throwable) {
+        public void complete(@Nullable Throwable throwable) {
             if (throwable == null) {
                 complete();
             } else {
@@ -528,7 +531,7 @@ class NettyRequestAdapter implements MuRequest {
 
         @Override
         public Future<Void> write(ByteBuffer data) {
-            NettyResponseAdaptor response = request.httpExchange.response;
+            NettyResponseAdaptor response = request.exchange().response;
             try {
                 return response.writeAndFlush(data);
             } catch (Throwable e) {

--- a/src/main/java/io/muserver/NettyRequestParameters.java
+++ b/src/main/java/io/muserver/NettyRequestParameters.java
@@ -123,7 +123,7 @@ class NettyRequestParameters implements RequestParameters {
 
 
     @Override
-    public boolean equals(Object o) {
+    public boolean equals(@Nullable Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         NettyRequestParameters that = (NettyRequestParameters) o;

--- a/src/main/java/io/muserver/NettyRequestParameters.java
+++ b/src/main/java/io/muserver/NettyRequestParameters.java
@@ -91,7 +91,7 @@ class NettyRequestParameters implements RequestParameters {
 
     @Override
     public boolean getBoolean(String name) {
-        String val = get(name, "").toLowerCase();
+        String val = Objects.requireNonNull(get(name, "")).toLowerCase();
         return isTruthy(val);
     }
 

--- a/src/main/java/io/muserver/NettyResponseAdaptor.java
+++ b/src/main/java/io/muserver/NettyResponseAdaptor.java
@@ -26,6 +26,7 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import org.jspecify.annotations.Nullable;
 
 import static io.muserver.ContentTypes.TEXT_PLAIN_UTF8;
+import static java.util.Objects.requireNonNull;
 
 abstract class NettyResponseAdaptor implements MuResponse {
     private static final Logger log = LoggerFactory.getLogger(NettyResponseAdaptor.class);
@@ -42,7 +43,11 @@ abstract class NettyResponseAdaptor implements MuResponse {
     protected @Nullable HttpExchange httpExchange;
 
     public void setExchange(HttpExchange httpExchange) {
-        this.httpExchange = httpExchange;
+        this.httpExchange = requireNonNull(httpExchange, "httpExchange");
+    }
+
+    final HttpExchange exchange() {
+        return requireNonNull(httpExchange, "Exchange has not been set");
     }
 
     protected void outputState(ResponseState state) {
@@ -53,7 +58,7 @@ abstract class NettyResponseAdaptor implements MuResponse {
         }
         this.state = state;
         for (ResponseStateChangeListener listener : listeners) {
-            listener.onStateChange(httpExchange, state);
+            listener.onStateChange(exchange(), state);
         }
     }
 
@@ -119,7 +124,7 @@ abstract class NettyResponseAdaptor implements MuResponse {
     }
 
     protected @Nullable ChannelFuture startStreaming() {
-        assert httpExchange.inLoop() : "Not in event loop";
+        assert exchange().inLoop() : "Not in event loop";
         if (state != ResponseState.NOTHING) {
             throw new IllegalStateException("Cannot start streaming when state is " + state);
         }
@@ -131,7 +136,7 @@ abstract class NettyResponseAdaptor implements MuResponse {
     }
 
     static CharSequence getVaryWithAE(@Nullable String curValue) {
-        if (Mutils.nullOrEmpty(curValue)) {
+        if (curValue == null || curValue.isEmpty()) {
             return HeaderNames.ACCEPT_ENCODING;
         } else {
             if (!curValue.toLowerCase().contains(HeaderNames.ACCEPT_ENCODING)) {
@@ -149,9 +154,10 @@ abstract class NettyResponseAdaptor implements MuResponse {
     }
 
     ChannelFuture writeAndFlush(ByteBuffer data) {
-        if (!httpExchange.inLoop()) {
-            ChannelPromise promise = httpExchange.ctx.newPromise();
-            httpExchange.ctx.executor().submit(() -> writeAndFlush(data).addListener(f -> {
+        HttpExchange exchange = exchange();
+        if (!exchange.inLoop()) {
+            ChannelPromise promise = exchange.ctx.newPromise();
+            exchange.ctx.executor().submit(() -> writeAndFlush(data).addListener(f -> {
                 if (f.isSuccess()) {
                     promise.setSuccess();
                 } else {
@@ -169,7 +175,7 @@ abstract class NettyResponseAdaptor implements MuResponse {
                 }
                 return writeAndFlush(Unpooled.wrappedBuffer(data));
             } catch (Throwable e) {
-                return httpExchange.ctx.newFailedFuture(e);
+                return exchange.ctx.newFailedFuture(e);
             }
         }
     }
@@ -206,7 +212,7 @@ abstract class NettyResponseAdaptor implements MuResponse {
 
     public void sendChunk(String text) {
         throwIfAsync();
-        httpExchange.block(() -> {
+        exchange().block(() -> {
             throwIfFinished();
             if (state == ResponseState.NOTHING) {
                 startStreaming();
@@ -230,7 +236,11 @@ abstract class NettyResponseAdaptor implements MuResponse {
     }
 
     public void contentType(@Nullable CharSequence contentType) {
-        headers.set(HeaderNames.CONTENT_TYPE, contentType);
+        if (contentType == null) {
+            headers.remove(HeaderNames.CONTENT_TYPE);
+        } else {
+            headers.set(HeaderNames.CONTENT_TYPE, contentType);
+        }
     }
 
     public void addCookie(Cookie cookie) {
@@ -246,12 +256,12 @@ abstract class NettyResponseAdaptor implements MuResponse {
     public OutputStream outputStream(int bufferSize) {
         if (this.outputStream == null) {
             ChunkedHttpOutputStream nonBuffered = new ChunkedHttpOutputStream(this);
-            httpExchange.block(() -> {
+            exchange().block(() -> {
                 startStreaming();
                 outputStream = bufferSize > 0 ? new BufferedOutputStream(nonBuffered, bufferSize) : nonBuffered;
             });
         }
-        return this.outputStream;
+        return requireNonNull(this.outputStream);
     }
 
     private void throwIfAsync() {
@@ -269,7 +279,7 @@ abstract class NettyResponseAdaptor implements MuResponse {
             OutputStreamWriter os = new OutputStreamWriter(outputStream(), StandardCharsets.UTF_8);
             this.writer = new PrintWriter(os);
         }
-        return this.writer;
+        return requireNonNull(this.writer);
     }
 
     @Override
@@ -288,7 +298,7 @@ abstract class NettyResponseAdaptor implements MuResponse {
     }
 
     void complete() {
-        assert httpExchange.inLoop() : "Not in event loop";
+        assert exchange().inLoop() : "Not in event loop";
 
         ResponseState finalState = ResponseState.FINISHED;
 
@@ -319,7 +329,7 @@ abstract class NettyResponseAdaptor implements MuResponse {
     @Override
     public void write(String text) {
         throwIfAsync();
-        httpExchange.block(() -> writeOnLoop(text).addListener(f -> outputState(f, ResponseState.FULL_SENT)));
+        exchange().block(() -> writeOnLoop(text).addListener(f -> outputState(f, ResponseState.FULL_SENT)));
     }
 
     ChannelFuture writeOnLoop(String text) {
@@ -343,8 +353,9 @@ abstract class NettyResponseAdaptor implements MuResponse {
     protected abstract ChannelFuture writeLastContentMarker();
 
     public final void redirect(URI newLocation) {
-        if (!httpExchange.inLoop()) {
-            httpExchange.ctx.executor().execute(() -> redirect(newLocation));
+        HttpExchange exchange = exchange();
+        if (!exchange.inLoop()) {
+            exchange.ctx.executor().execute(() -> redirect(newLocation));
         } else {
             URI absoluteUrl = request.uri().resolve(newLocation).normalize();
             if (status < 300 || status > 303) {

--- a/src/main/java/io/muserver/ParameterizedHeader.java
+++ b/src/main/java/io/muserver/ParameterizedHeader.java
@@ -167,8 +167,8 @@ public class ParameterizedHeader {
      */
     public String toString() {
         StringBuilder sb = new StringBuilder();
-        Map<String, String> parameters = this.parameters();
-        for (Map.Entry<String, String> entry : parameters.entrySet()) {
+        Map<String, @Nullable String> parameters = this.parameters();
+        for (Map.Entry<String, @Nullable String> entry : parameters.entrySet()) {
             if (sb.length() > 0) {
                 sb.append(", ");
             }

--- a/src/main/java/io/muserver/ParameterizedHeaderWithValue.java
+++ b/src/main/java/io/muserver/ParameterizedHeaderWithValue.java
@@ -182,7 +182,9 @@ public class ParameterizedHeaderWithValue {
                     }
             }
 
-            results.add(new ParameterizedHeaderWithValue(value, parameters == null ? Collections.emptyMap() : parameters));
+            results.add(new ParameterizedHeaderWithValue(
+                Objects.requireNonNull(value, "A header value is required"),
+                parameters == null ? Collections.emptyMap() : parameters));
         }
 
         return results;

--- a/src/main/java/io/muserver/PreReader.java
+++ b/src/main/java/io/muserver/PreReader.java
@@ -3,6 +3,7 @@ package io.muserver;
 import io.netty.channel.ChannelDuplexHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.util.ReferenceCountUtil;
+import org.jspecify.annotations.Nullable;
 
 /**
  * This pre-emptively reads a message from the channel before the HTTP handler has actually asked for it.
@@ -11,7 +12,7 @@ import io.netty.util.ReferenceCountUtil;
  */
 class PreReader extends ChannelDuplexHandler {
 
-    private Object pendingMsg;
+    private @Nullable Object pendingMsg;
     private boolean wantsToRead = false;
 
     @Override

--- a/src/main/java/io/muserver/ProxiedConnectionInfo.java
+++ b/src/main/java/io/muserver/ProxiedConnectionInfo.java
@@ -78,7 +78,7 @@ class ProxiedConnectionInfoImpl implements ProxiedConnectionInfo {
     }
 
     @Override
-    public boolean equals(Object o) {
+    public boolean equals(@Nullable Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         ProxiedConnectionInfoImpl that = (ProxiedConnectionInfoImpl) o;

--- a/src/main/java/io/muserver/RateLimit.java
+++ b/src/main/java/io/muserver/RateLimit.java
@@ -1,18 +1,20 @@
 package io.muserver;
 
+import org.jspecify.annotations.Nullable;
+
 import java.util.concurrent.TimeUnit;
 
 /**
  * Specifies the limits allowed for a single value, such as an IP address.
  */
 public class RateLimit {
-    final String bucket;
+    final @Nullable String bucket;
     final long allowed;
     final RateLimitRejectionAction action;
     final long per;
     final TimeUnit perUnit;
 
-    RateLimit(String bucket, long allowed, RateLimitRejectionAction action, long per, TimeUnit perUnit) {
+    RateLimit(@Nullable String bucket, long allowed, RateLimitRejectionAction action, long per, TimeUnit perUnit) {
         this.bucket = bucket;
         this.allowed = allowed;
         this.action = action;

--- a/src/main/java/io/muserver/RateLimitBuilder.java
+++ b/src/main/java/io/muserver/RateLimitBuilder.java
@@ -1,5 +1,7 @@
 package io.muserver;
 
+import org.jspecify.annotations.Nullable;
+
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -11,7 +13,7 @@ public class RateLimitBuilder {
     private long rate = 100;
     private long per = 1;
     private TimeUnit perUnit = TimeUnit.SECONDS;
-    private String bucket;
+    private @Nullable String bucket;
     private RateLimitRejectionAction action = RateLimitRejectionAction.SEND_429;
 
     /**

--- a/src/main/java/io/muserver/RejectedRequestImpl.java
+++ b/src/main/java/io/muserver/RejectedRequestImpl.java
@@ -9,7 +9,7 @@ class RejectedRequestImpl implements RejectedRequest {
 
     private final int status;
     private final String reason;
-    private final String method;
+    private final @Nullable String method;
     private final @Nullable URI uri;
     private final HttpConnection connection;
 

--- a/src/main/java/io/muserver/RequestBodyReader.java
+++ b/src/main/java/io/muserver/RequestBodyReader.java
@@ -12,6 +12,7 @@ import io.netty.handler.codec.http2.Http2Exception;
 import jakarta.ws.rs.ClientErrorException;
 import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.Response;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -28,6 +29,7 @@ import java.util.concurrent.atomic.AtomicLong;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Collections.emptyList;
+import static java.util.Objects.requireNonNull;
 
 interface FormRequestBodyReader {
     RequestParameters params();
@@ -37,7 +39,7 @@ interface FormRequestBodyReader {
 
 abstract class RequestBodyReader {
 
-    private final CompletableFuture<Throwable> future = new CompletableFuture<>();
+    private final CompletableFuture<@Nullable Throwable> future = new CompletableFuture<>();
     private final AtomicLong bytes = new AtomicLong();
     final long maxSize;
 
@@ -53,7 +55,7 @@ abstract class RequestBodyReader {
         return future.isDone();
     }
 
-    protected Throwable currentError() {
+    protected @Nullable Throwable currentError() {
         return future.getNow(null);
     }
 
@@ -191,7 +193,7 @@ abstract class RequestBodyReader {
 
     static class UrlEncodedBodyReader extends RequestBodyReader implements FormRequestBodyReader {
         private final StringRequestBodyReader stringReader;
-        private RequestParameters form;
+        private @Nullable RequestParameters form;
 
         public UrlEncodedBodyReader(StringRequestBodyReader stringReader) {
             super(stringReader.maxSize);
@@ -205,7 +207,7 @@ abstract class RequestBodyReader {
 
         @Override
         public RequestParameters params() {
-            return form;
+            return requireNonNull(form, "Form data has not been fully read");
         }
 
 
@@ -226,12 +228,12 @@ abstract class RequestBodyReader {
     static class MultipartFormReader extends RequestBodyReader implements FormRequestBodyReader {
         private static final Logger log = LoggerFactory.getLogger(MultipartFormReader.class);
         private final HttpPostMultipartRequestDecoder multipartRequestDecoder;
-        private RequestParameters form;
+        private @Nullable RequestParameters form;
         private final HashMap<String, List<UploadedFile>> uploads = new HashMap<>();
 
         @Override
         public RequestParameters params() {
-            return form;
+            return requireNonNull(form, "Form data has not been fully read");
         }
 
         public MultipartFormReader(long maxSize, HttpRequest nettyRequest, Charset charset) {
@@ -303,7 +305,7 @@ abstract class RequestBodyReader {
     static class StringRequestBodyReader extends RequestBodyReader {
         private final Charset bodyCharset;
         private final CompositeByteBuf list = Unpooled.compositeBuffer();
-        private volatile String result;
+        private volatile @Nullable String result;
 
         public StringRequestBodyReader(long maxSize, Charset bodyCharset) {
             super(maxSize);

--- a/src/main/java/io/muserver/RequestBodyReaderInputStreamAdapter.java
+++ b/src/main/java/io/muserver/RequestBodyReaderInputStreamAdapter.java
@@ -2,16 +2,19 @@ package io.muserver;
 
 import io.netty.buffer.ByteBuf;
 import jakarta.ws.rs.WebApplicationException;
+import org.jspecify.annotations.Nullable;
 
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InterruptedIOException;
 
+import static java.util.Objects.requireNonNull;
+
 class RequestBodyReaderInputStreamAdapter extends RequestBodyReader {
     private boolean receivedLast = false;
     private boolean finished = false;
-    private ByteBuf currentBuf;
-    private DoneCallback currentCallback;
+    private @Nullable ByteBuf currentBuf;
+    private @Nullable DoneCallback currentCallback;
     private boolean userClosed = false;
     private final Object lock = new Object();
 
@@ -76,8 +79,9 @@ class RequestBodyReaderInputStreamAdapter extends RequestBodyReader {
         public long skip(long n) throws IOException {
             synchronized (lock) {
                 waitForData();
-                int toSkip = Math.min((int) n, currentBuf.readableBytes());
-                currentBuf.skipBytes(toSkip);
+                ByteBuf buffer = requireNonNull(currentBuf);
+                int toSkip = Math.min((int) n, buffer.readableBytes());
+                buffer.skipBytes(toSkip);
                 afterConsumed();
                 return toSkip;
             }
@@ -175,10 +179,11 @@ class RequestBodyReaderInputStreamAdapter extends RequestBodyReader {
 
 
     private void afterConsumed() throws IOException {
-        if (currentBuf.readableBytes() == 0) {
+        ByteBuf buffer = requireNonNull(currentBuf);
+        if (buffer.readableBytes() == 0) {
             currentBuf = null;
             try {
-                currentCallback.onComplete(null);
+                requireNonNull(currentCallback).onComplete(null);
                 currentCallback = null;
             } catch (Exception e) {
                 throw new IOException("Error completing done callback", e);

--- a/src/main/java/io/muserver/SSLInfoImpl.java
+++ b/src/main/java/io/muserver/SSLInfoImpl.java
@@ -14,6 +14,8 @@ import java.util.List;
 
 import org.jspecify.annotations.Nullable;
 
+import static java.util.Objects.requireNonNull;
+
 class SSLInfoImpl implements SSLInfo {
     private static final Logger log = LoggerFactory.getLogger(SSLInfoImpl.class);
     private final String providerName;
@@ -61,7 +63,7 @@ class SSLInfoImpl implements SSLInfo {
                     }
                 }},
                 new SecureRandom());
-            conn = (HttpsURLConnection) httpsUri.toURL().openConnection();
+            conn = (HttpsURLConnection) requireNonNull(httpsUri, "HTTPS URI has not been set").toURL().openConnection();
             conn.setSSLSocketFactory(ctx.getSocketFactory());
             conn.setHostnameVerifier((arg0, arg1) -> true);
             conn.connect();

--- a/src/main/java/io/muserver/ServerSettings.java
+++ b/src/main/java/io/muserver/ServerSettings.java
@@ -1,5 +1,7 @@
 package io.muserver;
 
+import org.jspecify.annotations.Nullable;
+
 import java.util.List;
 import java.util.Set;
 
@@ -11,9 +13,11 @@ class ServerSettings {
     final int maxUrlSize;
     final boolean gzipEnabled;
     final Set<String> mimeTypesToGzip;
-    final List<RateLimiterImpl> rateLimiters;
+    final @Nullable List<RateLimiterImpl> rateLimiters;
 
-    ServerSettings(long minimumGzipSize, int maxHeadersSize, long requestReadTimeoutMillis, long maxRequestSize, int maxUrlSize, boolean gzipEnabled, Set<String> mimeTypesToGzip, List<RateLimiterImpl> rateLimiters) {
+    ServerSettings(long minimumGzipSize, int maxHeadersSize, long requestReadTimeoutMillis, long maxRequestSize,
+                   int maxUrlSize, boolean gzipEnabled, Set<String> mimeTypesToGzip,
+                   @Nullable List<RateLimiterImpl> rateLimiters) {
         this.minimumGzipSize = minimumGzipSize;
         this.maxHeadersSize = maxHeadersSize;
         this.requestReadTimeoutMillis = requestReadTimeoutMillis;
@@ -24,7 +28,7 @@ class ServerSettings {
         this.rateLimiters = rateLimiters;
     }
 
-    boolean shouldCompress(String declaredLength, String contentType) {
+    boolean shouldCompress(@Nullable String declaredLength, @Nullable String contentType) {
         if (!gzipEnabled) {
             return false;
         }

--- a/src/main/java/io/muserver/SniKeyManager.java
+++ b/src/main/java/io/muserver/SniKeyManager.java
@@ -1,5 +1,7 @@
 package io.muserver;
 
+import org.jspecify.annotations.Nullable;
+
 import javax.net.ssl.*;
 import java.net.Socket;
 import java.security.Principal;
@@ -11,10 +13,10 @@ class SniKeyManager extends X509ExtendedKeyManager {
     // with thanks to https://github.com/grahamedgecombe/netty-sni-example
 
     private final X509ExtendedKeyManager keyManager;
-    private final String defaultAlias;
+    private final @Nullable String defaultAlias;
     private final Map<String, String> sanToAliasMap;
 
-    public SniKeyManager(X509ExtendedKeyManager keyManager, String defaultAlias, Map<String, String> sanToAliasMap) {
+    public SniKeyManager(X509ExtendedKeyManager keyManager, @Nullable String defaultAlias, Map<String, String> sanToAliasMap) {
         this.keyManager = keyManager;
         this.defaultAlias = defaultAlias;
         this.sanToAliasMap = sanToAliasMap;
@@ -46,11 +48,11 @@ class SniKeyManager extends X509ExtendedKeyManager {
     }
 
     @Override
-    public String chooseEngineServerAlias(String keyType, Principal[] issuers, SSLEngine engine) {
+    public @Nullable String chooseEngineServerAlias(String keyType, Principal[] issuers, SSLEngine engine) {
         ExtendedSSLSession session = (ExtendedSSLSession) engine.getHandshakeSession();
 
         // Pick first SNIHostName in the list of SNI names.
-        String sniHostname = null;
+        @Nullable String sniHostname = null;
         for (SNIServerName name : session.getRequestedServerNames()) {
             if (name.getType() == StandardConstants.SNI_HOST_NAME) {
                 sniHostname = ((SNIHostName) name).getAsciiName();
@@ -58,7 +60,7 @@ class SniKeyManager extends X509ExtendedKeyManager {
             }
         }
 
-        String hostname = sanToAliasMap.getOrDefault(sniHostname, sniHostname);
+        @Nullable String hostname = sanToAliasMap.getOrDefault(sniHostname, sniHostname);
 
         // If we got given a hostname over SNI, check if we have a cert and key for that hostname. If so, we use it.
         // Otherwise, we fall back to the default certificate.

--- a/src/main/java/io/muserver/SsePublisher.java
+++ b/src/main/java/io/muserver/SsePublisher.java
@@ -125,12 +125,12 @@ class SsePublisherImpl implements SsePublisher {
     }
 
     @Override
-    public void send(String message, String event) throws IOException {
+    public void send(String message, @Nullable String event) throws IOException {
         send(message, event, null);
     }
 
     @Override
-    public void send(String message, String event, String eventID) throws IOException {
+    public void send(String message, @Nullable String event, @Nullable String eventID) throws IOException {
         sendChunk(dataText(message, event, eventID));
     }
 
@@ -169,7 +169,7 @@ class SsePublisherImpl implements SsePublisher {
         return value.contains("\n") || value.contains("\r");
     }
 
-    static String dataText(String message, String event, String eventID) {
+    static String dataText(String message, @Nullable String event, @Nullable String eventID) {
         StringBuilder raw = new StringBuilder();
         if (eventID != null) {
             ensureNoLineBreaks(eventID, "SSE IDs");

--- a/src/main/java/io/muserver/SslContextProvider.java
+++ b/src/main/java/io/muserver/SslContextProvider.java
@@ -11,6 +11,7 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static java.util.Arrays.asList;
+import static java.util.Objects.requireNonNull;
 
 class SslContextProvider {
 
@@ -18,25 +19,30 @@ class SslContextProvider {
     private volatile SSLInfo sslInfo;
 
     SslContextProvider(SslContext context) {
-        set(context);
+        sslInfo = createSslInfo(context);
+        nettySslContext.set(context);
     }
 
     public SslContext get() {
-        return nettySslContext.get();
+        return requireNonNull(nettySslContext.get());
     }
 
     public void set(SslContext newValue) {
-        String provider = (newValue instanceof JdkSslContext)
+        sslInfo = createSslInfo(newValue);
+        nettySslContext.set(newValue);
+    }
+
+    private static SSLInfo createSslInfo(SslContext context) {
+        String provider = (context instanceof JdkSslContext)
             ? "JDK"
-            : (newValue instanceof OpenSslContext || newValue instanceof ReferenceCountedOpenSslContext)
+            : (context instanceof OpenSslContext || context instanceof ReferenceCountedOpenSslContext)
             ? "OpenSSL"
             : "unknown";
-        SSLEngine engine = newValue.newEngine(ByteBufAllocator.DEFAULT);
+        SSLEngine engine = context.newEngine(ByteBufAllocator.DEFAULT);
         List<String> protocols = asList(engine.getEnabledProtocols());
         List<String> ciphers = asList(engine.getEnabledCipherSuites());
-        sslInfo = new SSLInfoImpl(provider, protocols, ciphers);
         engine.closeOutbound();
-        nettySslContext.set(newValue);
+        return new SSLInfoImpl(provider, protocols, ciphers);
     }
 
     SSLInfo sslInfo() {

--- a/src/main/java/io/muserver/UploadedFile.java
+++ b/src/main/java/io/muserver/UploadedFile.java
@@ -2,11 +2,13 @@ package io.muserver;
 
 import io.netty.handler.codec.http.multipart.DiskFileUpload;
 import io.netty.handler.codec.http.multipart.FileUpload;
+import org.jspecify.annotations.Nullable;
 
 import java.io.*;
 import java.nio.charset.StandardCharsets;
 
 import static io.muserver.Mutils.notNull;
+import static java.util.Objects.requireNonNull;
 
 /**
  * A file uploaded by the user, for example with an <code>&lt;input type=&quot;file&quot; name=&quot;name&quot;&gt;</code>
@@ -75,7 +77,7 @@ public interface UploadedFile {
 }
 class MuUploadedFile implements UploadedFile {
     private final FileUpload fu;
-    private File file;
+    private @Nullable File file;
 
     MuUploadedFile(FileUpload fileUpload) {
         fu = fileUpload;
@@ -94,7 +96,7 @@ class MuUploadedFile implements UploadedFile {
                 file = fu.getFile();
             }
         }
-        return file;
+        return requireNonNull(file);
     }
 
     @Override

--- a/src/main/java/io/muserver/WebSocketHandler.java
+++ b/src/main/java/io/muserver/WebSocketHandler.java
@@ -2,6 +2,7 @@ package io.muserver;
 
 import io.netty.handler.codec.http.DefaultHttpHeaders;
 import io.netty.handler.codec.http.HttpHeaders;
+import org.jspecify.annotations.Nullable;
 
 /**
  * A handler that can establish a web socket based on web socket upgrade requests.
@@ -10,12 +11,13 @@ import io.netty.handler.codec.http.HttpHeaders;
 public class WebSocketHandler implements MuHandler {
 
     private final MuWebSocketFactory factory;
-    private final String path;
+    private final @Nullable String path;
     private final long idleReadTimeoutMills;
     private final long pingAfterWriteMillis;
     private final int maxFramePayloadLength;
 
-    WebSocketHandler(MuWebSocketFactory factory, String path, long idleReadTimeoutMills, long pingAfterWriteMillis, int maxFramePayloadLength) {
+    WebSocketHandler(MuWebSocketFactory factory, @Nullable String path, long idleReadTimeoutMills,
+                     long pingAfterWriteMillis, int maxFramePayloadLength) {
         this.factory = factory;
         this.path = path;
         this.idleReadTimeoutMills = idleReadTimeoutMills;
@@ -28,7 +30,8 @@ public class WebSocketHandler implements MuHandler {
         if (request.method() != Method.GET) {
             return false;
         }
-        if (Mutils.hasValue(path) && !path.equals(request.relativePath())) {
+        String configuredPath = path;
+        if (configuredPath != null && !configuredPath.isEmpty() && !configuredPath.equals(request.relativePath())) {
             return false;
         }
 
@@ -67,4 +70,3 @@ public class WebSocketHandler implements MuHandler {
             '}';
     }
 }
-

--- a/src/main/java/io/muserver/WebSocketHandlerBuilder.java
+++ b/src/main/java/io/muserver/WebSocketHandlerBuilder.java
@@ -9,8 +9,8 @@ import org.jspecify.annotations.Nullable;
  */
 public class WebSocketHandlerBuilder implements MuHandlerBuilder<WebSocketHandler> {
 
-    private MuWebSocketFactory factory;
-    private String path;
+    private @Nullable MuWebSocketFactory factory;
+    private @Nullable String path;
     private long idleReadTimeoutMills = TimeUnit.MINUTES.toMillis(5);
     private long pingAfterWriteMillis = TimeUnit.SECONDS.toMillis(30);
     private int maxFramePayloadLength = 65536;

--- a/src/main/java/io/muserver/handlers/CORSHandlerBuilder.java
+++ b/src/main/java/io/muserver/handlers/CORSHandlerBuilder.java
@@ -19,8 +19,8 @@ import static java.util.Arrays.asList;
  */
 public class CORSHandlerBuilder implements MuHandlerBuilder<CORSHandler> {
 
-    private CORSConfig corsConfig;
-    private Set<Method> allowedMethods;
+    private @Nullable CORSConfig corsConfig;
+    private @Nullable Set<Method> allowedMethods;
 
     /**
      * Sets the CORS configuration for the handler

--- a/src/main/java/io/muserver/handlers/CSRFProtectionHandlerBuilder.java
+++ b/src/main/java/io/muserver/handlers/CSRFProtectionHandlerBuilder.java
@@ -19,7 +19,7 @@ public class CSRFProtectionHandlerBuilder implements MuHandlerBuilder<CSRFProtec
 
     private final Set<String> trustedOrigins = new HashSet<>();
     private final Set<String> bypassPaths = new HashSet<>();
-    private MuHandler rejectionHandler;
+    private @Nullable MuHandler rejectionHandler;
 
     /**
      * Adds a trusted origin. Requests with an <code>Origin</code> header exactly matching this value are allowed.

--- a/src/main/java/io/muserver/handlers/DirectoryLister.java
+++ b/src/main/java/io/muserver/handlers/DirectoryLister.java
@@ -1,6 +1,7 @@
 package io.muserver.handlers;
 
 import io.muserver.Mutils;
+import org.jspecify.annotations.Nullable;
 
 import java.io.IOException;
 import java.io.Writer;
@@ -155,7 +156,7 @@ class DirectoryLister {
             return open(null);
         }
 
-        El open(Map<String, String> attributes) throws IOException {
+        El open(@Nullable Map<String, String> attributes) throws IOException {
             writer.write("<" + tag);
             if (attributes != null) {
                 for (Map.Entry<String, String> entry : attributes.entrySet()) {

--- a/src/main/java/io/muserver/handlers/ResourceHandler.java
+++ b/src/main/java/io/muserver/handlers/ResourceHandler.java
@@ -1,6 +1,7 @@
 package io.muserver.handlers;
 
 import io.muserver.*;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -23,15 +24,15 @@ public class ResourceHandler implements MuHandler {
     private static final Logger log = LoggerFactory.getLogger(ResourceHandler.class);
 
     private final Map<String, ResourceType> extensionToResourceType;
-    private final String defaultFile;
+    private final @Nullable String defaultFile;
     private final boolean directoryListingEnabled;
     private final ResourceProviderFactory resourceProviderFactory;
-    private final String directoryListingCss;
-    private final DateTimeFormatter dateFormatter;
-    private final ResourceCustomizer resourceCustomizer;
+    private final @Nullable String directoryListingCss;
+    private final @Nullable DateTimeFormatter dateFormatter;
+    private final @Nullable ResourceCustomizer resourceCustomizer;
     private final BareDirectoryRequestAction bareDirectoryRequestAction;
 
-    ResourceHandler(ResourceProviderFactory resourceProviderFactory, String defaultFile, Map<String, ResourceType> extensionToResourceType, boolean directoryListingEnabled, String directoryListingCss, DateTimeFormatter dateFormatter, ResourceCustomizer resourceCustomizer, BareDirectoryRequestAction bareDirectoryRequestAction) {
+    ResourceHandler(ResourceProviderFactory resourceProviderFactory, @Nullable String defaultFile, Map<String, ResourceType> extensionToResourceType, boolean directoryListingEnabled, @Nullable String directoryListingCss, @Nullable DateTimeFormatter dateFormatter, @Nullable ResourceCustomizer resourceCustomizer, BareDirectoryRequestAction bareDirectoryRequestAction) {
         this.resourceProviderFactory = resourceProviderFactory;
         this.extensionToResourceType = extensionToResourceType;
         this.defaultFile = defaultFile;
@@ -80,13 +81,13 @@ public class ResourceHandler implements MuHandler {
             }
         } else {
             String filename = requestPath.substring(requestPath.lastIndexOf('/'));
-            Date lastModified = provider.lastModified();
-            Long totalSize = provider.fileSize();
+            @Nullable Date lastModified = provider.lastModified();
+            @Nullable Long totalSize = provider.fileSize();
             addHeaders(response, filename, totalSize, lastModified, request);
             boolean sendBody = request.method() != Method.HEAD;
 
             String ims = request.headers().get(HeaderNames.IF_MODIFIED_SINCE);
-            if (ims != null) {
+            if (ims != null && lastModified != null) {
                 try {
                     long lastModTime = lastModified.getTime() / 1000;
                     long lastAccessed = Mutils.fromHttpDate(ims).getTime() / 1000;
@@ -135,12 +136,14 @@ public class ResourceHandler implements MuHandler {
         try (OutputStreamWriter osw = new OutputStreamWriter(response.outputStream(), StandardCharsets.UTF_8);
              BufferedWriter writer = new BufferedWriter(osw, 8192)) {
             writer.write("<!DOCTYPE html>\n");
-            new DirectoryLister(writer, provider, request.contextPath(), request.relativePath(), directoryListingCss, dateFormatter).render();
+            new DirectoryLister(writer, provider, request.contextPath(), request.relativePath(),
+                java.util.Objects.requireNonNull(directoryListingCss, "Directory listing CSS was not initialized"),
+                java.util.Objects.requireNonNull(dateFormatter, "Directory listing date formatter was not initialized")).render();
         }
     }
 
 
-    private void addHeaders(MuResponse response, String fileName, Long fileSize, Date lastModified, MuRequest request) {
+    private void addHeaders(MuResponse response, String fileName, @Nullable Long fileSize, @Nullable Date lastModified, MuRequest request) {
         int ind = fileName.lastIndexOf('.');
         ResourceType type;
         if (ind == -1) {

--- a/src/main/java/io/muserver/handlers/ResourceHandlerBuilder.java
+++ b/src/main/java/io/muserver/handlers/ResourceHandlerBuilder.java
@@ -18,6 +18,7 @@ import java.util.Scanner;
 import org.jspecify.annotations.Nullable;
 
 import static io.muserver.handlers.ResourceType.DEFAULT_EXTENSION_MAPPINGS;
+import static java.util.Objects.requireNonNull;
 
 /**
  * <p>Used to create a {@link ResourceHandler} for serving static files.</p>
@@ -26,13 +27,13 @@ import static io.muserver.handlers.ResourceType.DEFAULT_EXTENSION_MAPPINGS;
  */
 public class ResourceHandlerBuilder implements MuHandlerBuilder<ResourceHandler> {
 
-    private DateTimeFormatter directoryListingDateFormatter;
+    private @Nullable DateTimeFormatter directoryListingDateFormatter;
     private Map<String, ResourceType> extensionToResourceType = DEFAULT_EXTENSION_MAPPINGS;
-    private String defaultFile = "index.html";
-    private ResourceProviderFactory resourceProviderFactory;
+    private @Nullable String defaultFile = "index.html";
+    private @Nullable ResourceProviderFactory resourceProviderFactory;
     private boolean directoryListingEnabled = false;
-    private String directoryListingCss = null;
-    private ResourceCustomizer resourceCustomizer = null;
+    private @Nullable String directoryListingCss;
+    private @Nullable ResourceCustomizer resourceCustomizer;
     private BareDirectoryRequestAction bareDirectoryRequestAction = BareDirectoryRequestAction.REDIRECT_WITH_TRAILING_SLASH;
 
     /**
@@ -107,7 +108,7 @@ public class ResourceHandlerBuilder implements MuHandlerBuilder<ResourceHandler>
     /**
      * @return The current value of this property
      */
-    public DateTimeFormatter directoryListingDateFormatter() {
+    public @Nullable DateTimeFormatter directoryListingDateFormatter() {
         return directoryListingDateFormatter;
     }
 
@@ -121,7 +122,7 @@ public class ResourceHandlerBuilder implements MuHandlerBuilder<ResourceHandler>
     /**
      * @return The current value of this property
      */
-    public String defaultFile() {
+    public @Nullable String defaultFile() {
         return defaultFile;
     }
 
@@ -135,14 +136,14 @@ public class ResourceHandlerBuilder implements MuHandlerBuilder<ResourceHandler>
     /**
      * @return The current value of this property
      */
-    public String directoryListingCss() {
+    public @Nullable String directoryListingCss() {
         return directoryListingCss;
     }
 
     /**
      * @return The current value of this property
      */
-    public ResourceCustomizer resourceCustomizer() {
+    public @Nullable ResourceCustomizer resourceCustomizer() {
         return resourceCustomizer;
     }
 
@@ -179,22 +180,24 @@ public class ResourceHandlerBuilder implements MuHandlerBuilder<ResourceHandler>
         if (resourceProviderFactory == null) {
             throw new IllegalStateException("No resourceProviderFactory has been set");
         }
-        String css = this.directoryListingCss;
+        ResourceProviderFactory providerFactory = requireNonNull(resourceProviderFactory);
+        @Nullable String css = this.directoryListingCss;
         if (directoryListingEnabled && css == null) {
-            InputStream cssStream = RestHandlerBuilder.class.getResourceAsStream("/io/muserver/resources/api.css");
+            InputStream cssStream = requireNonNull(RestHandlerBuilder.class.getResourceAsStream("/io/muserver/resources/api.css"),
+                "Bundled directory listing CSS was not found");
             Scanner scanner = new Scanner(cssStream, "UTF-8").useDelimiter("\\A");
             css = scanner.next();
             scanner.close();
         }
 
-        DateTimeFormatter formatterToUse = this.directoryListingDateFormatter;
+        @Nullable DateTimeFormatter formatterToUse = this.directoryListingDateFormatter;
         if (directoryListingEnabled && formatterToUse == null) {
             formatterToUse = DateTimeFormatter.ofPattern("yyyy/MM/dd hh:mm:ss")
                 .withLocale(Locale.US)
                 .withZone(ZoneId.systemDefault());
         }
 
-        return new ResourceHandler(resourceProviderFactory, defaultFile, extensionToResourceType, directoryListingEnabled, css, formatterToUse, this.resourceCustomizer, this.bareDirectoryRequestAction);
+        return new ResourceHandler(providerFactory, defaultFile, extensionToResourceType, directoryListingEnabled, css, formatterToUse, this.resourceCustomizer, this.bareDirectoryRequestAction);
     }
 
 

--- a/src/main/java/io/muserver/handlers/ResourceProvider.java
+++ b/src/main/java/io/muserver/handlers/ResourceProvider.java
@@ -180,10 +180,10 @@ class ClasspathCache implements ResourceProviderFactory {
 class AsyncFileProvider implements ResourceProvider, CompletionHandler<Integer, Object> {
     private static final Logger log = LoggerFactory.getLogger(AsyncFileProvider.class);
     private final Path localPath;
-    private AsynchronousFileChannel channel;
+    private @Nullable AsynchronousFileChannel channel;
     private long curPos = 0;
-    private ByteBuffer buf;
-    private AsyncHandle handle;
+    private @Nullable ByteBuffer buf;
+    private @Nullable AsyncHandle handle;
     private long maxLen;
     private long bytesSent = 0;
 
@@ -238,7 +238,7 @@ class AsyncFileProvider implements ResourceProvider, CompletionHandler<Integer, 
             handle = request.handleAsync();
             channel = AsynchronousFileChannel.open(localPath, StandardOpenOption.READ);
             buf = ByteBuffer.allocate(8192);
-            channel.read(buf, curPos, handle, this);
+            requiredChannel().read(requiredBuffer(), curPos, requiredHandle(), this);
         }
     }
 
@@ -249,27 +249,29 @@ class AsyncFileProvider implements ResourceProvider, CompletionHandler<Integer, 
 
     @Override
     public void completed(Integer bytesRead, Object a) {
-        buf.flip();
+        ByteBuffer buffer = requiredBuffer();
+        AsyncHandle asyncHandle = requiredHandle();
+        buffer.flip();
         if (bytesRead == -1) {
-            handle.complete();
+            asyncHandle.complete();
             closeChannelQuietly();
         } else {
 
             // for range requests, more bytes may be read than should be written, so the write is limited
             long remaining = Math.max(0, maxLen - bytesSent);
-            if (remaining < buf.limit()) {
-                buf.limit((int) remaining);
+            if (remaining < buffer.limit()) {
+                buffer.limit((int) remaining);
             }
 
-            handle.write(buf, error -> {
+            asyncHandle.write(buffer, error -> {
                 if (error == null) {
-                    buf.clear();
+                    buffer.clear();
                     curPos += bytesRead;
                     bytesSent += bytesRead;
-                    channel.read(buf, curPos, null, AsyncFileProvider.this);
+                    requiredChannel().read(buffer, curPos, null, AsyncFileProvider.this);
                 } else {
                     closeChannelQuietly();
-                    handle.complete(error);
+                    asyncHandle.complete(error);
                 }
             });
         }
@@ -277,7 +279,7 @@ class AsyncFileProvider implements ResourceProvider, CompletionHandler<Integer, 
 
     private void closeChannelQuietly() {
         try {
-            channel.close();
+            requiredChannel().close();
         } catch (IOException e) {
             log.debug("Error while closing file channel " + localPath, e);
         }
@@ -286,7 +288,19 @@ class AsyncFileProvider implements ResourceProvider, CompletionHandler<Integer, 
     @Override
     public void failed(Throwable exc, Object a) {
         log.info("File read failure for " + localPath, exc);
-        handle.complete(exc);
+        requiredHandle().complete(exc);
+    }
+
+    private AsynchronousFileChannel requiredChannel() {
+        return Objects.requireNonNull(channel, "File transfer has not been initialized");
+    }
+
+    private ByteBuffer requiredBuffer() {
+        return Objects.requireNonNull(buf, "File transfer has not been initialized");
+    }
+
+    private AsyncHandle requiredHandle() {
+        return Objects.requireNonNull(handle, "File transfer has not been initialized");
     }
 }
 
@@ -296,7 +310,7 @@ class ClasspathResourceProvider implements ResourceProvider {
     private final @Nullable Long fileSize;
     private final @Nullable Date lastModified;
     private final Path path;
-    private final InputStream inputStream;
+    private final @Nullable InputStream inputStream;
 
     ClasspathResourceProvider(boolean exists, boolean isDir, @Nullable Long fileSize, @Nullable Date lastModified, Path path, @Nullable InputStream inputStream) {
         this.exists = exists;
@@ -327,12 +341,12 @@ class ClasspathResourceProvider implements ResourceProvider {
     }
 
     @Override
-    public Long fileSize() {
+    public @Nullable Long fileSize() {
         return fileSize;
     }
 
     @Override
-    public Date lastModified() {
+    public @Nullable Date lastModified() {
         return lastModified;
     }
 
@@ -343,7 +357,7 @@ class ClasspathResourceProvider implements ResourceProvider {
             while (totalSkipped < bytes) {
                 long skipped;
                 try {
-                    skipped = inputStream.skip(bytes);
+                    skipped = requiredInputStream().skip(bytes);
                 } catch (IOException e) {
                     return false;
                 }
@@ -365,7 +379,7 @@ class ClasspathResourceProvider implements ResourceProvider {
                     byte[] buffer = new byte[8192];
                     long soFar = 0;
                     int read;
-                    while (soFar < maxLen && (read = inputStream.read(buffer)) > -1) {
+                    while (soFar < maxLen && (read = requiredInputStream().read(buffer)) > -1) {
                         soFar += read;
                         if (soFar > maxLen) {
                             read -= soFar - maxLen;
@@ -377,7 +391,7 @@ class ClasspathResourceProvider implements ResourceProvider {
                 }
             }
         } finally {
-            inputStream.close();
+            requiredInputStream().close();
         }
     }
 
@@ -386,4 +400,7 @@ class ClasspathResourceProvider implements ResourceProvider {
         return Files.list(path);
     }
 
+    private InputStream requiredInputStream() {
+        return Objects.requireNonNull(inputStream, "This resource has no input stream");
+    }
 }

--- a/src/main/java/io/muserver/openapi/CallbackObject.java
+++ b/src/main/java/io/muserver/openapi/CallbackObject.java
@@ -1,5 +1,6 @@
 package io.muserver.openapi;
 
+import org.jspecify.annotations.Nullable;
 import java.io.IOException;
 import java.io.Writer;
 import java.util.Map;
@@ -13,9 +14,9 @@ public class CallbackObject implements JsonWriter {
 
     private final Map<String, PathItemObject> callbacks;
 
-    CallbackObject(Map<String, PathItemObject> callbacks) {
+    CallbackObject(@Nullable Map<String, PathItemObject> callbacks) {
         notNull("callbacks", callbacks);
-        this.callbacks = callbacks;
+        this.callbacks = java.util.Objects.requireNonNull(callbacks);
     }
 
     @Override

--- a/src/main/java/io/muserver/openapi/DiscriminatorObject.java
+++ b/src/main/java/io/muserver/openapi/DiscriminatorObject.java
@@ -16,9 +16,9 @@ public class DiscriminatorObject implements JsonWriter {
     private final String propertyName;
     private final @Nullable Map<String, String> mapping;
 
-    DiscriminatorObject(String propertyName, @Nullable Map<String, String> mapping) {
+    DiscriminatorObject(@Nullable String propertyName, @Nullable Map<String, String> mapping) {
         notNull("propertyName", propertyName);
-        this.propertyName = propertyName;
+        this.propertyName = java.util.Objects.requireNonNull(propertyName);
         this.mapping = mapping;
     }
 

--- a/src/main/java/io/muserver/openapi/ExternalDocumentationObject.java
+++ b/src/main/java/io/muserver/openapi/ExternalDocumentationObject.java
@@ -16,10 +16,10 @@ public class ExternalDocumentationObject implements JsonWriter {
     private final @Nullable String description;
     private final URI url;
 
-    ExternalDocumentationObject(@Nullable String description, URI url) {
-        notNull("url", url);
+    ExternalDocumentationObject(@Nullable String description, @Nullable URI url) {
         this.description = description;
-        this.url = url;
+        notNull("url", url);
+        this.url = java.util.Objects.requireNonNull(url);
     }
 
     @Override

--- a/src/main/java/io/muserver/openapi/LicenseObject.java
+++ b/src/main/java/io/muserver/openapi/LicenseObject.java
@@ -17,9 +17,9 @@ public class LicenseObject implements JsonWriter {
     private final String name;
     private final @Nullable URI url;
 
-    LicenseObject(String name, @Nullable URI url) {
+    LicenseObject(@Nullable String name, @Nullable URI url) {
         notNull("name", name);
-        this.name = name;
+        this.name = java.util.Objects.requireNonNull(name);
         this.url = url;
     }
 

--- a/src/main/java/io/muserver/openapi/OAuthFlowObject.java
+++ b/src/main/java/io/muserver/openapi/OAuthFlowObject.java
@@ -20,14 +20,14 @@ public class OAuthFlowObject implements JsonWriter {
     private final @Nullable URI refreshUrl;
     private final Map<String, String> scopes;
 
-    OAuthFlowObject(URI authorizationUrl, URI tokenUrl, @Nullable URI refreshUrl, Map<String, String> scopes) {
+    OAuthFlowObject(@Nullable URI authorizationUrl, @Nullable URI tokenUrl, @Nullable URI refreshUrl, @Nullable Map<String, String> scopes) {
         notNull("authorizationUrl", authorizationUrl);
+        this.authorizationUrl = java.util.Objects.requireNonNull(authorizationUrl);
         notNull("tokenUrl", tokenUrl);
-        notNull("scopes", scopes);
-        this.authorizationUrl = authorizationUrl;
-        this.tokenUrl = tokenUrl;
+        this.tokenUrl = java.util.Objects.requireNonNull(tokenUrl);
         this.refreshUrl = refreshUrl;
-        this.scopes = scopes;
+        notNull("scopes", scopes);
+        this.scopes = java.util.Objects.requireNonNull(scopes);
     }
 
     @Override

--- a/src/main/java/io/muserver/openapi/OpenAPIObject.java
+++ b/src/main/java/io/muserver/openapi/OpenAPIObject.java
@@ -15,7 +15,7 @@ import static io.muserver.openapi.Jsonizer.append;
  */
 public class OpenAPIObject implements JsonWriter {
 
-    private final @Nullable String openapi = "3.0.1";
+    private final String openapi = "3.0.1";
     private final InfoObject info;
     private final @Nullable List<ServerObject> servers;
     private final PathsObject paths;
@@ -24,15 +24,15 @@ public class OpenAPIObject implements JsonWriter {
     private final @Nullable List<TagObject> tags;
     private final @Nullable ExternalDocumentationObject externalDocs;
 
-    OpenAPIObject(InfoObject info, @Nullable List<ServerObject> servers, PathsObject paths, @Nullable ComponentsObject components, @Nullable List<SecurityRequirementObject> security, @Nullable List<TagObject> tags, @Nullable ExternalDocumentationObject externalDocs) {
-        notNull("info", info);
-        notNull("paths", paths);
+    OpenAPIObject(@Nullable InfoObject info, @Nullable List<ServerObject> servers, @Nullable PathsObject paths, @Nullable ComponentsObject components, @Nullable List<SecurityRequirementObject> security, @Nullable List<TagObject> tags, @Nullable ExternalDocumentationObject externalDocs) {
         if (tags != null && tags.size() != tags.stream().map(t -> t.name()).collect(Collectors.toSet()).size()) {
             throw new IllegalArgumentException("Tags must have unique names");
         }
-        this.info = info;
+        notNull("info", info);
+        this.info = java.util.Objects.requireNonNull(info);
         this.servers = servers;
-        this.paths = paths;
+        notNull("paths", paths);
+        this.paths = java.util.Objects.requireNonNull(paths);
         this.components = components;
         this.security = security;
         this.tags = tags;

--- a/src/main/java/io/muserver/openapi/OperationObject.java
+++ b/src/main/java/io/muserver/openapi/OperationObject.java
@@ -31,7 +31,7 @@ public class OperationObject implements JsonWriter {
     private final @Nullable List<ServerObject> servers;
 
     OperationObject(@Nullable List<String> tags, @Nullable String summary, @Nullable String description, @Nullable ExternalDocumentationObject externalDocs,
-                           @Nullable String operationId, @Nullable List<ParameterObject> parameters, @Nullable RequestBodyObject requestBody, ResponsesObject responses,
+                           @Nullable String operationId, @Nullable List<ParameterObject> parameters, @Nullable RequestBodyObject requestBody, @Nullable ResponsesObject responses,
                            @Nullable Map<String, CallbackObject> callbacks, @Nullable Boolean deprecated, @Nullable List<SecurityRequirementObject> security,
                            @Nullable List<ServerObject> servers) {
         notNull("responses", responses);
@@ -48,7 +48,8 @@ public class OperationObject implements JsonWriter {
         this.operationId = operationId;
         this.parameters = parameters;
         this.requestBody = requestBody;
-        this.responses = responses;
+        notNull("responses", responses);
+        this.responses = java.util.Objects.requireNonNull(responses);
         this.callbacks = callbacks;
         this.deprecated = deprecated;
         this.security = security;

--- a/src/main/java/io/muserver/openapi/ParameterObject.java
+++ b/src/main/java/io/muserver/openapi/ParameterObject.java
@@ -33,11 +33,13 @@ public class ParameterObject implements JsonWriter {
     private final @Nullable Map<String, ExampleObject> examples;
     private final @Nullable Map<String, MediaTypeObject> content;
 
-    ParameterObject(String name, String in, @Nullable String description, Boolean required, @Nullable Boolean deprecated, @Nullable Boolean allowEmptyValue,
+    ParameterObject(@Nullable String name, @Nullable String in, @Nullable String description, Boolean required, @Nullable Boolean deprecated, @Nullable Boolean allowEmptyValue,
                     @Nullable String style, @Nullable Boolean explode, @Nullable Boolean allowReserved, @Nullable SchemaObject schema, @Nullable Object example,
                     @Nullable Map<String, ExampleObject> examples, @Nullable Map<String, MediaTypeObject> content) {
         notNull("name", name);
+        name = java.util.Objects.requireNonNull(name);
         notNull("in", in);
+        in = java.util.Objects.requireNonNull(in);
         if (!allowedIns.contains(in)) {
             throw new IllegalArgumentException("'in' must be one of " + allowedIns + " but was " + in);
         }

--- a/src/main/java/io/muserver/openapi/RequestBodyObject.java
+++ b/src/main/java/io/muserver/openapi/RequestBodyObject.java
@@ -19,10 +19,10 @@ public class RequestBodyObject implements JsonWriter {
     private final Map<String, MediaTypeObject> content;
     private final @Nullable Boolean required;
 
-    RequestBodyObject(@Nullable String description, Map<String, MediaTypeObject> content, @Nullable Boolean required) {
-        notNull("content", content);
+    RequestBodyObject(@Nullable String description, @Nullable Map<String, MediaTypeObject> content, @Nullable Boolean required) {
         this.description = description;
-        this.content = content;
+        notNull("content", content);
+        this.content = java.util.Objects.requireNonNull(content);
         this.required = required;
     }
 

--- a/src/main/java/io/muserver/openapi/ResponseObject.java
+++ b/src/main/java/io/muserver/openapi/ResponseObject.java
@@ -19,9 +19,9 @@ public class ResponseObject implements JsonWriter {
     private final @Nullable Map<String, MediaTypeObject> content;
     private final @Nullable Map<String, LinkObject> links;
 
-    ResponseObject(String description, @Nullable Map<String, HeaderObject> headers, @Nullable Map<String, MediaTypeObject> content, @Nullable Map<String, LinkObject> links) {
+    ResponseObject(@Nullable String description, @Nullable Map<String, HeaderObject> headers, @Nullable Map<String, MediaTypeObject> content, @Nullable Map<String, LinkObject> links) {
         notNull("description", description);
-        this.description = description;
+        this.description = java.util.Objects.requireNonNull(description);
         this.headers = headers;
         this.content = content;
         this.links = links;

--- a/src/main/java/io/muserver/openapi/ResponsesObject.java
+++ b/src/main/java/io/muserver/openapi/ResponsesObject.java
@@ -17,8 +17,9 @@ public class ResponsesObject implements JsonWriter {
     private final @Nullable ResponseObject defaultValue;
     private final Map<String, ResponseObject> httpStatusCodes;
 
-    ResponsesObject(@Nullable ResponseObject defaultValue, Map<String, ResponseObject> httpStatusCodes) {
+    ResponsesObject(@Nullable ResponseObject defaultValue, @Nullable Map<String, ResponseObject> httpStatusCodes) {
         notNull("httpStatusCodes", httpStatusCodes);
+        httpStatusCodes = java.util.Objects.requireNonNull(httpStatusCodes);
         if (httpStatusCodes.isEmpty()) {
             throw new IllegalArgumentException("'httpStatusCodes' must contain at least one value");
         }

--- a/src/main/java/io/muserver/openapi/SecurityRequirementObject.java
+++ b/src/main/java/io/muserver/openapi/SecurityRequirementObject.java
@@ -1,5 +1,6 @@
 package io.muserver.openapi;
 
+import org.jspecify.annotations.Nullable;
 import java.io.IOException;
 import java.io.Writer;
 import java.util.List;
@@ -15,9 +16,9 @@ public class SecurityRequirementObject implements JsonWriter {
 
     private final Map<String, List<String>> requirements;
 
-    SecurityRequirementObject(Map<String, List<String>> requirements) {
+    SecurityRequirementObject(@Nullable Map<String, List<String>> requirements) {
         notNull("requirements", requirements);
-        this.requirements = requirements;
+        this.requirements = java.util.Objects.requireNonNull(requirements);
     }
 
     @Override

--- a/src/main/java/io/muserver/openapi/SecuritySchemeObject.java
+++ b/src/main/java/io/muserver/openapi/SecuritySchemeObject.java
@@ -26,8 +26,9 @@ public class SecuritySchemeObject implements JsonWriter {
     private final @Nullable OAuthFlowsObject flows;
     private final @Nullable URI openIdConnectUrl;
 
-    SecuritySchemeObject(String type, @Nullable String description, @Nullable String name, @Nullable String in, @Nullable String scheme, @Nullable String bearerFormat, @Nullable OAuthFlowsObject flows, @Nullable URI openIdConnectUrl) {
+    SecuritySchemeObject(@Nullable String type, @Nullable String description, @Nullable String name, @Nullable String in, @Nullable String scheme, @Nullable String bearerFormat, @Nullable OAuthFlowsObject flows, @Nullable URI openIdConnectUrl) {
         notNull("type", type);
+        type = java.util.Objects.requireNonNull(type);
         if (!validTypes.contains(type)) {
             throw new IllegalArgumentException("'type' must be one of " + validTypes + " but was " + type);
         }

--- a/src/main/java/io/muserver/openapi/ServerObject.java
+++ b/src/main/java/io/muserver/openapi/ServerObject.java
@@ -17,9 +17,9 @@ public class ServerObject implements JsonWriter {
     private final @Nullable String description;
     private final @Nullable Map<String, ServerVariableObject> variables;
 
-    ServerObject(String url, @Nullable String description, @Nullable Map<String, ServerVariableObject> variables) {
+    ServerObject(@Nullable String url, @Nullable String description, @Nullable Map<String, ServerVariableObject> variables) {
         notNull("url", url);
-        this.url = url;
+        this.url = java.util.Objects.requireNonNull(url);
         this.description = description;
         this.variables = variables;
     }

--- a/src/main/java/io/muserver/openapi/ServerVariableObject.java
+++ b/src/main/java/io/muserver/openapi/ServerVariableObject.java
@@ -17,10 +17,10 @@ public class ServerVariableObject implements JsonWriter {
     private final String defaultValue;
     private final @Nullable String description;
 
-    ServerVariableObject(@Nullable List<String> enumValues, String defaultValue, @Nullable String description) {
-        notNull("defaultValue", defaultValue);
+    ServerVariableObject(@Nullable List<String> enumValues, @Nullable String defaultValue, @Nullable String description) {
         this.enumValues = enumValues;
-        this.defaultValue = defaultValue;
+        notNull("defaultValue", defaultValue);
+        this.defaultValue = java.util.Objects.requireNonNull(defaultValue);
         this.description = description;
     }
 

--- a/src/main/java/io/muserver/openapi/TagObject.java
+++ b/src/main/java/io/muserver/openapi/TagObject.java
@@ -18,9 +18,9 @@ public class TagObject implements JsonWriter {
     private final @Nullable String description;
     private final @Nullable ExternalDocumentationObject externalDocs;
 
-    TagObject(String name, @Nullable String description, @Nullable ExternalDocumentationObject externalDocs) {
+    TagObject(@Nullable String name, @Nullable String description, @Nullable ExternalDocumentationObject externalDocs) {
         notNull("name", name);
-        this.name = name;
+        this.name = java.util.Objects.requireNonNull(name);
         this.description = description;
         this.externalDocs = externalDocs;
     }

--- a/src/main/java/io/muserver/rest/ApiResponse.java
+++ b/src/main/java/io/muserver/rest/ApiResponse.java
@@ -3,6 +3,7 @@ package io.muserver.rest;
 import java.lang.annotation.*;
 import java.lang.reflect.Method;
 import java.lang.reflect.Type;
+import org.jspecify.annotations.Nullable;
 
 /**
  * <p>Describes a response code and description for an API method, for documentation purposes.</p>
@@ -60,10 +61,10 @@ class ApiResponseObj {
     final String message;
     final ResponseHeader[] responseHeaders;
     final Class<?> response;
-    final Type genericReturnType;
+    final @Nullable Type genericReturnType;
     final String[] contentType;
-    final String example;
-    public ApiResponseObj(String code, String message, ResponseHeader[] responseHeaders, Class<?> response, Type genericReturnType, String[] contentType, String example) {
+    final @Nullable String example;
+    public ApiResponseObj(String code, String message, ResponseHeader[] responseHeaders, Class<?> response, @Nullable Type genericReturnType, String[] contentType, @Nullable String example) {
         this.code = code;
         this.message = message;
         this.responseHeaders = responseHeaders;

--- a/src/main/java/io/muserver/rest/ApplicationRegistrar.java
+++ b/src/main/java/io/muserver/rest/ApplicationRegistrar.java
@@ -20,6 +20,7 @@ import jakarta.ws.rs.ext.ReaderInterceptor;
 import jakarta.ws.rs.ext.ReaderInterceptorContext;
 import jakarta.ws.rs.ext.WriterInterceptor;
 import jakarta.ws.rs.ext.WriterInterceptorContext;
+import org.jspecify.annotations.Nullable;
 
 import java.io.IOException;
 import java.lang.annotation.Annotation;
@@ -214,11 +215,11 @@ final class ApplicationRegistrar {
         return result;
     }
 
-    private static ResourceInfo resourceInfo(Object value) {
+    private static @Nullable ResourceInfo resourceInfo(Object value) {
         return value instanceof ResourceInfo ? (ResourceInfo) value : null;
     }
 
-    private static boolean hasBindings(ResourceInfo resourceInfo, Set<Class<? extends Annotation>> requiredBindings) {
+    private static boolean hasBindings(@Nullable ResourceInfo resourceInfo, Set<Class<? extends Annotation>> requiredBindings) {
         if (requiredBindings.isEmpty()) {
             return true;
         }

--- a/src/main/java/io/muserver/rest/AsyncResponseAdapter.java
+++ b/src/main/java/io/muserver/rest/AsyncResponseAdapter.java
@@ -70,7 +70,7 @@ class AsyncResponseAdapter implements AsyncResponse, ResponseCompleteListener {
 
     @Override
     public boolean resume(Throwable response) {
-        return resume((Object) response);
+        return resume((Object) Objects.requireNonNull(response, "response"));
     }
 
     @Override
@@ -85,7 +85,7 @@ class AsyncResponseAdapter implements AsyncResponse, ResponseCompleteListener {
 
     @Override
     public boolean cancel(Date retryAfter) {
-        return doCancel(Mutils.toHttpDate(retryAfter));
+        return doCancel(Mutils.toHttpDate(Objects.requireNonNull(retryAfter, "retryAfter")));
     }
 
     private boolean doCancel(@Nullable Object retryAfterValue) {
@@ -113,6 +113,7 @@ class AsyncResponseAdapter implements AsyncResponse, ResponseCompleteListener {
 
     @Override
     public boolean setTimeout(long time, TimeUnit unit) {
+        Objects.requireNonNull(unit, "unit");
         if (!isSuspended) {
             return false;
         }
@@ -139,16 +140,23 @@ class AsyncResponseAdapter implements AsyncResponse, ResponseCompleteListener {
 
     @Override
     public Collection<Class<?>> register(Class<?> callback) {
+        Objects.requireNonNull(callback, "callback");
         throw new NotImplementedException("Mu-Server does not instantiate classes for you. Please use register(Object) with an instantiated callback instead.");
     }
 
     @Override
     public Map<Class<?>, Collection<Class<?>>> register(Class<?> callback, Class<?>... callbacks) {
+        Objects.requireNonNull(callback, "callback");
+        Objects.requireNonNull(callbacks, "callbacks");
+        for (Class<?> additionalCallback : callbacks) {
+            Objects.requireNonNull(additionalCallback, "callbacks element");
+        }
         throw new NotImplementedException("Mu-Server does not instantiate classes for you. Please use register(Object, Object...) with instantiated callbacks instead.");
     }
 
     @Override
     public Collection<Class<?>> register(Object callback) {
+        Objects.requireNonNull(callback, "callback");
         Collection<Class<?>> added = new HashSet<>();
         if (callback instanceof ConnectionCallback) {
             added.add(ConnectionCallback.class);
@@ -163,10 +171,12 @@ class AsyncResponseAdapter implements AsyncResponse, ResponseCompleteListener {
 
     @Override
     public Map<Class<?>, Collection<Class<?>>> register(Object callback, Object... callbacks) {
+        Objects.requireNonNull(callback, "callback");
+        Objects.requireNonNull(callbacks, "callbacks");
         Map<Class<?>, Collection<Class<?>>> added = new HashMap<>();
         register(callback, added);
         for (Object cb : callbacks) {
-            register(cb, added);
+            register(Objects.requireNonNull(cb, "callbacks element"), added);
         }
         return added;
     }

--- a/src/main/java/io/muserver/rest/AsyncResponseAdapter.java
+++ b/src/main/java/io/muserver/rest/AsyncResponseAdapter.java
@@ -11,6 +11,7 @@ import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.jspecify.annotations.Nullable;
 
 import java.util.*;
 import java.util.concurrent.Executors;
@@ -28,11 +29,11 @@ class AsyncResponseAdapter implements AsyncResponse, ResponseCompleteListener {
     private volatile boolean isSuspended;
     private volatile boolean isCancelled;
     private volatile boolean isDone;
-    private volatile ScheduledFuture<?> cancelEvent;
-    private volatile TimeoutHandler timeoutHandler;
+    private volatile @Nullable ScheduledFuture<?> cancelEvent;
+    private volatile @Nullable TimeoutHandler timeoutHandler;
     private final List<ConnectionCallback> connectionCallbacks = new ArrayList<>();
     private final List<CompletionCallback> completionCallbacks = new ArrayList<>();
-    private Throwable exceptionWhileWriting = null;
+    private @Nullable Throwable exceptionWhileWriting;
 
     AsyncResponseAdapter(AsyncHandle asyncHandle, Consumer resultConsumer) {
         this.asyncHandle = asyncHandle;
@@ -44,9 +45,10 @@ class AsyncResponseAdapter implements AsyncResponse, ResponseCompleteListener {
     }
 
     @Override
-    public boolean resume(Object response) {
-        if (cancelEvent != null) {
-            isCancelled = isCancelled || cancelEvent.cancel(false);
+    public boolean resume(@Nullable Object response) {
+        ScheduledFuture<?> event = cancelEvent;
+        if (event != null) {
+            isCancelled = isCancelled || event.cancel(false);
             cancelEvent = null;
         }
         if (isSuspended) {
@@ -86,7 +88,7 @@ class AsyncResponseAdapter implements AsyncResponse, ResponseCompleteListener {
         return doCancel(Mutils.toHttpDate(retryAfter));
     }
 
-    private boolean doCancel(Object retryAfterValue) {
+    private boolean doCancel(@Nullable Object retryAfterValue) {
         Response.ResponseBuilder resp = Response.status(503);
         if (retryAfterValue != null) {
             resp.header(HeaderNames.RETRY_AFTER.toString(), retryAfterValue);
@@ -132,7 +134,7 @@ class AsyncResponseAdapter implements AsyncResponse, ResponseCompleteListener {
 
     @Override
     public void setTimeoutHandler(TimeoutHandler handler) {
-        this.timeoutHandler = handler;
+        this.timeoutHandler = Objects.requireNonNull(handler, "handler");
     }
 
     @Override
@@ -199,6 +201,6 @@ class AsyncResponseAdapter implements AsyncResponse, ResponseCompleteListener {
     }
 
     interface Consumer {
-        void accept(Object response) throws Exception;
+        void accept(@Nullable Object response) throws Exception;
     }
 }

--- a/src/main/java/io/muserver/rest/BuiltInParamConverterProvider.java
+++ b/src/main/java/io/muserver/rest/BuiltInParamConverterProvider.java
@@ -6,6 +6,7 @@ import io.muserver.UploadedFile;
 import jakarta.ws.rs.core.PathSegment;
 import jakarta.ws.rs.ext.ParamConverter;
 import jakarta.ws.rs.ext.ParamConverterProvider;
+import org.jspecify.annotations.Nullable;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Constructor;
@@ -53,7 +54,7 @@ class BuiltInParamConverterProvider implements ParamConverterProvider {
 
 
     @Override
-    public <T> ParamConverter getConverter(Class<T> rawType, Type genericType, Annotation[] annotations) {
+    public <T> @Nullable ParamConverter getConverter(Class<T> rawType, Type genericType, Annotation[] annotations) {
 
         if (String.class.isAssignableFrom(rawType)) {
             return stringParamConverter;
@@ -92,7 +93,7 @@ class BuiltInParamConverterProvider implements ParamConverterProvider {
 
     private static class UploadedFileConverter implements ParamConverter<UploadedFile> {
         @Override
-        public UploadedFile fromString(String value) {
+        public @Nullable UploadedFile fromString(@Nullable String value) {
             return null;
         }
         @Override
@@ -104,7 +105,7 @@ class BuiltInParamConverterProvider implements ParamConverterProvider {
     // Not actually used because it is handled specially in ResourceMethodParam but needs to exist during parameter setup
     private static class DummyCookieConverter implements ParamConverter<Cookie> {
         @Override
-        public Cookie fromString(String value) {
+        public @Nullable Cookie fromString(@Nullable String value) {
             return null;
         }
         @Override
@@ -135,9 +136,9 @@ class BuiltInParamConverterProvider implements ParamConverterProvider {
             this.boxedClass = boxedClass;
             this.stringToValue = stringToValue;
         }
-        public T fromString(String value) {
+        public @Nullable T fromString(@Nullable String value) {
             if (Mutils.nullOrEmpty(value)) return null;
-            return stringToValue.apply(value);
+            return stringToValue.apply(java.util.Objects.requireNonNull(value));
         }
         public String toString(T value) {
             return String.valueOf(value);
@@ -157,7 +158,7 @@ class BuiltInParamConverterProvider implements ParamConverterProvider {
             this.primitiveClass = primitiveClass;
             this.stringToValue = stringToValue;
         }
-        public T fromString(String value) {
+        public T fromString(@Nullable String value) {
             if (value == null || value.isEmpty()) {
                 return defaultValue;
             }
@@ -176,12 +177,12 @@ class BuiltInParamConverterProvider implements ParamConverterProvider {
 
     private static class EnumConverter<E extends Enum<E>>  implements ParamConverter<E> {
         private final Class<E> enumClass;
-        private final StaticMethodConverter<E> fromStringConverter;
+        private final @Nullable StaticMethodConverter<E> fromStringConverter;
         private EnumConverter(Class<E> enumClass) {
             this.enumClass = enumClass;
             this.fromStringConverter = StaticMethodConverter.tryToCreateFromString(enumClass);
         }
-        public E fromString(String value) {
+        public @Nullable E fromString(@Nullable String value) {
             if (Mutils.nullOrEmpty(value)) return null;
             if (fromStringConverter != null) return fromStringConverter.fromString(value);
             return Enum.valueOf(enumClass, value);
@@ -200,7 +201,7 @@ class BuiltInParamConverterProvider implements ParamConverterProvider {
         private ConstructorConverter(Constructor<T> constructor) {
             this.constructor = constructor;
         }
-        public T fromString(String value) {
+        public @Nullable T fromString(@Nullable String value) {
             if (Mutils.nullOrEmpty(value)) return null;
             try {
                 return constructor.newInstance(value);
@@ -214,7 +215,7 @@ class BuiltInParamConverterProvider implements ParamConverterProvider {
         public String toString() {
             return "ConstructorConverter{" + constructor + '}';
         }
-        static <T> ConstructorConverter<T> tryToCreate(Class<T> clazz) {
+        static <T> @Nullable ConstructorConverter<T> tryToCreate(Class<T> clazz) {
             try {
                 Constructor constructor = clazz.getConstructor(String.class);
                 int modifiers = constructor.getModifiers();
@@ -234,7 +235,7 @@ class BuiltInParamConverterProvider implements ParamConverterProvider {
         private StaticMethodConverter(Method staticMethod) {
             this.staticMethod = staticMethod;
         }
-        public T fromString(String value) {
+        public @Nullable T fromString(@Nullable String value) {
             if (Mutils.nullOrEmpty(value)) return null;
             try {
                 return (T) staticMethod.invoke(null, value);
@@ -249,7 +250,7 @@ class BuiltInParamConverterProvider implements ParamConverterProvider {
             return staticMethod.toString();
         }
 
-        static <T> StaticMethodConverter<T> tryToCreate(Class clazz) {
+        static <T> @Nullable StaticMethodConverter<T> tryToCreate(Class clazz) {
             Method[] declaredMethods = clazz.getDeclaredMethods();
             Method staticMethod = getSingleParamPublicStaticMethodNamed(clazz, declaredMethods, "valueOf");
             if (staticMethod == null) {
@@ -265,7 +266,7 @@ class BuiltInParamConverterProvider implements ParamConverterProvider {
             return new StaticMethodConverter<>(staticMethod);
         }
 
-        static <T> StaticMethodConverter<T> tryToCreateFromString(Class clazz) {
+        static <T> @Nullable StaticMethodConverter<T> tryToCreateFromString(Class clazz) {
             Method[] declaredMethods = clazz.getDeclaredMethods();
             Method staticMethod = getSingleParamPublicStaticMethodNamed(clazz, declaredMethods, "fromString");
             if (staticMethod == null) return null;
@@ -273,8 +274,8 @@ class BuiltInParamConverterProvider implements ParamConverterProvider {
             return new StaticMethodConverter<>(staticMethod);
         }
 
-        private static Method getSingleParamPublicStaticMethodNamed(Class clazz, Method[] declaredMethods, String name) {
-            Method staticMethod = null;
+        private static @Nullable Method getSingleParamPublicStaticMethodNamed(Class clazz, Method[] declaredMethods, String name) {
+            @Nullable Method staticMethod = null;
             for (Method method : declaredMethods) {
                 int modifiers = method.getModifiers();
                 if (Modifier.isStatic(modifiers) && Modifier.isPublic(modifiers) && method.getReturnType().equals(clazz)) {

--- a/src/main/java/io/muserver/rest/CORSConfig.java
+++ b/src/main/java/io/muserver/rest/CORSConfig.java
@@ -160,7 +160,7 @@ public class CORSConfig {
     }
 
     @Override
-    public boolean equals(Object o) {
+    public boolean equals(@Nullable Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         CORSConfig that = (CORSConfig) o;

--- a/src/main/java/io/muserver/rest/CORSConfig.java
+++ b/src/main/java/io/muserver/rest/CORSConfig.java
@@ -52,7 +52,8 @@ public class CORSConfig {
         return written;
     }
 
-    boolean writeHeadersInternal(MuRequest request, MuResponse response, Set<RequestMatcher.MatchedMethod> matchedMethodsForPath) {
+    boolean writeHeadersInternal(MuRequest request, MuResponse response,
+                                 @Nullable Set<RequestMatcher.MatchedMethod> matchedMethodsForPath) {
 
         Headers respHeaders = response.headers();
         if (!respHeaders.containsValue(HeaderNames.VARY, HeaderNames.ORIGIN, true)) {
@@ -60,7 +61,7 @@ public class CORSConfig {
         }
 
         String origin = request.headers().get(HeaderNames.ORIGIN);
-        if (Mutils.nullOrEmpty(origin)) {
+        if (origin == null || origin.isEmpty()) {
             return false;
         }
 

--- a/src/main/java/io/muserver/rest/CORSConfigBuilder.java
+++ b/src/main/java/io/muserver/rest/CORSConfigBuilder.java
@@ -22,7 +22,7 @@ import static java.util.Arrays.asList;
 public class CORSConfigBuilder {
 
     private boolean allowCredentials = false;
-    private Collection<String> allowedOrigins = Collections.emptySet();
+    private @Nullable Collection<String> allowedOrigins = Collections.emptySet();
     private List<Pattern> allowedOriginRegex = new ArrayList<>();
     private Collection<String> exposedHeaders = Collections.emptySet();
     private Collection<String> allowedHeaders = Collections.emptySet();

--- a/src/main/java/io/muserver/rest/CacheControlHeaderDelegate.java
+++ b/src/main/java/io/muserver/rest/CacheControlHeaderDelegate.java
@@ -43,6 +43,7 @@ https://github.com/jersey/jersey/blob/12e5d8bdf22bcd2676a1032ed69473cf2bbc48c7/c
  */
 package io.muserver.rest;
 
+import io.muserver.Mutils;
 import io.muserver.ParameterizedHeader;
 import jakarta.ws.rs.core.CacheControl;
 import jakarta.ws.rs.ext.RuntimeDelegate;
@@ -58,6 +59,7 @@ class CacheControlHeaderDelegate implements RuntimeDelegate.HeaderDelegate<Cache
     private static final Pattern WHITESPACE = Pattern.compile("\\s");
     @Override
     public CacheControl fromString(String value) {
+        Mutils.notNull("value", value);
         ParameterizedHeader dir = ParameterizedHeader.fromString(value);
         CacheControl cc = new CacheControl();
         Map<String, String> pams = new HashMap<>(dir.parameters());
@@ -91,6 +93,7 @@ class CacheControlHeaderDelegate implements RuntimeDelegate.HeaderDelegate<Cache
 
     @Override
     public String toString(CacheControl value) {
+        Mutils.notNull("value", value);
         StringBuilder sb = new StringBuilder();
         if (value.isPrivate()) {
             appendQuotedWithSeparator(sb, "private", buildListValue(value.getPrivateFields()));

--- a/src/main/java/io/muserver/rest/CacheControlHeaderDelegate.java
+++ b/src/main/java/io/muserver/rest/CacheControlHeaderDelegate.java
@@ -46,6 +46,7 @@ package io.muserver.rest;
 import io.muserver.ParameterizedHeader;
 import jakarta.ws.rs.core.CacheControl;
 import jakarta.ws.rs.ext.RuntimeDelegate;
+import org.jspecify.annotations.Nullable;
 
 import java.util.HashMap;
 import java.util.List;
@@ -154,7 +155,7 @@ class CacheControlHeaderDelegate implements RuntimeDelegate.HeaderDelegate<Cache
         b.append(value);
     }
 
-    static void appendWithSeparator(StringBuilder b, String field, String value) {
+    static void appendWithSeparator(StringBuilder b, String field, @Nullable String value) {
         appendWithSeparator(b, field);
         if (value != null && !value.isEmpty()) {
             b.append("=");
@@ -162,7 +163,7 @@ class CacheControlHeaderDelegate implements RuntimeDelegate.HeaderDelegate<Cache
         }
     }
 
-    static String quoteIfWhitespace(String value) {
+    static @Nullable String quoteIfWhitespace(@Nullable String value) {
         if (value == null) {
             return null;
         }

--- a/src/main/java/io/muserver/rest/CombinedMediaType.java
+++ b/src/main/java/io/muserver/rest/CombinedMediaType.java
@@ -1,6 +1,7 @@
 package io.muserver.rest;
 
 import jakarta.ws.rs.core.MediaType;
+import org.jspecify.annotations.Nullable;
 
 import java.util.Objects;
 
@@ -11,16 +12,16 @@ class CombinedMediaType implements Comparable<CombinedMediaType> {
 
     public static CombinedMediaType NONMATCH = new CombinedMediaType(null, null, 1.0, 1.0, 0, null);
 
-    public final String type;
-    public final String subType;
+    public final @Nullable String type;
+    public final @Nullable String subType;
     public final double q;
     public final double qs;
     public final int d;
     public final boolean isWildcardType;
     public final boolean isWildcardSubtype;
-    public final String charset;
+    public final @Nullable String charset;
 
-    CombinedMediaType(String type, String subType, double q, double qs, int d, String charset) {
+    CombinedMediaType(@Nullable String type, @Nullable String subType, double q, double qs, int d, @Nullable String charset) {
         this.type = type;
         this.subType = subType;
         this.q = q;

--- a/src/main/java/io/muserver/rest/CombinedMediaType.java
+++ b/src/main/java/io/muserver/rest/CombinedMediaType.java
@@ -74,7 +74,7 @@ class CombinedMediaType implements Comparable<CombinedMediaType> {
     }
 
     @Override
-    public boolean equals(Object o) {
+    public boolean equals(@Nullable Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         CombinedMediaType that = (CombinedMediaType) o;

--- a/src/main/java/io/muserver/rest/CookieHeaderDelegate.java
+++ b/src/main/java/io/muserver/rest/CookieHeaderDelegate.java
@@ -1,5 +1,6 @@
 package io.muserver.rest;
 
+import io.muserver.Mutils;
 import io.netty.handler.codec.http.cookie.ClientCookieEncoder;
 import io.netty.handler.codec.http.cookie.DefaultCookie;
 import io.netty.handler.codec.http.cookie.ServerCookieDecoder;
@@ -18,6 +19,7 @@ class CookieHeaderDelegate implements RuntimeDelegate.HeaderDelegate<Cookie> {
 
     @Override
     public Cookie fromString(String value) {
+        Mutils.notNull("value", value);
         Set<io.netty.handler.codec.http.cookie.Cookie> decoded = decoder.decode(value);
         io.netty.handler.codec.http.cookie.Cookie nv = decoded.iterator().next();
         return new Cookie(nv.name(), nv.value());
@@ -25,6 +27,7 @@ class CookieHeaderDelegate implements RuntimeDelegate.HeaderDelegate<Cookie> {
 
     @Override
     public String toString(Cookie cookie) {
+        Mutils.notNull("cookie", cookie);
         DefaultCookie nettyCookie = new DefaultCookie(cookie.getName(), cookie.getValue());
         nettyCookie.setPath(cookie.getPath());
         nettyCookie.setDomain(cookie.getDomain());

--- a/src/main/java/io/muserver/rest/DateHeaderDelegate.java
+++ b/src/main/java/io/muserver/rest/DateHeaderDelegate.java
@@ -10,6 +10,7 @@ class DateHeaderDelegate implements RuntimeDelegate.HeaderDelegate<Date> {
 
     @Override
     public Date fromString(String value) {
+        Mutils.notNull("value", value);
         try {
             return Mutils.fromHttpDate(value);
         } catch (DateTimeParseException e) {
@@ -19,6 +20,7 @@ class DateHeaderDelegate implements RuntimeDelegate.HeaderDelegate<Date> {
 
     @Override
     public String toString(Date value) {
+        Mutils.notNull("value", value);
         return Mutils.toHttpDate(value);
     }
 }

--- a/src/main/java/io/muserver/rest/DescriptionData.java
+++ b/src/main/java/io/muserver/rest/DescriptionData.java
@@ -3,6 +3,7 @@ package io.muserver.rest;
 import io.muserver.Mutils;
 import io.muserver.openapi.ExternalDocumentationObject;
 import io.muserver.openapi.TagObject;
+import org.jspecify.annotations.Nullable;
 
 import java.lang.reflect.AnnotatedElement;
 import java.net.URI;
@@ -13,24 +14,24 @@ import static io.muserver.openapi.TagObjectBuilder.tagObject;
 
 class DescriptionData {
 
-    final String summary;
-    final String description;
-    final ExternalDocumentationObject externalDocumentation;
-    final String example;
+    final @Nullable String summary;
+    final @Nullable String description;
+    final @Nullable ExternalDocumentationObject externalDocumentation;
+    final @Nullable String example;
 
-    DescriptionData(String summary, String description, ExternalDocumentationObject externalDocumentation, String example) {
+    DescriptionData(@Nullable String summary, @Nullable String description, @Nullable ExternalDocumentationObject externalDocumentation, @Nullable String example) {
         this.summary = summary;
         this.description = description;
         this.externalDocumentation = externalDocumentation;
         this.example = example;
     }
 
-    static DescriptionData fromAnnotation(AnnotatedElement source, String defaultSummary) {
+    static DescriptionData fromAnnotation(AnnotatedElement source, @Nullable String defaultSummary) {
         Description description = source.getAnnotation(Description.class);
         if (description == null) {
             return new DescriptionData(defaultSummary, null, null, null);
         } else {
-            ExternalDocumentationObject externalDocumentation = null;
+            @Nullable ExternalDocumentationObject externalDocumentation = null;
             if (!description.documentationUrl().isEmpty()) {
                 try {
                     URI uri = new URI(description.documentationUrl());
@@ -48,17 +49,19 @@ class DescriptionData {
     }
 
     TagObject toTag() {
+        Mutils.notNull("summary", summary);
         return tagObject()
-            .withName(summary)
+            .withName(java.util.Objects.requireNonNull(summary))
             .withDescription(description)
             .withExternalDocs(externalDocumentation)
             .build();
     }
 
     public String summaryAndDescription() {
-        String s = Mutils.coalesce(summary, "");
-        if (!Mutils.nullOrEmpty(description)) {
-            s += " - " + description;
+        String s = summary == null ? "" : summary;
+        String details = description;
+        if (details != null && !details.isEmpty()) {
+            s += " - " + details;
         }
         return s;
     }

--- a/src/main/java/io/muserver/rest/EntityTagDelegate.java
+++ b/src/main/java/io/muserver/rest/EntityTagDelegate.java
@@ -1,5 +1,6 @@
 package io.muserver.rest;
 
+import io.muserver.Mutils;
 import jakarta.ws.rs.core.EntityTag;
 import jakarta.ws.rs.ext.RuntimeDelegate;
 
@@ -22,6 +23,7 @@ class EntityTagDelegate implements RuntimeDelegate.HeaderDelegate<EntityTag> {
 
     @Override
     public String toString(EntityTag value) {
+        Mutils.notNull("value", value);
         String quotedValue = quoted(value.getValue());
         return value.isWeak() ? "W/" + quotedValue : quotedValue;
     }

--- a/src/main/java/io/muserver/rest/GenericTypeResolver.java
+++ b/src/main/java/io/muserver/rest/GenericTypeResolver.java
@@ -29,7 +29,10 @@ final class GenericTypeResolver {
         return concreteTypeOrNull(resolve(type, concreteClass, declaringClass));
     }
 
-    static @Nullable Type resolveTypeArgument(Type type, Class<?> targetClass, int argumentIndex) {
+    static @Nullable Type resolveTypeArgument(@Nullable Type type, Class<?> targetClass, int argumentIndex) {
+        if (type == null) {
+            return null;
+        }
         TypeVariable<?> typeVariable = targetClass.getTypeParameters()[argumentIndex];
         Map<TypeVariable<?>, Type> typeArguments = new HashMap<>();
         if (!findTypeArguments(type, targetClass, new HashMap<>(), typeArguments)) {
@@ -106,7 +109,7 @@ final class GenericTypeResolver {
         return candidateClass != null && declaringClass.isAssignableFrom(candidateClass);
     }
 
-    static Class<?> rawClass(Type type) {
+    static @Nullable Class<?> rawClass(@Nullable Type type) {
         if (type instanceof Class) {
             return (Class<?>) type;
         }
@@ -162,11 +165,11 @@ final class GenericTypeResolver {
     }
 
     private static final class ResolvedParameterizedType implements ParameterizedType {
-        private final Type owner;
+        private final @Nullable Type owner;
         private final Type rawType;
         private final Type[] arguments;
 
-        private ResolvedParameterizedType(Type owner, Type rawType, Type[] arguments) {
+        private ResolvedParameterizedType(@Nullable Type owner, Type rawType, Type[] arguments) {
             this.owner = owner;
             this.rawType = rawType;
             this.arguments = arguments.clone();
@@ -183,7 +186,7 @@ final class GenericTypeResolver {
         }
 
         @Override
-        public Type getOwnerType() {
+        public @Nullable Type getOwnerType() {
             return owner;
         }
 

--- a/src/main/java/io/muserver/rest/GenericTypeResolver.java
+++ b/src/main/java/io/muserver/rest/GenericTypeResolver.java
@@ -191,7 +191,7 @@ final class GenericTypeResolver {
         }
 
         @Override
-        public boolean equals(Object other) {
+        public boolean equals(@Nullable Object other) {
             if (!(other instanceof ParameterizedType)) {
                 return false;
             }
@@ -254,7 +254,7 @@ final class GenericTypeResolver {
         }
 
         @Override
-        public boolean equals(Object other) {
+        public boolean equals(@Nullable Object other) {
             return other instanceof GenericArrayType
                 && componentType.equals(((GenericArrayType) other).getGenericComponentType());
         }
@@ -295,7 +295,7 @@ final class GenericTypeResolver {
         }
 
         @Override
-        public boolean equals(Object other) {
+        public boolean equals(@Nullable Object other) {
             if (!(other instanceof WildcardType)) {
                 return false;
             }

--- a/src/main/java/io/muserver/rest/HtmlDocumentor.java
+++ b/src/main/java/io/muserver/rest/HtmlDocumentor.java
@@ -3,6 +3,7 @@ package io.muserver.rest;
 import io.muserver.Mutils;
 import io.muserver.openapi.*;
 import jakarta.ws.rs.core.MediaType;
+import org.jspecify.annotations.Nullable;
 
 import java.io.BufferedWriter;
 import java.io.IOException;
@@ -70,8 +71,12 @@ class HtmlDocumentor {
         LicenseObject license = api.info().license();
         if (license != null) {
             metaData.content(" | License: ");
-            String name = license.name() == null ? license.url().toString() : license.name();
-            new El("a").open(Collections.singletonMap("href", "mailto:" + license.url())).content(name).close();
+            URI licenseUrl = license.url();
+            if (licenseUrl == null) {
+                metaData.content(license.name());
+            } else {
+                new El("a").open(Collections.singletonMap("href", licenseUrl.toString())).content(license.name()).close();
+            }
         }
 
         if (api.info().termsOfService() != null) {
@@ -88,18 +93,19 @@ class HtmlDocumentor {
 
 
         El nav = new El("ul").open(singletonMap("class", "nav operation"));
-        for (TagObject tag : api.tags()) {
+        List<TagObject> tags = api.tags() == null ? Collections.emptyList() : api.tags();
+        for (TagObject tag : tags) {
             El li = new El("li").open();
             new El("a").open(singletonMap("href", "#" + Mutils.htmlEncode(tag.name()))).content(tag.name()).close();
 
             El subNav = new El("ul").open(singletonMap("class", "subNav"));
-            for (Map.Entry<String, PathItemObject> entry : api.paths().pathItemObjects().entrySet()) {
+            for (Map.Entry<String, PathItemObject> entry : pathItems().entrySet()) {
                 String url = entry.getKey();
                 PathItemObject item = entry.getValue();
-                for (Map.Entry<String, OperationObject> operationObjectEntry : item.operations().entrySet()) {
+                for (Map.Entry<String, OperationObject> operationObjectEntry : operations(item).entrySet()) {
                     String method = operationObjectEntry.getKey();
                     OperationObject operation = operationObjectEntry.getValue();
-                    if (operation.tags().contains(tag.name())) {
+                    if (operationTags(operation).contains(tag.name())) {
 
                         El subNavLi = new El("li").open();
                         new El("a").open(singletonMap("href", "#" + Mutils.htmlEncode(operation.operationId()))).content(method.toUpperCase() + " " + url).close();
@@ -118,20 +124,20 @@ class HtmlDocumentor {
         nav.close();
 
 
-        for (TagObject tag : api.tags()) {
+        for (TagObject tag : tags) {
             El tagContainer = new El("div").open(singletonMap("class", "tagContainer"));
             new El("h2").open(singletonMap("id", Mutils.htmlEncode(tag.name()))).content(tag.name()).close();
             renderIfValue("p", tag.description());
             renderExternalLinksParagraph(tag.externalDocs());
 
-            for (Map.Entry<String, PathItemObject> entry : api.paths().pathItemObjects().entrySet()) {
+            for (Map.Entry<String, PathItemObject> entry : pathItems().entrySet()) {
                 String url = entry.getKey();
                 PathItemObject item = entry.getValue();
-                for (Map.Entry<String, OperationObject> operationObjectEntry : item.operations().entrySet()) {
+                for (Map.Entry<String, OperationObject> operationObjectEntry : operations(item).entrySet()) {
                     String method = operationObjectEntry.getKey();
                     OperationObject operation = operationObjectEntry.getValue();
 
-                    if (operation.tags().contains(tag.name())) {
+                    if (operationTags(operation).contains(tag.name())) {
 
                         Map<String, String> operationAttributes = new HashMap<>();
                         operationAttributes.put("id", Mutils.htmlEncode(operation.operationId()));
@@ -154,7 +160,8 @@ class HtmlDocumentor {
                         StringBuilder curlHeaders = new StringBuilder();
 
                         RequestBodyObject requestBody = operation.requestBody();
-                        if (!operation.parameters().isEmpty()) {
+                        List<ParameterObject> parameters = operation.parameters() == null ? Collections.emptyList() : operation.parameters();
+                        if (!parameters.isEmpty()) {
                             render("h4", "Parameters");
                             El table = new El("table").open(singletonMap("class", "parameterTable"));
 
@@ -169,7 +176,7 @@ class HtmlDocumentor {
                             El tbody = new El("tbody").open();
 
 
-                            for (ParameterObject parameter : operation.parameters()) {
+                            for (ParameterObject parameter : parameters) {
                                 El row = new El("tr").open();
                                 render("td", parameter.name());
                                 String type = parameter.in();
@@ -184,8 +191,8 @@ class HtmlDocumentor {
                                 }
 
                                 SchemaObject schema = parameter.schema();
-                                Object defaultVal = null;
-                                ExternalDocumentationObject externalDocs = null;
+                                @Nullable Object defaultVal = null;
+                                @Nullable ExternalDocumentationObject externalDocs = null;
                                 if (schema != null) {
                                     type += " - " + schema.type();
                                     if (schema.format() != null) {
@@ -257,7 +264,7 @@ class HtmlDocumentor {
                                     El row = new El("tr").open();
                                     render("td", formName);
 
-                                    String type = schema.type();
+                                    @Nullable String type = schema.type();
                                     if (schema.format() != null) {
                                         type += " (" + schema.format() + ")";
                                     }
@@ -343,11 +350,26 @@ class HtmlDocumentor {
         html.close();
     }
 
-    private static String bashValue(Object value) {
+    private Map<String, PathItemObject> pathItems() {
+        Map<String, PathItemObject> paths = api.paths().pathItemObjects();
+        return paths == null ? Collections.emptyMap() : paths;
+    }
+
+    private static Map<String, OperationObject> operations(PathItemObject item) {
+        Map<String, OperationObject> operations = item.operations();
+        return operations == null ? Collections.emptyMap() : operations;
+    }
+
+    private static List<String> operationTags(OperationObject operation) {
+        List<String> tags = operation.tags();
+        return tags == null ? Collections.emptyList() : tags;
+    }
+
+    private static String bashValue(@Nullable Object value) {
         return value == null || "".equals(value) ? "" : value.toString().replace("'", "'\\''");
     }
 
-    private void renderExternalLinksParagraph(ExternalDocumentationObject externalDocs) throws IOException {
+    private void renderExternalLinksParagraph(@Nullable ExternalDocumentationObject externalDocs) throws IOException {
         if (externalDocs != null) {
             String url = externalDocs.url().toString();
             String desc = externalDocs.description() == null ? url : externalDocs.description();
@@ -357,7 +379,7 @@ class HtmlDocumentor {
         }
     }
 
-    private void renderExamples(Object example, Map<String, ExampleObject> examples, Object defaultVal) throws IOException {
+    private void renderExamples(@Nullable Object example, @Nullable Map<String, ExampleObject> examples, @Nullable Object defaultVal) throws IOException {
         if (example != null) {
             El div = new El("div").open().content("Example: ");
             render("code", example.toString());
@@ -381,13 +403,13 @@ class HtmlDocumentor {
         }
     }
 
-    private void renderIfValue(String tag, String value) throws IOException {
+    private void renderIfValue(String tag, @Nullable String value) throws IOException {
         if (value != null) {
             new El(tag).open().content(value).close();
         }
     }
 
-    private void render(String tag, String value) throws IOException {
+    private void render(String tag, @Nullable String value) throws IOException {
         new El(tag).open().content(value).close();
     }
 
@@ -403,7 +425,7 @@ class HtmlDocumentor {
             return open(null);
         }
 
-        El open(Map<String, String> attributes) throws IOException {
+        El open(@Nullable Map<String, String> attributes) throws IOException {
             writer.write("<" + tag);
             if (attributes != null) {
                 for (Map.Entry<String, String> entry : attributes.entrySet()) {
@@ -419,7 +441,7 @@ class HtmlDocumentor {
             return this;
         }
 
-        El content(Object... vals) throws IOException {
+        El content(@Nullable Object... vals) throws IOException {
             if (vals != null) {
                 for (Object val : vals) {
                     if (val != null) {

--- a/src/main/java/io/muserver/rest/JaxClassLocator.java
+++ b/src/main/java/io/muserver/rest/JaxClassLocator.java
@@ -1,5 +1,6 @@
 package io.muserver.rest;
 
+import org.jspecify.annotations.Nullable;
 import java.lang.annotation.Annotation;
 
 /**
@@ -7,16 +8,16 @@ import java.lang.annotation.Annotation;
  * As per the spec, the class and its super classes are checked before interfaces.
  */
 class JaxClassLocator {
-    static Class<?> getClassWithJaxRSAnnotations(Class<?> start) {
-        Class<?> clazz = start;
-        while (clazz != Object.class) {
+    static @Nullable Class<?> getClassWithJaxRSAnnotations(Class<?> start) {
+        @Nullable Class<?> clazz = start;
+        while (clazz != null && clazz != Object.class) {
             if (hasAtLeastOneJaxRSAnnotation(clazz.getDeclaredAnnotations())) {
                 return clazz;
             }
             clazz = clazz.getSuperclass();
         }
         clazz = start;
-        while (clazz != Object.class) {
+        while (clazz != null && clazz != Object.class) {
             for (Class<?> interfaceClass : clazz.getInterfaces()) {
                 if (hasAtLeastOneJaxRSAnnotation(interfaceClass.getDeclaredAnnotations())) {
                     return interfaceClass;

--- a/src/main/java/io/muserver/rest/JaxOutboundSseEvent.java
+++ b/src/main/java/io/muserver/rest/JaxOutboundSseEvent.java
@@ -36,7 +36,7 @@ class JaxOutboundSseEvent implements OutboundSseEvent {
 
     @Override
     public @Nullable Type getGenericType() {
-        return genericType == null ? null : genericType.getType();
+        return genericType == null ? type : genericType.getType();
     }
 
     @Override

--- a/src/main/java/io/muserver/rest/JaxOutboundSseEvent.java
+++ b/src/main/java/io/muserver/rest/JaxOutboundSseEvent.java
@@ -4,20 +4,21 @@ import jakarta.ws.rs.core.GenericType;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.sse.OutboundSseEvent;
 import jakarta.ws.rs.sse.SseEvent;
+import org.jspecify.annotations.Nullable;
 
 import java.lang.reflect.Type;
 
 class JaxOutboundSseEvent implements OutboundSseEvent {
-    private final String id;
-    private final String name;
+    private final @Nullable String id;
+    private final @Nullable String name;
     private final long milliseconds;
     private final MediaType mediaType;
-    private final String comment;
-    private final Class type;
-    private final Object data;
-    private final GenericType genericType;
+    private final @Nullable String comment;
+    private final @Nullable Class type;
+    private final @Nullable Object data;
+    private final @Nullable GenericType genericType;
 
-    JaxOutboundSseEvent(String id, String name, long milliseconds, MediaType mediaType, String comment, Class type, Object data, GenericType genericType) {
+    JaxOutboundSseEvent(@Nullable String id, @Nullable String name, long milliseconds, MediaType mediaType, @Nullable String comment, @Nullable Class type, @Nullable Object data, @Nullable GenericType genericType) {
         this.id = id;
         this.name = name;
         this.milliseconds = milliseconds;
@@ -29,12 +30,12 @@ class JaxOutboundSseEvent implements OutboundSseEvent {
     }
 
     @Override
-    public Class<?> getType() {
+    public @Nullable Class<?> getType() {
         return type;
     }
 
     @Override
-    public Type getGenericType() {
+    public @Nullable Type getGenericType() {
         return genericType == null ? null : genericType.getType();
     }
 
@@ -44,22 +45,22 @@ class JaxOutboundSseEvent implements OutboundSseEvent {
     }
 
     @Override
-    public Object getData() {
+    public @Nullable Object getData() {
         return data;
     }
 
     @Override
-    public String getId() {
+    public @Nullable String getId() {
         return id;
     }
 
     @Override
-    public String getName() {
+    public @Nullable String getName() {
         return name;
     }
 
     @Override
-    public String getComment() {
+    public @Nullable String getComment() {
         return comment;
     }
 

--- a/src/main/java/io/muserver/rest/JaxOutboundSseEventBuilder.java
+++ b/src/main/java/io/muserver/rest/JaxOutboundSseEventBuilder.java
@@ -4,16 +4,17 @@ import jakarta.ws.rs.core.GenericType;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.sse.OutboundSseEvent;
 import jakarta.ws.rs.sse.SseEvent;
+import org.jspecify.annotations.Nullable;
 
 class JaxOutboundSseEventBuilder implements OutboundSseEvent.Builder {
-    private String id;
-    private String name;
+    private @Nullable String id;
+    private @Nullable String name;
     private long milliseconds = SseEvent.RECONNECT_NOT_SET;
     private MediaType mediaType = MediaType.TEXT_PLAIN_TYPE;
-    private String comment;
-    private Class type;
-    private Object data;
-    private GenericType genericType;
+    private @Nullable String comment;
+    private @Nullable Class type;
+    private @Nullable Object data;
+    private @Nullable GenericType genericType;
 
     @Override
     public OutboundSseEvent.Builder id(String id) {

--- a/src/main/java/io/muserver/rest/JaxOutboundSseEventBuilder.java
+++ b/src/main/java/io/muserver/rest/JaxOutboundSseEventBuilder.java
@@ -17,13 +17,13 @@ class JaxOutboundSseEventBuilder implements OutboundSseEvent.Builder {
     private @Nullable GenericType genericType;
 
     @Override
-    public OutboundSseEvent.Builder id(String id) {
+    public OutboundSseEvent.Builder id(@Nullable String id) {
         this.id = id;
         return this;
     }
 
     @Override
-    public OutboundSseEvent.Builder name(String name) {
+    public OutboundSseEvent.Builder name(@Nullable String name) {
         this.name = name;
         return this;
     }
@@ -42,7 +42,7 @@ class JaxOutboundSseEventBuilder implements OutboundSseEvent.Builder {
     }
 
     @Override
-    public OutboundSseEvent.Builder comment(String comment) {
+    public OutboundSseEvent.Builder comment(@Nullable String comment) {
         this.comment = comment;
         return this;
     }
@@ -52,6 +52,7 @@ class JaxOutboundSseEventBuilder implements OutboundSseEvent.Builder {
         if (type == null) throw new NullPointerException("type");
         if (data == null) throw new NullPointerException("data");
         this.type = type;
+        this.genericType = null;
         this.data = data;
         return this;
     }
@@ -60,6 +61,7 @@ class JaxOutboundSseEventBuilder implements OutboundSseEvent.Builder {
     public OutboundSseEvent.Builder data(GenericType type, Object data) {
         if (type == null) throw new NullPointerException("type");
         if (data == null) throw new NullPointerException("data");
+        this.type = type.getRawType();
         this.genericType = type;
         this.data = data;
         return this;
@@ -70,6 +72,7 @@ class JaxOutboundSseEventBuilder implements OutboundSseEvent.Builder {
         if (data == null) throw new NullPointerException("data");
         this.data = data;
         this.type = data.getClass();
+        this.genericType = null;
         return this;
     }
 

--- a/src/main/java/io/muserver/rest/JaxRSRequest.java
+++ b/src/main/java/io/muserver/rest/JaxRSRequest.java
@@ -11,6 +11,7 @@ import jakarta.ws.rs.core.Cookie;
 import jakarta.ws.rs.ext.MessageBodyReader;
 import jakarta.ws.rs.ext.ReaderInterceptor;
 import jakarta.ws.rs.ext.ReaderInterceptorContext;
+import org.jspecify.annotations.Nullable;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -27,16 +28,16 @@ class JaxRSRequest implements Request, ContainerRequestContext, ReaderIntercepto
     private final String relativePath;
     private final JaxRsHttpHeadersAdapter jaxHeaders;
     private UriInfo uriInfo;
-    private RequestMatcher.MatchedMethod matchedMethod;
+    private RequestMatcher.@Nullable MatchedMethod matchedMethod;
     private SecurityContext securityContext;
     private Annotation[] annotations = JaxRSResponse.Builder.EMPTY_ANNOTATIONS;
-    private Class<?> type;
-    private Type genericType;
+    private @Nullable Class<?> type;
+    private @Nullable Type genericType;
     private int nextReader;
     private final List<ReaderInterceptor> readerInterceptors;
     private final EntityProviders entityProviders;
     private String httpMethod;
-    private Response abortResponse;
+    private @Nullable Response abortResponse;
     private boolean requestFilterChainRunning;
     private boolean responseFilterChainStarted;
     private boolean exceptionMapperUsed;
@@ -68,7 +69,7 @@ class JaxRSRequest implements Request, ContainerRequestContext, ReaderIntercepto
         return matchedMethod.resourceMethod.hasAll(toCheck);
     }
 
-    Response mapExceptionOnce(CustomExceptionMapper exceptionMapper, Exception exception) {
+    @Nullable Response mapExceptionOnce(CustomExceptionMapper exceptionMapper, Exception exception) {
         if (exceptionMapperUsed) {
             return null;
         }
@@ -80,12 +81,12 @@ class JaxRSRequest implements Request, ContainerRequestContext, ReaderIntercepto
     }
 
     @Override
-    public Object getProperty(String name) {
+    public @Nullable Object getProperty(String name) {
         if (MuRuntimeDelegate.MU_REQUEST_PROPERTY.equals(name)) {
             return muRequest;
         } else if (MuRuntimeDelegate.RESOURCE_INFO_PROPERTY.equals(name)) {
-            Class<?> resourceInstanceClass = (matchedMethod == null) ? null : matchedMethod.matchedClass.resourceClass.resourceInstance.getClass();
-            java.lang.reflect.Method resourceInstanceMethod = (matchedMethod == null) ? null : matchedMethod.resourceMethod.methodHandle;
+            @Nullable Class<?> resourceInstanceClass = (matchedMethod == null) ? null : matchedMethod.matchedClass.resourceClass.requiredResourceInstance().getClass();
+            java.lang.reflect.@Nullable Method resourceInstanceMethod = (matchedMethod == null) ? null : matchedMethod.resourceMethod.methodHandle;
             return new MuResourceInfo(resourceInstanceClass, resourceInstanceMethod);
         }
         return muRequest.attribute(name);
@@ -133,7 +134,7 @@ class JaxRSRequest implements Request, ContainerRequestContext, ReaderIntercepto
 
     @Override
     public Class<?> getType() {
-        return type;
+        return Objects.requireNonNull(type, "The request entity type has not been set");
     }
 
     @Override
@@ -143,7 +144,7 @@ class JaxRSRequest implements Request, ContainerRequestContext, ReaderIntercepto
 
     @Override
     public Type getGenericType() {
-        return genericType;
+        return Objects.requireNonNull(genericType, "The request entity generic type has not been set");
     }
 
     @Override
@@ -181,7 +182,7 @@ class JaxRSRequest implements Request, ContainerRequestContext, ReaderIntercepto
     }
 
     @Override
-    public Variant selectVariant(List<Variant> variants) {
+    public @Nullable Variant selectVariant(List<Variant> variants) {
         if (variants == null) {
             throw new IllegalArgumentException("variants is null");
         }
@@ -208,7 +209,7 @@ class JaxRSRequest implements Request, ContainerRequestContext, ReaderIntercepto
     }
 
     @Override
-    public Response.ResponseBuilder evaluatePreconditions(EntityTag eTag) {
+    public Response.@Nullable ResponseBuilder evaluatePreconditions(EntityTag eTag) {
         if (eTag == null) {
             throw new IllegalArgumentException("eTag is null");
         }
@@ -216,7 +217,7 @@ class JaxRSRequest implements Request, ContainerRequestContext, ReaderIntercepto
         return ifMatchBuilder != null ? ifMatchBuilder : evaluateIfNoneMatch(eTag);
     }
 
-    private Response.ResponseBuilder evaluateIfMatch(EntityTag eTag) {
+    private Response.@Nullable ResponseBuilder evaluateIfMatch(EntityTag eTag) {
         boolean anyMatch = false;
         List<String> ifMatches = muRequest.headers().getAll(HeaderNames.IF_MATCH);
         if (ifMatches.isEmpty()) {
@@ -239,7 +240,7 @@ class JaxRSRequest implements Request, ContainerRequestContext, ReaderIntercepto
     }
 
 
-    private Response.ResponseBuilder evaluateIfNoneMatch(EntityTag eTag) {
+    private Response.@Nullable ResponseBuilder evaluateIfNoneMatch(EntityTag eTag) {
         List<String> ifNoneMatchTags = muRequest.headers().getAll(HeaderNames.IF_NONE_MATCH);
         boolean getOrHead = isGetOrHead();
         if (!getOrHead && eTag.isWeak()) {
@@ -265,7 +266,7 @@ class JaxRSRequest implements Request, ContainerRequestContext, ReaderIntercepto
     }
 
     @Override
-    public Response.ResponseBuilder evaluatePreconditions(Date lastModified) {
+    public Response.@Nullable ResponseBuilder evaluatePreconditions(Date lastModified) {
         if (lastModified == null) {
             throw new IllegalArgumentException("lastModified is null");
         }
@@ -273,7 +274,7 @@ class JaxRSRequest implements Request, ContainerRequestContext, ReaderIntercepto
         return ifUnmodifiedSince != null ? ifUnmodifiedSince : evaluateIfModifiedSince(lastModified);
     }
 
-    private Response.ResponseBuilder evaluateIfModifiedSince(Date lastModified) {
+    private Response.@Nullable ResponseBuilder evaluateIfModifiedSince(Date lastModified) {
         long lastModifiedSeconds = lastModified.getTime() / 1000;
         Long ifModifiedMillis = muRequest.headers().getTimeMillis(HeaderNames.IF_MODIFIED_SINCE);
         if (ifModifiedMillis == null || lastModifiedSeconds > (ifModifiedMillis / 1000)) {
@@ -282,7 +283,7 @@ class JaxRSRequest implements Request, ContainerRequestContext, ReaderIntercepto
             return isGetOrHead() ? Response.notModified() : null;
         }
     }
-    private Response.ResponseBuilder evaluateIfUnmodifiedSince(Date lastModified) {
+    private Response.@Nullable ResponseBuilder evaluateIfUnmodifiedSince(Date lastModified) {
         long lastModifiedSeconds = lastModified.getTime() / 1000;
         Long ifUnmodifiedSince = muRequest.headers().getTimeMillis(HeaderNames.IF_UNMODIFIED_SINCE);
         if (ifUnmodifiedSince == null || lastModifiedSeconds <= (ifUnmodifiedSince / 1000)) {
@@ -295,7 +296,7 @@ class JaxRSRequest implements Request, ContainerRequestContext, ReaderIntercepto
 
 
     @Override
-    public Response.ResponseBuilder evaluatePreconditions(Date lastModified, EntityTag eTag) {
+    public Response.@Nullable ResponseBuilder evaluatePreconditions(Date lastModified, EntityTag eTag) {
         if (lastModified == null) {
             throw new IllegalArgumentException("lastModified is null");
         }
@@ -323,7 +324,7 @@ class JaxRSRequest implements Request, ContainerRequestContext, ReaderIntercepto
     }
 
     @Override
-    public Response.ResponseBuilder evaluatePreconditions() {
+    public Response.@Nullable ResponseBuilder evaluatePreconditions() {
         return muRequest.headers().get(HeaderNames.IF_MATCH) == null ? null
             : Response.status(Response.Status.PRECONDITION_FAILED).entity(new ClientErrorException("Precondition failed: if-match", 412));
     }
@@ -397,17 +398,17 @@ class JaxRSRequest implements Request, ContainerRequestContext, ReaderIntercepto
     }
 
     @Override
-    public String getHeaderString(String name) {
+    public @Nullable String getHeaderString(String name) {
         return jaxHeaders.getHeaderString(name);
     }
 
     @Override
-    public Date getDate() {
+    public @Nullable Date getDate() {
         return jaxHeaders.getDate();
     }
 
     @Override
-    public Locale getLanguage() {
+    public @Nullable Locale getLanguage() {
         return jaxHeaders.getLanguage();
     }
 
@@ -417,7 +418,7 @@ class JaxRSRequest implements Request, ContainerRequestContext, ReaderIntercepto
     }
 
     @Override
-    public MediaType getMediaType() {
+    public @Nullable MediaType getMediaType() {
         return jaxHeaders.getMediaType();
     }
 
@@ -488,7 +489,7 @@ class JaxRSRequest implements Request, ContainerRequestContext, ReaderIntercepto
         }
     }
 
-    Response getAbortResponse() {
+    @Nullable Response getAbortResponse() {
         return abortResponse;
     }
 
@@ -526,21 +527,21 @@ class JaxRSRequest implements Request, ContainerRequestContext, ReaderIntercepto
 
     private static class MuResourceInfo implements ResourceInfo {
 
-        private final Class<?> clazz;
-        private final java.lang.reflect.Method method;
+        private final @Nullable Class<?> clazz;
+        private final java.lang.reflect.@Nullable Method method;
 
-        private MuResourceInfo(Class<?> clazz, java.lang.reflect.Method method) {
+        private MuResourceInfo(@Nullable Class<?> clazz, java.lang.reflect.@Nullable Method method) {
             this.clazz = clazz;
             this.method = method;
         }
 
         @Override
-        public java.lang.reflect.Method getResourceMethod() {
+        public java.lang.reflect.@Nullable Method getResourceMethod() {
             return method;
         }
 
         @Override
-        public Class<?> getResourceClass() {
+        public @Nullable Class<?> getResourceClass() {
             return clazz;
         }
     }

--- a/src/main/java/io/muserver/rest/JaxRSRequest.java
+++ b/src/main/java/io/muserver/rest/JaxRSRequest.java
@@ -29,7 +29,7 @@ class JaxRSRequest implements Request, ContainerRequestContext, ReaderIntercepto
     private final JaxRsHttpHeadersAdapter jaxHeaders;
     private UriInfo uriInfo;
     private RequestMatcher.@Nullable MatchedMethod matchedMethod;
-    private SecurityContext securityContext;
+    private @Nullable SecurityContext securityContext;
     private Annotation[] annotations = JaxRSResponse.Builder.EMPTY_ANNOTATIONS;
     private @Nullable Class<?> type;
     private @Nullable Type genericType;
@@ -106,7 +106,7 @@ class JaxRSRequest implements Request, ContainerRequestContext, ReaderIntercepto
     }
 
     @Override
-    public void setProperty(String name, Object object) {
+    public void setProperty(String name, @Nullable Object object) {
         if (object == null) {
             removeProperty(name);
         } else {
@@ -133,22 +133,22 @@ class JaxRSRequest implements Request, ContainerRequestContext, ReaderIntercepto
     }
 
     @Override
-    public Class<?> getType() {
-        return Objects.requireNonNull(type, "The request entity type has not been set");
+    public @Nullable Class<?> getType() {
+        return type;
     }
 
     @Override
-    public void setType(Class<?> type) {
+    public void setType(@Nullable Class<?> type) {
         this.type = type;
     }
 
     @Override
-    public Type getGenericType() {
-        return Objects.requireNonNull(genericType, "The request entity generic type has not been set");
+    public @Nullable Type getGenericType() {
+        return genericType;
     }
 
     @Override
-    public void setGenericType(Type genericType) {
+    public void setGenericType(@Nullable Type genericType) {
         this.genericType = genericType;
     }
 
@@ -369,8 +369,8 @@ class JaxRSRequest implements Request, ContainerRequestContext, ReaderIntercepto
         }
 
         // 2. Identify the Java type of the parameter whose value will be mapped from the entity body.
-        Class<?> type = getType();
-        Type genericType = getGenericType();
+        Class<?> type = Objects.requireNonNull(getType(), "The request entity type has not been set");
+        Type genericType = Objects.requireNonNull(getGenericType(), "The request entity generic type has not been set");
         Annotation[] annotations = getAnnotations();
 
         // 3 & 4: Select a reader that supports the media type of the request and isReadable
@@ -389,7 +389,7 @@ class JaxRSRequest implements Request, ContainerRequestContext, ReaderIntercepto
 
     @Override
     public void setInputStream(InputStream is) {
-        setEntityStream(is);
+        setEntityStream(Objects.requireNonNull(is, "is"));
     }
 
     @Override
@@ -423,7 +423,7 @@ class JaxRSRequest implements Request, ContainerRequestContext, ReaderIntercepto
     }
 
     @Override
-    public void setMediaType(MediaType mediaType) {
+    public void setMediaType(@Nullable MediaType mediaType) {
         if (mediaType == null) {
             jaxHeaders.getMutableRequestHeaders().remove("content-type");
         } else {
@@ -459,16 +459,16 @@ class JaxRSRequest implements Request, ContainerRequestContext, ReaderIntercepto
     @Override
     public void setEntityStream(InputStream input) {
         ensureNotInResponseFilter("setEntityStream");
-        this.inputStream = input;
+        this.inputStream = Objects.requireNonNull(input, "input");
     }
 
     @Override
-    public SecurityContext getSecurityContext() {
+    public @Nullable SecurityContext getSecurityContext() {
         return securityContext;
     }
 
     @Override
-    public void setSecurityContext(SecurityContext context) {
+    public void setSecurityContext(@Nullable SecurityContext context) {
         ensureNotInResponseFilter("setSecurityContext");
         this.securityContext = context;
     }

--- a/src/main/java/io/muserver/rest/JaxRSResponse.java
+++ b/src/main/java/io/muserver/rest/JaxRSResponse.java
@@ -87,22 +87,22 @@ class JaxRSResponse extends Response implements ContainerResponseContext, Writer
     }
 
     @Override
-    public Class<?> getType() {
-        return Objects.requireNonNull(objWithType.type, "The response entity type has not been set");
+    public @Nullable Class<?> getType() {
+        return objWithType.type;
     }
 
     @Override
-    public void setType(Class<?> type) {
+    public void setType(@Nullable Class<?> type) {
         objWithType = new ObjWithType(type, objWithType.genericType, objWithType.response, objWithType.entity);
     }
 
     @Override
-    public Type getGenericType() {
-        return Objects.requireNonNull(objWithType.genericType, "The response entity generic type has not been set");
+    public @Nullable Type getGenericType() {
+        return objWithType.genericType;
     }
 
     @Override
-    public void setGenericType(Type genericType) {
+    public void setGenericType(@Nullable Type genericType) {
         objWithType = new ObjWithType(objWithType.type, genericType, objWithType.response, objWithType.entity);
     }
 
@@ -113,7 +113,13 @@ class JaxRSResponse extends Response implements ContainerResponseContext, Writer
 
     @Override
     public void setStatus(int code) {
-        this.status = Status.fromStatusCode(code);
+        if (code < 100 || code > 599) {
+            throw new IllegalArgumentException("Status must be between 100 and 599, but was " + code);
+        }
+        Status standardStatus = Status.fromStatusCode(code);
+        this.status = standardStatus == null
+            ? new CustomStatus(Status.Family.familyOf(code), code, "")
+            : standardStatus;
     }
 
     @Override
@@ -123,7 +129,7 @@ class JaxRSResponse extends Response implements ContainerResponseContext, Writer
 
     @Override
     public void setStatusInfo(StatusType statusInfo) {
-        this.status = statusInfo;
+        this.status = Objects.requireNonNull(statusInfo, "statusInfo");
     }
 
     @Override
@@ -132,12 +138,12 @@ class JaxRSResponse extends Response implements ContainerResponseContext, Writer
     }
 
     @Override
-    public Class<?> getEntityClass() {
+    public @Nullable Class<?> getEntityClass() {
         return getType();
     }
 
     @Override
-    public Type getEntityType() {
+    public @Nullable Type getEntityType() {
         return getGenericType();
     }
 
@@ -325,7 +331,7 @@ class JaxRSResponse extends Response implements ContainerResponseContext, Writer
     }
 
     @Override
-    public EntityTag getEntityTag() {
+    public @Nullable EntityTag getEntityTag() {
         Object first = headers.getFirst(HeaderNames.ETAG.toString());
         if (first == null || first instanceof  EntityTag) return (EntityTag)first;
         return EntityTag.valueOf(first.toString());
@@ -454,7 +460,7 @@ class JaxRSResponse extends Response implements ContainerResponseContext, Writer
     }
 
     @Override
-    public void setProperty(String name, Object object) {
+    public void setProperty(String name, @Nullable Object object) {
         requiredRequestContext().setProperty(name, object);
     }
 
@@ -540,12 +546,12 @@ class JaxRSResponse extends Response implements ContainerResponseContext, Writer
         @Override
         public ResponseBuilder entity(@Nullable Object entity, Annotation[] annotations) {
             this.entity = entity;
-            this.annotations = annotations;
+            this.annotations = Objects.requireNonNull(annotations, "annotations");
             return this;
         }
 
         @Override
-        public ResponseBuilder allow(String... methods) {
+        public ResponseBuilder allow(String @Nullable ... methods) {
             if (methods == null || (methods.length == 1 && methods[0] == null)) {
                 return allow((Set<String>) null);
             } else {
@@ -577,8 +583,8 @@ class JaxRSResponse extends Response implements ContainerResponseContext, Writer
 
 
         @Override
-        public ResponseBuilder cacheControl(CacheControl cacheControl) {
-            return setHeader(HeaderNames.CACHE_CONTROL, cacheControl.toString(), false);
+        public ResponseBuilder cacheControl(@Nullable CacheControl cacheControl) {
+            return setHeader(HeaderNames.CACHE_CONTROL, cacheControl == null ? null : cacheControl.toString(), false);
         }
 
         @Override
@@ -604,12 +610,12 @@ class JaxRSResponse extends Response implements ContainerResponseContext, Writer
         }
 
         @Override
-        public ResponseBuilder header(String name, Object value) {
+        public ResponseBuilder header(String name, @Nullable Object value) {
             return setHeader(name, value, true); // TODO should this actually be false?
         }
 
         @Override
-        public ResponseBuilder replaceAll(MultivaluedMap<String, Object> headers) {
+        public ResponseBuilder replaceAll(@Nullable MultivaluedMap<String, Object> headers) {
             this.headers.clear();
             if (headers != null) {
                 for (Map.Entry<String, List<Object>> entry : headers.entrySet()) {
@@ -653,13 +659,13 @@ class JaxRSResponse extends Response implements ContainerResponseContext, Writer
         }
 
         @Override
-        public ResponseBuilder contentLocation(URI location) {
+        public ResponseBuilder contentLocation(@Nullable URI location) {
             return setHeader(HeaderNames.CONTENT_LOCATION, location, false);
         }
 
         @Override
-        public ResponseBuilder cookie(NewCookie... cookies) {
-            this.cookies = cookies;
+        public ResponseBuilder cookie(NewCookie @Nullable ... cookies) {
+            this.cookies = cookies == null ? new NewCookie[0] : cookies;
             if (cookies == null) {
                 headers.remove(HeaderNames.SET_COOKIE.toString());
             }
@@ -667,37 +673,41 @@ class JaxRSResponse extends Response implements ContainerResponseContext, Writer
         }
 
         @Override
-        public ResponseBuilder expires(Date expires) {
+        public ResponseBuilder expires(@Nullable Date expires) {
             return setHeader(HeaderNames.EXPIRES, expires, false);
         }
 
         @Override
-        public ResponseBuilder lastModified(Date lastModified) {
+        public ResponseBuilder lastModified(@Nullable Date lastModified) {
             return setHeader(HeaderNames.LAST_MODIFIED, lastModified, false);
         }
 
         @Override
-        public ResponseBuilder location(URI location) {
+        public ResponseBuilder location(@Nullable URI location) {
             return setHeader(HeaderNames.LOCATION, location, false);
         }
 
         @Override
-        public ResponseBuilder tag(EntityTag tag) {
+        public ResponseBuilder tag(@Nullable EntityTag tag) {
             return setHeader(HeaderNames.ETAG, tag, false);
         }
 
         @Override
-        public ResponseBuilder tag(String tag) {
-            return tag(new EntityTag(tag));
+        public ResponseBuilder tag(@Nullable String tag) {
+            return tag == null ? tag((EntityTag) null) : tag(new EntityTag(tag));
         }
 
         @Override
-        public ResponseBuilder variants(Variant... variants) {
-            return variants(asList(variants));
+        public ResponseBuilder variants(Variant @Nullable ... variants) {
+            return variants(variants == null ? null : asList(variants));
         }
 
         @Override
-        public ResponseBuilder variants(List<Variant> variants) {
+        public ResponseBuilder variants(@Nullable List<Variant> variants) {
+            if (variants == null) {
+                this.headers.remove("vary");
+                return this;
+            }
             for (Variant variant : variants) {
                 if (variant == null) {
                     this.headers.remove("vary");
@@ -721,7 +731,7 @@ class JaxRSResponse extends Response implements ContainerResponseContext, Writer
         }
 
         @Override
-        public ResponseBuilder links(Link... links) {
+        public ResponseBuilder links(Link @Nullable ... links) {
             if (links == null) {
                 linkHeaders.clear();
             } else {

--- a/src/main/java/io/muserver/rest/JaxRSResponse.java
+++ b/src/main/java/io/muserver/rest/JaxRSResponse.java
@@ -11,6 +11,7 @@ import jakarta.ws.rs.ext.MessageBodyReader;
 import jakarta.ws.rs.ext.RuntimeDelegate;
 import jakarta.ws.rs.ext.WriterInterceptor;
 import jakarta.ws.rs.ext.WriterInterceptorContext;
+import org.jspecify.annotations.Nullable;
 
 import java.io.*;
 import java.lang.annotation.Annotation;
@@ -35,15 +36,15 @@ class JaxRSResponse extends Response implements ContainerResponseContext, Writer
     private final NewCookie[] cookies;
     private final List<Link> links;
     private Annotation[] annotations;
-    private OutputStream outputStream;
+    private @Nullable OutputStream outputStream;
 
-    private JaxRSRequest requestContext;
-    private List<WriterInterceptor> writerInterceptors;
+    private @Nullable JaxRSRequest requestContext;
+    private @Nullable List<WriterInterceptor> writerInterceptors;
     private int nextWriter = 0;
 
     private boolean isClosed = false;
 
-    private ByteArrayInputStream inputStreamBuffer;
+    private @Nullable ByteArrayInputStream inputStreamBuffer;
 
     JaxRSResponse(StatusType status, MultivaluedMap<String, Object> headers, ObjWithType entity, NewCookie[] cookies, List<Link> links, Annotation[] annotations) {
         this.status = status;
@@ -87,7 +88,7 @@ class JaxRSResponse extends Response implements ContainerResponseContext, Writer
 
     @Override
     public Class<?> getType() {
-        return objWithType.type;
+        return Objects.requireNonNull(objWithType.type, "The response entity type has not been set");
     }
 
     @Override
@@ -97,7 +98,7 @@ class JaxRSResponse extends Response implements ContainerResponseContext, Writer
 
     @Override
     public Type getGenericType() {
-        return objWithType.genericType;
+        return Objects.requireNonNull(objWithType.genericType, "The response entity generic type has not been set");
     }
 
     @Override
@@ -126,7 +127,7 @@ class JaxRSResponse extends Response implements ContainerResponseContext, Writer
     }
 
     @Override
-    public Object getEntity() {
+    public @Nullable Object getEntity() {
         return objWithType.entity;
     }
 
@@ -141,7 +142,7 @@ class JaxRSResponse extends Response implements ContainerResponseContext, Writer
     }
 
     @Override
-    public void setEntity(Object entity) {
+    public void setEntity(@Nullable Object entity) {
         objWithType = ObjWithType.objType(entity);
         if (entity instanceof Response) {
             Response resp = (Response) entity;
@@ -151,7 +152,7 @@ class JaxRSResponse extends Response implements ContainerResponseContext, Writer
 
     @Override
     public OutputStream getOutputStream() {
-        return outputStream;
+        return requiredOutputStream();
     }
 
     @Override
@@ -160,7 +161,7 @@ class JaxRSResponse extends Response implements ContainerResponseContext, Writer
     }
 
     @Override
-    public void setEntity(Object entity, Annotation[] annotations, MediaType mediaType) {
+    public void setEntity(@Nullable Object entity, Annotation @Nullable [] annotations, @Nullable MediaType mediaType) {
         setEntity(entity);
         setAnnotations(annotations == null ? Builder.EMPTY_ANNOTATIONS : annotations);
         setMediaType(mediaType);
@@ -173,7 +174,7 @@ class JaxRSResponse extends Response implements ContainerResponseContext, Writer
 
     @Override
     public OutputStream getEntityStream() {
-        return outputStream;
+        return requiredOutputStream();
     }
 
     @Override
@@ -186,19 +187,22 @@ class JaxRSResponse extends Response implements ContainerResponseContext, Writer
         return readEntity0(entityType, null, new Annotation[0]);
     }
 
-    private <T> T readEntity0(Class<T> entityType, Type genericType, Annotation[] annotations) {
-        if (inputStreamBuffer == null && !(InputStream.class.isAssignableFrom(getEntity().getClass()))) {
-            throw new IllegalStateException("The entity is not an input stream, it is " + getEntity().getClass());
+    private <T> T readEntity0(Class<T> entityType, @Nullable Type genericType, Annotation[] annotations) {
+        Object entity = Objects.requireNonNull(getEntity(), "The response has no entity");
+        if (inputStreamBuffer == null && !(entity instanceof InputStream)) {
+            throw new IllegalStateException("The entity is not an input stream, it is " + entity.getClass());
         }
         if (isClosed) throw new IllegalStateException("Cannot read entity; the response is closed");
-        InputStream toRead = inputStreamBuffer != null ? inputStreamBuffer : (InputStream) getEntity();
+        InputStream toRead = inputStreamBuffer != null ? inputStreamBuffer : (InputStream) entity;
+        Type typeToRead = genericType == null ? entityType : genericType;
+        MediaType mediaType = getMediaType() == null ? MediaType.APPLICATION_OCTET_STREAM_TYPE : getMediaType();
         EntityProviders ep = new EntityProviders(EntityProviders.builtInReaders(), emptyList());
-        MessageBodyReader<T> reader = (MessageBodyReader<T>) ep.selectReader(entityType, genericType, annotations, getMediaType());
+        MessageBodyReader<T> reader = (MessageBodyReader<T>) ep.selectReader(entityType, typeToRead, annotations, mediaType);
         if (reader == null) {
             throw new ProcessingException("Cannot read this entity type");
         }
         try {
-            T result = reader.readFrom(entityType, genericType, annotations, getMediaType(), getStringHeaders(), toRead);
+            T result = reader.readFrom(entityType, typeToRead, annotations, mediaType, getStringHeaders(), toRead);
             if (inputStreamBuffer != null) {
                 inputStreamBuffer.reset();
             } else {
@@ -277,13 +281,13 @@ class JaxRSResponse extends Response implements ContainerResponseContext, Writer
     }
 
     @Override
-    public MediaType getMediaType() {
+    public @Nullable MediaType getMediaType() {
         String h = getHeaderString("content-type");
         return h == null ? null : MediaTypeParser.fromString(h);
     }
 
     @Override
-    public void setMediaType(MediaType mediaType) {
+    public void setMediaType(@Nullable MediaType mediaType) {
         if (mediaType == null) {
             headers.remove("content-type");
         } else {
@@ -292,7 +296,7 @@ class JaxRSResponse extends Response implements ContainerResponseContext, Writer
     }
 
     @Override
-    public Locale getLanguage() {
+    public @Nullable Locale getLanguage() {
         String h = getHeaderString(HeaderNames.CONTENT_LANGUAGE.toString());
         if (h == null) return null;
         return Locale.forLanguageTag(h);
@@ -328,23 +332,23 @@ class JaxRSResponse extends Response implements ContainerResponseContext, Writer
     }
 
     @Override
-    public Date getDate() {
+    public @Nullable Date getDate() {
         return dateFromHeader("date");
     }
 
-    private Date dateFromHeader(String name) {
+    private @Nullable Date dateFromHeader(String name) {
         Object date = headers.getFirst(name);
         if (date == null || date.getClass().isAssignableFrom(Date.class)) return (Date)date;
         return Mutils.fromHttpDate(date.toString());
     }
 
     @Override
-    public Date getLastModified() {
+    public @Nullable Date getLastModified() {
         return dateFromHeader("last-modified");
     }
 
     @Override
-    public URI getLocation() {
+    public @Nullable URI getLocation() {
         String s = getHeaderString("location");
         return s == null ? null : URI.create(s);
     }
@@ -360,12 +364,12 @@ class JaxRSResponse extends Response implements ContainerResponseContext, Writer
     }
 
     @Override
-    public Link getLink(String relation) {
+    public @Nullable Link getLink(String relation) {
         return links.stream().filter(link -> link.getRels().contains(relation)).findFirst().orElse(null);
     }
 
     @Override
-    public Link.Builder getLinkBuilder(String relation) {
+    public Link.@Nullable Builder getLinkBuilder(String relation) {
         Link link = getLink(relation);
         if (link == null) {
             return null;
@@ -400,11 +404,11 @@ class JaxRSResponse extends Response implements ContainerResponseContext, Writer
     }
 
     @Override
-    public String getHeaderString(String name) {
+    public @Nullable String getHeaderString(String name) {
         return headerValueToString(headers.getFirst(name));
     }
 
-    private static String headerValueToString(Object value) {
+    private static @Nullable String headerValueToString(@Nullable Object value) {
         if (value == null || value instanceof String) {
             return (String)value;
         }
@@ -427,11 +431,12 @@ class JaxRSResponse extends Response implements ContainerResponseContext, Writer
 
     @Override
     public void proceed() throws IOException, WebApplicationException {
-        while (nextWriter < writerInterceptors.size()) {
+        List<WriterInterceptor> interceptors = Objects.requireNonNull(writerInterceptors, "Writer interceptors have not been initialized");
+        while (nextWriter < interceptors.size()) {
             nextWriter++;
-            WriterInterceptor nextInterceptor = writerInterceptors.get(nextWriter - 1);
+            WriterInterceptor nextInterceptor = interceptors.get(nextWriter - 1);
             List<Class<? extends Annotation>> filterBindings = ResourceClass.getNameBindingAnnotations(nextInterceptor.getClass());
-            if (requestContext.methodHasAnnotations(filterBindings)) {
+            if (requiredRequestContext().methodHasAnnotations(filterBindings)) {
                 nextInterceptor.aroundWriteTo(this);
                 return;
             }
@@ -439,27 +444,35 @@ class JaxRSResponse extends Response implements ContainerResponseContext, Writer
     }
 
     @Override
-    public Object getProperty(String name) {
-        return requestContext.getProperty(name);
+    public @Nullable Object getProperty(String name) {
+        return requiredRequestContext().getProperty(name);
     }
 
     @Override
     public Collection<String> getPropertyNames() {
-        return requestContext.getPropertyNames();
+        return requiredRequestContext().getPropertyNames();
     }
 
     @Override
     public void setProperty(String name, Object object) {
-        requestContext.setProperty(name, object);
+        requiredRequestContext().setProperty(name, object);
     }
 
     @Override
     public void removeProperty(String name) {
-        requestContext.removeProperty(name);
+        requiredRequestContext().removeProperty(name);
     }
 
     public void setRequestContext(JaxRSRequest requestContext) {
         this.requestContext = requestContext;
+    }
+
+    private OutputStream requiredOutputStream() {
+        return Objects.requireNonNull(outputStream, "The response entity stream has not been set");
+    }
+
+    private JaxRSRequest requiredRequestContext() {
+        return Objects.requireNonNull(requestContext, "The response request context has not been set");
     }
 
     // End interceptor specific things
@@ -477,11 +490,11 @@ class JaxRSResponse extends Response implements ContainerResponseContext, Writer
 
         private final MultivaluedMap<String, Object> headers = new LowercasedMultivaluedHashMap<>();
         private final List<Link> linkHeaders = new ArrayList<>();
-        private StatusType status;
-        private Object entity;
+        private @Nullable StatusType status;
+        private @Nullable Object entity;
         private Annotation[] annotations = EMPTY_ANNOTATIONS;
         private NewCookie[] cookies = new NewCookie[0];
-        private MediaType type;
+        private @Nullable MediaType type;
 
         @Override
         public Response build() {
@@ -494,7 +507,7 @@ class JaxRSResponse extends Response implements ContainerResponseContext, Writer
             if (this.type != null) {
                 headers.putSingle(HeaderNames.CONTENT_TYPE.toString(), this.type.toString());
             }
-            return new JaxRSResponse(status, headers, ObjWithType.objType(entity), cookies, linkHeaders, annotations);
+            return new JaxRSResponse(Objects.requireNonNull(status), headers, ObjWithType.objType(entity), cookies, linkHeaders, annotations);
         }
 
         @Override
@@ -508,24 +521,24 @@ class JaxRSResponse extends Response implements ContainerResponseContext, Writer
         }
 
         @Override
-        public ResponseBuilder status(int code, String reasonPhrase) {
+        public ResponseBuilder status(int code, @Nullable String reasonPhrase) {
             if (code < 100 || code > 599) {
                 throw new IllegalArgumentException("Status must be between 100 and 599, but was " + code);
             }
             this.status = Status.fromStatusCode(code);
             if (this.status == null || reasonPhrase != null) {
-                this.status = new CustomStatus(Status.Family.familyOf(code), code, reasonPhrase);
+                this.status = new CustomStatus(Status.Family.familyOf(code), code, reasonPhrase == null ? "" : reasonPhrase);
             }
             return this;
         }
 
         @Override
-        public ResponseBuilder entity(Object entity) {
+        public ResponseBuilder entity(@Nullable Object entity) {
             return entity(entity, EMPTY_ANNOTATIONS);
         }
 
         @Override
-        public ResponseBuilder entity(Object entity, Annotation[] annotations) {
+        public ResponseBuilder entity(@Nullable Object entity, Annotation[] annotations) {
             this.entity = entity;
             this.annotations = annotations;
             return this;
@@ -541,7 +554,7 @@ class JaxRSResponse extends Response implements ContainerResponseContext, Writer
         }
 
         @Override
-        public ResponseBuilder allow(Set<String> methods) {
+        public ResponseBuilder allow(@Nullable Set<String> methods) {
             if (methods == null) {
                 return setHeader(HttpHeaderNames.ALLOW, null, true);
             }
@@ -569,11 +582,11 @@ class JaxRSResponse extends Response implements ContainerResponseContext, Writer
         }
 
         @Override
-        public ResponseBuilder encoding(String encoding) {
+        public ResponseBuilder encoding(@Nullable String encoding) {
             return setHeader(HeaderNames.CONTENT_ENCODING, encoding, false);
         }
 
-        private ResponseBuilder setHeader(CharSequence name, Object value, boolean append) {
+        private ResponseBuilder setHeader(CharSequence name, @Nullable Object value, boolean append) {
             if (value instanceof Iterable) {
                 ((Iterable) value).forEach(v -> setHeader(name, v, append));
             } else {
@@ -607,23 +620,23 @@ class JaxRSResponse extends Response implements ContainerResponseContext, Writer
         }
 
         @Override
-        public ResponseBuilder language(String language) {
+        public ResponseBuilder language(@Nullable String language) {
             return setHeader(HeaderNames.CONTENT_LANGUAGE, language, false);
         }
 
         @Override
-        public ResponseBuilder language(Locale language) {
+        public ResponseBuilder language(@Nullable Locale language) {
             return language(language == null ? null : language.toLanguageTag());
         }
 
         @Override
-        public ResponseBuilder type(MediaType type) {
+        public ResponseBuilder type(@Nullable MediaType type) {
             this.type = type;
             return this;
         }
 
         @Override
-        public ResponseBuilder type(String type) {
+        public ResponseBuilder type(@Nullable String type) {
             if (type == null) {
                 this.type = null;
                 return this;
@@ -632,7 +645,7 @@ class JaxRSResponse extends Response implements ContainerResponseContext, Writer
         }
 
         @Override
-        public ResponseBuilder variant(Variant variant) {
+        public ResponseBuilder variant(@Nullable Variant variant) {
             language(variant == null ? null : variant.getLanguage());
             type(variant == null ? null : variant.getMediaType());
             encoding(variant == null ? null : variant.getEncoding());

--- a/src/main/java/io/muserver/rest/JaxRsHttpHeadersAdapter.java
+++ b/src/main/java/io/muserver/rest/JaxRsHttpHeadersAdapter.java
@@ -19,7 +19,7 @@ class JaxRsHttpHeadersAdapter implements HttpHeaders {
     private static final List<MediaType> WILDCARD_MEDIA_TYPES = Collections.singletonList(MediaType.WILDCARD_TYPE);
     private final Headers muHeaders;
     private final List<io.muserver.Cookie> muCookies;
-    private MultivaluedMap<String, String> copy;
+    private @Nullable MultivaluedMap<String, String> copy;
 
     JaxRsHttpHeadersAdapter(Headers headers, List<io.muserver.Cookie> cookies) {
         muHeaders = headers;
@@ -54,7 +54,7 @@ class JaxRsHttpHeadersAdapter implements HttpHeaders {
             }
             copy = c;
         }
-        return copy;
+        return Objects.requireNonNull(copy);
     }
 
     @Override
@@ -69,7 +69,7 @@ class JaxRsHttpHeadersAdapter implements HttpHeaders {
     @Override
     public List<Locale> getAcceptableLanguages() {
         try {
-            return getLocalesFromHeader(HeaderNames.ACCEPT_LANGUAGE, WILDCARD_LOCALES);
+            return Objects.requireNonNull(getLocalesFromHeader(HeaderNames.ACCEPT_LANGUAGE, WILDCARD_LOCALES));
         } catch (IllegalArgumentException e) {
             throw new BadRequestException("Invalid accept-language header");
         }

--- a/src/main/java/io/muserver/rest/JaxSseEventSinkImpl.java
+++ b/src/main/java/io/muserver/rest/JaxSseEventSinkImpl.java
@@ -11,6 +11,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.ByteArrayOutputStream;
+import java.lang.reflect.Type;
+import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.TimeUnit;
@@ -42,6 +44,7 @@ class JaxSseEventSinkImpl implements SseEventSink {
 
     @Override
     public CompletionStage<?> send(OutboundSseEvent event) {
+        Objects.requireNonNull(event, "event");
         if (isClosed()) {
             throw new IllegalStateException("The SSE stream was already closed");
         }
@@ -55,11 +58,17 @@ class JaxSseEventSinkImpl implements SseEventSink {
             if (event.getComment() != null) {
                 stage = ssePublisher.sendComment(event.getComment());
             }
-            if (event.getData() != null) {
-                MessageBodyWriter messageBodyWriter = entityProviders.selectWriter(event.getType(), event.getGenericType(),
+            Object dataObject = event.getData();
+            if (dataObject != null) {
+                Class<?> dataType = Objects.requireNonNull(event.getType(), "An SSE event with data must have a raw type");
+                Type genericDataType = event.getGenericType();
+                if (genericDataType == null) {
+                    genericDataType = dataType;
+                }
+                MessageBodyWriter messageBodyWriter = entityProviders.selectWriter(dataType, genericDataType,
                     JaxRSResponse.Builder.EMPTY_ANNOTATIONS, event.getMediaType());
                 try (ByteArrayOutputStream out = new ByteArrayOutputStream()) {
-                    messageBodyWriter.writeTo(event.getData(), event.getType(), event.getGenericType(), JaxRSResponse.Builder.EMPTY_ANNOTATIONS,
+                    messageBodyWriter.writeTo(dataObject, dataType, genericDataType, JaxRSResponse.Builder.EMPTY_ANNOTATIONS,
                         event.getMediaType(), muHeadersToJaxObj(response.headers()), out);
                     String data = new String(out.toByteArray(), UTF_8);
                     stage = ssePublisher.send(data, event.getName(), event.getId());

--- a/src/main/java/io/muserver/rest/Jaxutils.java
+++ b/src/main/java/io/muserver/rest/Jaxutils.java
@@ -1,5 +1,6 @@
 package io.muserver.rest;
 
+import org.jspecify.annotations.Nullable;
 import java.io.ByteArrayOutputStream;
 import java.nio.ByteBuffer;
 import java.nio.charset.CharacterCodingException;
@@ -57,7 +58,7 @@ class Jaxutils {
         return decoded.toString();
     }
 
-    private static IllegalArgumentException invalid(String value, Exception cause) {
+    private static IllegalArgumentException invalid(String value, @Nullable Exception cause) {
         return new IllegalArgumentException("Invalid UTF-8 percent encoding in " + value, cause);
     }
 

--- a/src/main/java/io/muserver/rest/LazyAccessInputStream.java
+++ b/src/main/java/io/muserver/rest/LazyAccessInputStream.java
@@ -1,6 +1,7 @@
 package io.muserver.rest;
 
 import io.muserver.MuRequest;
+import org.jspecify.annotations.Nullable;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -11,7 +12,7 @@ import java.io.InputStream;
 class LazyAccessInputStream extends InputStream {
 
     private final MuRequest request;
-    private InputStream inputStream;
+    private @Nullable InputStream inputStream;
 
     LazyAccessInputStream(MuRequest request) {
         this.request = request;
@@ -21,7 +22,7 @@ class LazyAccessInputStream extends InputStream {
         if (inputStream == null) {
             inputStream = request.inputStream().orElse(EmptyInputStream.INSTANCE);
         }
-        return inputStream;
+        return java.util.Objects.requireNonNull(inputStream);
     }
 
     @Override

--- a/src/main/java/io/muserver/rest/LazyAccessOutputStream.java
+++ b/src/main/java/io/muserver/rest/LazyAccessOutputStream.java
@@ -1,6 +1,7 @@
 package io.muserver.rest;
 
 import io.muserver.MuResponse;
+import org.jspecify.annotations.Nullable;
 
 import java.io.IOException;
 import java.io.OutputStream;
@@ -12,7 +13,7 @@ import java.util.Objects;
 class LazyAccessOutputStream extends OutputStream {
     private final MuResponse muResponse;
     private final Runnable beforeFirstWrite;
-    private OutputStream os;
+    private @Nullable OutputStream os;
     private boolean prepared;
 
     private OutputStream out() {
@@ -20,7 +21,7 @@ class LazyAccessOutputStream extends OutputStream {
             prepare();
             os = muResponse.outputStream();
         }
-        return os;
+        return Objects.requireNonNull(os);
     }
 
     LazyAccessOutputStream(MuResponse muResponse, Runnable beforeFirstWrite) {

--- a/src/main/java/io/muserver/rest/LinkHeaderDelegate.java
+++ b/src/main/java/io/muserver/rest/LinkHeaderDelegate.java
@@ -6,6 +6,7 @@ import jakarta.ws.rs.core.Link;
 import jakarta.ws.rs.core.UriBuilder;
 import jakarta.ws.rs.core.UriBuilderException;
 import jakarta.ws.rs.ext.RuntimeDelegate;
+import org.jspecify.annotations.Nullable;
 
 import java.net.URI;
 import java.util.*;
@@ -84,19 +85,19 @@ class LinkHeaderDelegate implements RuntimeDelegate.HeaderDelegate<Link> {
 
         private final URI uri;
         private final List<String> rels;
-        private final String title;
-        private final String type;
+        private final @Nullable String title;
+        private final @Nullable String type;
         private final Map<String, String> params;
 
-        MuLink(URI uri, List<String> rels, String title, String type, Map<String, String> params) {
+        MuLink(URI uri, List<String> rels, @Nullable String title, @Nullable String type, Map<String, String> params) {
             Mutils.notNull("uri", uri);
+            this.uri = java.util.Objects.requireNonNull(uri);
             Mutils.notNull("rels", rels);
-            Mutils.notNull("params", params);
-            this.uri = uri;
-            this.rels = rels;
+            this.rels = java.util.Objects.requireNonNull(rels);
             this.title = title;
             this.type = type;
-            this.params = params;
+            Mutils.notNull("params", params);
+            this.params = java.util.Objects.requireNonNull(params);
         }
 
         @Override
@@ -110,7 +111,7 @@ class LinkHeaderDelegate implements RuntimeDelegate.HeaderDelegate<Link> {
         }
 
         @Override
-        public String getRel() {
+        public @Nullable String getRel() {
             return rels.isEmpty() ? null : rels.get(0);
         }
 
@@ -120,12 +121,12 @@ class LinkHeaderDelegate implements RuntimeDelegate.HeaderDelegate<Link> {
         }
 
         @Override
-        public String getTitle() {
+        public @Nullable String getTitle() {
             return title;
         }
 
         @Override
-        public String getType() {
+        public @Nullable String getType() {
             return type;
         }
 
@@ -159,12 +160,12 @@ class LinkHeaderDelegate implements RuntimeDelegate.HeaderDelegate<Link> {
 
     static class MuLinkBuilder implements Link.Builder {
 
-        private UriBuilder uri;
-        private List<String> rels;
-        private String title;
-        private String type;
-        private Map<String, String> params;
-        private URI baseUri;
+        private @Nullable UriBuilder uri;
+        private @Nullable List<String> rels;
+        private @Nullable String title;
+        private @Nullable String type;
+        private @Nullable Map<String, String> params;
+        private @Nullable URI baseUri;
 
         @Override
         public Link.Builder link(Link link) {
@@ -249,7 +250,7 @@ class LinkHeaderDelegate implements RuntimeDelegate.HeaderDelegate<Link> {
         }
 
         @Override
-        public Link buildRelativized(URI relativeTo, Object... values) {
+        public Link buildRelativized(@Nullable URI relativeTo, Object... values) {
             if (this.uri == null) {
                 throw new UriBuilderException("No URI has been set");
             }
@@ -260,7 +261,9 @@ class LinkHeaderDelegate implements RuntimeDelegate.HeaderDelegate<Link> {
             if (relativeTo != null) {
                 built = relativeTo.relativize(built);
             }
-            return new MuLink(built, coalesce(rels, emptyList()), title, type, coalesce(params, emptyMap()));
+            List<String> relsToUse = rels == null ? emptyList() : rels;
+            Map<String, String> paramsToUse = params == null ? emptyMap() : params;
+            return new MuLink(built, relsToUse, title, type, paramsToUse);
         }
     }
 }

--- a/src/main/java/io/muserver/rest/LinkHeaderDelegate.java
+++ b/src/main/java/io/muserver/rest/LinkHeaderDelegate.java
@@ -40,11 +40,19 @@ class LinkHeaderDelegate implements RuntimeDelegate.HeaderDelegate<Link> {
         }
 
         Map<String, String> parma = h.parameters();
-        Link.Builder builder = new MuLinkBuilder()
-            .uri(uri.substring(1, uri.length() - 1))
-            .rel(parma.get("rel"))
-            .title(parma.get("title"))
-            .type(parma.get("type"));
+        Link.Builder builder = new MuLinkBuilder().uri(uri.substring(1, uri.length() - 1));
+        String rel = parma.get("rel");
+        if (rel != null) {
+            builder.rel(rel);
+        }
+        String title = parma.get("title");
+        if (title != null) {
+            builder.title(title);
+        }
+        String type = parma.get("type");
+        if (type != null) {
+            builder.type(type);
+        }
 
         for (Map.Entry<String, String> entry : parma.entrySet()) {
             String key = entry.getKey();
@@ -59,6 +67,7 @@ class LinkHeaderDelegate implements RuntimeDelegate.HeaderDelegate<Link> {
 
     @Override
     public String toString(Link value) {
+        Mutils.notNull("value", value);
         StringBuilder sb = new StringBuilder();
         sb.append("<").append(value.getUri().toString()).append(">");
         if (value.getRels().size() > 0) {
@@ -141,7 +150,7 @@ class LinkHeaderDelegate implements RuntimeDelegate.HeaderDelegate<Link> {
         }
 
         @Override
-        public boolean equals(Object o) {
+        public boolean equals(@Nullable Object o) {
             if (this == o) return true;
             if (o == null || getClass() != o.getClass()) return false;
             MuLink muLink = (MuLink) o;
@@ -169,6 +178,7 @@ class LinkHeaderDelegate implements RuntimeDelegate.HeaderDelegate<Link> {
 
         @Override
         public Link.Builder link(Link link) {
+            Mutils.notNull("link", link);
             this.uri = link.getUriBuilder();
             this.rels = link.getRels();
             this.title = link.getTitle();
@@ -184,36 +194,42 @@ class LinkHeaderDelegate implements RuntimeDelegate.HeaderDelegate<Link> {
 
         @Override
         public Link.Builder uri(URI uri) {
+            Mutils.notNull("uri", uri);
             this.uri = UriBuilder.fromUri(uri);
             return this;
         }
 
         @Override
         public Link.Builder uri(String uri) {
+            Mutils.notNull("uri", uri);
             this.uri = UriBuilder.fromUri(uri);
             return this;
         }
 
         @Override
         public Link.Builder baseUri(URI uri) {
+            Mutils.notNull("uri", uri);
             this.baseUri = uri;
             return this;
         }
 
         @Override
         public Link.Builder baseUri(String uri) {
+            Mutils.notNull("uri", uri);
             return baseUri(URI.create(uri));
         }
 
         @Override
         public Link.Builder uriBuilder(UriBuilder uriBuilder) {
+            Mutils.notNull("uriBuilder", uriBuilder);
             this.uri = uriBuilder;
             return this;
         }
 
         @Override
         public Link.Builder rel(String rel) {
-            if (rel == null || rel.isEmpty()) {
+            Mutils.notNull("rel", rel);
+            if (rel.isEmpty()) {
                 return this;
             }
             if (rels == null) {
@@ -225,18 +241,22 @@ class LinkHeaderDelegate implements RuntimeDelegate.HeaderDelegate<Link> {
 
         @Override
         public Link.Builder title(String title) {
+            Mutils.notNull("title", title);
             this.title = title;
             return this;
         }
 
         @Override
         public Link.Builder type(String type) {
+            Mutils.notNull("type", type);
             this.type = type;
             return this;
         }
 
         @Override
         public Link.Builder param(String name, String value) {
+            Mutils.notNull("name", name);
+            Mutils.notNull("value", value);
             if (params == null) {
                 params = new HashMap<>();
             }
@@ -246,11 +266,16 @@ class LinkHeaderDelegate implements RuntimeDelegate.HeaderDelegate<Link> {
 
         @Override
         public Link build(Object... values) {
-            return buildRelativized(null, values);
+            return buildInternal(null, values);
         }
 
         @Override
-        public Link buildRelativized(@Nullable URI relativeTo, Object... values) {
+        public Link buildRelativized(URI relativeTo, Object... values) {
+            Mutils.notNull("relativeTo", relativeTo);
+            return buildInternal(relativeTo, values);
+        }
+
+        private Link buildInternal(@Nullable URI relativeTo, Object... values) {
             if (this.uri == null) {
                 throw new UriBuilderException("No URI has been set");
             }

--- a/src/main/java/io/muserver/rest/LowercasedMultivaluedHashMap.java
+++ b/src/main/java/io/muserver/rest/LowercasedMultivaluedHashMap.java
@@ -24,12 +24,12 @@ class LowercasedMultivaluedHashMap<V> extends AbstractMultivaluedMap<String, V> 
      */
     private static class LowercasedHashMap<V> extends HashMap<String, V> {
         @Override
-        public @Nullable V get(Object key) {
+        public @Nullable V get(@Nullable Object key) {
             return super.get(toLower(key));
         }
 
         @Override
-        public boolean containsKey(Object key) {
+        public boolean containsKey(@Nullable Object key) {
             return super.containsKey(toLower(key));
         }
 
@@ -46,12 +46,12 @@ class LowercasedMultivaluedHashMap<V> extends AbstractMultivaluedMap<String, V> 
         }
 
         @Override
-        public @Nullable V remove(Object key) {
+        public @Nullable V remove(@Nullable Object key) {
             return super.remove(toLower(key));
         }
 
         @Override
-        public V getOrDefault(Object key, V defaultValue) {
+        public @Nullable V getOrDefault(@Nullable Object key, @Nullable V defaultValue) {
             return super.getOrDefault(toLower(key), defaultValue);
         }
 
@@ -61,7 +61,7 @@ class LowercasedMultivaluedHashMap<V> extends AbstractMultivaluedMap<String, V> 
         }
 
         @Override
-        public boolean remove(Object key, Object value) {
+        public boolean remove(@Nullable Object key, @Nullable Object value) {
             return super.remove(toLower(key), value);
         }
 
@@ -95,7 +95,7 @@ class LowercasedMultivaluedHashMap<V> extends AbstractMultivaluedMap<String, V> 
             return super.merge(key.toLowerCase(), value, remappingFunction);
         }
 
-        private static Object toLower(Object val) {
+        private static @Nullable Object toLower(@Nullable Object val) {
             if (val instanceof String) {
                 return ((String) val).toLowerCase();
             }

--- a/src/main/java/io/muserver/rest/LowercasedMultivaluedHashMap.java
+++ b/src/main/java/io/muserver/rest/LowercasedMultivaluedHashMap.java
@@ -1,6 +1,7 @@
 package io.muserver.rest;
 
 import jakarta.ws.rs.core.AbstractMultivaluedMap;
+import org.jspecify.annotations.Nullable;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -23,7 +24,7 @@ class LowercasedMultivaluedHashMap<V> extends AbstractMultivaluedMap<String, V> 
      */
     private static class LowercasedHashMap<V> extends HashMap<String, V> {
         @Override
-        public V get(Object key) {
+        public @Nullable V get(Object key) {
             return super.get(toLower(key));
         }
 
@@ -33,7 +34,7 @@ class LowercasedMultivaluedHashMap<V> extends AbstractMultivaluedMap<String, V> 
         }
 
         @Override
-        public V put(String key, V value) {
+        public @Nullable V put(String key, V value) {
             return super.put(key.toLowerCase(), value);
         }
 
@@ -45,7 +46,7 @@ class LowercasedMultivaluedHashMap<V> extends AbstractMultivaluedMap<String, V> 
         }
 
         @Override
-        public V remove(Object key) {
+        public @Nullable V remove(Object key) {
             return super.remove(toLower(key));
         }
 
@@ -55,7 +56,7 @@ class LowercasedMultivaluedHashMap<V> extends AbstractMultivaluedMap<String, V> 
         }
 
         @Override
-        public V putIfAbsent(String key, V value) {
+        public @Nullable V putIfAbsent(String key, V value) {
             return super.putIfAbsent(key.toLowerCase(), value);
         }
 
@@ -70,27 +71,27 @@ class LowercasedMultivaluedHashMap<V> extends AbstractMultivaluedMap<String, V> 
         }
 
         @Override
-        public V replace(String key, V value) {
+        public @Nullable V replace(String key, V value) {
             return super.replace(key.toLowerCase(), value);
         }
 
         @Override
-        public V computeIfAbsent(String key, Function<? super String, ? extends V> mappingFunction) {
+        public @Nullable V computeIfAbsent(String key, Function<? super String, ? extends V> mappingFunction) {
             return super.computeIfAbsent(key.toLowerCase(), mappingFunction);
         }
 
         @Override
-        public V computeIfPresent(String key, BiFunction<? super String, ? super V, ? extends V> remappingFunction) {
+        public @Nullable V computeIfPresent(String key, BiFunction<? super String, ? super V, ? extends V> remappingFunction) {
             return super.computeIfPresent(key.toLowerCase(), remappingFunction);
         }
 
         @Override
-        public V compute(String key, BiFunction<? super String, ? super V, ? extends V> remappingFunction) {
+        public @Nullable V compute(String key, BiFunction<? super String, ? super V, ? extends V> remappingFunction) {
             return super.compute(key.toLowerCase(), remappingFunction);
         }
 
         @Override
-        public V merge(String key, V value, BiFunction<? super V, ? super V, ? extends V> remappingFunction) {
+        public @Nullable V merge(String key, V value, BiFunction<? super V, ? super V, ? extends V> remappingFunction) {
             return super.merge(key.toLowerCase(), value, remappingFunction);
         }
 

--- a/src/main/java/io/muserver/rest/MediaTypeDeterminer.java
+++ b/src/main/java/io/muserver/rest/MediaTypeDeterminer.java
@@ -82,13 +82,13 @@ class MediaTypeDeterminer {
         // 8. For each member of M,m: • If m is a concrete type, set Mselected = m, finish.
         for (CombinedMediaType mediaType : m) {
             if (mediaType.isConcrete()) {
-                return new MediaType(mediaType.type, mediaType.subType, mediaType.charset);
+                return new MediaType(Objects.requireNonNull(mediaType.type), Objects.requireNonNull(mediaType.subType), mediaType.charset);
             }
         }
 
         // 9. If M contains ‘*/*’ or ‘application/*’, set Mselected = ‘application/octet-stream’, finish
         for (CombinedMediaType mediaType : m) {
-            if ((mediaType.isWildcardType || mediaType.type.equals("application")) && mediaType.isWildcardSubtype) {
+            if ((mediaType.isWildcardType || "application".equals(mediaType.type)) && mediaType.isWildcardSubtype) {
                 return MediaType.APPLICATION_OCTET_STREAM_TYPE;
             }
         }

--- a/src/main/java/io/muserver/rest/MediaTypeHeaderDelegate.java
+++ b/src/main/java/io/muserver/rest/MediaTypeHeaderDelegate.java
@@ -1,6 +1,7 @@
 package io.muserver.rest;
 
 import io.muserver.MediaTypeParser;
+import io.muserver.Mutils;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.ext.RuntimeDelegate;
 import org.jspecify.annotations.Nullable;
@@ -19,11 +20,13 @@ class MediaTypeHeaderDelegate implements RuntimeDelegate.HeaderDelegate<MediaTyp
 
     @Override
     public MediaType fromString(String value) {
+        Mutils.notNull("value", value);
         return MediaTypeParser.fromString(value);
     }
 
     @Override
     public String toString(MediaType mediaType) {
+        Mutils.notNull("mediaType", mediaType);
         return MediaTypeParser.toString(mediaType);
     }
 

--- a/src/main/java/io/muserver/rest/MediaTypeHeaderDelegate.java
+++ b/src/main/java/io/muserver/rest/MediaTypeHeaderDelegate.java
@@ -3,6 +3,7 @@ package io.muserver.rest;
 import io.muserver.MediaTypeParser;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.ext.RuntimeDelegate;
+import org.jspecify.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -26,7 +27,7 @@ class MediaTypeHeaderDelegate implements RuntimeDelegate.HeaderDelegate<MediaTyp
         return MediaTypeParser.toString(mediaType);
     }
 
-    static List<MediaType> fromStrings(List<String> accepts) {
+    static List<MediaType> fromStrings(@Nullable List<String> accepts) {
         if (accepts == null || accepts.isEmpty()) {
             return Collections.emptyList();
         }
@@ -39,7 +40,7 @@ class MediaTypeHeaderDelegate implements RuntimeDelegate.HeaderDelegate<MediaTyp
         return results;
     }
 
-    static boolean atLeastOneCompatible(List<MediaType> providerProduces, List<MediaType> consumerAccepts, String checkParameter) {
+    static boolean atLeastOneCompatible(List<MediaType> providerProduces, List<MediaType> consumerAccepts, @Nullable String checkParameter) {
         for (MediaType clientAccept : consumerAccepts) {
             for (MediaType produce : providerProduces) {
                 boolean compatible = produce.isCompatible(clientAccept);
@@ -47,7 +48,7 @@ class MediaTypeHeaderDelegate implements RuntimeDelegate.HeaderDelegate<MediaTyp
                     if (checkParameter != null) {
                         String clientParam = clientAccept.getParameters().get(checkParameter);
                         if (clientParam != null) {
-                            String serverParam = produce.getParameters().get(checkParameter);
+                            @Nullable String serverParam = produce.getParameters().get(checkParameter);
                             compatible = clientParam.equalsIgnoreCase(serverParam);
                         }
                     }

--- a/src/main/java/io/muserver/rest/MuPathSegment.java
+++ b/src/main/java/io/muserver/rest/MuPathSegment.java
@@ -4,6 +4,7 @@ import io.muserver.Mutils;
 import jakarta.ws.rs.core.MultivaluedHashMap;
 import jakarta.ws.rs.core.MultivaluedMap;
 import jakarta.ws.rs.core.PathSegment;
+import org.jspecify.annotations.Nullable;
 
 import java.util.*;
 import java.util.function.Function;
@@ -58,7 +59,7 @@ class MuPathSegment implements PathSegment {
     }
 
     @Override
-    public boolean equals(Object o) {
+    public boolean equals(@Nullable Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         MuPathSegment that = (MuPathSegment) o;

--- a/src/main/java/io/muserver/rest/MuPathSegment.java
+++ b/src/main/java/io/muserver/rest/MuPathSegment.java
@@ -95,7 +95,7 @@ class MuPathSegment implements PathSegment {
     }
 
     public List<MuPathSegment> resolve(String name, String value, boolean encodeSlashInPath) {
-        String newPath = MuUriBuilder.resolve(path, name, value);
+        String newPath = Objects.requireNonNull(MuUriBuilder.resolve(path, name, value));
         MultivaluedMap<String, String> newParams = new MultivaluedHashMap<>();
         for (Map.Entry<String, List<String>> matrixParam : params.entrySet()) {
             newParams.put(MuUriBuilder.resolve(matrixParam.getKey(), name, value), matrixParam.getValue().stream()

--- a/src/main/java/io/muserver/rest/MuRuntimeDelegate.java
+++ b/src/main/java/io/muserver/rest/MuRuntimeDelegate.java
@@ -126,6 +126,7 @@ public class MuRuntimeDelegate extends RuntimeDelegate {
     @Override
     @SuppressWarnings("unchecked")
     public <T> HeaderDelegate<T> createHeaderDelegate(Class<T> type) throws IllegalArgumentException {
+        Mutils.notNull("type", type);
         HeaderDelegate<T> headerDelegate = headerDelegates.get(type);
         if (headerDelegate != null) {
             return (HeaderDelegate<T>) headerDelegate;

--- a/src/main/java/io/muserver/rest/MuRuntimeDelegate.java
+++ b/src/main/java/io/muserver/rest/MuRuntimeDelegate.java
@@ -96,7 +96,7 @@ public class MuRuntimeDelegate extends RuntimeDelegate {
         }
         Collection<NewCookie> newCookies = from.getCookies().values();
         if (!newCookies.isEmpty()) {
-            var headerDelegate = singleton.createHeaderDelegate(NewCookie.class);
+            var headerDelegate = getInstance().createHeaderDelegate(NewCookie.class);
             for (NewCookie cookie : newCookies) {
                 to.headers().add(HeaderNames.SET_COOKIE, headerDelegate.toString(cookie));
             }

--- a/src/main/java/io/muserver/rest/MuSeBootstrap.java
+++ b/src/main/java/io/muserver/rest/MuSeBootstrap.java
@@ -7,6 +7,7 @@ import io.muserver.MuServerBuilder;
 import jakarta.ws.rs.ApplicationPath;
 import jakarta.ws.rs.SeBootstrap;
 import jakarta.ws.rs.core.Application;
+import org.jspecify.annotations.Nullable;
 
 import javax.net.ssl.SSLContext;
 import java.lang.reflect.InvocationTargetException;
@@ -187,7 +188,7 @@ final class MuSeBootstrap {
         }
 
         @Override
-        public Object property(String name) {
+        public @Nullable Object property(String name) {
             return properties.get(name);
         }
     }
@@ -214,7 +215,7 @@ final class MuSeBootstrap {
             }
             return CompletableFuture.completedFuture(new StopResult() {
                 @Override
-                public <T> T unwrap(Class<T> nativeClass) {
+                public <T> @Nullable T unwrap(Class<T> nativeClass) {
                     return null;
                 }
             });

--- a/src/main/java/io/muserver/rest/MuSeBootstrap.java
+++ b/src/main/java/io/muserver/rest/MuSeBootstrap.java
@@ -133,7 +133,7 @@ final class MuSeBootstrap {
         }
 
         @Override
-        public SeBootstrap.Configuration.Builder property(String name, Object value) {
+        public SeBootstrap.Configuration.Builder property(String name, @Nullable Object value) {
             Objects.requireNonNull(name, "name");
             if (PROPERTY_TYPES.containsKey(name)) {
                 if (value == null) {

--- a/src/main/java/io/muserver/rest/MuSecurityContext.java
+++ b/src/main/java/io/muserver/rest/MuSecurityContext.java
@@ -1,17 +1,18 @@
 package io.muserver.rest;
 
 import jakarta.ws.rs.core.SecurityContext;
+import org.jspecify.annotations.Nullable;
 
 import java.security.Principal;
 
 class MuSecurityContext implements SecurityContext {
 
-    private final Principal principal;
+    private final @Nullable Principal principal;
     private final Authorizer authorizer;
     private final boolean isHttps;
-    private final String authenticationScheme;
+    private final @Nullable String authenticationScheme;
 
-    MuSecurityContext(Principal principal, Authorizer authorizer, boolean isHttps, String authenticationScheme) {
+    MuSecurityContext(@Nullable Principal principal, Authorizer authorizer, boolean isHttps, @Nullable String authenticationScheme) {
         this.principal = principal;
         this.authorizer = authorizer;
         this.isHttps = isHttps;
@@ -19,13 +20,13 @@ class MuSecurityContext implements SecurityContext {
     }
 
     @Override
-    public Principal getUserPrincipal() {
+    public @Nullable Principal getUserPrincipal() {
         return principal;
     }
 
     @Override
     public boolean isUserInRole(String role) {
-        return authorizer.isInRole(principal, role);
+        return principal != null && authorizer.isInRole(principal, role);
     }
 
     @Override
@@ -34,7 +35,7 @@ class MuSecurityContext implements SecurityContext {
     }
 
     @Override
-    public String getAuthenticationScheme() {
+    public @Nullable String getAuthenticationScheme() {
         return authenticationScheme;
     }
 

--- a/src/main/java/io/muserver/rest/MuUriBuilder.java
+++ b/src/main/java/io/muserver/rest/MuUriBuilder.java
@@ -27,21 +27,21 @@ class MuUriBuilder extends UriBuilder {
         MuRuntimeDelegate.ensureSet();
     }
 
-    private String scheme;
-    private String userInfo;
-    private String host;
+    private @Nullable String scheme;
+    private @Nullable String userInfo;
+    private @Nullable String host;
     private int port = -1;
     private List<MuPathSegment> pathSegments = new ArrayList<>();
     private MultivaluedMap<String, String> query = new MultivaluedHashMap<>();
-    private String fragment;
+    private @Nullable String fragment;
     private boolean hasPrecedingSlash = false;
     private boolean hasTrailingSlash = false;
 
     MuUriBuilder() {
     }
 
-    private MuUriBuilder(String scheme, String userInfo, String host, int port, List<MuPathSegment> pathSegments,
-                         boolean hasPrecedingSlash, boolean hasTrailingSlash, MultivaluedMap<String, String> query, String fragment) {
+    private MuUriBuilder(@Nullable String scheme, @Nullable String userInfo, @Nullable String host, int port, List<MuPathSegment> pathSegments,
+                         boolean hasPrecedingSlash, boolean hasTrailingSlash, MultivaluedMap<String, String> query, @Nullable String fragment) {
         this.scheme = scheme;
         this.userInfo = userInfo;
         this.host = host;
@@ -128,7 +128,7 @@ class MuUriBuilder extends UriBuilder {
     public UriBuilder path(String path) {
         Mutils.notNull("path", path);
         setSlashes(path);
-        this.pathSegments.addAll(MuUriInfo.pathStringToSegments(decode(path), false).collect(toList()));
+        this.pathSegments.addAll(MuUriInfo.pathStringToSegments(Objects.requireNonNull(decode(path)), false).collect(toList()));
         return this;
     }
 
@@ -185,7 +185,7 @@ class MuUriBuilder extends UriBuilder {
         Mutils.notNull("segments", segments);
         for (String segment : segments) {
             Mutils.notNull("segment", segment);
-            this.pathSegments.addAll(MuUriInfo.pathStringToSegments(decode(segment), true).collect(toList()));
+            this.pathSegments.addAll(MuUriInfo.pathStringToSegments(Objects.requireNonNull(decode(segment)), true).collect(toList()));
         }
         this.hasTrailingSlash = false;
         return this;
@@ -496,7 +496,7 @@ class MuUriBuilder extends UriBuilder {
         return map;
     }
 
-    private static void addTemplateNames(List<String> sorted, String value) {
+    private static void addTemplateNames(List<String> sorted, @Nullable String value) {
         if (value != null) {
             List<String> toAdd = UriPattern.uriTemplateToRegex(value).namedGroups();
             for (String s : toAdd) {
@@ -507,7 +507,7 @@ class MuUriBuilder extends UriBuilder {
         }
     }
 
-    private static String decode(Object value) {
+    private static @Nullable String decode(@Nullable Object value) {
         return value == null ? null : Jaxutils.leniantUrlDecode(value.toString());
     }
 

--- a/src/main/java/io/muserver/rest/MuUriBuilder.java
+++ b/src/main/java/io/muserver/rest/MuUriBuilder.java
@@ -62,6 +62,7 @@ class MuUriBuilder extends UriBuilder {
 
     @Override
     public UriBuilder uri(URI uri) {
+        Mutils.notNull("uri", uri);
         scheme(uri.getScheme());
         userInfo(uri.getUserInfo());
         host(uri.getHost());
@@ -90,6 +91,7 @@ class MuUriBuilder extends UriBuilder {
 
     @Override
     public UriBuilder schemeSpecificPart(String ssp) {
+        Mutils.notNull("ssp", ssp);
         MuUriBuilder builder = (MuUriBuilder) fromUri(URI.create(scheme + "://" + ssp));
         this.scheme = builder.scheme;
         this.userInfo = builder.userInfo;
@@ -101,19 +103,19 @@ class MuUriBuilder extends UriBuilder {
     }
 
     @Override
-    public UriBuilder scheme(String scheme) {
+    public UriBuilder scheme(@Nullable String scheme) {
         this.scheme = decode(scheme);
         return this;
     }
 
     @Override
-    public UriBuilder userInfo(String userInfo) {
+    public UriBuilder userInfo(@Nullable String userInfo) {
         this.userInfo = decode(userInfo);
         return this;
     }
 
     @Override
-    public UriBuilder host(String host) {
+    public UriBuilder host(@Nullable String host) {
         this.host = decode(host);
         return this;
     }
@@ -133,9 +135,11 @@ class MuUriBuilder extends UriBuilder {
     }
 
     @Override
-    public UriBuilder replacePath(String path) {
+    public UriBuilder replacePath(@Nullable String path) {
         this.pathSegments.clear();
-        return path(path);
+        this.hasPrecedingSlash = false;
+        this.hasTrailingSlash = false;
+        return path == null ? this : path(path);
     }
 
     @Override
@@ -192,7 +196,7 @@ class MuUriBuilder extends UriBuilder {
     }
 
     @Override
-    public UriBuilder replaceMatrix(String matrix) {
+    public UriBuilder replaceMatrix(@Nullable String matrix) {
         MultivaluedMap<String, String> params = getOrCreateCurrentSegment().getMatrixParameters();
         params.clear();
         if (matrix != null) {
@@ -222,12 +226,11 @@ class MuUriBuilder extends UriBuilder {
     }
 
     @Override
-    public UriBuilder replaceMatrixParam(String name, Object... values) {
+    public UriBuilder replaceMatrixParam(String name, Object @Nullable ... values) {
         Mutils.notNull("name", name);
-        Mutils.notNull("values", values);
         MultivaluedMap<String, String> params = getOrCreateCurrentSegment().getMatrixParameters();
-        params.replace(name, Stream.of(values).map(Object::toString).collect(toList()));
-        return this;
+        params.remove(name);
+        return values == null || values.length == 0 ? this : matrixParam(name, values);
     }
 
     private MuPathSegment getOrCreateCurrentSegment() {
@@ -242,7 +245,7 @@ class MuUriBuilder extends UriBuilder {
     }
 
     @Override
-    public UriBuilder replaceQuery(String qs) {
+    public UriBuilder replaceQuery(@Nullable String qs) {
         if (qs == null) {
             this.query.clear();
         } else {
@@ -268,14 +271,14 @@ class MuUriBuilder extends UriBuilder {
     }
 
     @Override
-    public UriBuilder replaceQueryParam(String name, Object... values) {
+    public UriBuilder replaceQueryParam(String name, Object @Nullable ... values) {
         Mutils.notNull("name", name);
         query.remove(name);
         return values == null ? this : queryParam(name, values);
     }
 
     @Override
-    public UriBuilder fragment(String fragment) {
+    public UriBuilder fragment(@Nullable String fragment) {
         this.fragment = decode(fragment);
         return this;
     }

--- a/src/main/java/io/muserver/rest/MuUriInfo.java
+++ b/src/main/java/io/muserver/rest/MuUriInfo.java
@@ -3,6 +3,7 @@ package io.muserver.rest;
 import io.muserver.Mutils;
 import io.netty.handler.codec.http.QueryStringDecoder;
 import jakarta.ws.rs.core.*;
+import org.jspecify.annotations.Nullable;
 
 import java.net.URI;
 import java.util.ArrayList;
@@ -24,9 +25,9 @@ class MuUriInfo implements UriInfo {
     private final URI baseUri;
     private final URI requestUri;
     private final String encodedRelativePath;
-    private final RequestMatcher.MatchedMethod matchedMethod;
+    private final RequestMatcher.@Nullable MatchedMethod matchedMethod;
 
-    MuUriInfo(URI baseUri, URI requestUri, String encodedRelativePath, RequestMatcher.MatchedMethod matchedMethod) {
+    MuUriInfo(URI baseUri, URI requestUri, String encodedRelativePath, RequestMatcher.@Nullable MatchedMethod matchedMethod) {
         this.baseUri = baseUri;
         this.requestUri = requestUri;
         this.encodedRelativePath = encodedRelativePath;
@@ -168,7 +169,7 @@ class MuUriInfo implements UriInfo {
 
     @Override
     public List<String> getMatchedURIs(boolean decode) {
-        RequestMatcher.MatchedMethod mm = matchedMethod;
+        RequestMatcher.@Nullable MatchedMethod mm = matchedMethod;
         if (mm == null) {
             return Collections.emptyList();
         }
@@ -183,7 +184,8 @@ class MuUriInfo implements UriInfo {
 
     @Override
     public List<Object> getMatchedResources() {
-        return matchedMethod == null ? Collections.emptyList() : Collections.singletonList(matchedMethod.matchedClass.resourceClass.resourceInstance);
+        return matchedMethod == null ? Collections.emptyList()
+            : Collections.singletonList(matchedMethod.matchedClass.resourceClass.requiredResourceInstance());
     }
 
     @Override

--- a/src/main/java/io/muserver/rest/ObjWithType.java
+++ b/src/main/java/io/muserver/rest/ObjWithType.java
@@ -2,18 +2,19 @@ package io.muserver.rest;
 
 import jakarta.ws.rs.core.GenericEntity;
 import jakarta.ws.rs.core.Response;
+import org.jspecify.annotations.Nullable;
 
 import java.lang.reflect.Type;
 
 class ObjWithType {
     private static final ObjWithType EMPTY = new ObjWithType(null, null, null, null);
 
-    final Class type;
-    final Type genericType;
-    final JaxRSResponse response;
-    final Object entity;
+    final @Nullable Class type;
+    final @Nullable Type genericType;
+    final @Nullable JaxRSResponse response;
+    final @Nullable Object entity;
 
-    ObjWithType(Class type, Type genericType, JaxRSResponse response, Object entity) {
+    ObjWithType(@Nullable Class type, @Nullable Type genericType, @Nullable JaxRSResponse response, @Nullable Object entity) {
         this.type = type;
         this.genericType = genericType;
         this.response = response;
@@ -32,16 +33,16 @@ class ObjWithType {
         }
     }
 
-    static ObjWithType objType(Object valueFromMethod) {
+    static ObjWithType objType(@Nullable Object valueFromMethod) {
         return objType(valueFromMethod, null);
     }
 
-    static ObjWithType objType(Object valueFromMethod, Type resourceMethodReturnType) {
+    static ObjWithType objType(@Nullable Object valueFromMethod, @Nullable Type resourceMethodReturnType) {
         if (valueFromMethod == null) {
             return EMPTY;
         }
-        Object entity;
-        JaxRSResponse response;
+        @Nullable Object entity;
+        @Nullable JaxRSResponse response;
         if (valueFromMethod instanceof Response) {
             response = JaxRSResponse.from((Response) valueFromMethod);
             entity = response.getEntity();
@@ -49,8 +50,8 @@ class ObjWithType {
             response = null;
             entity = valueFromMethod;
         }
-        Class type;
-        Type genericType;
+        @Nullable Class type;
+        @Nullable Type genericType;
         if (entity instanceof GenericEntity) {
             GenericEntity ge = (GenericEntity) entity;
             entity = ge.getEntity();

--- a/src/main/java/io/muserver/rest/OpenApiDocumentor.java
+++ b/src/main/java/io/muserver/rest/OpenApiDocumentor.java
@@ -25,16 +25,16 @@ import static java.util.Collections.singletonList;
 
 class OpenApiDocumentor implements MuHandler {
     private final List<ResourceClass> roots;
-    private final String openApiJsonUrl;
+    private final @Nullable String openApiJsonUrl;
     private final OpenAPIObject openAPIObject;
-    private final String openApiHtmlUrl;
-    private final String openApiHtmlCss;
+    private final @Nullable String openApiHtmlUrl;
+    private final @Nullable String openApiHtmlCss;
     private final CORSConfig corsConfig;
     private final List<SchemaReference> customSchemas;
     private final SchemaObjectCustomizer schemaObjectCustomizer;
     private final List<ParamConverterProvider> paramConverterProviders;
 
-    OpenApiDocumentor(List<ResourceClass> roots, String openApiJsonUrl, String openApiHtmlUrl, OpenAPIObject openAPIObject, String openApiHtmlCss, CORSConfig corsConfig, List<SchemaReference> customSchemas, SchemaObjectCustomizer schemaObjectCustomizer, List<ParamConverterProvider> paramConverterProviders) {
+    OpenApiDocumentor(List<ResourceClass> roots, @Nullable String openApiJsonUrl, @Nullable String openApiHtmlUrl, OpenAPIObject openAPIObject, @Nullable String openApiHtmlCss, CORSConfig corsConfig, List<SchemaReference> customSchemas, SchemaObjectCustomizer schemaObjectCustomizer, List<ParamConverterProvider> paramConverterProviders) {
         this.customSchemas = customSchemas;
         this.schemaObjectCustomizer = schemaObjectCustomizer;
         this.paramConverterProviders = paramConverterProviders;
@@ -110,7 +110,9 @@ class OpenApiDocumentor implements MuHandler {
 
             try (OutputStreamWriter osw = new OutputStreamWriter(response.outputStream(), StandardCharsets.UTF_8);
                  BufferedWriter writer = new BufferedWriter(osw, 8192)) {
-                new HtmlDocumentor(writer, builtApi, openApiHtmlCss, request.uri()).writeHtml();
+                new HtmlDocumentor(writer, builtApi,
+                    Objects.requireNonNull(openApiHtmlCss, "OpenAPI HTML CSS was not initialized"),
+                    request.uri()).writeHtml();
             }
         }
 
@@ -137,7 +139,12 @@ class OpenApiDocumentor implements MuHandler {
 
             Map<String, OperationObject> operations;
             if (pathItems.containsKey(path)) {
-                operations = pathItems.get(path).operations();
+                PathItemObjectBuilder pathItem = Objects.requireNonNull(pathItems.get(path));
+                Map<String, OperationObject> configuredOperations = pathItem.operations();
+                operations = configuredOperations == null ? new LinkedHashMap<>() : configuredOperations;
+                if (configuredOperations == null) {
+                    pathItem.withOperations(operations);
+                }
             } else {
                 operations = new LinkedHashMap<>();
                 PathItemObjectBuilder pathItem = pathItemObject()
@@ -159,17 +166,18 @@ class OpenApiDocumentor implements MuHandler {
 
             String opIdPath = getPathWithoutRegex(root, method, parentResourcePath).replace("{", "_").replace("}", "_");
             String opPath = Mutils.trim(opIdPath, "/").replace("/", "_");
-            String opKey = method.httpMethod.name().toLowerCase();
+            String opKey = method.requiredHttpMethod().name().toLowerCase();
             OperationObject existing = operations.get(opKey);
             if (existing == null) {
                 existing = method.createOperationBuilder(customSchemas)
-                    .withOperationId(method.httpMethod.name() + "_" + opPath)
+                    .withOperationId(method.requiredHttpMethod().name() + "_" + opPath)
                     .withTags(singletonList(root.tag.name()))
                     .withParameters(parameters)
                     .build();
             } else {
                 OperationObject curOO = method.createOperationBuilder(customSchemas).build();
-                List<ParameterObject> combinedParams = new ArrayList<>(existing.parameters());
+                List<ParameterObject> combinedParams = new ArrayList<>(
+                    existing.parameters() == null ? Collections.emptyList() : existing.parameters());
                 for (ParameterObject po : parameters) {
                     // add to combinedParams if none with same name and in
                     if (combinedParams.stream().noneMatch(p -> p.name().equals(po.name()) &&
@@ -216,17 +224,17 @@ class OpenApiDocumentor implements MuHandler {
 class SchemaReference {
     final String id;
     final Class<?> type;
-    final Type genericType;
+    final @Nullable Type genericType;
     final SchemaObject schema;
 
-    SchemaReference(String id, Class<?> type, Type genericType, SchemaObject schema) {
+    SchemaReference(String id, Class<?> type, @Nullable Type genericType, SchemaObject schema) {
         this.id = id;
         this.type = type;
         this.genericType = genericType;
         this.schema = schema;
     }
 
-    static @Nullable SchemaReference find(List<SchemaReference> references, Class<?> type, Type genericType) {
+    static @Nullable SchemaReference find(List<SchemaReference> references, Class<?> type, @Nullable Type genericType) {
         for (SchemaReference reference : references) {
             if (reference.type.equals(type)) {
                 return reference;

--- a/src/main/java/io/muserver/rest/ProblemDetailsException.java
+++ b/src/main/java/io/muserver/rest/ProblemDetailsException.java
@@ -20,7 +20,7 @@ public class ProblemDetailsException extends WebApplicationException {
     private final @Nullable URI instance;
     private final Map<String, @Nullable Object> extensionMembers;
 
-    ProblemDetailsException(int status, String title, @Nullable String detail, @Nullable URI type, @Nullable URI instance, Map<String, @Nullable Object> extensionMembers, Throwable cause) {
+    ProblemDetailsException(int status, String title, @Nullable String detail, @Nullable URI type, @Nullable URI instance, Map<String, @Nullable Object> extensionMembers, @Nullable Throwable cause) {
         super(detail != null ? detail : title, cause, status);
         this.status = status;
         this.title = title;

--- a/src/main/java/io/muserver/rest/ProblemDetailsExceptionMapper.java
+++ b/src/main/java/io/muserver/rest/ProblemDetailsExceptionMapper.java
@@ -6,6 +6,7 @@ import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.ext.ExceptionMapper;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -129,8 +130,8 @@ public class ProblemDetailsExceptionMapper <E extends Throwable> implements Exce
         }
     }
 
-    private static Response toResponse(int status, String title, String detail, URI type, URI instance, Map<String, Object> extensionMembers) {
-        Map<String, Object> values = new LinkedHashMap<>();
+    private static Response toResponse(int status, String title, @Nullable String detail, @Nullable URI type, @Nullable URI instance, @Nullable Map<String, @Nullable Object> extensionMembers) {
+        Map<String, @Nullable Object> values = new LinkedHashMap<>();
         if (type != null) {
             values.put("type", type);
         }

--- a/src/main/java/io/muserver/rest/ReadOnlyMultivaluedMap.java
+++ b/src/main/java/io/muserver/rest/ReadOnlyMultivaluedMap.java
@@ -2,6 +2,7 @@ package io.muserver.rest;
 
 import jakarta.ws.rs.core.MultivaluedHashMap;
 import jakarta.ws.rs.core.MultivaluedMap;
+import org.jspecify.annotations.Nullable;
 
 import java.io.Serializable;
 import java.util.Collection;
@@ -97,7 +98,7 @@ class ReadOnlyMultivaluedMap<K, V> implements MultivaluedMap<K, V>, Serializable
         return actual.isEmpty();
     }
 
-    public List<V> get(Object key) {
+    public @Nullable List<V> get(Object key) {
         return actual.get(key);
     }
 

--- a/src/main/java/io/muserver/rest/ReadOnlyMultivaluedMap.java
+++ b/src/main/java/io/muserver/rest/ReadOnlyMultivaluedMap.java
@@ -50,7 +50,7 @@ class ReadOnlyMultivaluedMap<K, V> implements MultivaluedMap<K, V>, Serializable
         throw new NotImplementedException("Invalid access for readonly map");
     }
 
-    public V getFirst(K key) {
+    public @Nullable V getFirst(K key) {
         return actual.getFirst(key);
     }
 
@@ -66,7 +66,7 @@ class ReadOnlyMultivaluedMap<K, V> implements MultivaluedMap<K, V>, Serializable
         return actual.hashCode();
     }
 
-    public boolean equals(Object o) {
+    public boolean equals(@Nullable Object o) {
         return actual.equals(o);
     }
 
@@ -78,7 +78,7 @@ class ReadOnlyMultivaluedMap<K, V> implements MultivaluedMap<K, V>, Serializable
         return actual.size();
     }
 
-    public List<V> remove(Object key) {
+    public List<V> remove(@Nullable Object key) {
         throw new NotImplementedException("Invalid access for readonly map");
     }
 
@@ -98,7 +98,7 @@ class ReadOnlyMultivaluedMap<K, V> implements MultivaluedMap<K, V>, Serializable
         return actual.isEmpty();
     }
 
-    public @Nullable List<V> get(Object key) {
+    public @Nullable List<V> get(@Nullable Object key) {
         return actual.get(key);
     }
 
@@ -106,11 +106,11 @@ class ReadOnlyMultivaluedMap<K, V> implements MultivaluedMap<K, V>, Serializable
         return actual.entrySet();
     }
 
-    public boolean containsValue(Object value) {
+    public boolean containsValue(@Nullable Object value) {
         return actual.containsValue(value);
     }
 
-    public boolean containsKey(Object key) {
+    public boolean containsKey(@Nullable Object key) {
         return actual.containsKey(key);
     }
 

--- a/src/main/java/io/muserver/rest/RequestMatcher.java
+++ b/src/main/java/io/muserver/rest/RequestMatcher.java
@@ -9,6 +9,7 @@ import jakarta.ws.rs.NotSupportedException;
 import jakarta.ws.rs.ServerErrorException;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.PathSegment;
+import org.jspecify.annotations.Nullable;
 
 import java.net.URI;
 import java.util.*;
@@ -42,13 +43,13 @@ class RequestMatcher {
         String path = requestContext.relativePath();
         Set<MatchedMethod> candidateMethods = getMatchedMethodsForPath(path, subResourceLocator);
         MuRequest req = requestContext.muRequest;
-        String requestBodyContentType = req.headers().get(HeaderNames.CONTENT_TYPE);
+        @Nullable String requestBodyContentType = req.headers().get(HeaderNames.CONTENT_TYPE);
         return stepThreeIdentifyTheMethodThatWillHandleTheRequest(httpMethod, candidateMethods, requestBodyContentType, acceptHeaders);
     }
 
     Set<MatchedMethod> getMatchedMethodsForPath(String path, Function<MatchedMethod, ResourceClass> subResourceLocator) throws NotMatchedException {
         StepOneOutput stepOneOutput = stepOneIdentifyASetOfCandidateRootResourceClassesMatchingTheRequest(path);
-        URI methodURI = stepOneOutput.unmatchedGroup == null ? null : URI.create(UriPattern.trimSlashes(stepOneOutput.unmatchedGroup));
+        @Nullable URI methodURI = stepOneOutput.unmatchedGroup == null ? null : URI.create(UriPattern.trimSlashes(stepOneOutput.unmatchedGroup));
         return stepTwoObtainASetOfCandidateResourceMethodsForTheRequest(methodURI, stepOneOutput.candidates, subResourceLocator);
     }
 
@@ -82,7 +83,7 @@ class RequestMatcher {
         }
         // Set Rmatch to be the first member of E and set U to be the value of the final capturing group of Rmatch when matched against U
         UriPattern rMatch = candidates.get(0).resourceClass.pathPattern;
-        String u = rMatch.matcher(uri).lastGroup();
+        @Nullable String u = rMatch.matcher(uri).lastGroup();
 
         // Let C0 be the set of classes Z such that R(TZ) = Rmatch. By definition, all root resource classes in C0 must be annotated with the same URI path template modulo variable names
 
@@ -92,7 +93,7 @@ class RequestMatcher {
         return new StepOneOutput(u, c0);
     }
 
-    private Set<MatchedMethod> stepTwoObtainASetOfCandidateResourceMethodsForTheRequest(URI relativeUri, List<MatchedClass> candidateClasses, Function<MatchedMethod, ResourceClass> subResourceLocator) throws NotMatchedException {
+    private Set<MatchedMethod> stepTwoObtainASetOfCandidateResourceMethodsForTheRequest(@Nullable URI relativeUri, List<MatchedClass> candidateClasses, Function<MatchedMethod, ResourceClass> subResourceLocator) throws NotMatchedException {
         if (relativeUri == null) {
             // handle section 3.7.2 - 2(a)
             Set<MatchedMethod> candidates = getNonLocatorMethods(candidateClasses, false);
@@ -107,7 +108,7 @@ class RequestMatcher {
             for (ResourceMethod resourceMethod : candidateClass.resourceClass.resourceMethods) {
                 if (resourceMethod.isSubResource() || resourceMethod.isSubResourceLocator()) {
                     if (relativeUri != null) {
-                        PathMatch matcher = resourceMethod.pathPattern.matcher(relativeUri);
+                        PathMatch matcher = resourceMethod.requiredPathPattern().matcher(relativeUri);
                         // 2(c) add and 2(d) filter out
                         if (matcher.fullyMatches() || (resourceMethod.isSubResourceLocator() && matcher.prefixMatches())) {
                             Map<String, PathSegment> combinedParams = new HashMap<>(candidateClass.pathMatch.segments());
@@ -131,14 +132,14 @@ class RequestMatcher {
             ResourceMethod rm1 = o1.resourceMethod;
             ResourceMethod rm2 = o2.resourceMethod;
             // "Sort E using the number of literal characters4 in each member as the primary key (descending order)"
-            int c = Integer.compare(rm2.pathPattern.numberOfLiterals, rm1.pathPattern.numberOfLiterals);
+                int c = Integer.compare(rm2.requiredPathPattern().numberOfLiterals, rm1.requiredPathPattern().numberOfLiterals);
             if (c == 0) {
                 // "the number of capturing groups as a secondary key (descending order)"
-                c = Integer.compare(rm2.pathPattern.capturingGroupCount(), rm1.pathPattern.capturingGroupCount());
+                c = Integer.compare(rm2.requiredPathPattern().capturingGroupCount(), rm1.requiredPathPattern().capturingGroupCount());
             }
             if (c == 0) {
                 // " and the number of capturing groups with non-default regular expressions (i.e. not ‘([ˆ/]+?)’) as the tertiary key (descending order)"
-                c = Integer.compare(rm2.pathPattern.nonDefaultCapturingGroupCount(), rm1.pathPattern.nonDefaultCapturingGroupCount());
+                c = Integer.compare(rm2.requiredPathPattern().nonDefaultCapturingGroupCount(), rm1.requiredPathPattern().nonDefaultCapturingGroupCount());
             }
             if (c == 0) {
                 // "and the source of each member as quaternary key sorting those derived from sub-resource methods ahead of those derived from sub-resource locators"
@@ -149,11 +150,11 @@ class RequestMatcher {
         });
 
         // 2(g) Set Rmatch to be the first member of E
-        UriPattern matcher = candidates.get(0).resourceMethod.pathPattern;
+        UriPattern matcher = candidates.get(0).resourceMethod.requiredPathPattern();
 
         // 2(h) M = { subresource methods of all classes in C′ where R(T_method) = R_match (excluding sub-resource locators) }
         Set<MatchedMethod> m = candidates.stream()
-            .filter(rm -> !rm.resourceMethod.isSubResourceLocator() && rm.resourceMethod.pathPattern.equals(matcher))
+            .filter(rm -> !rm.resourceMethod.isSubResourceLocator() && rm.resourceMethod.requiredPathPattern().equals(matcher))
             .collect(toSet());
         if (!m.isEmpty()) {
             return m;
@@ -161,7 +162,7 @@ class RequestMatcher {
 
         // 2(i) Let L be a sub-resource locator such that Rmatch = R(TL)
         Set<MatchedMethod> l = candidates.stream()
-            .filter(rm -> rm.resourceMethod.isSubResourceLocator() && rm.resourceMethod.pathPattern.equals(matcher))
+            .filter(rm -> rm.resourceMethod.isSubResourceLocator() && rm.resourceMethod.requiredPathPattern().equals(matcher))
             .collect(toSet());
         if (l.isEmpty()) {
             throw new NotMatchedException();
@@ -240,7 +241,7 @@ class RequestMatcher {
                 '}';
         }
 
-        public String getPathParam(String key) {
+        public @Nullable String getPathParam(String key) {
             PathSegment segment = pathParams.get(key);
             return segment == null ? null : segment.getPath();
         }
@@ -254,10 +255,10 @@ class RequestMatcher {
         }
     }
 
-    private MatchedMethod stepThreeIdentifyTheMethodThatWillHandleTheRequest(Method method, Set<MatchedMethod> candidates, String requestBodyContentType, List<MediaType> acceptHeaders) throws NotAllowedException, NotAcceptableException, NotSupportedException {
+    private MatchedMethod stepThreeIdentifyTheMethodThatWillHandleTheRequest(Method method, Set<MatchedMethod> candidates, @Nullable String requestBodyContentType, List<MediaType> acceptHeaders) throws NotAllowedException, NotAcceptableException, NotSupportedException {
         List<MatchedMethod> result = candidates.stream().filter(rm -> rm.resourceMethod.httpMethod == method).collect(toList());
         if (result.isEmpty()) {
-            List<String> allowed = candidates.stream().map(c -> c.resourceMethod.httpMethod.name()).distinct().collect(toList());
+            List<String> allowed = candidates.stream().map(c -> c.resourceMethod.requiredHttpMethod().name()).distinct().collect(toList());
             throw new NotAllowedException(allowed.get(0), allowed.subList(1, allowed.size()).toArray(new String[0]));
         }
 
@@ -299,10 +300,10 @@ class RequestMatcher {
     }
 
     static class StepOneOutput {
-        final String unmatchedGroup;
+        final @Nullable String unmatchedGroup;
         final List<RequestMatcher.MatchedClass> candidates;
 
-        StepOneOutput(String unmatchedGroup, List<RequestMatcher.MatchedClass> candidates) {
+        StepOneOutput(@Nullable String unmatchedGroup, List<RequestMatcher.MatchedClass> candidates) {
             this.unmatchedGroup = unmatchedGroup;
             this.candidates = candidates;
         }

--- a/src/main/java/io/muserver/rest/ResourceClass.java
+++ b/src/main/java/io/muserver/rest/ResourceClass.java
@@ -8,6 +8,7 @@ import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.ext.ParamConverterProvider;
+import org.jspecify.annotations.Nullable;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.AnnotatedElement;
@@ -27,10 +28,11 @@ class ResourceClass {
 
     final UriPattern pathPattern;
     final Class<?> resourceClass;
-    final Object resourceInstance;
+    final @Nullable Object resourceInstance;
     final List<MediaType> produces;
     final List<MediaType> consumes;
-    List<ResourceMethod> resourceMethods;
+    List<ResourceMethod> resourceMethods = Collections.emptyList();
+    private boolean methodInfoSet;
     final String pathTemplate;
     final TagObject tag;
     final List<Class<? extends Annotation>> nameBindingAnnotations;
@@ -39,9 +41,9 @@ class ResourceClass {
     /**
      * If this class is sub-resource, then this is the locator method. Otherwise null.
      */
-    final ResourceMethod locatorMethod;
+    final @Nullable ResourceMethod locatorMethod;
 
-    private ResourceClass(UriPattern pathPattern, String pathTemplate, Class<?> resourceClass, Object resourceInstance, List<MediaType> consumes, List<MediaType> produces, TagObject tag, List<Class<? extends Annotation>> nameBindingAnnotations, SchemaObjectCustomizer schemaObjectCustomizer, ResourceMethod locatorMethod) {
+    private ResourceClass(UriPattern pathPattern, String pathTemplate, Class<?> resourceClass, @Nullable Object resourceInstance, List<MediaType> consumes, List<MediaType> produces, TagObject tag, List<Class<? extends Annotation>> nameBindingAnnotations, SchemaObjectCustomizer schemaObjectCustomizer, @Nullable ResourceMethod locatorMethod) {
         this.pathPattern = pathPattern;
         this.pathTemplate = pathTemplate;
         this.resourceClass = resourceClass;
@@ -67,7 +69,7 @@ class ResourceClass {
     }
 
     private void setupMethodInfo(List<ParamConverterProvider> paramConverterProviders) {
-        if (resourceMethods != null) {
+        if (methodInfoSet) {
             throw new IllegalStateException("Cannot call setupMethodInfo twice");
         }
 
@@ -78,7 +80,7 @@ class ResourceClass {
                 continue;
             }
             java.lang.reflect.Method annotationSource = JaxMethodLocator.getMethodThatHasJaxRSAnnotations(restMethod, resourceClass);
-            Method httpMethod = ResourceMethod.getMuMethod(annotationSource);
+            @Nullable Method httpMethod = ResourceMethod.getMuMethod(annotationSource);
             restMethod.setAccessible(true);
             Path methodPath = annotationSource.getAnnotation(Path.class);
             if (methodPath == null && httpMethod == null) {
@@ -87,7 +89,7 @@ class ResourceClass {
 
             List<Class<? extends Annotation>> methodNameBindingAnnotations = getNameBindingAnnotations(annotationSource);
 
-            UriPattern methodPattern = methodPath == null ? null : UriPattern.uriTemplateToRegex(methodPath.value());
+            @Nullable UriPattern methodPattern = methodPath == null ? null : UriPattern.uriTemplateToRegex(methodPath.value());
 
 
             List<MediaType> methodProduces = MediaTypeDeterminer.supportedProducesTypes(annotationSource);
@@ -100,11 +102,12 @@ class ResourceClass {
                 params.add(resourceMethodParam);
             }
             DescriptionData descriptionData = DescriptionData.fromAnnotation(restMethod, null);
-            String pathTemplate = methodPath == null ? null : methodPath.value();
+            @Nullable String pathTemplate = methodPath == null ? null : methodPath.value();
             boolean isDeprecated = annotationSource.isAnnotationPresent(Deprecated.class);
             resourceMethods.add(new ResourceMethod(this, methodPattern, restMethod, params, httpMethod, pathTemplate, methodProduces, methodConsumes, schemaObjectCustomizer, descriptionData, isDeprecated, methodNameBindingAnnotations, annotationSource.getAnnotations()));
         }
         this.resourceMethods = Collections.unmodifiableList(resourceMethods);
+        this.methodInfoSet = true;
     }
 
     static List<Class<? extends Annotation>> getNameBindingAnnotations(AnnotatedElement annotationSource) {
@@ -154,7 +157,7 @@ class ResourceClass {
         return resourceClass;
     }
 
-    private static List<MediaType> getProduces(List<MediaType> existing, Class<?> annotationSource) {
+    private static List<MediaType> getProduces(@Nullable List<MediaType> existing, Class<?> annotationSource) {
         Produces produces = annotationSource.getAnnotation(Produces.class);
         List<MediaType> producesList = new ArrayList<>(MediaTypeHeaderDelegate.fromStrings(produces == null ? null : asList(produces.value())));
         if (existing != null) {
@@ -163,7 +166,7 @@ class ResourceClass {
         return producesList;
     }
 
-    private static List<MediaType> getConsumes(List<MediaType> existing, Class<?> annotationSource) {
+    private static List<MediaType> getConsumes(@Nullable List<MediaType> existing, Class<?> annotationSource) {
         Consumes consumes = annotationSource.getAnnotation(Consumes.class);
         List<MediaType> consumesList = new ArrayList<>(MediaTypeHeaderDelegate.fromStrings(consumes == null ? null : asList(consumes.value())));
         if (existing != null) {
@@ -172,12 +175,16 @@ class ResourceClass {
         return consumesList;
     }
 
-    static ResourceClass forSubResourceLocator(ResourceMethod rm, Class<?> instanceClass, Object instance, SchemaObjectCustomizer schemaObjectCustomizer, List<ParamConverterProvider> paramConverterProviders) {
-        List<MediaType> existingConsumes = rm.effectiveConsumes.isEmpty() || (rm.directlyConsumes.isEmpty() && rm.effectiveConsumes.size() == 1 && rm.effectiveConsumes.get(0) == MediaType.WILDCARD_TYPE) ? null : rm.effectiveConsumes;
+    static ResourceClass forSubResourceLocator(ResourceMethod rm, Class<?> instanceClass, @Nullable Object instance, SchemaObjectCustomizer schemaObjectCustomizer, List<ParamConverterProvider> paramConverterProviders) {
+        @Nullable List<MediaType> existingConsumes = rm.effectiveConsumes.isEmpty() || (rm.directlyConsumes.isEmpty() && rm.effectiveConsumes.size() == 1 && rm.effectiveConsumes.get(0) == MediaType.WILDCARD_TYPE) ? null : rm.effectiveConsumes;
         List<MediaType> consumes = getConsumes(existingConsumes, instanceClass);
-        List<MediaType> existingProduces = rm.effectiveProduces.isEmpty() || (rm.directlyProduces.isEmpty() && rm.effectiveProduces.size() == 1 && rm.effectiveProduces.get(0) == MediaType.WILDCARD_TYPE) ? null : rm.effectiveProduces;
+        @Nullable List<MediaType> existingProduces = rm.effectiveProduces.isEmpty() || (rm.directlyProduces.isEmpty() && rm.effectiveProduces.size() == 1 && rm.effectiveProduces.get(0) == MediaType.WILDCARD_TYPE) ? null : rm.effectiveProduces;
         List<MediaType> produces = getProduces(existingProduces, instanceClass);
-        ResourceClass resourceClass = new ResourceClass(rm.pathPattern, rm.pathTemplate, instanceClass, instance, consumes, produces, rm.resourceClass.tag, rm.resourceClass.nameBindingAnnotations, schemaObjectCustomizer, rm);
+        ResourceClass resourceClass = new ResourceClass(
+            java.util.Objects.requireNonNull(rm.pathPattern, "Sub-resource locator had no path pattern"),
+            java.util.Objects.requireNonNull(rm.pathTemplate, "Sub-resource locator had no path template"),
+            instanceClass, instance, consumes, produces, rm.resourceClass.tag,
+            rm.resourceClass.nameBindingAnnotations, schemaObjectCustomizer, rm);
         resourceClass.setupMethodInfo(paramConverterProviders);
         return resourceClass;
     }
@@ -190,5 +197,9 @@ class ResourceClass {
 
     String resourceClassName() {
         return resourceClass.getName();
+    }
+
+    Object requiredResourceInstance() {
+        return java.util.Objects.requireNonNull(resourceInstance, "Resource instance is not available");
     }
 }

--- a/src/main/java/io/muserver/rest/ResourceMethod.java
+++ b/src/main/java/io/muserver/rest/ResourceMethod.java
@@ -27,11 +27,11 @@ import static java.util.stream.Collectors.toMap;
 
 class ResourceMethod {
     final ResourceClass resourceClass;
-    final UriPattern pathPattern;
+    final @Nullable UriPattern pathPattern;
     final java.lang.reflect.Method methodHandle;
     final @Nullable Type genericReturnType;
-    final Method httpMethod;
-    final String pathTemplate;
+    final @Nullable Method httpMethod;
+    final @Nullable String pathTemplate;
     final List<MediaType> effectiveConsumes;
     final List<MediaType> directlyConsumes;
     final List<MediaType> directlyProduces;
@@ -43,7 +43,7 @@ class ResourceMethod {
     private final List<Class<? extends Annotation>> nameBindingAnnotations;
     final Annotation[] methodAnnotations; // the annotations defined on the method to be passed to the message body writers
 
-    ResourceMethod(ResourceClass resourceClass, UriPattern pathPattern, java.lang.reflect.Method methodHandle, List<ResourceMethodParam> params, Method httpMethod, String pathTemplate, List<MediaType> produces, List<MediaType> consumes, SchemaObjectCustomizer schemaObjectCustomizer, DescriptionData descriptionData, boolean isDeprecated, List<Class<? extends Annotation>> nameBindingAnnotations, Annotation[] methodAnnotations) {
+    ResourceMethod(ResourceClass resourceClass, @Nullable UriPattern pathPattern, java.lang.reflect.Method methodHandle, List<ResourceMethodParam> params, @Nullable Method httpMethod, @Nullable String pathTemplate, List<MediaType> produces, List<MediaType> consumes, SchemaObjectCustomizer schemaObjectCustomizer, DescriptionData descriptionData, boolean isDeprecated, List<Class<? extends Annotation>> nameBindingAnnotations, Annotation[] methodAnnotations) {
         this.resourceClass = resourceClass;
         this.pathPattern = pathPattern;
         this.methodHandle = methodHandle;
@@ -89,11 +89,19 @@ class ResourceMethod {
         return httpMethod == null;
     }
 
-    Object invoke(Object... params) throws Exception {
+    UriPattern requiredPathPattern() {
+        return Objects.requireNonNull(pathPattern, "Resource method has no path pattern");
+    }
+
+    Method requiredHttpMethod() {
+        return Objects.requireNonNull(httpMethod, "Sub-resource locator has no HTTP method");
+    }
+
+    @Nullable Object invoke(@Nullable Object... params) throws Exception {
         try {
-            return methodHandle.invoke(resourceClass.resourceInstance, params);
+            return methodHandle.invoke(resourceClass.requiredResourceInstance(), params);
         } catch (InvocationTargetException e) {
-            Throwable cause = e.getCause();
+            @Nullable Throwable cause = e.getCause();
             if (cause instanceof Exception) {
                 throw (Exception) cause;
             }
@@ -109,14 +117,14 @@ class ResourceMethod {
         for (ApiResponseObj apiResponse : apiResponseList) {
             Class<?> responseClass = apiResponse.response;
 
-            Stream<MediaType> responseTypesStream = apiResponse.contentType.length != 0 ?
+            @Nullable Stream<MediaType> responseTypesStream = apiResponse.contentType.length != 0 ?
                 Stream.of(apiResponse.contentType).map(MediaType::valueOf)
                 : "204".equals(apiResponse.code) ? null : effectiveProduces.stream();
 
-            Map<String, MediaTypeObject> content = responseTypesStream == null ? null : responseTypesStream.collect(toMap(MediaType::toString,
+            @Nullable Map<String, MediaTypeObject> content = responseTypesStream == null ? null : responseTypesStream.collect(toMap(MediaType::toString,
                 mt -> {
-                    SchemaObject responseSchema;
-                    Object example = nullOrEmpty(apiResponse.example) ? null : apiResponse.example;
+                    @Nullable SchemaObject responseSchema;
+                    @Nullable Object example = nullOrEmpty(apiResponse.example) ? null : apiResponse.example;
 
                     if (void.class.isAssignableFrom(responseClass)) {
                         responseSchema = null;
@@ -150,7 +158,7 @@ class ResourceMethod {
 
         MediaType requestBodyMediaType = effectiveConsumes.get(0);
         String requestBodyMimeType = requestBodyMediaType.toString();
-        RequestBodyObject requestBody = params.stream()
+        @Nullable RequestBodyObject requestBody = params.stream()
             .filter(p -> p instanceof ResourceMethodParam.MessageBodyParam)
             .map(ResourceMethodParam.MessageBodyParam.class::cast)
             .map(messageBodyParam -> {
@@ -159,7 +167,7 @@ class ResourceMethod {
                 SchemaReference schemaReference = SchemaReference.find(customSchemas, bodyType, bodyParameterizedType);
                 SchemaObjectBuilder builder = schemaReference != null ? schemaReference.schema.toBuilder() :
                     schemaObjectFrom(bodyType, bodyParameterizedType, messageBodyParam.isRequired)
-                        .withTitle(messageBodyParam.descriptionData.summary)
+                        .withTitle(Objects.requireNonNull(messageBodyParam.descriptionData).summary)
                         .withDescription(messageBodyParam.descriptionData.description);
                 return requestBodyObject()
                     .withContent(singletonMap(requestBodyMimeType,
@@ -168,7 +176,7 @@ class ResourceMethod {
                                 schemaObjectCustomizer.customize(builder,
                                     schemaContext(SchemaObjectCustomizerTarget.REQUEST_BODY, null, bodyType, bodyParameterizedType, requestBodyMediaType))
                                     .build())
-                            .withExample(messageBodyParam.descriptionData.example)
+                            .withExample(Objects.requireNonNull(messageBodyParam.descriptionData).example)
                             .build()))
                     .withDescription(messageBodyParam.descriptionData.summaryAndDescription())
                     .withRequired(messageBodyParam.isRequired)
@@ -238,7 +246,7 @@ class ResourceMethod {
             ;
     }
 
-    private SchemaObjectCustomizerContext schemaContext(SchemaObjectCustomizerTarget target, String parameter, Class<?> type, Type parameterizedType, MediaType mediaType) {
+    private SchemaObjectCustomizerContext schemaContext(SchemaObjectCustomizerTarget target, @Nullable String parameter, Class<?> type, @Nullable Type parameterizedType, MediaType mediaType) {
         return new SchemaObjectCustomizerContext(target, type, parameterizedType, resourceClass.resourceInstance, methodHandle, parameter, mediaType);
     }
 
@@ -263,9 +271,9 @@ class ResourceMethod {
         return result;
     }
 
-    static Method getMuMethod(java.lang.reflect.Method restMethod) {
+    static @Nullable Method getMuMethod(java.lang.reflect.Method restMethod) {
         Annotation[] annotations = restMethod.getAnnotations();
-        Method value = null;
+        @Nullable Method value = null;
         for (Annotation annotation : annotations) {
             Class<? extends Annotation> anno = annotation.annotationType();
             HttpMethod httpMethodAnno = anno.getAnnotation(HttpMethod.class);

--- a/src/main/java/io/muserver/rest/ResourceMethodParam.java
+++ b/src/main/java/io/muserver/rest/ResourceMethodParam.java
@@ -27,6 +27,7 @@ import java.util.stream.Collectors;
 import static io.muserver.openapi.ParameterObjectBuilder.parameterObject;
 import static io.muserver.openapi.SchemaObjectBuilder.schemaObjectFrom;
 import static java.util.Collections.emptyList;
+import static java.util.Objects.requireNonNull;
 
 abstract class ResourceMethodParam {
 
@@ -36,10 +37,10 @@ abstract class ResourceMethodParam {
     final Type genericType;
     final Annotation[] annotations;
     final ValueSource source;
-    final DescriptionData descriptionData;
+    final @Nullable DescriptionData descriptionData;
     final boolean isRequired;
 
-    ResourceMethodParam(int index, ValueSource source, ResolvedParameter parameter, DescriptionData descriptionData, boolean isRequired) {
+    ResourceMethodParam(int index, ValueSource source, ResolvedParameter parameter, @Nullable DescriptionData descriptionData, boolean isRequired) {
         this.index = index;
         this.source = source;
         this.parameterHandle = parameter.handle;
@@ -50,16 +51,16 @@ abstract class ResourceMethodParam {
         this.isRequired = isRequired;
     }
 
-    static ResourceMethodParam fromParameter(int index, Parameter parameterHandle, List<ParamConverterProvider> paramConverterProviders, UriPattern methodPattern) {
+    static ResourceMethodParam fromParameter(int index, Parameter parameterHandle, List<ParamConverterProvider> paramConverterProviders, @Nullable UriPattern methodPattern) {
         return fromParameter(index, parameterHandle, parameterHandle,
             parameterHandle.getDeclaringExecutable().getDeclaringClass(), paramConverterProviders, methodPattern);
     }
 
     static ResourceMethodParam fromParameter(int index, Parameter parameterHandle, Parameter annotationSource, Class<?> concreteClass,
-                                             List<ParamConverterProvider> paramConverterProviders, UriPattern methodPattern) {
+                                             List<ParamConverterProvider> paramConverterProviders, @Nullable UriPattern methodPattern) {
 
         ResolvedParameter parameter = new ResolvedParameter(parameterHandle, annotationSource, concreteClass);
-        Pattern pattern = null;
+        @Nullable Pattern pattern = null;
         ValueSource source = getSource(annotationSource);
         boolean isRequired = source == ValueSource.PATH_PARAM || hasDeclared(annotationSource, Required.class);
         if (source == ValueSource.MESSAGE_BODY) {
@@ -76,7 +77,7 @@ abstract class ResourceMethodParam {
             ParamConverter<?> converter = getParamConverter(parameter, paramConverterProviders);
             boolean lazyDefaultValue = converter.getClass().getDeclaredAnnotation(ParamConverter.Lazy.class) != null;
             boolean explicitDefault = hasDeclared(annotationSource, DefaultValue.class);
-            Object defaultValue = getDefaultValue(parameter, annotationSource, converter, lazyDefaultValue, source, key);
+            @Nullable Object defaultValue = getDefaultValue(parameter, annotationSource, converter, lazyDefaultValue, source, key);
 
             isRequired |= (!explicitDefault && parameter.type.isPrimitive());
 
@@ -103,8 +104,9 @@ abstract class ResourceMethodParam {
 
         private ResolvedParameter(Parameter handle, Parameter annotationSource, Class<?> concreteClass) {
             this.handle = handle;
-            this.genericType = GenericTypeResolver.resolve(handle.getParameterizedType(), concreteClass,
+            Type resolvedType = GenericTypeResolver.resolve(handle.getParameterizedType(), concreteClass,
                 handle.getDeclaringExecutable().getDeclaringClass());
+            this.genericType = resolvedType == null ? handle.getParameterizedType() : resolvedType;
             Class<?> resolvedClass = GenericTypeResolver.rawClass(genericType);
             this.type = resolvedClass == null ? handle.getType() : resolvedClass;
             this.annotations = combinedAnnotations(handle, annotationSource);
@@ -134,22 +136,22 @@ abstract class ResourceMethodParam {
 
     static class RequestBasedParam extends ResourceMethodParam {
 
-        private final Object defaultValue;
+        private final @Nullable Object defaultValue;
         final boolean encodedRequested;
         private final boolean lazyDefaultValue;
         private final ParamConverter paramConverter;
         final String key;
         final boolean isDeprecated;
-        private final Pattern pattern;
+        private final @Nullable Pattern pattern;
         private final boolean explicitDefault;
 
         ParameterObjectBuilder createDocumentationBuilder() {
             ParameterObjectBuilder builder = parameterObject()
-                .withIn(source.openAPIIn)
+                .withIn(requireNonNull(source.openAPIIn, "Parameter source is not represented as an OpenAPI parameter"))
                 .withRequired(isRequired)
                 .withDeprecated(isDeprecated ? true : null)
                 .withName(key);
-            ExternalDocumentationObject externalDoc = null;
+            @Nullable ExternalDocumentationObject externalDoc = null;
             if (descriptionData != null) {
                 String desc = descriptionData.summaryAndDescription();
                 builder
@@ -157,7 +159,7 @@ abstract class ResourceMethodParam {
                     .withExample(descriptionData.example);
                 externalDoc = descriptionData.externalDocumentation;
             }
-            Pattern patternIfNotDefault = this.pattern == null || UriPattern.DEFAULT_CAPTURING_GROUP_PATTERN.equals(this.pattern.pattern()) ? null : this.pattern;
+            @Nullable Pattern patternIfNotDefault = this.pattern == null || UriPattern.DEFAULT_CAPTURING_GROUP_PATTERN.equals(this.pattern.pattern()) ? null : this.pattern;
             return builder.withSchema(
                 schemaObjectFrom(type, genericType, isRequired)
                     .withDefaultValue(source == ValueSource.PATH_PARAM || !hasExplicitDefault() ? null : defaultValue())
@@ -167,7 +169,7 @@ abstract class ResourceMethodParam {
             );
         }
 
-        RequestBasedParam(int index, ValueSource source, ResolvedParameter parameter, @Nullable Object defaultValue, boolean encodedRequested, boolean lazyDefaultValue, ParamConverter paramConverter, DescriptionData descriptionData, String key, boolean isDeprecated, boolean isRequired, Pattern pattern, boolean explicitDefault) {
+        RequestBasedParam(int index, ValueSource source, ResolvedParameter parameter, @Nullable Object defaultValue, boolean encodedRequested, boolean lazyDefaultValue, ParamConverter paramConverter, DescriptionData descriptionData, String key, boolean isDeprecated, boolean isRequired, @Nullable Pattern pattern, boolean explicitDefault) {
             super(index, source, parameter, descriptionData, isRequired);
             this.defaultValue = defaultValue;
             this.encodedRequested = encodedRequested;
@@ -188,7 +190,7 @@ abstract class ResourceMethodParam {
         }
 
 
-        public Object defaultValue() {
+        public @Nullable Object defaultValue() {
             boolean skipConverter = defaultValue != null && !lazyDefaultValue;
             return convertValue(parameterHandle, type, paramConverter, skipConverter, defaultValue, source, key);
         }
@@ -266,13 +268,13 @@ abstract class ResourceMethodParam {
                     : emptyList();
             boolean isSpecified = specifiedValue != null && !specifiedValue.isEmpty();
             if (encodedRequested && isSpecified) {
-                specifiedValue = specifiedValue.stream()
+                specifiedValue = requireNonNull(specifiedValue).stream()
                     .map(value -> source == ValueSource.FORM_PARAM ? FormUrlEncoder.formUrlEncode(value) : Mutils.urlEncode(value))
                     .collect(Collectors.toList());
             }
             if (collection != null) {
                 if (isSpecified) {
-                    for (String stringValue : specifiedValue) {
+                    for (String stringValue : requireNonNull(specifiedValue)) {
                         collection.add(ResourceMethodParam.convertValue(parameterHandle, type, paramConverter, false, stringValue, source, key));
                     }
                 } else if (hasExplicitDefault()) {
@@ -280,7 +282,7 @@ abstract class ResourceMethodParam {
                 }
                 return readOnly(collection);
             } else {
-                return isSpecified ? ResourceMethodParam.convertValue(parameterHandle, type, paramConverter, false, specifiedValue.get(0), source, key) : defaultValue();
+                return isSpecified ? ResourceMethodParam.convertValue(parameterHandle, type, paramConverter, false, requireNonNull(specifiedValue).get(0), source, key) : defaultValue();
             }
         }
 
@@ -301,8 +303,8 @@ abstract class ResourceMethodParam {
                 : Collections.unmodifiableCollection(collection);
         }
 
-        private List<String> getParamValues(MultivaluedMap<String, String> queryParameters, String key, CollectionParameterStrategy cps, boolean isCollectionType) {
-            List<String> values = queryParameters.get(key);
+        private @Nullable List<String> getParamValues(MultivaluedMap<String, String> queryParameters, String key, CollectionParameterStrategy cps, boolean isCollectionType) {
+            @Nullable List<String> values = queryParameters.get(key);
             if (isCollectionType && values != null && cps == CollectionParameterStrategy.SPLIT_ON_COMMA) {
                 List<String> copy = new ArrayList<>(values.size());
                 for (String value : values) {
@@ -334,7 +336,7 @@ abstract class ResourceMethodParam {
             return emptyList();
         }
 
-        static Collection<Object> createCollection(Class<?> collectionType) {
+        static @Nullable Collection<Object> createCollection(Class<?> collectionType) {
             if (SortedSet.class.equals(collectionType)) {
                 return new TreeSet<>();
             } else if (Set.class.equals(collectionType)) {
@@ -411,7 +413,7 @@ abstract class ResourceMethodParam {
         throw new MuException("Could not find a suitable ParamConverter for " + parameterizedType + " at " + parameter.handle.getDeclaringExecutable());
     }
 
-    private static Object getDefaultValue(ResolvedParameter parameter, Parameter annotationSource, ParamConverter<?> converter, boolean lazyDefaultValue, ValueSource source, String parameterName) {
+    private static @Nullable Object getDefaultValue(ResolvedParameter parameter, Parameter annotationSource, ParamConverter<?> converter, boolean lazyDefaultValue, ValueSource source, String parameterName) {
         DefaultValue annotation = annotationSource.getDeclaredAnnotation(DefaultValue.class);
         if (annotation == null) {
             return converter instanceof HasDefaultValue ? ((HasDefaultValue) converter).getDefault() : null;
@@ -419,7 +421,7 @@ abstract class ResourceMethodParam {
         return convertValue(parameter.handle, parameter.type, converter, lazyDefaultValue, annotation.value(), source, parameterName);
     }
 
-    private static Object convertValue(Parameter parameterHandle, Class<?> parameterType, ParamConverter<?> converter, boolean skipConverter, Object value, ValueSource source, String parameterName) {
+    private static @Nullable Object convertValue(Parameter parameterHandle, Class<?> parameterType, @Nullable ParamConverter<?> converter, boolean skipConverter, @Nullable Object value, ValueSource source, String parameterName) {
         if (converter == null || skipConverter) {
             return value;
         } else {
@@ -447,15 +449,15 @@ abstract class ResourceMethodParam {
     enum ValueSource {
         MESSAGE_BODY(null), QUERY_PARAM("query"), MATRIX_PARAM(null), PATH_PARAM("path"), COOKIE_PARAM("cookie"), HEADER_PARAM("header"), FORM_PARAM(null), CONTEXT(null), SUSPENDED(null);
 
-        final String openAPIIn;
+        final @Nullable String openAPIIn;
 
-        ValueSource(String openAPIIn) {
+        ValueSource(@Nullable String openAPIIn) {
             this.openAPIIn = openAPIIn;
         }
     }
 
     interface HasDefaultValue {
-        Object getDefault();
+        @Nullable Object getDefault();
     }
 
 }

--- a/src/main/java/io/muserver/rest/RestHandler.java
+++ b/src/main/java/io/muserver/rest/RestHandler.java
@@ -13,6 +13,7 @@ import jakarta.ws.rs.ext.ReaderInterceptor;
 import jakarta.ws.rs.ext.WriterInterceptor;
 import jakarta.ws.rs.sse.Sse;
 import jakarta.ws.rs.sse.SseEventSink;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -36,7 +37,7 @@ public class RestHandler implements MuHandler {
 
     private final RequestMatcher requestMatcher;
     private final EntityProviders entityProviders;
-    private final MuHandler documentor;
+    private final @Nullable MuHandler documentor;
     private final CustomExceptionMapper customExceptionMapper;
     private final FilterManagerThing filterManagerThing;
     private final CORSConfig corsConfig;
@@ -47,7 +48,7 @@ public class RestHandler implements MuHandler {
     private final List<WriterInterceptor> writerInterceptors;
     private final CollectionParameterStrategy collectionParameterStrategy;
 
-    RestHandler(EntityProviders entityProviders, List<ResourceClass> roots, MuHandler documentor, CustomExceptionMapper customExceptionMapper, FilterManagerThing filterManagerThing, CORSConfig corsConfig, List<ParamConverterProvider> paramConverterProviders, SchemaObjectCustomizer schemaObjectCustomizer, List<ReaderInterceptor> readerInterceptors, List<WriterInterceptor> writerInterceptors, CollectionParameterStrategy collectionParameterStrategy) {
+    RestHandler(EntityProviders entityProviders, List<ResourceClass> roots, @Nullable MuHandler documentor, CustomExceptionMapper customExceptionMapper, FilterManagerThing filterManagerThing, CORSConfig corsConfig, List<ParamConverterProvider> paramConverterProviders, SchemaObjectCustomizer schemaObjectCustomizer, List<ReaderInterceptor> readerInterceptors, List<WriterInterceptor> writerInterceptors, CollectionParameterStrategy collectionParameterStrategy) {
         this.requestMatcher = new RequestMatcher(roots);
         this.entityProviders = entityProviders;
         this.documentor = documentor;
@@ -86,12 +87,14 @@ public class RestHandler implements MuHandler {
             }
 
             Function<RequestMatcher.MatchedMethod,ResourceClass> subResourceLocator = matchedMethod -> {
-                Function<ResourceMethod, Object> onSuspended = resourceMethod -> {
+                Function<ResourceMethod, @Nullable Object> onSuspended = resourceMethod -> {
                     throw new MuException("Suspended is not supported on sub-resource locators. Method: " + resourceMethod.methodHandle);
                 };
                 ResourceMethod rm = matchedMethod.resourceMethod;
                 try {
-                    Object instance = invokeResourceMethod(requestContext, muResponse, matchedMethod, onSuspended, entityProviders, collectionParameterStrategy);
+                    Object instance = Objects.requireNonNull(
+                        invokeResourceMethod(requestContext, muResponse, matchedMethod, onSuspended, entityProviders, collectionParameterStrategy),
+                        "Sub-resource locator returned null");
                     return ResourceClass.forSubResourceLocator(rm, instance.getClass(), instance, schemaObjectCustomizer, paramConverterProviders);
                 } catch (WebApplicationException wae) {
                     throw wae;
@@ -123,7 +126,7 @@ public class RestHandler implements MuHandler {
             List<MediaType> produces = producesRef = mm.resourceMethod.resourceClass.produces;
             List<MediaType> directlyProduces = directlyProducesRef = mm.resourceMethod.directlyProduces;
             Annotation[] methodAnnotations = mm.resourceMethod.methodAnnotations;
-            Type methodReturnType = mm.resourceMethod.genericReturnType;
+            @Nullable Type methodReturnType = mm.resourceMethod.genericReturnType;
 
             filterManagerThing.onPostMatch(requestContext);
             if (requestContext.getAbortResponse() != null) {
@@ -131,7 +134,7 @@ public class RestHandler implements MuHandler {
                 return true;
             }
 
-            Function<ResourceMethod, Object> suspendedParamCallback = rm -> {
+            Function<ResourceMethod, @Nullable Object> suspendedParamCallback = rm -> {
                 if (muRequest.isAsync()) {
                     throw new MuException("A REST method can only have one @Suspended attribute. Error for " + rm);
                 }
@@ -140,7 +143,7 @@ public class RestHandler implements MuHandler {
             };
 
 
-            Object result = invokeResourceMethod(requestContext, muResponse, mm, suspendedParamCallback, entityProviders, collectionParameterStrategy);
+            @Nullable Object result = invokeResourceMethod(requestContext, muResponse, mm, suspendedParamCallback, entityProviders, collectionParameterStrategy);
 
             if (!muRequest.isAsync()) {
                 if (result instanceof CompletionStage) {
@@ -173,15 +176,15 @@ public class RestHandler implements MuHandler {
         return true;
     }
 
-    private static Type completionStageResultType(Type returnType) {
+    private static @Nullable Type completionStageResultType(@Nullable Type returnType) {
         return GenericTypeResolver.resolveTypeArgument(returnType, CompletionStage.class, 0);
     }
 
-    static Object invokeResourceMethod(JaxRSRequest requestContext, MuResponse muResponse, RequestMatcher.MatchedMethod mm, Function<ResourceMethod, Object> suspendedParamCallback, EntityProviders entityProviders, CollectionParameterStrategy collectionParameterStrategy) throws Exception {
+    static @Nullable Object invokeResourceMethod(JaxRSRequest requestContext, MuResponse muResponse, RequestMatcher.MatchedMethod mm, Function<ResourceMethod, @Nullable Object> suspendedParamCallback, EntityProviders entityProviders, CollectionParameterStrategy collectionParameterStrategy) throws Exception {
         ResourceMethod rm = mm.resourceMethod;
-        Object[] params = new Object[rm.methodHandle.getParameterCount()];
+        @Nullable Object[] params = new Object[rm.methodHandle.getParameterCount()];
         for (ResourceMethodParam param : rm.params) {
-            Object paramValue;
+            @Nullable Object paramValue;
             if (param.source == ResourceMethodParam.ValueSource.MESSAGE_BODY) {
                 paramValue = readRequestEntity(requestContext, param);
             } else if (param.source == ResourceMethodParam.ValueSource.CONTEXT) {
@@ -227,11 +230,11 @@ public class RestHandler implements MuHandler {
         }
     }
 
-    private void sendResponse(int nestingLevel, JaxRSRequest requestContext, MuResponse muResponse, List<MediaType> acceptHeaders, List<MediaType> produces, List<MediaType> directlyProduces, Annotation[] annotations, Object result) throws Exception {
+    private void sendResponse(int nestingLevel, JaxRSRequest requestContext, MuResponse muResponse, List<MediaType> acceptHeaders, List<MediaType> produces, List<MediaType> directlyProduces, Annotation[] annotations, @Nullable Object result) throws Exception {
         sendResponse(nestingLevel, requestContext, muResponse, acceptHeaders, produces, directlyProduces, annotations, result, null);
     }
 
-    private void sendResponse(int nestingLevel, JaxRSRequest requestContext, MuResponse muResponse, List<MediaType> acceptHeaders, List<MediaType> produces, List<MediaType> directlyProduces, Annotation[] annotations, Object result, Type resourceMethodReturnType) throws Exception {
+    private void sendResponse(int nestingLevel, JaxRSRequest requestContext, MuResponse muResponse, List<MediaType> acceptHeaders, List<MediaType> produces, List<MediaType> directlyProduces, Annotation[] annotations, @Nullable Object result, @Nullable Type resourceMethodReturnType) throws Exception {
         try {
             if (requestContext.hasEntity()) {
                 requestContext.getEntityStream().close();
@@ -298,7 +301,8 @@ public class RestHandler implements MuHandler {
                         MuRuntimeDelegate.writeResponseHeaders(requestContext.getUriInfo().getBaseUri(), jaxRSResponse, muResponse, isHttp1);
                     } else {
 
-                        MediaType responseMediaType = jaxRSResponse.getMediaType();
+                        MediaType responseMediaType = Objects.requireNonNull(jaxRSResponse.getMediaType(),
+                            "A response entity must have a media type");
 
                         Class entityType = jaxRSResponse.getEntityClass();
                         Type entityGenericType = jaxRSResponse.getEntityType();
@@ -401,7 +405,7 @@ public class RestHandler implements MuHandler {
         return paramValue;
     }
 
-    static MuUriInfo createUriInfo(String relativePath, RequestMatcher.MatchedMethod mm, URI baseUri, URI requestUri) {
+    static MuUriInfo createUriInfo(String relativePath, RequestMatcher.@Nullable MatchedMethod mm, URI baseUri, URI requestUri) {
         return new MuUriInfo(baseUri, requestUri, Mutils.trim(relativePath, "/"), mm);
     }
 

--- a/src/main/java/io/muserver/rest/RestHandler.java
+++ b/src/main/java/io/muserver/rest/RestHandler.java
@@ -304,12 +304,14 @@ public class RestHandler implements MuHandler {
                         MediaType responseMediaType = Objects.requireNonNull(jaxRSResponse.getMediaType(),
                             "A response entity must have a media type");
 
-                        Class entityType = jaxRSResponse.getEntityClass();
-                        Type entityGenericType = jaxRSResponse.getEntityType();
+                        Class entityType = Objects.requireNonNull(jaxRSResponse.getEntityClass(),
+                            "A response entity must have a raw type");
+                        Type entityGenericType = Objects.requireNonNull(jaxRSResponse.getEntityType(),
+                            "A response entity must have a generic type");
                         MessageBodyWriter messageBodyWriter = entityProviders.selectWriter(entityType, entityGenericType, writerAnnontations, responseMediaType);
 
                         if (entityProviders.isBuiltInWriter(messageBodyWriter)) {
-                            long size = messageBodyWriter.getSize(jaxRSResponse.getEntity(), jaxRSResponse.getType(), jaxRSResponse.getGenericType(), writerAnnontations, responseMediaType);
+                            long size = messageBodyWriter.getSize(jaxRSResponse.getEntity(), entityType, entityGenericType, writerAnnontations, responseMediaType);
                             if (size >= 0) {
                                 jaxRSResponse.getHeaders().putSingle("content-length", Long.toString(size));
                             }
@@ -318,7 +320,7 @@ public class RestHandler implements MuHandler {
                         applyDefaultCharset(jaxRSResponse);
 
                         try {
-                            messageBodyWriter.writeTo(jaxRSResponse.getEntity(), jaxRSResponse.getType(), jaxRSResponse.getGenericType(), writerAnnontations,
+                            messageBodyWriter.writeTo(jaxRSResponse.getEntity(), entityType, entityGenericType, writerAnnontations,
                                 jaxRSResponse.getMediaType(), jaxRSResponse.getHeaders(), jaxRSResponse.getOutputStream());
                             out.prepare();
                         } catch (Exception e) {
@@ -374,7 +376,7 @@ public class RestHandler implements MuHandler {
         }
     }
 
-    private static Object getContextParam(JaxRSRequest requestContext, MuResponse muResponse, RequestMatcher.MatchedMethod mm, ResourceMethodParam param, EntityProviders providers) {
+    private static @Nullable Object getContextParam(JaxRSRequest requestContext, MuResponse muResponse, RequestMatcher.MatchedMethod mm, ResourceMethodParam param, EntityProviders providers) {
         MuRequest request = requestContext.muRequest;
         Object paramValue;
         Class<?> type = param.type;

--- a/src/main/java/io/muserver/rest/RestHandlerBuilder.java
+++ b/src/main/java/io/muserver/rest/RestHandlerBuilder.java
@@ -42,17 +42,17 @@ public class RestHandlerBuilder implements MuHandlerBuilder<RestHandler> {
     private final List<ReaderInterceptor> readerInterceptors = new ArrayList<>();
     private final List<ParamConverterProvider> customParamConverterProviders = new ArrayList<>();
     private final List<SchemaReference> customSchemas = new ArrayList<>();
-    private String openApiJsonUrl = null;
-    private String openApiHtmlUrl = null;
-    private OpenAPIObjectBuilder openAPIObject;
-    private String openApiHtmlCss = null;
+    private @Nullable String openApiJsonUrl;
+    private @Nullable String openApiHtmlUrl;
+    private @Nullable OpenAPIObjectBuilder openAPIObject;
+    private @Nullable String openApiHtmlCss;
     private final Map<Class<? extends Throwable>, ExceptionMapper<? extends Throwable>> exceptionMappers = new HashMap<>();
     private final List<ContainerRequestFilter> preMatchRequestFilters = new ArrayList<>();
     private final List<ContainerRequestFilter> requestFilters = new ArrayList<>();
     private final List<ContainerResponseFilter> responseFilters = new ArrayList<>();
     private CORSConfig corsConfig = CORSConfigBuilder.disabled().build();
     private final List<SchemaObjectCustomizer> schemaObjectCustomizers = new ArrayList<>();
-    private CollectionParameterStrategy collectionParameterStrategy;
+    private @Nullable CollectionParameterStrategy collectionParameterStrategy;
 
     /**
      * Adds one or more rest resources to this handler
@@ -120,7 +120,7 @@ public class RestHandlerBuilder implements MuHandlerBuilder<RestHandler> {
     public <P> RestHandlerBuilder addCustomParamConverter(Class<P> paramClass, ParamConverter<P> converter) {
         return addCustomParamConverterProvider(new ParamConverterProvider() {
             @Override
-            public <T> ParamConverter<T> getConverter(Class<T> rawType, Type genericType, Annotation[] annotations) {
+            public <T> @Nullable ParamConverter<T> getConverter(Class<T> rawType, Type genericType, Annotation[] annotations) {
                 if (!rawType.equals(paramClass)) {
                     return null;
                 }
@@ -482,28 +482,28 @@ public class RestHandlerBuilder implements MuHandlerBuilder<RestHandler> {
     /**
      * @return The current value of this property
      */
-    public String openApiJsonUrl() {
+    public @Nullable String openApiJsonUrl() {
         return openApiJsonUrl;
     }
 
     /**
      * @return The current value of this property
      */
-    public String openApiHtmlUrl() {
+    public @Nullable String openApiHtmlUrl() {
         return openApiHtmlUrl;
     }
 
     /**
      * @return The current value of this property
      */
-    public OpenAPIObjectBuilder openAPIObject() {
+    public @Nullable OpenAPIObjectBuilder openAPIObject() {
         return openAPIObject;
     }
 
     /**
      * @return The current value of this property
      */
-    public String openApiHtmlCss() {
+    public @Nullable String openApiHtmlCss() {
         return openApiHtmlCss;
     }
 
@@ -553,7 +553,7 @@ public class RestHandlerBuilder implements MuHandlerBuilder<RestHandler> {
      * @return The current value of this property
      */
     public CollectionParameterStrategy collectionParameterStrategy() {
-        return collectionParameterStrategy;
+        return collectionParameterStrategy == null ? CollectionParameterStrategy.NO_TRANSFORM : collectionParameterStrategy;
     }
 
     /**
@@ -580,10 +580,12 @@ public class RestHandlerBuilder implements MuHandlerBuilder<RestHandler> {
         }
         List<ResourceClass> roots = Collections.unmodifiableList(list);
 
-        OpenApiDocumentor documentor = null;
+        @Nullable OpenApiDocumentor documentor = null;
         if (openApiHtmlUrl != null || openApiJsonUrl != null) {
             if (openApiHtmlCss == null) {
-                InputStream cssStream = RestHandlerBuilder.class.getResourceAsStream("/io/muserver/resources/api.css");
+                InputStream cssStream = Objects.requireNonNull(
+                    RestHandlerBuilder.class.getResourceAsStream("/io/muserver/resources/api.css"),
+                    "Bundled OpenAPI CSS was not found");
                 Scanner scanner = new Scanner(cssStream, "UTF-8").useDelimiter("\\A");
                 openApiHtmlCss = scanner.next();
                 scanner.close();

--- a/src/main/java/io/muserver/rest/SchemaObjectCustomizerContext.java
+++ b/src/main/java/io/muserver/rest/SchemaObjectCustomizerContext.java
@@ -2,6 +2,7 @@ package io.muserver.rest;
 
 import io.muserver.openapi.SchemaObject;
 import jakarta.ws.rs.core.MediaType;
+import org.jspecify.annotations.Nullable;
 
 import java.lang.reflect.Method;
 import java.lang.reflect.Type;
@@ -16,13 +17,13 @@ public class SchemaObjectCustomizerContext {
 
     private final SchemaObjectCustomizerTarget target;
     private final Class<?> type;
-    private final Type parameterizedType;
-    private final Object resource;
+    private final @Nullable Type parameterizedType;
+    private final @Nullable Object resource;
     private final Method method;
-    private final String parameter;
+    private final @Nullable String parameter;
     private final MediaType mediaType;
 
-    SchemaObjectCustomizerContext(SchemaObjectCustomizerTarget target, Class<?> type, Type parameterizedType, Object resource, Method method, String parameter, MediaType mediaType) {
+    SchemaObjectCustomizerContext(SchemaObjectCustomizerTarget target, Class<?> type, @Nullable Type parameterizedType, @Nullable Object resource, Method method, @Nullable String parameter, MediaType mediaType) {
         this.target = requireNonNull(target, "target");
         this.type = requireNonNull(type, "type");
         this.parameterizedType = parameterizedType;
@@ -44,7 +45,7 @@ public class SchemaObjectCustomizerContext {
      * returned by a sub-resource-locator, this will be null.
      * @return The rest resource that creates or consumes the object being described
      */
-    public Object resource() {
+    public @Nullable Object resource() {
         return resource;
     }
 

--- a/src/main/java/io/muserver/rest/StringEntityProviders.java
+++ b/src/main/java/io/muserver/rest/StringEntityProviders.java
@@ -12,6 +12,7 @@ import jakarta.ws.rs.core.MultivaluedHashMap;
 import jakarta.ws.rs.core.MultivaluedMap;
 import jakarta.ws.rs.ext.MessageBodyReader;
 import jakarta.ws.rs.ext.MessageBodyWriter;
+import org.jspecify.annotations.Nullable;
 
 import java.io.*;
 import java.lang.annotation.Annotation;
@@ -138,7 +139,7 @@ class StringEntityProviders {
         }
 
         @Override
-        public T readFrom(Class<T> type, Type genericType, Annotation[] annotations, MediaType mediaType, MultivaluedMap<String, String> httpHeaders, InputStream entityStream) throws IOException, WebApplicationException {
+        public @Nullable T readFrom(Class<T> type, Type genericType, Annotation[] annotations, MediaType mediaType, MultivaluedMap<String, String> httpHeaders, InputStream entityStream) throws IOException, WebApplicationException {
             String s = new String(Mutils.toByteArray(entityStream, 512), EntityProviders.charsetFor(mediaType));
             if (Mutils.nullOrEmpty(s)) {
                 return null;

--- a/src/main/java/io/muserver/rest/UriParameterConversionException.java
+++ b/src/main/java/io/muserver/rest/UriParameterConversionException.java
@@ -2,6 +2,7 @@ package io.muserver.rest;
 
 import jakarta.ws.rs.MatrixParam;
 import jakarta.ws.rs.NotFoundException;
+import org.jspecify.annotations.Nullable;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.ext.ExceptionMapper;
@@ -26,10 +27,10 @@ import java.util.Objects;
  */
 public final class UriParameterConversionException extends NotFoundException {
     private final String parameterName;
-    private final String parameterValue;
+    private final @Nullable String parameterValue;
     private final Class<?> targetType;
 
-    UriParameterConversionException(String parameterName, String parameterValue, Class<?> targetType, Throwable cause) {
+    UriParameterConversionException(String parameterName, @Nullable String parameterValue, Class<?> targetType, Throwable cause) {
         super("Could not convert URI parameter \"" + parameterName + "\" with value \"" + parameterValue + "\" to " + targetType.getTypeName(), cause);
         this.parameterName = Objects.requireNonNull(parameterName, "parameterName");
         this.parameterValue = parameterValue;
@@ -46,7 +47,7 @@ public final class UriParameterConversionException extends NotFoundException {
     /**
      * @return the supplied parameter value, or {@code null} if no value was supplied
      */
-    public String getParameterValue() {
+    public @Nullable String getParameterValue() {
         return parameterValue;
     }
 

--- a/src/main/java/io/muserver/rest/UriPattern.java
+++ b/src/main/java/io/muserver/rest/UriPattern.java
@@ -8,6 +8,7 @@ import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import org.jspecify.annotations.Nullable;
 
 /**
  * A pattern representing a URI template, such as <code>/fruit</code> or <code>/fruit/{name}</code> etc.
@@ -39,7 +40,7 @@ public class UriPattern {
         this.pathWithoutRegex = pathWithoutRegex;
     }
 
-    String regexFor(String name) {
+    @Nullable String regexFor(String name) {
         int i = namedGroups.indexOf(name);
         if (i == -1) return null;
         return namedGroupRegexes.get(i);

--- a/src/main/java/io/muserver/rest/UriPattern.java
+++ b/src/main/java/io/muserver/rest/UriPattern.java
@@ -247,7 +247,7 @@ public class UriPattern {
     }
 
     @Override
-    public boolean equals(Object o) {
+    public boolean equals(@Nullable Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         UriPattern that = (UriPattern) o;

--- a/src/test/java/io/muserver/rest/JaxRSResponseTest.java
+++ b/src/test/java/io/muserver/rest/JaxRSResponseTest.java
@@ -294,6 +294,53 @@ public class JaxRSResponseTest {
     }
 
     @Test
+    public void nullableBuilderArgumentsRemovePreviouslyConfiguredMetadata() {
+        Response response = new JaxRSResponse.Builder()
+            .cacheControl(cacheControl())
+            .cacheControl(null)
+            .contentLocation(URI.create("/content"))
+            .contentLocation(null)
+            .cookie(new NewCookie("name", "value"))
+            .cookie((NewCookie[]) null)
+            .expires(new Date())
+            .expires(null)
+            .header("custom", "value")
+            .header("custom", null)
+            .lastModified(new Date())
+            .lastModified(null)
+            .location(URI.create("/location"))
+            .location(null)
+            .tag("tag")
+            .tag((String) null)
+            .variants(new Variant(MediaType.TEXT_PLAIN_TYPE, (Locale) null, null))
+            .variants((java.util.List<Variant>) null)
+            .links(Link.fromUri("/link").rel("related").build())
+            .links((Link[]) null)
+            .build();
+
+        assertThat(response.getHeaders(), anEmptyMap());
+        assertThat(response.getCookies(), anEmptyMap());
+        assertThat(response.getLinks(), empty());
+    }
+
+    @Test
+    public void customStatusCodesStillHaveNonNullStatusInfo() {
+        JaxRSResponse response = (JaxRSResponse) Response.ok().build();
+        response.setStatus(299);
+
+        assertThat(response.getStatus(), is(299));
+        assertThat(response.getStatusInfo(), notNullValue());
+    }
+
+    @Test
+    public void responseWithoutEntityHasNoEntityTypeInformation() {
+        JaxRSResponse response = (JaxRSResponse) Response.noContent().build();
+
+        assertThat(response.getEntityClass(), nullValue());
+        assertThat(response.getEntityType(), nullValue());
+    }
+
+    @Test
     public void canBufferInputStreams() throws IOException {
         AtomicInteger closeCount = new AtomicInteger(0);
         try (InputStream inputStream = new ByteArrayInputStream("Hello world".getBytes(StandardCharsets.UTF_8)) {

--- a/src/test/java/io/muserver/rest/JaxSseImplTest.java
+++ b/src/test/java/io/muserver/rest/JaxSseImplTest.java
@@ -2,6 +2,7 @@ package io.muserver.rest;
 
 
 import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.GenericType;
 import jakarta.ws.rs.sse.OutboundSseEvent;
 import org.junit.Test;
 
@@ -21,7 +22,7 @@ public class JaxSseImplTest {
             .data("Not ignored")
             .name("Event name")
             .build();
-        assertThat(event.getGenericType(), is(nullValue()));
+        assertThat(event.getGenericType(), equalTo(String.class));
         assertThat(event.getMediaType(), is(MediaType.APPLICATION_SVG_XML_TYPE));
         assertThat(event.getComment(), is("A comment"));
         assertThat(event.getReconnectDelay(), is(1000L));
@@ -29,6 +30,19 @@ public class JaxSseImplTest {
         assertThat(event.getName(), is("Event name"));
         assertThat(event.getType(), equalTo(String.class));
         assertThat(event.getData(), is("Not ignored"));
+    }
+
+    @Test
+    public void replacingGenericDataKeepsRawAndGenericTypesConsistent() {
+        GenericType<java.util.List<String>> genericType = new GenericType<java.util.List<String>>() {
+        };
+        OutboundSseEvent event = new JaxSseImpl().newEventBuilder()
+            .data(String.class, "old")
+            .data(genericType, java.util.Collections.singletonList("new"))
+            .build();
+
+        assertThat(event.getType(), equalTo(java.util.List.class));
+        assertThat(event.getGenericType(), equalTo(genericType.getType()));
     }
 
 }

--- a/src/test/java/io/muserver/rest/MuUriBuilderTest.java
+++ b/src/test/java/io/muserver/rest/MuUriBuilderTest.java
@@ -204,6 +204,20 @@ public class MuUriBuilderTest {
     }
 
     @Test
+    public void nullableUriComponentsAreRemoved() {
+        URI uri = MuUriBuilder.fromUri(u("https://user@example.org/path;matrix=value?query=value#fragment"))
+            .scheme(null)
+            .userInfo(null)
+            .host(null)
+            .replacePath(null)
+            .replaceQuery(null)
+            .fragment(null)
+            .build();
+
+        assertThat(uri.toString(), equalTo(""));
+    }
+
+    @Test
     public void pathsAreAppended() {
         URI uri = MuUriBuilder.fromUri(u("http://example.org/blah"))
             .path("ha/har")
@@ -321,6 +335,16 @@ public class MuUriBuilderTest {
         uriBuilder.matrixParam("color", "black", "solid", "1px");
         uriBuilder.replaceMatrixParam("color", "orange", "bright");
         assertThat(uriBuilder.build().toString(), equalTo("/hello;color=red/blah;color=orange;color=bright"));
+    }
+
+    @Test
+    public void replacingMatrixParamWithNullRemovesIt() {
+        URI uri = UriBuilder.fromPath("/hello")
+            .matrixParam("color", "red")
+            .replaceMatrixParam("color", (Object[]) null)
+            .build();
+
+        assertThat(uri.toString(), equalTo("/hello"));
     }
 
     @Test

--- a/src/test/java/io/muserver/rest/RequestMatcherTest.java
+++ b/src/test/java/io/muserver/rest/RequestMatcherTest.java
@@ -474,7 +474,8 @@ public class RequestMatcherTest {
                 return emptyList();
             }
         };
-        InputStream inputStream = requestHasEntity ? new ByteArrayInputStream("Hello".getBytes(StandardCharsets.US_ASCII)) : null;
+        InputStream inputStream = new ByteArrayInputStream(
+            requestHasEntity ? "Hello".getBytes(StandardCharsets.US_ASCII) : new byte[0]);
         JaxRSRequest rc = new JaxRSRequest(request, null, inputStream, request.uri().getPath(), null, emptyList(), null);
         return rm.findResourceMethod(rc, method, acceptHeaders, null);
     }


### PR DESCRIPTION
## What changed

- Audited all 252 production Java sources in the four `@NullMarked` package trees.
- Corrected nullable lifecycle fields, optional API values, reflection/JAX-RS results, builder state, WebSocket/SSE state, generic element/value positions, and every `equals(Object)` override.
- Added a standards-driven Jakarta REST pass using the 3.1 API sources and Javadocs as the primary contract, then implementation behavior and existing compatibility tests where the specification is silent.
- Preserved required public API inputs as non-null and added runtime validation at public/SPI trust boundaries.
- Added a Maven `nullaway` profile using NullAway JSpecify mode, scoped to production sources.
- Enabled NullAway 0.13.8 with Error Prone 2.50.0 in the Java 21 CI `verify` build; Java 11/17/25 and release builds remain unchanged.
- Added no NullAway suppressions.

## Jakarta REST findings

- `JaxRSRequest` and `JaxRSResponse` interceptor type/generic-type metadata is nullable while it is unset or cleared. Serialization and deserialization now require it only at the terminal provider invocation.
- Entity streams remain non-null. A matcher fixture that constructed an incomplete request context was corrected, and public stream setters reject null.
- Response-builder and URI-builder arguments documented by Jakarta as null-to-remove/reset are explicitly nullable and implement that behavior.
- Header delegates, async response callbacks, SSE send operations, link builders, and other required public inputs reject null at entry.
- Response entity type/class and entity-tag accessors now expose their documented optional result.
- SSE generic type state is kept consistent across builder overloads; third-party events missing a generic type safely fall back to their raw type.
- Several obvious behavior defects found by the contract pass were fixed and covered, including custom response status codes, null cookie reset, URI component removal, matrix parameter replacement, and stale SSE type metadata.

NullAway catches flow errors, but it cannot infer third-party API null contracts. The Jakarta decisions above therefore come from the API documentation and actual lifecycle behavior, not from making the checker green.

## Compatibility and impact

- Public JVM descriptors are unchanged.
- Required public inputs still fail fast when callers pass null; legal or observable nulls are explicitly annotated.
- CI treats NullAway findings as compilation errors on the Java 21 job.
- Plain local and release builds do not activate NullAway unless `-Pnullaway` is supplied.
- Tests remain outside NullAway because many intentionally exercise invalid null calls and partial lifecycle fixtures.

## Validation

Against the latest `master` (`52dd50ce`):

- `mvn -Pnetty-4.1,nullaway clean verify` on Java 21 — latest NullAway/Error Prone analysis compiled all production sources successfully
- `mvn verify` — 933 tests, 0 failures/errors, 99.96 seconds locally
- focused Jakarta contract/SSE/URI/response tests — 89 tests, success
- `git diff --check` — clean

A companion draft PR, #124, carries the reviewed changes into `mu4` while preserving its rewritten implementation.