### PR TITLE
Carry JSpecify nullability audit into mu4

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,9 +22,9 @@ jobs:
           java-version: ${{ matrix.java }}
           distribution: 'temurin'
           cache: 'maven'
-      - name: Build with Maven and NullAway on JDK 11
-        if: matrix.java == 11
+      - name: Build with Maven and NullAway on JDK 21
+        if: matrix.java == 21
         run: mvn --batch-mode --update-snapshots -Pnullaway verify
       - name: Build with Maven on JDK ${{ matrix.java }}
-        if: matrix.java != 11
+        if: matrix.java != 21
         run: mvn --batch-mode --update-snapshots verify

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,5 +22,9 @@ jobs:
           java-version: ${{ matrix.java }}
           distribution: 'temurin'
           cache: 'maven'
+      - name: Build with Maven and NullAway on JDK 11
+        if: matrix.java == 11
+        run: mvn --batch-mode --update-snapshots -Pnullaway verify
       - name: Build with Maven on JDK ${{ matrix.java }}
+        if: matrix.java != 11
         run: mvn --batch-mode --update-snapshots verify

--- a/pom.xml
+++ b/pom.xml
@@ -14,13 +14,13 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <error-prone.version>2.31.0</error-prone.version>
+        <error-prone.version>2.50.0</error-prone.version>
         <!-- Unused in mu4; retained so Netty version updates merge cleanly from master. -->
         <netty.version.4.1>4.1.135.Final</netty.version.4.1>
         <netty.version.4.2>4.2.14.Final</netty.version.4.2>
         <netty.version>${netty.version.4.1}</netty.version>
         <netty.codec.artifactId>netty-codec</netty.codec.artifactId>
-        <nullaway.version>0.12.10</nullaway.version>
+        <nullaway.version>0.13.8</nullaway.version>
         <slf4j.version>2.0.16</slf4j.version>
         <jetty.version>9.4.57.v20241219</jetty.version>
         <jdk.version>11</jdk.version>
@@ -318,7 +318,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.13.0</version>
+                <version>3.15.0</version>
                 <executions>
                     <execution>
                         <id>default-compile</id>
@@ -346,6 +346,7 @@
                 <configuration>
                     <source>${jdk.version}</source>
                     <target>${jdk.version}</target>
+                    <release>${jdk.version}</release>
                     <failOnWarning>true</failOnWarning>
                     <showWarnings>true</showWarnings>
                     <compilerArgs>

--- a/pom.xml
+++ b/pom.xml
@@ -14,11 +14,13 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <error-prone.version>2.31.0</error-prone.version>
         <!-- Unused in mu4; retained so Netty version updates merge cleanly from master. -->
         <netty.version.4.1>4.1.135.Final</netty.version.4.1>
         <netty.version.4.2>4.2.14.Final</netty.version.4.2>
         <netty.version>${netty.version.4.1}</netty.version>
         <netty.codec.artifactId>netty-codec</netty.codec.artifactId>
+        <nullaway.version>0.12.10</nullaway.version>
         <slf4j.version>2.0.16</slf4j.version>
         <jetty.version>9.4.57.v20241219</jetty.version>
         <jdk.version>11</jdk.version>
@@ -355,6 +357,59 @@
     </build>
 
     <profiles>
+        <profile>
+            <id>nullaway</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-compiler-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>testCompile</id>
+                                <configuration>
+                                    <!-- Keep NullAway on production code; tests intentionally exercise null contracts and lifecycle setup. -->
+                                    <compilerArgs combine.self="override">
+                                        <arg>-proc:none</arg>
+                                    </compilerArgs>
+                                </configuration>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <fork>true</fork>
+                            <annotationProcessorPaths>
+                                <path>
+                                    <groupId>com.google.errorprone</groupId>
+                                    <artifactId>error_prone_core</artifactId>
+                                    <version>${error-prone.version}</version>
+                                </path>
+                                <path>
+                                    <groupId>com.uber.nullaway</groupId>
+                                    <artifactId>nullaway</artifactId>
+                                    <version>${nullaway.version}</version>
+                                </path>
+                            </annotationProcessorPaths>
+                            <compilerArgs combine.self="override">
+                                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED</arg>
+                                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED</arg>
+                                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED</arg>
+                                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED</arg>
+                                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED</arg>
+                                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED</arg>
+                                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED</arg>
+                                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED</arg>
+                                <arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED</arg>
+                                <arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED</arg>
+                                <arg>-XDcompilePolicy=simple</arg>
+                                <arg>-XDaddTypeAnnotationsToSymbol=true</arg>
+                                <arg>--should-stop=ifError=FLOW</arg>
+                                <arg>-Xplugin:ErrorProne -XepDisableAllChecks -Xep:NullAway:ERROR -XepOpt:NullAway:OnlyNullMarked=true -XepOpt:NullAway:JSpecifyMode=true</arg>
+                            </compilerArgs>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
         <profile>
             <id>release</id>
             <build>

--- a/src/main/java/io/muserver/AsyncHandle.java
+++ b/src/main/java/io/muserver/AsyncHandle.java
@@ -49,7 +49,7 @@ public interface AsyncHandle {
      * @param data The data to write
      * @return A future that is resolved when the write succeeds or fails.
      */
-    Future<Void> write(ByteBuffer data);
+    Future<@Nullable Void> write(ByteBuffer data);
 
     /**
      * Add a listener for when request processing is complete. One use of this is to detect early client disconnects

--- a/src/main/java/io/muserver/BaseHttpConnection.java
+++ b/src/main/java/io/muserver/BaseHttpConnection.java
@@ -76,7 +76,7 @@ abstract class BaseHttpConnection implements HttpConnection {
             if (!handled) throw new HttpException(HttpStatus.NOT_FOUND_404, "This page is not available. Sorry about that.");
 
             if (muRequest.isAsync()) {
-                var asyncHandle = muRequest.getAsyncHandle();
+                var asyncHandle = java.util.Objects.requireNonNull(muRequest.getAsyncHandle());
                     // TODO set proper timeout
                 asyncHandle.waitForCompletion(Long.MAX_VALUE);
             }

--- a/src/main/java/io/muserver/BaseWebSocket.java
+++ b/src/main/java/io/muserver/BaseWebSocket.java
@@ -70,7 +70,7 @@ public abstract class BaseWebSocket implements MuWebSocket {
         // Adapter code for old-style implementations that rely on non-blocking behaviour.
         // This calls the old-style methods in a new thread and blocks until the done callback is invoked.
         // Overriders of this base class should just override this method and block until the data is finished with.
-        var result = new CompletableFuture<@Nullable Void>();
+        CompletableFuture<@Nullable Void> result = new CompletableFuture<>();
         CompletableFuture.runAsync(() -> {
             try {
                 onText(message, true, error -> {
@@ -97,7 +97,7 @@ public abstract class BaseWebSocket implements MuWebSocket {
     public void onTextFragment(ByteBuffer textFragment, boolean isLast) throws Exception {
         bufferIt(textFragment);
         if (isLast) {
-            onText(fragmentBuffer.decodeUTF8());
+            onText(java.util.Objects.requireNonNull(fragmentBuffer).decodeUTF8());
             fragmentBuffer = null;
         }
     }
@@ -113,7 +113,7 @@ public abstract class BaseWebSocket implements MuWebSocket {
         bufferIt(buffer);
 
         if (isLast) {
-            var full = fragmentBuffer.toByteBuffer();
+            var full = java.util.Objects.requireNonNull(fragmentBuffer).toByteBuffer();
             fragmentBuffer = null;
             onBinary(full);
         }
@@ -158,7 +158,7 @@ public abstract class BaseWebSocket implements MuWebSocket {
         // Adapter code for old-style implementations that rely on non-blocking behaviour.
         // This calls the old-style methods in a new thread and blocks until the done callback is invoked.
         // Overriders of this base class should just override this method and block until the data is finished with.
-        var result = new CompletableFuture<@Nullable Void>();
+        CompletableFuture<@Nullable Void> result = new CompletableFuture<>();
         CompletableFuture.runAsync(() -> {
             try {
                 onBinary(buffer, true, error -> {
@@ -175,7 +175,7 @@ public abstract class BaseWebSocket implements MuWebSocket {
         blockUntilDone(result);
     }
 
-    private static void blockUntilDone(CompletableFuture<Void> result) throws Exception {
+    private static void blockUntilDone(CompletableFuture<@Nullable Void> result) throws Exception {
         try {
             result.get();
         } catch (ExecutionException e) {

--- a/src/main/java/io/muserver/ContextHandler.java
+++ b/src/main/java/io/muserver/ContextHandler.java
@@ -25,7 +25,7 @@ public class ContextHandler implements MuHandler {
      * @param muHandlers The handlers
      */
     ContextHandler(@Nullable String contextPath, List<MuHandler> muHandlers) {
-        String slashTrimmed = Mutils.trim(Mutils.coalesce(contextPath, "").trim(), "/");
+        String slashTrimmed = Mutils.trim(java.util.Objects.requireNonNull(Mutils.coalesce(contextPath, "")).trim(), "/");
         this.hasContext = !slashTrimmed.isEmpty();
         this.contextPath = Stream.of(slashTrimmed.split("/"))
             .map(Mutils::urlEncode)

--- a/src/main/java/io/muserver/Cookie.java
+++ b/src/main/java/io/muserver/Cookie.java
@@ -1,6 +1,5 @@
 package io.muserver;
 
-
 import org.jspecify.annotations.Nullable;
 
 import java.util.Objects;
@@ -94,7 +93,7 @@ public class Cookie {
     }
 
     @Override
-    public boolean equals(Object o) {
+    public boolean equals(@Nullable Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         Cookie cookie = (Cookie) o;

--- a/src/main/java/io/muserver/CookieBuilder.java
+++ b/src/main/java/io/muserver/CookieBuilder.java
@@ -205,9 +205,11 @@ public class CookieBuilder {
      * @return Returns a newly created cookie.
      */
     public Cookie build() {
-        if (Mutils.nullOrEmpty(name)) throw new IllegalStateException("A cookie name must be specified");
-        if (value == null) throw new IllegalStateException("A cookie value cannot be null");
-        return new Cookie(name, value, domain, path, maxAge, sameSite, secure, httpOnly);
+        String cookieName = name;
+        String cookieValue = value;
+        if (cookieName == null || cookieName.isEmpty()) throw new IllegalStateException("A cookie name must be specified");
+        if (cookieValue == null) throw new IllegalStateException("A cookie value cannot be null");
+        return new Cookie(cookieName, cookieValue, domain, path, maxAge, sameSite, secure, httpOnly);
     }
 
     /**
@@ -301,8 +303,8 @@ public class CookieBuilder {
             }
 
             CookieBuilder builder = CookieBuilder.newCookie()
-                .withName(name)
-                .withValue(value);
+                .withName(Objects.requireNonNull(name))
+                .withValue(Objects.requireNonNull(value));
             results.add(builder);
         }
         return results;
@@ -434,7 +436,7 @@ public class CookieBuilder {
                                 if (parameters == null) {
                                     parameters = new LinkedHashMap<>(); // keeps insertion order
                                 }
-                                parameters.put(paramName.toLowerCase(), buffer.toString());
+                                parameters.put(Objects.requireNonNull(paramName).toLowerCase(), buffer.toString());
                                 buffer.setLength(0);
                                 paramName = null;
                                 state = State.PARAM_NAME;
@@ -469,7 +471,7 @@ public class CookieBuilder {
                     if (parameters == null) {
                         parameters = new LinkedHashMap<>(); // keeps insertion order
                     }
-                    parameters.put(paramName.toLowerCase(), buffer.toString());
+                    parameters.put(Objects.requireNonNull(paramName).toLowerCase(), buffer.toString());
                     buffer.setLength(0);
                     break;
                 default:
@@ -479,8 +481,8 @@ public class CookieBuilder {
             }
 
             builder = CookieBuilder.newCookie()
-                .withName(name)
-                .withValue(value);
+                .withName(Objects.requireNonNull(name))
+                .withValue(Objects.requireNonNull(value));
             if (parameters != null) {
                 if (parameters.containsKey("domain")) builder.withDomain(parameters.get("domain"));
                 if (parameters.containsKey("httponly")) builder.httpOnly(true);

--- a/src/main/java/io/muserver/ForwardedHeader.java
+++ b/src/main/java/io/muserver/ForwardedHeader.java
@@ -264,7 +264,7 @@ public class ForwardedHeader {
     }
 
     @Override
-    public boolean equals(Object o) {
+    public boolean equals(@Nullable Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         ForwardedHeader that = (ForwardedHeader) o;

--- a/src/main/java/io/muserver/ForwardedHeader.java
+++ b/src/main/java/io/muserver/ForwardedHeader.java
@@ -147,7 +147,7 @@ public class ForwardedHeader {
                         } else {
                             if (c == ';') {
                                 String val = buffer.toString();
-                                switch (paramName.toLowerCase()) {
+                                switch (Objects.requireNonNull(paramName).toLowerCase()) {
                                     case "by":
                                         by = val;
                                         break;
@@ -188,7 +188,7 @@ public class ForwardedHeader {
             switch (state) {
                 case PARAM_VALUE:
                     String val = buffer.toString();
-                    switch (paramName.toLowerCase()) {
+                    switch (Objects.requireNonNull(paramName).toLowerCase()) {
                         case "by":
                             by = val;
                             break;

--- a/src/main/java/io/muserver/HpackTable.java
+++ b/src/main/java/io/muserver/HpackTable.java
@@ -118,7 +118,7 @@ class HpackTable {
 
     FieldLine getValue(int code) throws Http2Exception {
         if (code <= 0) throw new Http2Exception(Http2ErrorCode.COMPRESSION_ERROR, "Invalid code");
-        if (code < staticMap.length) return staticMap[code];
+        if (code < staticMap.length) return java.util.Objects.requireNonNull(staticMap[code]);
         int dIndex = code - staticMap.length;
         if (dIndex >= dynamicQueue.size()) {
             throw new Http2Exception(Http2ErrorCode.COMPRESSION_ERROR, "Invalid dynamic code");
@@ -128,7 +128,7 @@ class HpackTable {
 
     int codeFor(FieldLine line) {
         for (int i = 1; i < staticMap.length; i++) {
-            var staticLine = staticMap[i];
+            var staticLine = java.util.Objects.requireNonNull(staticMap[i]);
             if (staticLine.equals(line)) return i;
         }
         int i = 0;
@@ -141,7 +141,7 @@ class HpackTable {
 
     int codeFor(HeaderString name) {
         for (int i = 1; i < staticMap.length; i++) {
-            var staticLine = staticMap[i];
+            var staticLine = java.util.Objects.requireNonNull(staticMap[i]);
             if (staticLine.name().equals(name)) return i;
         }
         int i = 0;

--- a/src/main/java/io/muserver/Http1BodyStream.java
+++ b/src/main/java/io/muserver/Http1BodyStream.java
@@ -41,7 +41,7 @@ class Http1BodyStream extends InputStream implements RequestTrailersAccessor {
     }
 
     State state() {
-        return status.get();
+        return java.util.Objects.requireNonNull(status.get());
     }
 
     @Override
@@ -49,12 +49,12 @@ class Http1BodyStream extends InputStream implements RequestTrailersAccessor {
         blockUntilData();
         int state = stateOrThrow();
         if (state == -1) return -1;
-        return bb.get();
+        return java.util.Objects.requireNonNull(bb).get();
     }
 
     private int stateOrThrow() throws IOException {
         if (tooBig()) throw new HttpException(HttpStatus.CONTENT_TOO_LARGE_413);
-        switch (status.get()) {
+        switch (state()) {
             case READING:
                 return 0;
             case EOF:
@@ -64,7 +64,7 @@ class Http1BodyStream extends InputStream implements RequestTrailersAccessor {
             case TIMED_OUT:
                 throw HttpException.requestTimeout();
         }
-        throw new IllegalStateException(status.get().toString());
+        throw new IllegalStateException(state().toString());
     }
 
     @Override
@@ -75,7 +75,7 @@ class Http1BodyStream extends InputStream implements RequestTrailersAccessor {
         if (len > b.length - off) throw new IndexOutOfBoundsException("Length too long");
         blockUntilData();
         if (stateOrThrow() == -1) return -1;
-        var bit = bb;
+        var bit = java.util.Objects.requireNonNull(bb);
         var toWrite = Math.min(len, bit.remaining());
         if (toWrite > 0) {
             bit.get(b, off, toWrite);
@@ -197,7 +197,7 @@ class Http1BodyStream extends InputStream implements RequestTrailersAccessor {
                 }
             }
         }
-        return status.get();
+        return state();
     }
 
     @Override

--- a/src/main/java/io/muserver/Http1Connection.java
+++ b/src/main/java/io/muserver/Http1Connection.java
@@ -98,12 +98,9 @@ class Http1Connection extends BaseHttpConnection {
 
                 URI serverUri = creator.uri().resolve(relativeUrl);
                 URI requestUri = Headtils.getUri(log, request.headers(), relativeUrl, serverUri);
-                Method method = request.getMethod();
-                HttpVersion httpVersion = request.getHttpVersion();
-                BodySize bodySize = request.getBodySize();
-                assert method != null;
-                assert httpVersion != null;
-                assert bodySize != null;
+                Method method = java.util.Objects.requireNonNull(request.getMethod(), "No HTTP method was parsed");
+                HttpVersion httpVersion = java.util.Objects.requireNonNull(request.getHttpVersion(), "No HTTP version was parsed");
+                BodySize bodySize = java.util.Objects.requireNonNull(request.getBodySize(), "No body size was parsed");
                 InputStream requestBody = (bodySize == BodySize.NONE) ? EmptyInputStream.INSTANCE : new Http1BodyStream(requestParser, server.maxRequestBodySize());
                 var muRequest = new Mu3Request(this, method, requestUri, serverUri, httpVersion, request.headers(), bodySize, requestBody);
                 clientSocket.setSoTimeout(requestTimeout);

--- a/src/main/java/io/muserver/Http1MessageParser.java
+++ b/src/main/java/io/muserver/Http1MessageParser.java
@@ -248,7 +248,7 @@ class Http1MessageParser implements Http1MessageReader {
                             if (isOkay) {
                                 var value = consumeAscii(buffer).trim();
                                 if (!value.isEmpty()) {
-                                    exchange.headers().add(headerName, value);
+                                    exchange.headers().add(Objects.requireNonNull(headerName), value);
                                 }
                             }
                             state = ParseState.HEADER_START;
@@ -263,7 +263,7 @@ class Http1MessageParser implements Http1MessageReader {
                             exc.setBodySize(body);
                             switch (body.type()) {
                                 case FIXED_SIZE: {
-                                    long len = body.size();
+                                    long len = Objects.requireNonNull(body.size());
                                     state = ParseState.FIXED_SIZE_BODY;
                                     remainingBytesToProxy = len;
                                     break;
@@ -550,4 +550,3 @@ class Http1MessageParser implements Http1MessageReader {
         throw new HttpException(HttpStatus.HTTP_VERSION_NOT_SUPPORTED_505);
     }
 }
-

--- a/src/main/java/io/muserver/Http1Response.java
+++ b/src/main/java/io/muserver/Http1Response.java
@@ -84,7 +84,7 @@ class Http1Response extends BaseResponse implements MuResponse, ResponseInfo {
         } else {
             throw new IllegalStateException("Cannot specify buffer size for response output stream when it has already been created");
         }
-        return wrappedOut;
+        return java.util.Objects.requireNonNull(wrappedOut);
     }
 
     @Override

--- a/src/main/java/io/muserver/Http2Connection.java
+++ b/src/main/java/io/muserver/Http2Connection.java
@@ -643,7 +643,7 @@ class Http2Connection extends BaseHttpConnection implements Http2Peer, CreditAva
             FieldBlock errorHeaders = new FieldBlock();
             errorHeaders.add(HeaderNames.PSEUDO_STATUS, e.status());
             errorHeaders.add(e.responseHeaders());
-            byte[] message = e.getMessage().getBytes(StandardCharsets.UTF_8);
+            byte[] message = rejectReason.getBytes(StandardCharsets.UTF_8);
             if (outgoingFlowControl.credit() >= message.length) {
                 errorHeaders.set(HeaderNames.CONTENT_TYPE, "text/plain;charset=utf-8");
                 errorHeaders.set(HeaderNames.CONTENT_LENGTH, message.length);
@@ -803,4 +803,3 @@ interface Http2Peer {
     int maxFrameSize();
     FieldBlockEncoder fieldBlockEncoder();
 }
-

--- a/src/main/java/io/muserver/Http2HeadersFrame.java
+++ b/src/main/java/io/muserver/Http2HeadersFrame.java
@@ -131,7 +131,7 @@ class Http2HeadersFrame implements LogicalHttp2Frame {
             throw invalidRequestException;
         }
 
-        return new Http2HeadersFrame(frameHeader.streamId(), endStream, headers);
+        return new Http2HeadersFrame(frameHeader.streamId(), endStream, java.util.Objects.requireNonNull(headers));
     }
 
     @Override

--- a/src/main/java/io/muserver/Http2Response.java
+++ b/src/main/java/io/muserver/Http2Response.java
@@ -91,7 +91,7 @@ class Http2Response extends BaseResponse {
             } catch (IOException e) {
                 throw new UncheckedIOException("Error while setting up output stream", e);
             }
-            return wrappedOut;
+            return java.util.Objects.requireNonNull(wrappedOut);
         } else {
             throw new IllegalStateException("Cannot specify buffer size for response output stream when it has already been created");
         }

--- a/src/main/java/io/muserver/Http2Stream.java
+++ b/src/main/java/io/muserver/Http2Stream.java
@@ -88,7 +88,7 @@ class Http2Stream implements ResponseInfo {
 
     @Override
     public boolean completedSuccessfully() {
-        return request.completedSuccessfully() && response.responseState().completedSuccessfully();
+        return request.completedSuccessfully() && requiredResponse().responseState().completedSuccessfully();
     }
 
     void onWindowUpdate(Http2WindowUpdate windowUpdate) throws Http2Exception {
@@ -102,8 +102,9 @@ class Http2Stream implements ResponseInfo {
     void onReset(Http2ResetStreamFrame rstStream) {
         state = State.CLOSED;
         outgoingFlowControl.terminate();
-        if (!response.responseState().endState()) {
-            response.setState(ResponseState.CLIENT_CANCELLED);
+        Http2Response currentResponse = requiredResponse();
+        if (!currentResponse.responseState().endState()) {
+            currentResponse.setState(ResponseState.CLIENT_CANCELLED);
         }
         request.onClientCancelled();
         if (bodyInputStream instanceof Http2BodyInputStream) {
@@ -212,7 +213,7 @@ class Http2Stream implements ResponseInfo {
     }
 
     public BaseResponse response() {
-        return response;
+        return requiredResponse();
     }
 
     static Http2Stream start(Http2Connection connection, Http2HeadersFrame headerFrame, Http2Settings serverSettings, Http2Settings clientSettings) throws Http2Exception {
@@ -367,10 +368,14 @@ class Http2Stream implements ResponseInfo {
     void cleanup() throws IOException, InterruptedException {
         try {
             request.cleanup();
-            response.cleanup();
+            requiredResponse().cleanup();
         } finally {
             endTime = System.currentTimeMillis();
         }
+    }
+
+    private Http2Response requiredResponse() {
+        return java.util.Objects.requireNonNull(response, "The HTTP/2 response has not been initialized");
     }
 
     void blockingWriteData(byte[] payload, int offset, int length) throws IOException, InterruptedException {

--- a/src/main/java/io/muserver/HttpMessages.java
+++ b/src/main/java/io/muserver/HttpMessages.java
@@ -128,11 +128,11 @@ class HttpRequestTemp implements HttpMessageTemp {
     }
 
     void writeTo(OutputStream out) throws IOException {
-        out.write(method.headerBytes());
+        out.write(java.util.Objects.requireNonNull(method).headerBytes());
         out.write(' ');
         out.write(url.getBytes(StandardCharsets.US_ASCII));
         out.write(' ');
-        out.write(httpVersion.headerBytes());
+        out.write(java.util.Objects.requireNonNull(httpVersion).headerBytes());
         out.write(CRLF);
         headers.writeAsHttp1(out);
         out.write(CRLF);
@@ -149,7 +149,7 @@ class HttpResponseTemp implements HttpMessageTemp {
     private @Nullable HttpRequestTemp request;
     private @Nullable HttpVersion httpVersion;
     private int statusCode;
-    private String reason;
+    private @Nullable String reason;
     private @Nullable BodySize bodySize;
     private final FieldBlock headers = new FieldBlock();
 
@@ -188,10 +188,11 @@ class HttpResponseTemp implements HttpMessageTemp {
         if (isInformational() || statusCode == 204 || statusCode == 304) return BodySize.NONE;
         var req = request;
         if (req == null) throw new IllegalStateException("Cannot tell the size without the request");
-        if (req.getMethod().isHead()) return BodySize.NONE;
+        Method requestMethod = java.util.Objects.requireNonNull(req.getMethod());
+        if (requestMethod.isHead()) return BodySize.NONE;
 
         // 6.3.2
-        if (req.getMethod() == Method.CONNECT) return BodySize.UNSPECIFIED;
+        if (requestMethod == Method.CONNECT) return BodySize.UNSPECIFIED;
 
         // 6.3.3
         var cl = headers.getAll(HeaderNames.CONTENT_LENGTH);
@@ -208,11 +209,11 @@ class HttpResponseTemp implements HttpMessageTemp {
     }
 
     void writeTo(OutputStream out) throws IOException {
-        out.write(httpVersion.headerBytes());
+        out.write(java.util.Objects.requireNonNull(httpVersion).headerBytes());
         out.write(' ');
         out.write(String.valueOf(statusCode).getBytes(StandardCharsets.US_ASCII));
         out.write(' ');
-        out.write(reason.getBytes(StandardCharsets.US_ASCII));
+        out.write(java.util.Objects.requireNonNull(reason).getBytes(StandardCharsets.US_ASCII));
         out.write(CRLF);
         headers.writeAsHttp1(out);
         out.write(CRLF);
@@ -242,7 +243,7 @@ class HttpResponseTemp implements HttpMessageTemp {
         this.reason = reason;
     }
 
-    public String getReason() {
+    public @Nullable String getReason() {
         return reason;
     }
 }

--- a/src/main/java/io/muserver/HttpsConfigBuilder.java
+++ b/src/main/java/io/muserver/HttpsConfigBuilder.java
@@ -370,7 +370,11 @@ public class HttpsConfigBuilder {
     private String[] getHttpsProtocolsArray(SSLContext sslContext) {
         List<String> supportedProtocols = asList(sslContext.getSupportedSSLParameters().getProtocols());
         List<String> protocolsToUse = new ArrayList<>();
-        for (String protocol : Mutils.coalesce(this.protocols, new String[]{"TLSv1.2", "TLSv1.3"})) {
+        String[] requestedProtocols = this.protocols;
+        if (requestedProtocols == null) {
+            requestedProtocols = new String[]{"TLSv1.2", "TLSv1.3"};
+        }
+        for (String protocol : requestedProtocols) {
             if (supportedProtocols.contains(protocol)) {
                 protocolsToUse.add(protocol);
             } else {

--- a/src/main/java/io/muserver/Mu3AsyncHandleImpl.java
+++ b/src/main/java/io/muserver/Mu3AsyncHandleImpl.java
@@ -43,7 +43,7 @@ class Mu3AsyncHandleImpl implements AsyncHandle {
     @Override
     public void setReadListener(RequestBodyListener readListener) {
         var requestFuture = CompletableFuture.runAsync(() -> {
-            var requestException = new AtomicReference<@Nullable Throwable>();
+            AtomicReference<@Nullable Throwable> requestException = new AtomicReference<>();
             try (var clientIn = request.body()) {
                 var buffer = new byte[8192];
                 int read;
@@ -127,24 +127,24 @@ class Mu3AsyncHandleImpl implements AsyncHandle {
                     complete(e);
                     throw e instanceof RuntimeException ? (RuntimeException) e : new RuntimeException("Error while writing body", e);
                 }
-            });
+            }).thenApply(ignored -> null);
         } finally {
             lock.unlock();
         }
     }
 
     @Override
-    public Future<Void> write(ByteBuffer data) {
+    public Future<@Nullable Void> write(ByteBuffer data) {
         try {
             lock.lock();
-            var writeFuture = responseFuture.thenRunAsync(() -> {
+            CompletableFuture<@Nullable Void> writeFuture = responseFuture.thenRunAsync(() -> {
                 try {
                     copyBufferToResponseOutput(data);
                 } catch (Throwable e) {
                     complete(e);
                     throw e instanceof RuntimeException ? (RuntimeException) e : new RuntimeException("Error while writing body", e);
                 }
-            });
+            }).thenApply(ignored -> null);
             responseFuture = writeFuture;
             return writeFuture;
         } finally {

--- a/src/main/java/io/muserver/Mu3Request.java
+++ b/src/main/java/io/muserver/Mu3Request.java
@@ -188,7 +188,7 @@ class Mu3Request implements MuRequest {
                     int bufferSize = (int) min(8192, declaredSize != null ? declaredSize : 8192);
                     try (InputStream b = body) {
                         MultipartFormParser formParser = new MultipartFormParser(server().tempDir(),
-                            boundary, b, bufferSize, charset);
+                            Objects.requireNonNull(boundary), b, bufferSize, charset);
                         this.form = formParser.parseFully();
                     }
                 } else {
@@ -253,8 +253,8 @@ class Mu3Request implements MuRequest {
     @Override
     public synchronized AsyncHandle handleAsync() {
         if (asyncHandle == null) {
-            assert response != null;
-            asyncHandle = new Mu3AsyncHandleImpl(this, response);
+            asyncHandle = new Mu3AsyncHandleImpl(this,
+                Objects.requireNonNull(response, "The response has not been initialized"));
         }
         if (clientCancelled) {
             asyncHandle.complete();
@@ -315,8 +315,8 @@ class Mu3Request implements MuRequest {
         try {
             if (body instanceof Http1BodyStream) {
                 var http1Body = (Http1BodyStream) body;
-                assert response != null;
-                boolean throwIfTooBig = response.status() != HttpStatus.CONTENT_TOO_LARGE_413;
+                boolean throwIfTooBig = Objects.requireNonNull(response, "The response has not been initialized").status()
+                    != HttpStatus.CONTENT_TOO_LARGE_413;
                 var bodyState = http1Body.discardRemaining(throwIfTooBig);
                 return bodyState == Http1BodyStream.State.EOF && !http1Body.tooBig();
             } else {

--- a/src/main/java/io/muserver/Mu3ServerImpl.java
+++ b/src/main/java/io/muserver/Mu3ServerImpl.java
@@ -84,7 +84,7 @@ class Mu3ServerImpl implements MuServer {
     @Override
     public URI uri() {
         var s = httpsUri();
-        return s != null ? s : httpUri();
+        return s != null ? s : Objects.requireNonNull(httpUri(), "The server has no configured URI");
     }
 
 

--- a/src/main/java/io/muserver/ParameterizedHeaderWithValue.java
+++ b/src/main/java/io/muserver/ParameterizedHeaderWithValue.java
@@ -183,7 +183,9 @@ public class ParameterizedHeaderWithValue {
                     }
             }
 
-            results.add(new ParameterizedHeaderWithValue(value, parameters == null ? Collections.emptyMap() : parameters));
+            results.add(new ParameterizedHeaderWithValue(
+                Objects.requireNonNull(value, "A header value is required"),
+                parameters == null ? Collections.emptyMap() : parameters));
         }
 
         return results;

--- a/src/main/java/io/muserver/RejectedRequestImpl.java
+++ b/src/main/java/io/muserver/RejectedRequestImpl.java
@@ -1,5 +1,7 @@
 package io.muserver;
 
+import org.jspecify.annotations.Nullable;
+
 import java.net.URI;
 import java.util.Optional;
 
@@ -7,11 +9,11 @@ class RejectedRequestImpl implements RejectedRequest {
 
     private final int status;
     private final String reason;
-    private final String method;
-    private final URI uri;
+    private final @Nullable String method;
+    private final @Nullable URI uri;
     private final HttpConnection connection;
 
-    RejectedRequestImpl(int status, String reason, String method, String uri, HttpConnection connection) {
+    RejectedRequestImpl(int status, String reason, @Nullable String method, @Nullable String uri, HttpConnection connection) {
         this.status = status;
         this.reason = reason;
         this.method = method;
@@ -19,7 +21,7 @@ class RejectedRequestImpl implements RejectedRequest {
         this.connection = connection;
     }
 
-    private static URI parseUriOrNull(String rawTarget) {
+    private static @Nullable URI parseUriOrNull(@Nullable String rawTarget) {
         if (rawTarget == null || rawTarget.isEmpty()) {
             return null;
         }

--- a/src/main/java/io/muserver/SimpleWebSocket.java
+++ b/src/main/java/io/muserver/SimpleWebSocket.java
@@ -80,7 +80,7 @@ public abstract class SimpleWebSocket implements MuWebSocket {
     public void onTextFragment(ByteBuffer textFragment, boolean isLast) throws Exception {
         bufferIt(textFragment);
         if (isLast) {
-            onText(fragmentBuffer.decodeUTF8());
+            onText(java.util.Objects.requireNonNull(fragmentBuffer).decodeUTF8());
             fragmentBuffer = null;
         }
     }
@@ -96,7 +96,7 @@ public abstract class SimpleWebSocket implements MuWebSocket {
         bufferIt(buffer);
 
         if (isLast) {
-            var full = fragmentBuffer.toByteBuffer();
+            var full = java.util.Objects.requireNonNull(fragmentBuffer).toByteBuffer();
             fragmentBuffer = null;
             onBinary(full);
         }

--- a/src/main/java/io/muserver/WebSocketHandler.java
+++ b/src/main/java/io/muserver/WebSocketHandler.java
@@ -28,7 +28,8 @@ public class WebSocketHandler implements MuHandler {
         if (request.method() != Method.GET) {
             return false;
         }
-        if (Mutils.hasValue(path) && !path.equals(request.relativePath())) {
+        String configuredPath = path;
+        if (configuredPath != null && !configuredPath.isEmpty() && !configuredPath.equals(request.relativePath())) {
             return false;
         }
         if (!request.headers().contains(HeaderNames.UPGRADE, HeaderValues.WEBSOCKET, true)) {

--- a/src/main/java/io/muserver/WebSocketHandlerBuilder.java
+++ b/src/main/java/io/muserver/WebSocketHandlerBuilder.java
@@ -40,7 +40,7 @@ public class WebSocketHandlerBuilder implements MuHandlerBuilder<WebSocketHandle
     public WebSocketHandlerBuilder withPath(@Nullable String path) {
         if (Mutils.nullOrEmpty(path)) {
             this.path = null;
-        } else if (path.startsWith("/")) {
+        } else if (java.util.Objects.requireNonNull(path).startsWith("/")) {
             this.path = path;
         } else {
             this.path = "/" + path;
@@ -201,4 +201,3 @@ public class WebSocketHandlerBuilder implements MuHandlerBuilder<WebSocketHandle
         }
     }
 }
-

--- a/src/main/java/io/muserver/WebsocketConnection.java
+++ b/src/main/java/io/muserver/WebsocketConnection.java
@@ -68,12 +68,12 @@ class WebsocketConnection implements MuWebSocketSession {
             writeLock.lock();
             try {
                 if (state == WebsocketSessionState.OPEN) {
-                    assert pingBuffer != null;
-                    pingBuffer.position(8)
+                    ByteBuffer ping = java.util.Objects.requireNonNull(pingBuffer);
+                    ping.position(8)
                         .limit(16)
                         .putLong(System.currentTimeMillis())
                         .flip();
-                    sendPing(pingBuffer);
+                    sendPing(ping);
                 }
                 if (state == WebsocketSessionState.OPEN) {
                     startPinging();
@@ -264,21 +264,21 @@ class WebsocketConnection implements MuWebSocketSession {
     }
 
     private ByteBuffer readAndUnmaskPayload(int len, byte[] maskingKey) throws IOException {
-        assert buffer != null;
-        if (len <= buffer.capacity()) {
+        ByteBuffer readBuffer = java.util.Objects.requireNonNull(buffer);
+        if (len <= readBuffer.capacity()) {
             readAtLeast(len);
-            unmask(buffer, maskingKey, len);
-            var tempLimit = buffer.limit();
-            buffer.limit(buffer.position() + len);
-            var slice = buffer.slice();
-            buffer.position(buffer.limit());
-            buffer.limit(tempLimit);
+            unmask(readBuffer, maskingKey, len);
+            var tempLimit = readBuffer.limit();
+            readBuffer.limit(readBuffer.position() + len);
+            var slice = readBuffer.slice();
+            readBuffer.position(readBuffer.limit());
+            readBuffer.limit(tempLimit);
             return slice;
         } else {
             var full = ByteBuffer.allocate(len);
             var toRead = len;
             while (toRead > 0) {
-                int nextLen = Math.min(toRead, buffer.capacity());
+                int nextLen = Math.min(toRead, readBuffer.capacity());
                 var slice = readAndUnmaskPayload(nextLen, maskingKey);
                 full.put(slice);
                 toRead = toRead - nextLen;
@@ -288,20 +288,21 @@ class WebsocketConnection implements MuWebSocketSession {
     }
 
     private void readAtLeast(int minBytes) throws IOException {
-        assert buffer != null;
-        assert inputStream != null;
-        if (minBytes > buffer.capacity()) throw new IllegalArgumentException("This buffer is not big enough");
-        while (buffer.remaining() < minBytes) {
-            if (buffer.capacity() - buffer.limit() < minBytes) {
-                buffer.compact().flip();
+        ByteBuffer readBuffer = java.util.Objects.requireNonNull(buffer);
+        InputStream input = java.util.Objects.requireNonNull(inputStream);
+        if (minBytes > readBuffer.capacity()) throw new IllegalArgumentException("This buffer is not big enough");
+        while (readBuffer.remaining() < minBytes) {
+            if (readBuffer.capacity() - readBuffer.limit() < minBytes) {
+                readBuffer.compact().flip();
             }
-            int read = inputStream.read(buffer.array(), buffer.arrayOffset() + buffer.position(), buffer.capacity() - buffer.limit());
+            int read = input.read(readBuffer.array(), readBuffer.arrayOffset() + readBuffer.position(),
+                readBuffer.capacity() - readBuffer.limit());
             if (read == -1) {
                 throw new ClientDisconnectedException();
             } else {
                 httpConnection.onBytesRead(read);
             }
-            buffer.limit(buffer.limit() + read);
+            readBuffer.limit(readBuffer.limit() + read);
         }
     }
 
@@ -472,7 +473,7 @@ class WebsocketConnection implements MuWebSocketSession {
 
     private void writeFragment(byte firstByte, byte@Nullable[] payload, int payloadOffset, int payloadLen, @Nullable MessageWritingState expectedState, @Nullable MessageWritingState endState) throws IOException {
         var header = header(firstByte, payloadLen);
-        assert outputStream != null;
+        OutputStream output = java.util.Objects.requireNonNull(outputStream);
         writeLock.lock();
         try {
             if (expectedState != null && messageWritingState != expectedState) {
@@ -481,11 +482,11 @@ class WebsocketConnection implements MuWebSocketSession {
             if (closeSent) {
                 throw new IllegalStateException("Cannot write websocket messages after close frame sent");
             }
-            outputStream.write(header, 0, header.length);
+            output.write(header, 0, header.length);
             if (payloadLen > 0) {
-                outputStream.write(payload, payloadOffset, payloadLen);
+                output.write(java.util.Objects.requireNonNull(payload), payloadOffset, payloadLen);
             }
-            outputStream.flush();
+            output.flush();
             if (endState != null) {
                 messageWritingState = endState;
             }

--- a/src/main/java/io/muserver/handlers/CSRFProtectionHandlerBuilder.java
+++ b/src/main/java/io/muserver/handlers/CSRFProtectionHandlerBuilder.java
@@ -3,6 +3,7 @@ package io.muserver.handlers;
 import io.muserver.MuHandler;
 import io.muserver.MuHandlerBuilder;
 import jakarta.ws.rs.BadRequestException;
+import org.jspecify.annotations.Nullable;
 
 import java.util.Collections;
 import java.util.HashSet;
@@ -17,7 +18,7 @@ public class CSRFProtectionHandlerBuilder implements MuHandlerBuilder<CSRFProtec
 
     private final Set<String> trustedOrigins = new HashSet<>();
     private final Set<String> bypassPaths = new HashSet<>();
-    private MuHandler rejectionHandler;
+    private @Nullable MuHandler rejectionHandler;
 
     /**
      * Adds a trusted origin. Requests with an <code>Origin</code> header exactly matching this value are allowed.

--- a/src/main/java/io/muserver/handlers/ResourceHandler.java
+++ b/src/main/java/io/muserver/handlers/ResourceHandler.java
@@ -136,9 +136,9 @@ public class ResourceHandler implements MuHandler {
         try (OutputStreamWriter osw = new OutputStreamWriter(response.outputStream(), StandardCharsets.UTF_8);
              BufferedWriter writer = new BufferedWriter(osw, 8192)) {
             writer.write("<!DOCTYPE html>\n");
-            assert directoryListingCss != null; // because directory listing enabled
-            assert dateFormatter != null;
-            new DirectoryLister(writer, provider, request.contextPath(), request.relativePath(), directoryListingCss, dateFormatter).render();
+            new DirectoryLister(writer, provider, request.contextPath(), request.relativePath(),
+                java.util.Objects.requireNonNull(directoryListingCss, "Directory listing CSS was not initialized"),
+                java.util.Objects.requireNonNull(dateFormatter, "Directory listing date formatter was not initialized")).render();
         }
     }
 

--- a/src/main/java/io/muserver/handlers/ResourceProvider.java
+++ b/src/main/java/io/muserver/handlers/ResourceProvider.java
@@ -237,7 +237,7 @@ class AsyncFileProvider implements ResourceProvider, CompletionHandler<Integer, 
             handle = request.handleAsync();
             channel = AsynchronousFileChannel.open(localPath, StandardOpenOption.READ);
             buf = ByteBuffer.allocate(8192);
-            channel.read(buf, curPos, handle, this);
+            requiredChannel().read(requiredBuffer(), curPos, requiredHandle(), this);
         }
     }
 
@@ -248,27 +248,29 @@ class AsyncFileProvider implements ResourceProvider, CompletionHandler<Integer, 
 
     @Override
     public void completed(Integer bytesRead, Object a) {
-        buf.flip();
+        ByteBuffer buffer = requiredBuffer();
+        AsyncHandle asyncHandle = requiredHandle();
+        buffer.flip();
         if (bytesRead == -1) {
-            handle.complete();
+            asyncHandle.complete();
             closeChannelQuietly();
         } else {
 
             // for range requests, more bytes may be read than should be written, so the write is limited
             long remaining = Math.max(0, maxLen - bytesSent);
-            if (remaining < buf.limit()) {
-                buf.limit((int) remaining);
+            if (remaining < buffer.limit()) {
+                buffer.limit((int) remaining);
             }
 
-            handle.write(buf, error -> {
+            asyncHandle.write(buffer, error -> {
                 if (error == null) {
-                    buf.clear();
+                    buffer.clear();
                     curPos += bytesRead;
                     bytesSent += bytesRead;
-                    channel.read(buf, curPos, null, AsyncFileProvider.this);
+                    requiredChannel().read(buffer, curPos, null, AsyncFileProvider.this);
                 } else {
                     closeChannelQuietly();
-                    handle.complete(error);
+                    asyncHandle.complete(error);
                 }
             });
         }
@@ -276,7 +278,7 @@ class AsyncFileProvider implements ResourceProvider, CompletionHandler<Integer, 
 
     private void closeChannelQuietly() {
         try {
-            channel.close();
+            requiredChannel().close();
         } catch (IOException e) {
             log.debug("Error while closing file channel " + localPath, e);
         }
@@ -285,7 +287,19 @@ class AsyncFileProvider implements ResourceProvider, CompletionHandler<Integer, 
     @Override
     public void failed(Throwable exc, Object a) {
         log.info("File read failure for " + localPath, exc);
-        handle.complete(exc);
+        requiredHandle().complete(exc);
+    }
+
+    private AsynchronousFileChannel requiredChannel() {
+        return Objects.requireNonNull(channel, "File transfer has not been initialized");
+    }
+
+    private ByteBuffer requiredBuffer() {
+        return Objects.requireNonNull(buf, "File transfer has not been initialized");
+    }
+
+    private AsyncHandle requiredHandle() {
+        return Objects.requireNonNull(handle, "File transfer has not been initialized");
     }
 }
 
@@ -343,7 +357,7 @@ class ClasspathResourceProvider implements ResourceProvider {
             while (totalSkipped < bytes) {
                 long skipped;
                 try {
-                    skipped = inputStream.skip(bytes);
+                    skipped = requiredInputStream().skip(bytes);
                 } catch (IOException e) {
                     return false;
                 }
@@ -365,7 +379,7 @@ class ClasspathResourceProvider implements ResourceProvider {
                     byte[] buffer = new byte[8192];
                     long soFar = 0;
                     int read;
-                    while (soFar < maxLen && (read = inputStream.read(buffer)) > -1) {
+                    while (soFar < maxLen && (read = requiredInputStream().read(buffer)) > -1) {
                         soFar += read;
                         if (soFar > maxLen) {
                             read -= (soFar - maxLen);
@@ -377,7 +391,7 @@ class ClasspathResourceProvider implements ResourceProvider {
                 }
             }
         } finally {
-            inputStream.close();
+            requiredInputStream().close();
         }
     }
 
@@ -386,4 +400,7 @@ class ClasspathResourceProvider implements ResourceProvider {
         return Files.list(path);
     }
 
+    private InputStream requiredInputStream() {
+        return Objects.requireNonNull(inputStream, "This resource has no input stream");
+    }
 }

--- a/src/main/java/io/muserver/openapi/CallbackObject.java
+++ b/src/main/java/io/muserver/openapi/CallbackObject.java
@@ -1,5 +1,6 @@
 package io.muserver.openapi;
 
+import org.jspecify.annotations.Nullable;
 import java.io.IOException;
 import java.io.Writer;
 import java.util.Map;
@@ -13,9 +14,9 @@ public class CallbackObject implements JsonWriter {
 
     private final Map<String, PathItemObject> callbacks;
 
-    CallbackObject(Map<String, PathItemObject> callbacks) {
+    CallbackObject(@Nullable Map<String, PathItemObject> callbacks) {
         notNull("callbacks", callbacks);
-        this.callbacks = callbacks;
+        this.callbacks = java.util.Objects.requireNonNull(callbacks);
     }
 
     @Override

--- a/src/main/java/io/muserver/openapi/DiscriminatorObject.java
+++ b/src/main/java/io/muserver/openapi/DiscriminatorObject.java
@@ -16,9 +16,9 @@ public class DiscriminatorObject implements JsonWriter {
     private final String propertyName;
     private final @Nullable Map<String, String> mapping;
 
-    DiscriminatorObject(String propertyName, @Nullable Map<String, String> mapping) {
+    DiscriminatorObject(@Nullable String propertyName, @Nullable Map<String, String> mapping) {
         notNull("propertyName", propertyName);
-        this.propertyName = propertyName;
+        this.propertyName = java.util.Objects.requireNonNull(propertyName);
         this.mapping = mapping;
     }
 

--- a/src/main/java/io/muserver/openapi/ExternalDocumentationObject.java
+++ b/src/main/java/io/muserver/openapi/ExternalDocumentationObject.java
@@ -16,10 +16,10 @@ public class ExternalDocumentationObject implements JsonWriter {
     private final @Nullable String description;
     private final URI url;
 
-    ExternalDocumentationObject(@Nullable String description, URI url) {
-        notNull("url", url);
+    ExternalDocumentationObject(@Nullable String description, @Nullable URI url) {
         this.description = description;
-        this.url = url;
+        notNull("url", url);
+        this.url = java.util.Objects.requireNonNull(url);
     }
 
     @Override

--- a/src/main/java/io/muserver/openapi/LicenseObject.java
+++ b/src/main/java/io/muserver/openapi/LicenseObject.java
@@ -17,9 +17,9 @@ public class LicenseObject implements JsonWriter {
     private final String name;
     private final @Nullable URI url;
 
-    LicenseObject(String name, @Nullable URI url) {
+    LicenseObject(@Nullable String name, @Nullable URI url) {
         notNull("name", name);
-        this.name = name;
+        this.name = java.util.Objects.requireNonNull(name);
         this.url = url;
     }
 

--- a/src/main/java/io/muserver/openapi/OAuthFlowObject.java
+++ b/src/main/java/io/muserver/openapi/OAuthFlowObject.java
@@ -20,14 +20,14 @@ public class OAuthFlowObject implements JsonWriter {
     private final @Nullable URI refreshUrl;
     private final Map<String, String> scopes;
 
-    OAuthFlowObject(URI authorizationUrl, URI tokenUrl, @Nullable URI refreshUrl, Map<String, String> scopes) {
+    OAuthFlowObject(@Nullable URI authorizationUrl, @Nullable URI tokenUrl, @Nullable URI refreshUrl, @Nullable Map<String, String> scopes) {
         notNull("authorizationUrl", authorizationUrl);
+        this.authorizationUrl = java.util.Objects.requireNonNull(authorizationUrl);
         notNull("tokenUrl", tokenUrl);
-        notNull("scopes", scopes);
-        this.authorizationUrl = authorizationUrl;
-        this.tokenUrl = tokenUrl;
+        this.tokenUrl = java.util.Objects.requireNonNull(tokenUrl);
         this.refreshUrl = refreshUrl;
-        this.scopes = scopes;
+        notNull("scopes", scopes);
+        this.scopes = java.util.Objects.requireNonNull(scopes);
     }
 
     @Override

--- a/src/main/java/io/muserver/openapi/OpenAPIObject.java
+++ b/src/main/java/io/muserver/openapi/OpenAPIObject.java
@@ -15,7 +15,7 @@ import static io.muserver.openapi.Jsonizer.append;
  */
 public class OpenAPIObject implements JsonWriter {
 
-    private final @Nullable String openapi = "3.0.1";
+    private final String openapi = "3.0.1";
     private final InfoObject info;
     private final @Nullable List<ServerObject> servers;
     private final PathsObject paths;
@@ -24,15 +24,15 @@ public class OpenAPIObject implements JsonWriter {
     private final @Nullable List<TagObject> tags;
     private final @Nullable ExternalDocumentationObject externalDocs;
 
-    OpenAPIObject(InfoObject info, @Nullable List<ServerObject> servers, PathsObject paths, @Nullable ComponentsObject components, @Nullable List<SecurityRequirementObject> security, @Nullable List<TagObject> tags, @Nullable ExternalDocumentationObject externalDocs) {
-        notNull("info", info);
-        notNull("paths", paths);
+    OpenAPIObject(@Nullable InfoObject info, @Nullable List<ServerObject> servers, @Nullable PathsObject paths, @Nullable ComponentsObject components, @Nullable List<SecurityRequirementObject> security, @Nullable List<TagObject> tags, @Nullable ExternalDocumentationObject externalDocs) {
         if (tags != null && tags.size() != tags.stream().map(t -> t.name()).collect(Collectors.toSet()).size()) {
             throw new IllegalArgumentException("Tags must have unique names");
         }
-        this.info = info;
+        notNull("info", info);
+        this.info = java.util.Objects.requireNonNull(info);
         this.servers = servers;
-        this.paths = paths;
+        notNull("paths", paths);
+        this.paths = java.util.Objects.requireNonNull(paths);
         this.components = components;
         this.security = security;
         this.tags = tags;

--- a/src/main/java/io/muserver/openapi/OperationObject.java
+++ b/src/main/java/io/muserver/openapi/OperationObject.java
@@ -31,7 +31,7 @@ public class OperationObject implements JsonWriter {
     private final @Nullable List<ServerObject> servers;
 
     OperationObject(@Nullable List<String> tags, @Nullable String summary, @Nullable String description, @Nullable ExternalDocumentationObject externalDocs,
-                           @Nullable String operationId, @Nullable List<ParameterObject> parameters, @Nullable RequestBodyObject requestBody, ResponsesObject responses,
+                           @Nullable String operationId, @Nullable List<ParameterObject> parameters, @Nullable RequestBodyObject requestBody, @Nullable ResponsesObject responses,
                            @Nullable Map<String, CallbackObject> callbacks, @Nullable Boolean deprecated, @Nullable List<SecurityRequirementObject> security,
                            @Nullable List<ServerObject> servers) {
         notNull("responses", responses);
@@ -48,7 +48,8 @@ public class OperationObject implements JsonWriter {
         this.operationId = operationId;
         this.parameters = parameters;
         this.requestBody = requestBody;
-        this.responses = responses;
+        notNull("responses", responses);
+        this.responses = java.util.Objects.requireNonNull(responses);
         this.callbacks = callbacks;
         this.deprecated = deprecated;
         this.security = security;

--- a/src/main/java/io/muserver/openapi/ParameterObject.java
+++ b/src/main/java/io/muserver/openapi/ParameterObject.java
@@ -33,11 +33,13 @@ public class ParameterObject implements JsonWriter {
     private final @Nullable Map<String, ExampleObject> examples;
     private final @Nullable Map<String, MediaTypeObject> content;
 
-    ParameterObject(String name, String in, @Nullable String description, Boolean required, @Nullable Boolean deprecated, @Nullable Boolean allowEmptyValue,
+    ParameterObject(@Nullable String name, @Nullable String in, @Nullable String description, Boolean required, @Nullable Boolean deprecated, @Nullable Boolean allowEmptyValue,
                     @Nullable String style, @Nullable Boolean explode, @Nullable Boolean allowReserved, @Nullable SchemaObject schema, @Nullable Object example,
                     @Nullable Map<String, ExampleObject> examples, @Nullable Map<String, MediaTypeObject> content) {
         notNull("name", name);
+        name = java.util.Objects.requireNonNull(name);
         notNull("in", in);
+        in = java.util.Objects.requireNonNull(in);
         if (!allowedIns.contains(in)) {
             throw new IllegalArgumentException("'in' must be one of " + allowedIns + " but was " + in);
         }

--- a/src/main/java/io/muserver/openapi/RequestBodyObject.java
+++ b/src/main/java/io/muserver/openapi/RequestBodyObject.java
@@ -19,10 +19,10 @@ public class RequestBodyObject implements JsonWriter {
     private final Map<String, MediaTypeObject> content;
     private final @Nullable Boolean required;
 
-    RequestBodyObject(@Nullable String description, Map<String, MediaTypeObject> content, @Nullable Boolean required) {
-        notNull("content", content);
+    RequestBodyObject(@Nullable String description, @Nullable Map<String, MediaTypeObject> content, @Nullable Boolean required) {
         this.description = description;
-        this.content = content;
+        notNull("content", content);
+        this.content = java.util.Objects.requireNonNull(content);
         this.required = required;
     }
 

--- a/src/main/java/io/muserver/openapi/ResponseObject.java
+++ b/src/main/java/io/muserver/openapi/ResponseObject.java
@@ -19,9 +19,9 @@ public class ResponseObject implements JsonWriter {
     private final @Nullable Map<String, MediaTypeObject> content;
     private final @Nullable Map<String, LinkObject> links;
 
-    ResponseObject(String description, @Nullable Map<String, HeaderObject> headers, @Nullable Map<String, MediaTypeObject> content, @Nullable Map<String, LinkObject> links) {
+    ResponseObject(@Nullable String description, @Nullable Map<String, HeaderObject> headers, @Nullable Map<String, MediaTypeObject> content, @Nullable Map<String, LinkObject> links) {
         notNull("description", description);
-        this.description = description;
+        this.description = java.util.Objects.requireNonNull(description);
         this.headers = headers;
         this.content = content;
         this.links = links;

--- a/src/main/java/io/muserver/openapi/ResponsesObject.java
+++ b/src/main/java/io/muserver/openapi/ResponsesObject.java
@@ -17,8 +17,9 @@ public class ResponsesObject implements JsonWriter {
     private final @Nullable ResponseObject defaultValue;
     private final Map<String, ResponseObject> httpStatusCodes;
 
-    ResponsesObject(@Nullable ResponseObject defaultValue, Map<String, ResponseObject> httpStatusCodes) {
+    ResponsesObject(@Nullable ResponseObject defaultValue, @Nullable Map<String, ResponseObject> httpStatusCodes) {
         notNull("httpStatusCodes", httpStatusCodes);
+        httpStatusCodes = java.util.Objects.requireNonNull(httpStatusCodes);
         if (httpStatusCodes.isEmpty()) {
             throw new IllegalArgumentException("'httpStatusCodes' must contain at least one value");
         }

--- a/src/main/java/io/muserver/openapi/SecurityRequirementObject.java
+++ b/src/main/java/io/muserver/openapi/SecurityRequirementObject.java
@@ -1,5 +1,6 @@
 package io.muserver.openapi;
 
+import org.jspecify.annotations.Nullable;
 import java.io.IOException;
 import java.io.Writer;
 import java.util.List;
@@ -15,9 +16,9 @@ public class SecurityRequirementObject implements JsonWriter {
 
     private final Map<String, List<String>> requirements;
 
-    SecurityRequirementObject(Map<String, List<String>> requirements) {
+    SecurityRequirementObject(@Nullable Map<String, List<String>> requirements) {
         notNull("requirements", requirements);
-        this.requirements = requirements;
+        this.requirements = java.util.Objects.requireNonNull(requirements);
     }
 
     @Override

--- a/src/main/java/io/muserver/openapi/SecuritySchemeObject.java
+++ b/src/main/java/io/muserver/openapi/SecuritySchemeObject.java
@@ -26,8 +26,9 @@ public class SecuritySchemeObject implements JsonWriter {
     private final @Nullable OAuthFlowsObject flows;
     private final @Nullable URI openIdConnectUrl;
 
-    SecuritySchemeObject(String type, @Nullable String description, @Nullable String name, @Nullable String in, @Nullable String scheme, @Nullable String bearerFormat, @Nullable OAuthFlowsObject flows, @Nullable URI openIdConnectUrl) {
+    SecuritySchemeObject(@Nullable String type, @Nullable String description, @Nullable String name, @Nullable String in, @Nullable String scheme, @Nullable String bearerFormat, @Nullable OAuthFlowsObject flows, @Nullable URI openIdConnectUrl) {
         notNull("type", type);
+        type = java.util.Objects.requireNonNull(type);
         if (!validTypes.contains(type)) {
             throw new IllegalArgumentException("'type' must be one of " + validTypes + " but was " + type);
         }

--- a/src/main/java/io/muserver/openapi/ServerObject.java
+++ b/src/main/java/io/muserver/openapi/ServerObject.java
@@ -17,9 +17,9 @@ public class ServerObject implements JsonWriter {
     private final @Nullable String description;
     private final @Nullable Map<String, ServerVariableObject> variables;
 
-    ServerObject(String url, @Nullable String description, @Nullable Map<String, ServerVariableObject> variables) {
+    ServerObject(@Nullable String url, @Nullable String description, @Nullable Map<String, ServerVariableObject> variables) {
         notNull("url", url);
-        this.url = url;
+        this.url = java.util.Objects.requireNonNull(url);
         this.description = description;
         this.variables = variables;
     }

--- a/src/main/java/io/muserver/openapi/ServerVariableObject.java
+++ b/src/main/java/io/muserver/openapi/ServerVariableObject.java
@@ -17,10 +17,10 @@ public class ServerVariableObject implements JsonWriter {
     private final String defaultValue;
     private final @Nullable String description;
 
-    ServerVariableObject(@Nullable List<String> enumValues, String defaultValue, @Nullable String description) {
-        notNull("defaultValue", defaultValue);
+    ServerVariableObject(@Nullable List<String> enumValues, @Nullable String defaultValue, @Nullable String description) {
         this.enumValues = enumValues;
-        this.defaultValue = defaultValue;
+        notNull("defaultValue", defaultValue);
+        this.defaultValue = java.util.Objects.requireNonNull(defaultValue);
         this.description = description;
     }
 

--- a/src/main/java/io/muserver/openapi/TagObject.java
+++ b/src/main/java/io/muserver/openapi/TagObject.java
@@ -18,9 +18,9 @@ public class TagObject implements JsonWriter {
     private final @Nullable String description;
     private final @Nullable ExternalDocumentationObject externalDocs;
 
-    TagObject(String name, @Nullable String description, @Nullable ExternalDocumentationObject externalDocs) {
+    TagObject(@Nullable String name, @Nullable String description, @Nullable ExternalDocumentationObject externalDocs) {
         notNull("name", name);
-        this.name = name;
+        this.name = java.util.Objects.requireNonNull(name);
         this.description = description;
         this.externalDocs = externalDocs;
     }

--- a/src/main/java/io/muserver/rest/ApiResponse.java
+++ b/src/main/java/io/muserver/rest/ApiResponse.java
@@ -3,6 +3,7 @@ package io.muserver.rest;
 import java.lang.annotation.*;
 import java.lang.reflect.Method;
 import java.lang.reflect.Type;
+import org.jspecify.annotations.Nullable;
 
 /**
  * <p>Describes a response code and description for an API method, for documentation purposes.</p>
@@ -60,10 +61,10 @@ class ApiResponseObj {
     final String message;
     final ResponseHeader[] responseHeaders;
     final Class<?> response;
-    final Type genericReturnType;
+    final @Nullable Type genericReturnType;
     final String[] contentType;
-    final String example;
-    public ApiResponseObj(String code, String message, ResponseHeader[] responseHeaders, Class<?> response, Type genericReturnType, String[] contentType, String example) {
+    final @Nullable String example;
+    public ApiResponseObj(String code, String message, ResponseHeader[] responseHeaders, Class<?> response, @Nullable Type genericReturnType, String[] contentType, @Nullable String example) {
         this.code = code;
         this.message = message;
         this.responseHeaders = responseHeaders;

--- a/src/main/java/io/muserver/rest/ApplicationRegistrar.java
+++ b/src/main/java/io/muserver/rest/ApplicationRegistrar.java
@@ -20,6 +20,7 @@ import jakarta.ws.rs.ext.ReaderInterceptor;
 import jakarta.ws.rs.ext.ReaderInterceptorContext;
 import jakarta.ws.rs.ext.WriterInterceptor;
 import jakarta.ws.rs.ext.WriterInterceptorContext;
+import org.jspecify.annotations.Nullable;
 
 import java.io.IOException;
 import java.lang.annotation.Annotation;
@@ -214,11 +215,11 @@ final class ApplicationRegistrar {
         return result;
     }
 
-    private static ResourceInfo resourceInfo(Object value) {
+    private static @Nullable ResourceInfo resourceInfo(Object value) {
         return value instanceof ResourceInfo ? (ResourceInfo) value : null;
     }
 
-    private static boolean hasBindings(ResourceInfo resourceInfo, Set<Class<? extends Annotation>> requiredBindings) {
+    private static boolean hasBindings(@Nullable ResourceInfo resourceInfo, Set<Class<? extends Annotation>> requiredBindings) {
         if (requiredBindings.isEmpty()) {
             return true;
         }

--- a/src/main/java/io/muserver/rest/AsyncResponseAdapter.java
+++ b/src/main/java/io/muserver/rest/AsyncResponseAdapter.java
@@ -69,7 +69,7 @@ class AsyncResponseAdapter implements AsyncResponse, ResponseCompleteListener {
 
     @Override
     public boolean resume(Throwable response) {
-        return resume((Object) response);
+        return resume((Object) Objects.requireNonNull(response, "response"));
     }
 
     @Override
@@ -84,7 +84,7 @@ class AsyncResponseAdapter implements AsyncResponse, ResponseCompleteListener {
 
     @Override
     public boolean cancel(Date retryAfter) {
-        return doCancel(Mutils.toHttpDate(retryAfter));
+        return doCancel(Mutils.toHttpDate(Objects.requireNonNull(retryAfter, "retryAfter")));
     }
 
     private boolean doCancel(@Nullable Object retryAfterValue) {
@@ -112,6 +112,7 @@ class AsyncResponseAdapter implements AsyncResponse, ResponseCompleteListener {
 
     @Override
     public boolean setTimeout(long time, TimeUnit unit) {
+        Objects.requireNonNull(unit, "unit");
         if (!isSuspended) {
             return false;
         }
@@ -138,16 +139,23 @@ class AsyncResponseAdapter implements AsyncResponse, ResponseCompleteListener {
 
     @Override
     public Collection<Class<?>> register(Class<?> callback) {
+        Objects.requireNonNull(callback, "callback");
         throw new NotImplementedException("Mu-Server does not instantiate classes for you. Please use register(Object) with an instantiated callback instead.");
     }
 
     @Override
     public Map<Class<?>, Collection<Class<?>>> register(Class<?> callback, Class<?>... callbacks) {
+        Objects.requireNonNull(callback, "callback");
+        Objects.requireNonNull(callbacks, "callbacks");
+        for (Class<?> additionalCallback : callbacks) {
+            Objects.requireNonNull(additionalCallback, "callbacks element");
+        }
         throw new NotImplementedException("Mu-Server does not instantiate classes for you. Please use register(Object, Object...) with instantiated callbacks instead.");
     }
 
     @Override
     public Collection<Class<?>> register(Object callback) {
+        Objects.requireNonNull(callback, "callback");
         Collection<Class<?>> added = new HashSet<>();
         if (callback instanceof ConnectionCallback) {
             added.add(ConnectionCallback.class);
@@ -162,12 +170,13 @@ class AsyncResponseAdapter implements AsyncResponse, ResponseCompleteListener {
 
     @Override
     public Map<Class<?>, Collection<Class<?>>> register(Object callback, Object... callbacks) {
+        Objects.requireNonNull(callback, "callback");
+        Objects.requireNonNull(callbacks, "callbacks");
         Map<Class<?>, Collection<Class<?>>> added = new HashMap<>();
         if (callback == null) throw new NullPointerException("callback");
         register(callback, added);
         for (Object cb : callbacks) {
-            if (cb == null) throw new NullPointerException("callback");
-            register(cb, added);
+            register(Objects.requireNonNull(cb, "callbacks element"), added);
         }
         return added;
     }

--- a/src/main/java/io/muserver/rest/AsyncResponseAdapter.java
+++ b/src/main/java/io/muserver/rest/AsyncResponseAdapter.java
@@ -10,6 +10,7 @@ import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.jspecify.annotations.Nullable;
 
 import java.util.*;
 import java.util.concurrent.Executors;
@@ -27,11 +28,11 @@ class AsyncResponseAdapter implements AsyncResponse, ResponseCompleteListener {
     private volatile boolean isSuspended;
     private volatile boolean isCancelled;
     private volatile boolean isDone;
-    private volatile ScheduledFuture<?> cancelEvent;
-    private volatile TimeoutHandler timeoutHandler;
+    private volatile @Nullable ScheduledFuture<?> cancelEvent;
+    private volatile @Nullable TimeoutHandler timeoutHandler;
     private final List<ConnectionCallback> connectionCallbacks = new ArrayList<>();
     private final List<CompletionCallback> completionCallbacks = new ArrayList<>();
-    private Throwable exceptionWhileWriting = null;
+    private @Nullable Throwable exceptionWhileWriting;
 
     AsyncResponseAdapter(AsyncHandle asyncHandle, Consumer resultConsumer) {
         this.asyncHandle = asyncHandle;
@@ -43,9 +44,10 @@ class AsyncResponseAdapter implements AsyncResponse, ResponseCompleteListener {
     }
 
     @Override
-    public boolean resume(Object response) {
-        if (cancelEvent != null) {
-            isCancelled = isCancelled || cancelEvent.cancel(false);
+    public boolean resume(@Nullable Object response) {
+        ScheduledFuture<?> event = cancelEvent;
+        if (event != null) {
+            isCancelled = isCancelled || event.cancel(false);
             cancelEvent = null;
         }
         if (isSuspended) {
@@ -85,7 +87,7 @@ class AsyncResponseAdapter implements AsyncResponse, ResponseCompleteListener {
         return doCancel(Mutils.toHttpDate(retryAfter));
     }
 
-    private boolean doCancel(Object retryAfterValue) {
+    private boolean doCancel(@Nullable Object retryAfterValue) {
         Response.ResponseBuilder resp = Response.status(503);
         if (retryAfterValue != null) {
             resp.header(HeaderNames.RETRY_AFTER.toString(), retryAfterValue);
@@ -131,7 +133,7 @@ class AsyncResponseAdapter implements AsyncResponse, ResponseCompleteListener {
 
     @Override
     public void setTimeoutHandler(TimeoutHandler handler) {
-        this.timeoutHandler = handler;
+        this.timeoutHandler = Objects.requireNonNull(handler, "handler");
     }
 
     @Override
@@ -200,6 +202,6 @@ class AsyncResponseAdapter implements AsyncResponse, ResponseCompleteListener {
     }
 
     interface Consumer {
-        void accept(Object response) throws Exception;
+        void accept(@Nullable Object response) throws Exception;
     }
 }

--- a/src/main/java/io/muserver/rest/BuiltInParamConverterProvider.java
+++ b/src/main/java/io/muserver/rest/BuiltInParamConverterProvider.java
@@ -6,6 +6,7 @@ import io.muserver.UploadedFile;
 import jakarta.ws.rs.core.PathSegment;
 import jakarta.ws.rs.ext.ParamConverter;
 import jakarta.ws.rs.ext.ParamConverterProvider;
+import org.jspecify.annotations.Nullable;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Constructor;
@@ -53,7 +54,7 @@ class BuiltInParamConverterProvider implements ParamConverterProvider {
 
 
     @Override
-    public <T> ParamConverter getConverter(Class<T> rawType, Type genericType, Annotation[] annotations) {
+    public <T> @Nullable ParamConverter getConverter(Class<T> rawType, Type genericType, Annotation[] annotations) {
 
         if (String.class.isAssignableFrom(rawType)) {
             return stringParamConverter;
@@ -92,7 +93,7 @@ class BuiltInParamConverterProvider implements ParamConverterProvider {
 
     private static class UploadedFileConverter implements ParamConverter<UploadedFile> {
         @Override
-        public UploadedFile fromString(String value) {
+        public @Nullable UploadedFile fromString(@Nullable String value) {
             return null;
         }
         @Override
@@ -104,7 +105,7 @@ class BuiltInParamConverterProvider implements ParamConverterProvider {
     // Not actually used because it is handled specially in ResourceMethodParam but needs to exist during parameter setup
     private static class DummyCookieConverter implements ParamConverter<Cookie> {
         @Override
-        public Cookie fromString(String value) {
+        public @Nullable Cookie fromString(@Nullable String value) {
             return null;
         }
         @Override
@@ -135,9 +136,9 @@ class BuiltInParamConverterProvider implements ParamConverterProvider {
             this.boxedClass = boxedClass;
             this.stringToValue = stringToValue;
         }
-        public T fromString(String value) {
+        public @Nullable T fromString(@Nullable String value) {
             if (Mutils.nullOrEmpty(value)) return null;
-            return stringToValue.apply(value);
+            return stringToValue.apply(java.util.Objects.requireNonNull(value));
         }
         public String toString(T value) {
             return String.valueOf(value);
@@ -157,7 +158,7 @@ class BuiltInParamConverterProvider implements ParamConverterProvider {
             this.primitiveClass = primitiveClass;
             this.stringToValue = stringToValue;
         }
-        public T fromString(String value) {
+        public T fromString(@Nullable String value) {
             if (value == null || value.isEmpty()) {
                 return defaultValue;
             }
@@ -176,12 +177,12 @@ class BuiltInParamConverterProvider implements ParamConverterProvider {
 
     private static class EnumConverter<E extends Enum<E>>  implements ParamConverter<E> {
         private final Class<E> enumClass;
-        private final StaticMethodConverter<E> fromStringConverter;
+        private final @Nullable StaticMethodConverter<E> fromStringConverter;
         private EnumConverter(Class<E> enumClass) {
             this.enumClass = enumClass;
             this.fromStringConverter = StaticMethodConverter.tryToCreateFromString(enumClass);
         }
-        public E fromString(String value) {
+        public @Nullable E fromString(@Nullable String value) {
             if (Mutils.nullOrEmpty(value)) return null;
             if (fromStringConverter != null) return fromStringConverter.fromString(value);
             return Enum.valueOf(enumClass, value);
@@ -200,7 +201,7 @@ class BuiltInParamConverterProvider implements ParamConverterProvider {
         private ConstructorConverter(Constructor<T> constructor) {
             this.constructor = constructor;
         }
-        public T fromString(String value) {
+        public @Nullable T fromString(@Nullable String value) {
             if (Mutils.nullOrEmpty(value)) return null;
             try {
                 return constructor.newInstance(value);
@@ -214,7 +215,7 @@ class BuiltInParamConverterProvider implements ParamConverterProvider {
         public String toString() {
             return "ConstructorConverter{" + constructor + '}';
         }
-        static <T> ConstructorConverter<T> tryToCreate(Class<T> clazz) {
+        static <T> @Nullable ConstructorConverter<T> tryToCreate(Class<T> clazz) {
             try {
                 Constructor constructor = clazz.getConstructor(String.class);
                 int modifiers = constructor.getModifiers();
@@ -234,7 +235,7 @@ class BuiltInParamConverterProvider implements ParamConverterProvider {
         private StaticMethodConverter(Method staticMethod) {
             this.staticMethod = staticMethod;
         }
-        public T fromString(String value) {
+        public @Nullable T fromString(@Nullable String value) {
             if (Mutils.nullOrEmpty(value)) return null;
             try {
                 return (T) staticMethod.invoke(null, value);
@@ -249,7 +250,7 @@ class BuiltInParamConverterProvider implements ParamConverterProvider {
             return staticMethod.toString();
         }
 
-        static <T> StaticMethodConverter<T> tryToCreate(Class clazz) {
+        static <T> @Nullable StaticMethodConverter<T> tryToCreate(Class clazz) {
             Method[] declaredMethods = clazz.getDeclaredMethods();
             Method staticMethod = getSingleParamPublicStaticMethodNamed(clazz, declaredMethods, "valueOf");
             if (staticMethod == null) {
@@ -265,7 +266,7 @@ class BuiltInParamConverterProvider implements ParamConverterProvider {
             return new StaticMethodConverter<>(staticMethod);
         }
 
-        static <T> StaticMethodConverter<T> tryToCreateFromString(Class clazz) {
+        static <T> @Nullable StaticMethodConverter<T> tryToCreateFromString(Class clazz) {
             Method[] declaredMethods = clazz.getDeclaredMethods();
             Method staticMethod = getSingleParamPublicStaticMethodNamed(clazz, declaredMethods, "fromString");
             if (staticMethod == null) return null;
@@ -273,8 +274,8 @@ class BuiltInParamConverterProvider implements ParamConverterProvider {
             return new StaticMethodConverter<>(staticMethod);
         }
 
-        private static Method getSingleParamPublicStaticMethodNamed(Class clazz, Method[] declaredMethods, String name) {
-            Method staticMethod = null;
+        private static @Nullable Method getSingleParamPublicStaticMethodNamed(Class clazz, Method[] declaredMethods, String name) {
+            @Nullable Method staticMethod = null;
             for (Method method : declaredMethods) {
                 int modifiers = method.getModifiers();
                 if (Modifier.isStatic(modifiers) && Modifier.isPublic(modifiers) && method.getReturnType().equals(clazz)) {

--- a/src/main/java/io/muserver/rest/CORSConfig.java
+++ b/src/main/java/io/muserver/rest/CORSConfig.java
@@ -51,7 +51,8 @@ public class CORSConfig {
         return written;
     }
 
-    boolean writeHeadersInternal(MuRequest request, MuResponse response, Set<RequestMatcher.MatchedMethod> matchedMethodsForPath) {
+    boolean writeHeadersInternal(MuRequest request, MuResponse response,
+                                 @Nullable Set<RequestMatcher.MatchedMethod> matchedMethodsForPath) {
 
         Headers respHeaders = response.headers();
         if (!respHeaders.containsValue(HeaderNames.VARY, HeaderNames.ORIGIN, true)) {
@@ -59,7 +60,7 @@ public class CORSConfig {
         }
 
         String origin = request.headers().get(HeaderNames.ORIGIN);
-        if (Mutils.nullOrEmpty(origin)) {
+        if (origin == null || origin.isEmpty()) {
             return false;
         }
 

--- a/src/main/java/io/muserver/rest/CORSConfig.java
+++ b/src/main/java/io/muserver/rest/CORSConfig.java
@@ -159,7 +159,7 @@ public class CORSConfig {
     }
 
     @Override
-    public boolean equals(Object o) {
+    public boolean equals(@Nullable Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         CORSConfig that = (CORSConfig) o;

--- a/src/main/java/io/muserver/rest/CORSConfigBuilder.java
+++ b/src/main/java/io/muserver/rest/CORSConfigBuilder.java
@@ -21,7 +21,7 @@ import static java.util.Arrays.asList;
 public class CORSConfigBuilder {
 
     private boolean allowCredentials = false;
-    private Collection<String> allowedOrigins = Collections.emptySet();
+    private @Nullable Collection<String> allowedOrigins = Collections.emptySet();
     private List<Pattern> allowedOriginRegex = new ArrayList<>();
     private Collection<String> exposedHeaders = Collections.emptySet();
     private Collection<String> allowedHeaders = Collections.emptySet();

--- a/src/main/java/io/muserver/rest/CacheControlHeaderDelegate.java
+++ b/src/main/java/io/muserver/rest/CacheControlHeaderDelegate.java
@@ -43,6 +43,7 @@ https://github.com/jersey/jersey/blob/12e5d8bdf22bcd2676a1032ed69473cf2bbc48c7/c
  */
 package io.muserver.rest;
 
+import io.muserver.Mutils;
 import io.muserver.ParameterizedHeader;
 import jakarta.ws.rs.core.CacheControl;
 import jakarta.ws.rs.ext.RuntimeDelegate;
@@ -58,6 +59,7 @@ class CacheControlHeaderDelegate implements RuntimeDelegate.HeaderDelegate<Cache
     private static final Pattern WHITESPACE = Pattern.compile("\\s");
     @Override
     public CacheControl fromString(String value) {
+        Mutils.notNull("value", value);
         ParameterizedHeader dir = ParameterizedHeader.fromString(value);
         CacheControl cc = new CacheControl();
         Map<String, String> pams = new HashMap<>(dir.parameters());
@@ -91,6 +93,7 @@ class CacheControlHeaderDelegate implements RuntimeDelegate.HeaderDelegate<Cache
 
     @Override
     public String toString(CacheControl value) {
+        Mutils.notNull("value", value);
         StringBuilder sb = new StringBuilder();
         if (value.isPrivate()) {
             appendQuotedWithSeparator(sb, "private", buildListValue(value.getPrivateFields()));

--- a/src/main/java/io/muserver/rest/CacheControlHeaderDelegate.java
+++ b/src/main/java/io/muserver/rest/CacheControlHeaderDelegate.java
@@ -46,6 +46,7 @@ package io.muserver.rest;
 import io.muserver.ParameterizedHeader;
 import jakarta.ws.rs.core.CacheControl;
 import jakarta.ws.rs.ext.RuntimeDelegate;
+import org.jspecify.annotations.Nullable;
 
 import java.util.HashMap;
 import java.util.List;
@@ -154,7 +155,7 @@ class CacheControlHeaderDelegate implements RuntimeDelegate.HeaderDelegate<Cache
         b.append(value);
     }
 
-    static void appendWithSeparator(StringBuilder b, String field, String value) {
+    static void appendWithSeparator(StringBuilder b, String field, @Nullable String value) {
         appendWithSeparator(b, field);
         if (value != null && !value.isEmpty()) {
             b.append("=");
@@ -162,7 +163,7 @@ class CacheControlHeaderDelegate implements RuntimeDelegate.HeaderDelegate<Cache
         }
     }
 
-    static String quoteIfWhitespace(String value) {
+    static @Nullable String quoteIfWhitespace(@Nullable String value) {
         if (value == null) {
             return null;
         }

--- a/src/main/java/io/muserver/rest/CombinedMediaType.java
+++ b/src/main/java/io/muserver/rest/CombinedMediaType.java
@@ -1,6 +1,7 @@
 package io.muserver.rest;
 
 import jakarta.ws.rs.core.MediaType;
+import org.jspecify.annotations.Nullable;
 
 import java.util.Objects;
 
@@ -11,16 +12,16 @@ class CombinedMediaType implements Comparable<CombinedMediaType> {
 
     public static CombinedMediaType NONMATCH = new CombinedMediaType(null, null, 1.0, 1.0, 0, null);
 
-    public final String type;
-    public final String subType;
+    public final @Nullable String type;
+    public final @Nullable String subType;
     public final double q;
     public final double qs;
     public final int d;
     public final boolean isWildcardType;
     public final boolean isWildcardSubtype;
-    public final String charset;
+    public final @Nullable String charset;
 
-    CombinedMediaType(String type, String subType, double q, double qs, int d, String charset) {
+    CombinedMediaType(@Nullable String type, @Nullable String subType, double q, double qs, int d, @Nullable String charset) {
         this.type = type;
         this.subType = subType;
         this.q = q;

--- a/src/main/java/io/muserver/rest/CombinedMediaType.java
+++ b/src/main/java/io/muserver/rest/CombinedMediaType.java
@@ -74,7 +74,7 @@ class CombinedMediaType implements Comparable<CombinedMediaType> {
     }
 
     @Override
-    public boolean equals(Object o) {
+    public boolean equals(@Nullable Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         CombinedMediaType that = (CombinedMediaType) o;

--- a/src/main/java/io/muserver/rest/CookieHeaderDelegate.java
+++ b/src/main/java/io/muserver/rest/CookieHeaderDelegate.java
@@ -22,6 +22,7 @@ class CookieHeaderDelegate implements RuntimeDelegate.HeaderDelegate<Cookie> {
 
     @Override
     public String toString(Cookie cookie) {
+        if (cookie == null) throw new IllegalArgumentException("Cookie was null");
         io.muserver.Cookie muc = CookieBuilder.newCookie()
             .withName(cookie.getName())
             .withValue(cookie.getValue())

--- a/src/main/java/io/muserver/rest/DateHeaderDelegate.java
+++ b/src/main/java/io/muserver/rest/DateHeaderDelegate.java
@@ -10,6 +10,7 @@ class DateHeaderDelegate implements RuntimeDelegate.HeaderDelegate<Date> {
 
     @Override
     public Date fromString(String value) {
+        Mutils.notNull("value", value);
         try {
             return Mutils.fromHttpDate(value);
         } catch (DateTimeParseException e) {
@@ -19,6 +20,7 @@ class DateHeaderDelegate implements RuntimeDelegate.HeaderDelegate<Date> {
 
     @Override
     public String toString(Date value) {
+        Mutils.notNull("value", value);
         return Mutils.toHttpDate(value);
     }
 }

--- a/src/main/java/io/muserver/rest/DescriptionData.java
+++ b/src/main/java/io/muserver/rest/DescriptionData.java
@@ -3,6 +3,7 @@ package io.muserver.rest;
 import io.muserver.Mutils;
 import io.muserver.openapi.ExternalDocumentationObject;
 import io.muserver.openapi.TagObject;
+import org.jspecify.annotations.Nullable;
 
 import java.lang.reflect.AnnotatedElement;
 import java.net.URI;
@@ -13,24 +14,24 @@ import static io.muserver.openapi.TagObjectBuilder.tagObject;
 
 class DescriptionData {
 
-    final String summary;
-    final String description;
-    final ExternalDocumentationObject externalDocumentation;
-    final String example;
+    final @Nullable String summary;
+    final @Nullable String description;
+    final @Nullable ExternalDocumentationObject externalDocumentation;
+    final @Nullable String example;
 
-    DescriptionData(String summary, String description, ExternalDocumentationObject externalDocumentation, String example) {
+    DescriptionData(@Nullable String summary, @Nullable String description, @Nullable ExternalDocumentationObject externalDocumentation, @Nullable String example) {
         this.summary = summary;
         this.description = description;
         this.externalDocumentation = externalDocumentation;
         this.example = example;
     }
 
-    static DescriptionData fromAnnotation(AnnotatedElement source, String defaultSummary) {
+    static DescriptionData fromAnnotation(AnnotatedElement source, @Nullable String defaultSummary) {
         Description description = source.getAnnotation(Description.class);
         if (description == null) {
             return new DescriptionData(defaultSummary, null, null, null);
         } else {
-            ExternalDocumentationObject externalDocumentation = null;
+            @Nullable ExternalDocumentationObject externalDocumentation = null;
             if (!description.documentationUrl().isEmpty()) {
                 try {
                     URI uri = new URI(description.documentationUrl());
@@ -48,17 +49,19 @@ class DescriptionData {
     }
 
     TagObject toTag() {
+        Mutils.notNull("summary", summary);
         return tagObject()
-            .withName(summary)
+            .withName(java.util.Objects.requireNonNull(summary))
             .withDescription(description)
             .withExternalDocs(externalDocumentation)
             .build();
     }
 
     public String summaryAndDescription() {
-        String s = Mutils.coalesce(summary, "");
-        if (!Mutils.nullOrEmpty(description)) {
-            s += " - " + description;
+        String s = summary == null ? "" : summary;
+        String details = description;
+        if (details != null && !details.isEmpty()) {
+            s += " - " + details;
         }
         return s;
     }

--- a/src/main/java/io/muserver/rest/EntityTagDelegate.java
+++ b/src/main/java/io/muserver/rest/EntityTagDelegate.java
@@ -1,5 +1,6 @@
 package io.muserver.rest;
 
+import io.muserver.Mutils;
 import jakarta.ws.rs.core.EntityTag;
 import jakarta.ws.rs.ext.RuntimeDelegate;
 
@@ -22,6 +23,7 @@ class EntityTagDelegate implements RuntimeDelegate.HeaderDelegate<EntityTag> {
 
     @Override
     public String toString(EntityTag value) {
+        Mutils.notNull("value", value);
         String quotedValue = quoted(value.getValue());
         return value.isWeak() ? "W/" + quotedValue : quotedValue;
     }

--- a/src/main/java/io/muserver/rest/GenericTypeResolver.java
+++ b/src/main/java/io/muserver/rest/GenericTypeResolver.java
@@ -29,7 +29,10 @@ final class GenericTypeResolver {
         return concreteTypeOrNull(resolve(type, concreteClass, declaringClass));
     }
 
-    static @Nullable Type resolveTypeArgument(Type type, Class<?> targetClass, int argumentIndex) {
+    static @Nullable Type resolveTypeArgument(@Nullable Type type, Class<?> targetClass, int argumentIndex) {
+        if (type == null) {
+            return null;
+        }
         TypeVariable<?> typeVariable = targetClass.getTypeParameters()[argumentIndex];
         Map<TypeVariable<?>, Type> typeArguments = new HashMap<>();
         if (!findTypeArguments(type, targetClass, new HashMap<>(), typeArguments)) {
@@ -106,7 +109,7 @@ final class GenericTypeResolver {
         return candidateClass != null && declaringClass.isAssignableFrom(candidateClass);
     }
 
-    static Class<?> rawClass(Type type) {
+    static @Nullable Class<?> rawClass(@Nullable Type type) {
         if (type instanceof Class) {
             return (Class<?>) type;
         }
@@ -162,11 +165,11 @@ final class GenericTypeResolver {
     }
 
     private static final class ResolvedParameterizedType implements ParameterizedType {
-        private final Type owner;
+        private final @Nullable Type owner;
         private final Type rawType;
         private final Type[] arguments;
 
-        private ResolvedParameterizedType(Type owner, Type rawType, Type[] arguments) {
+        private ResolvedParameterizedType(@Nullable Type owner, Type rawType, Type[] arguments) {
             this.owner = owner;
             this.rawType = rawType;
             this.arguments = arguments.clone();
@@ -183,7 +186,7 @@ final class GenericTypeResolver {
         }
 
         @Override
-        public Type getOwnerType() {
+        public @Nullable Type getOwnerType() {
             return owner;
         }
 

--- a/src/main/java/io/muserver/rest/GenericTypeResolver.java
+++ b/src/main/java/io/muserver/rest/GenericTypeResolver.java
@@ -191,7 +191,7 @@ final class GenericTypeResolver {
         }
 
         @Override
-        public boolean equals(Object other) {
+        public boolean equals(@Nullable Object other) {
             if (!(other instanceof ParameterizedType)) {
                 return false;
             }
@@ -254,7 +254,7 @@ final class GenericTypeResolver {
         }
 
         @Override
-        public boolean equals(Object other) {
+        public boolean equals(@Nullable Object other) {
             return other instanceof GenericArrayType
                 && componentType.equals(((GenericArrayType) other).getGenericComponentType());
         }
@@ -295,7 +295,7 @@ final class GenericTypeResolver {
         }
 
         @Override
-        public boolean equals(Object other) {
+        public boolean equals(@Nullable Object other) {
             if (!(other instanceof WildcardType)) {
                 return false;
             }

--- a/src/main/java/io/muserver/rest/HtmlDocumentor.java
+++ b/src/main/java/io/muserver/rest/HtmlDocumentor.java
@@ -3,6 +3,7 @@ package io.muserver.rest;
 import io.muserver.Mutils;
 import io.muserver.openapi.*;
 import jakarta.ws.rs.core.MediaType;
+import org.jspecify.annotations.Nullable;
 
 import java.io.BufferedWriter;
 import java.io.IOException;
@@ -70,8 +71,12 @@ class HtmlDocumentor {
         LicenseObject license = api.info().license();
         if (license != null) {
             metaData.content(" | License: ");
-            String name = license.name() == null ? license.url().toString() : license.name();
-            new El("a").open(Collections.singletonMap("href", "mailto:" + license.url())).content(name).close();
+            URI licenseUrl = license.url();
+            if (licenseUrl == null) {
+                metaData.content(license.name());
+            } else {
+                new El("a").open(Collections.singletonMap("href", licenseUrl.toString())).content(license.name()).close();
+            }
         }
 
         if (api.info().termsOfService() != null) {
@@ -88,18 +93,19 @@ class HtmlDocumentor {
 
 
         El nav = new El("ul").open(singletonMap("class", "nav operation"));
-        for (TagObject tag : api.tags()) {
+        List<TagObject> tags = api.tags() == null ? Collections.emptyList() : api.tags();
+        for (TagObject tag : tags) {
             El li = new El("li").open();
             new El("a").open(singletonMap("href", "#" + Mutils.htmlEncode(tag.name()))).content(tag.name()).close();
 
             El subNav = new El("ul").open(singletonMap("class", "subNav"));
-            for (Map.Entry<String, PathItemObject> entry : api.paths().pathItemObjects().entrySet()) {
+            for (Map.Entry<String, PathItemObject> entry : pathItems().entrySet()) {
                 String url = entry.getKey();
                 PathItemObject item = entry.getValue();
-                for (Map.Entry<String, OperationObject> operationObjectEntry : item.operations().entrySet()) {
+                for (Map.Entry<String, OperationObject> operationObjectEntry : operations(item).entrySet()) {
                     String method = operationObjectEntry.getKey();
                     OperationObject operation = operationObjectEntry.getValue();
-                    if (operation.tags().contains(tag.name())) {
+                    if (operationTags(operation).contains(tag.name())) {
 
                         El subNavLi = new El("li").open();
                         new El("a").open(singletonMap("href", "#" + Mutils.htmlEncode(operation.operationId()))).content(method.toUpperCase() + " " + url).close();
@@ -118,20 +124,20 @@ class HtmlDocumentor {
         nav.close();
 
 
-        for (TagObject tag : api.tags()) {
+        for (TagObject tag : tags) {
             El tagContainer = new El("div").open(singletonMap("class", "tagContainer"));
             new El("h2").open(singletonMap("id", Mutils.htmlEncode(tag.name()))).content(tag.name()).close();
             renderIfValue("p", tag.description());
             renderExternalLinksParagraph(tag.externalDocs());
 
-            for (Map.Entry<String, PathItemObject> entry : api.paths().pathItemObjects().entrySet()) {
+            for (Map.Entry<String, PathItemObject> entry : pathItems().entrySet()) {
                 String url = entry.getKey();
                 PathItemObject item = entry.getValue();
-                for (Map.Entry<String, OperationObject> operationObjectEntry : item.operations().entrySet()) {
+                for (Map.Entry<String, OperationObject> operationObjectEntry : operations(item).entrySet()) {
                     String method = operationObjectEntry.getKey();
                     OperationObject operation = operationObjectEntry.getValue();
 
-                    if (operation.tags().contains(tag.name())) {
+                    if (operationTags(operation).contains(tag.name())) {
 
                         Map<String, String> operationAttributes = new HashMap<>();
                         operationAttributes.put("id", Mutils.htmlEncode(operation.operationId()));
@@ -154,7 +160,8 @@ class HtmlDocumentor {
                         StringBuilder curlHeaders = new StringBuilder();
 
                         RequestBodyObject requestBody = operation.requestBody();
-                        if (!operation.parameters().isEmpty()) {
+                        List<ParameterObject> parameters = operation.parameters() == null ? Collections.emptyList() : operation.parameters();
+                        if (!parameters.isEmpty()) {
                             render("h4", "Parameters");
                             El table = new El("table").open(singletonMap("class", "parameterTable"));
 
@@ -169,7 +176,7 @@ class HtmlDocumentor {
                             El tbody = new El("tbody").open();
 
 
-                            for (ParameterObject parameter : operation.parameters()) {
+                            for (ParameterObject parameter : parameters) {
                                 El row = new El("tr").open();
                                 render("td", parameter.name());
                                 String type = parameter.in();
@@ -184,8 +191,8 @@ class HtmlDocumentor {
                                 }
 
                                 SchemaObject schema = parameter.schema();
-                                Object defaultVal = null;
-                                ExternalDocumentationObject externalDocs = null;
+                                @Nullable Object defaultVal = null;
+                                @Nullable ExternalDocumentationObject externalDocs = null;
                                 if (schema != null) {
                                     type += " - " + schema.type();
                                     if (schema.format() != null) {
@@ -257,7 +264,7 @@ class HtmlDocumentor {
                                     El row = new El("tr").open();
                                     render("td", formName);
 
-                                    String type = schema.type();
+                                    @Nullable String type = schema.type();
                                     if (schema.format() != null) {
                                         type += " (" + schema.format() + ")";
                                     }
@@ -343,11 +350,26 @@ class HtmlDocumentor {
         html.close();
     }
 
-    private static String bashValue(Object value) {
+    private Map<String, PathItemObject> pathItems() {
+        Map<String, PathItemObject> paths = api.paths().pathItemObjects();
+        return paths == null ? Collections.emptyMap() : paths;
+    }
+
+    private static Map<String, OperationObject> operations(PathItemObject item) {
+        Map<String, OperationObject> operations = item.operations();
+        return operations == null ? Collections.emptyMap() : operations;
+    }
+
+    private static List<String> operationTags(OperationObject operation) {
+        List<String> tags = operation.tags();
+        return tags == null ? Collections.emptyList() : tags;
+    }
+
+    private static String bashValue(@Nullable Object value) {
         return value == null || "".equals(value) ? "" : value.toString().replace("'", "'\\''");
     }
 
-    private void renderExternalLinksParagraph(ExternalDocumentationObject externalDocs) throws IOException {
+    private void renderExternalLinksParagraph(@Nullable ExternalDocumentationObject externalDocs) throws IOException {
         if (externalDocs != null) {
             String url = externalDocs.url().toString();
             String desc = externalDocs.description() == null ? url : externalDocs.description();
@@ -357,7 +379,7 @@ class HtmlDocumentor {
         }
     }
 
-    private void renderExamples(Object example, Map<String, ExampleObject> examples, Object defaultVal) throws IOException {
+    private void renderExamples(@Nullable Object example, @Nullable Map<String, ExampleObject> examples, @Nullable Object defaultVal) throws IOException {
         if (example != null) {
             El div = new El("div").open().content("Example: ");
             render("code", example.toString());
@@ -381,13 +403,13 @@ class HtmlDocumentor {
         }
     }
 
-    private void renderIfValue(String tag, String value) throws IOException {
+    private void renderIfValue(String tag, @Nullable String value) throws IOException {
         if (value != null) {
             new El(tag).open().content(value).close();
         }
     }
 
-    private void render(String tag, String value) throws IOException {
+    private void render(String tag, @Nullable String value) throws IOException {
         new El(tag).open().content(value).close();
     }
 
@@ -403,7 +425,7 @@ class HtmlDocumentor {
             return open(null);
         }
 
-        El open(Map<String, String> attributes) throws IOException {
+        El open(@Nullable Map<String, String> attributes) throws IOException {
             writer.write("<" + tag);
             if (attributes != null) {
                 for (Map.Entry<String, String> entry : attributes.entrySet()) {
@@ -419,7 +441,7 @@ class HtmlDocumentor {
             return this;
         }
 
-        El content(Object... vals) throws IOException {
+        El content(@Nullable Object... vals) throws IOException {
             if (vals != null) {
                 for (Object val : vals) {
                     if (val != null) {

--- a/src/main/java/io/muserver/rest/JaxClassLocator.java
+++ b/src/main/java/io/muserver/rest/JaxClassLocator.java
@@ -1,5 +1,6 @@
 package io.muserver.rest;
 
+import org.jspecify.annotations.Nullable;
 import java.lang.annotation.Annotation;
 
 /**
@@ -7,16 +8,16 @@ import java.lang.annotation.Annotation;
  * As per the spec, the class and its super classes are checked before interfaces.
  */
 class JaxClassLocator {
-    static Class<?> getClassWithJaxRSAnnotations(Class<?> start) {
-        Class<?> clazz = start;
-        while (clazz != Object.class) {
+    static @Nullable Class<?> getClassWithJaxRSAnnotations(Class<?> start) {
+        @Nullable Class<?> clazz = start;
+        while (clazz != null && clazz != Object.class) {
             if (hasAtLeastOneJaxRSAnnotation(clazz.getDeclaredAnnotations())) {
                 return clazz;
             }
             clazz = clazz.getSuperclass();
         }
         clazz = start;
-        while (clazz != Object.class) {
+        while (clazz != null && clazz != Object.class) {
             for (Class<?> interfaceClass : clazz.getInterfaces()) {
                 if (hasAtLeastOneJaxRSAnnotation(interfaceClass.getDeclaredAnnotations())) {
                     return interfaceClass;

--- a/src/main/java/io/muserver/rest/JaxOutboundSseEvent.java
+++ b/src/main/java/io/muserver/rest/JaxOutboundSseEvent.java
@@ -36,7 +36,7 @@ class JaxOutboundSseEvent implements OutboundSseEvent {
 
     @Override
     public @Nullable Type getGenericType() {
-        return genericType == null ? null : genericType.getType();
+        return genericType == null ? type : genericType.getType();
     }
 
     @Override

--- a/src/main/java/io/muserver/rest/JaxOutboundSseEvent.java
+++ b/src/main/java/io/muserver/rest/JaxOutboundSseEvent.java
@@ -4,20 +4,21 @@ import jakarta.ws.rs.core.GenericType;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.sse.OutboundSseEvent;
 import jakarta.ws.rs.sse.SseEvent;
+import org.jspecify.annotations.Nullable;
 
 import java.lang.reflect.Type;
 
 class JaxOutboundSseEvent implements OutboundSseEvent {
-    private final String id;
-    private final String name;
+    private final @Nullable String id;
+    private final @Nullable String name;
     private final long milliseconds;
     private final MediaType mediaType;
-    private final String comment;
-    private final Class type;
-    private final Object data;
-    private final GenericType genericType;
+    private final @Nullable String comment;
+    private final @Nullable Class type;
+    private final @Nullable Object data;
+    private final @Nullable GenericType genericType;
 
-    JaxOutboundSseEvent(String id, String name, long milliseconds, MediaType mediaType, String comment, Class type, Object data, GenericType genericType) {
+    JaxOutboundSseEvent(@Nullable String id, @Nullable String name, long milliseconds, MediaType mediaType, @Nullable String comment, @Nullable Class type, @Nullable Object data, @Nullable GenericType genericType) {
         this.id = id;
         this.name = name;
         this.milliseconds = milliseconds;
@@ -29,12 +30,12 @@ class JaxOutboundSseEvent implements OutboundSseEvent {
     }
 
     @Override
-    public Class<?> getType() {
+    public @Nullable Class<?> getType() {
         return type;
     }
 
     @Override
-    public Type getGenericType() {
+    public @Nullable Type getGenericType() {
         return genericType == null ? null : genericType.getType();
     }
 
@@ -44,22 +45,22 @@ class JaxOutboundSseEvent implements OutboundSseEvent {
     }
 
     @Override
-    public Object getData() {
+    public @Nullable Object getData() {
         return data;
     }
 
     @Override
-    public String getId() {
+    public @Nullable String getId() {
         return id;
     }
 
     @Override
-    public String getName() {
+    public @Nullable String getName() {
         return name;
     }
 
     @Override
-    public String getComment() {
+    public @Nullable String getComment() {
         return comment;
     }
 

--- a/src/main/java/io/muserver/rest/JaxOutboundSseEventBuilder.java
+++ b/src/main/java/io/muserver/rest/JaxOutboundSseEventBuilder.java
@@ -4,16 +4,17 @@ import jakarta.ws.rs.core.GenericType;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.sse.OutboundSseEvent;
 import jakarta.ws.rs.sse.SseEvent;
+import org.jspecify.annotations.Nullable;
 
 class JaxOutboundSseEventBuilder implements OutboundSseEvent.Builder {
-    private String id;
-    private String name;
+    private @Nullable String id;
+    private @Nullable String name;
     private long milliseconds = SseEvent.RECONNECT_NOT_SET;
     private MediaType mediaType = MediaType.TEXT_PLAIN_TYPE;
-    private String comment;
-    private Class type;
-    private Object data;
-    private GenericType genericType;
+    private @Nullable String comment;
+    private @Nullable Class type;
+    private @Nullable Object data;
+    private @Nullable GenericType genericType;
 
     @Override
     public OutboundSseEvent.Builder id(String id) {

--- a/src/main/java/io/muserver/rest/JaxOutboundSseEventBuilder.java
+++ b/src/main/java/io/muserver/rest/JaxOutboundSseEventBuilder.java
@@ -17,13 +17,13 @@ class JaxOutboundSseEventBuilder implements OutboundSseEvent.Builder {
     private @Nullable GenericType genericType;
 
     @Override
-    public OutboundSseEvent.Builder id(String id) {
+    public OutboundSseEvent.Builder id(@Nullable String id) {
         this.id = id;
         return this;
     }
 
     @Override
-    public OutboundSseEvent.Builder name(String name) {
+    public OutboundSseEvent.Builder name(@Nullable String name) {
         this.name = name;
         return this;
     }
@@ -42,7 +42,7 @@ class JaxOutboundSseEventBuilder implements OutboundSseEvent.Builder {
     }
 
     @Override
-    public OutboundSseEvent.Builder comment(String comment) {
+    public OutboundSseEvent.Builder comment(@Nullable String comment) {
         this.comment = comment;
         return this;
     }
@@ -52,6 +52,7 @@ class JaxOutboundSseEventBuilder implements OutboundSseEvent.Builder {
         if (type == null) throw new NullPointerException("type");
         if (data == null) throw new NullPointerException("data");
         this.type = type;
+        this.genericType = null;
         this.data = data;
         return this;
     }
@@ -60,6 +61,7 @@ class JaxOutboundSseEventBuilder implements OutboundSseEvent.Builder {
     public OutboundSseEvent.Builder data(GenericType type, Object data) {
         if (type == null) throw new NullPointerException("type");
         if (data == null) throw new NullPointerException("data");
+        this.type = type.getRawType();
         this.genericType = type;
         this.data = data;
         return this;
@@ -70,6 +72,7 @@ class JaxOutboundSseEventBuilder implements OutboundSseEvent.Builder {
         if (data == null) throw new NullPointerException("data");
         this.data = data;
         this.type = data.getClass();
+        this.genericType = null;
         return this;
     }
 

--- a/src/main/java/io/muserver/rest/JaxRSRequest.java
+++ b/src/main/java/io/muserver/rest/JaxRSRequest.java
@@ -11,6 +11,7 @@ import jakarta.ws.rs.core.Cookie;
 import jakarta.ws.rs.ext.MessageBodyReader;
 import jakarta.ws.rs.ext.ReaderInterceptor;
 import jakarta.ws.rs.ext.ReaderInterceptorContext;
+import org.jspecify.annotations.Nullable;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -27,16 +28,16 @@ class JaxRSRequest implements Request, ContainerRequestContext, ReaderIntercepto
     private final String relativePath;
     private final JaxRsHttpHeadersAdapter jaxHeaders;
     private UriInfo uriInfo;
-    private RequestMatcher.MatchedMethod matchedMethod;
+    private RequestMatcher.@Nullable MatchedMethod matchedMethod;
     private SecurityContext securityContext;
     private Annotation[] annotations = JaxRSResponse.Builder.EMPTY_ANNOTATIONS;
-    private Class<?> type;
-    private Type genericType;
+    private @Nullable Class<?> type;
+    private @Nullable Type genericType;
     private int nextReader;
     private final List<ReaderInterceptor> readerInterceptors;
     private final EntityProviders entityProviders;
     private String httpMethod;
-    private Response abortResponse;
+    private @Nullable Response abortResponse;
     private boolean requestFilterChainRunning;
     private boolean responseFilterChainStarted;
     private boolean exceptionMapperUsed;
@@ -68,7 +69,7 @@ class JaxRSRequest implements Request, ContainerRequestContext, ReaderIntercepto
         return matchedMethod.resourceMethod.hasAll(toCheck);
     }
 
-    Response mapExceptionOnce(CustomExceptionMapper exceptionMapper, Exception exception) {
+    @Nullable Response mapExceptionOnce(CustomExceptionMapper exceptionMapper, Exception exception) {
         if (exceptionMapperUsed) {
             return null;
         }
@@ -80,12 +81,12 @@ class JaxRSRequest implements Request, ContainerRequestContext, ReaderIntercepto
     }
 
     @Override
-    public Object getProperty(String name) {
+    public @Nullable Object getProperty(String name) {
         if (MuRuntimeDelegate.MU_REQUEST_PROPERTY.equals(name)) {
             return muRequest;
         } else if (MuRuntimeDelegate.RESOURCE_INFO_PROPERTY.equals(name)) {
-            Class<?> resourceInstanceClass = (matchedMethod == null) ? null : matchedMethod.matchedClass.resourceClass.resourceInstance.getClass();
-            java.lang.reflect.Method resourceInstanceMethod = (matchedMethod == null) ? null : matchedMethod.resourceMethod.methodHandle;
+            @Nullable Class<?> resourceInstanceClass = (matchedMethod == null) ? null : matchedMethod.matchedClass.resourceClass.requiredResourceInstance().getClass();
+            java.lang.reflect.@Nullable Method resourceInstanceMethod = (matchedMethod == null) ? null : matchedMethod.resourceMethod.methodHandle;
             return new MuResourceInfo(resourceInstanceClass, resourceInstanceMethod);
         }
         return muRequest.attribute(name);
@@ -133,7 +134,7 @@ class JaxRSRequest implements Request, ContainerRequestContext, ReaderIntercepto
 
     @Override
     public Class<?> getType() {
-        return type;
+        return Objects.requireNonNull(type, "The request entity type has not been set");
     }
 
     @Override
@@ -143,7 +144,7 @@ class JaxRSRequest implements Request, ContainerRequestContext, ReaderIntercepto
 
     @Override
     public Type getGenericType() {
-        return genericType;
+        return Objects.requireNonNull(genericType, "The request entity generic type has not been set");
     }
 
     @Override
@@ -181,7 +182,7 @@ class JaxRSRequest implements Request, ContainerRequestContext, ReaderIntercepto
     }
 
     @Override
-    public Variant selectVariant(List<Variant> variants) {
+    public @Nullable Variant selectVariant(List<Variant> variants) {
         if (variants == null) {
             throw new IllegalArgumentException("variants is null");
         }
@@ -208,7 +209,7 @@ class JaxRSRequest implements Request, ContainerRequestContext, ReaderIntercepto
     }
 
     @Override
-    public Response.ResponseBuilder evaluatePreconditions(EntityTag eTag) {
+    public Response.@Nullable ResponseBuilder evaluatePreconditions(EntityTag eTag) {
         if (eTag == null) {
             throw new IllegalArgumentException("eTag is null");
         }
@@ -216,7 +217,7 @@ class JaxRSRequest implements Request, ContainerRequestContext, ReaderIntercepto
         return ifMatchBuilder != null ? ifMatchBuilder : evaluateIfNoneMatch(eTag);
     }
 
-    private Response.ResponseBuilder evaluateIfMatch(EntityTag eTag) {
+    private Response.@Nullable ResponseBuilder evaluateIfMatch(EntityTag eTag) {
         boolean anyMatch = false;
         List<String> ifMatches = muRequest.headers().getAll(HeaderNames.IF_MATCH);
         if (ifMatches.isEmpty()) {
@@ -239,7 +240,7 @@ class JaxRSRequest implements Request, ContainerRequestContext, ReaderIntercepto
     }
 
 
-    private Response.ResponseBuilder evaluateIfNoneMatch(EntityTag eTag) {
+    private Response.@Nullable ResponseBuilder evaluateIfNoneMatch(EntityTag eTag) {
         List<String> ifNoneMatchTags = muRequest.headers().getAll(HeaderNames.IF_NONE_MATCH);
         boolean getOrHead = isGetOrHead();
         if (!getOrHead && eTag.isWeak()) {
@@ -265,7 +266,7 @@ class JaxRSRequest implements Request, ContainerRequestContext, ReaderIntercepto
     }
 
     @Override
-    public Response.ResponseBuilder evaluatePreconditions(Date lastModified) {
+    public Response.@Nullable ResponseBuilder evaluatePreconditions(Date lastModified) {
         if (lastModified == null) {
             throw new IllegalArgumentException("lastModified is null");
         }
@@ -273,7 +274,7 @@ class JaxRSRequest implements Request, ContainerRequestContext, ReaderIntercepto
         return ifUnmodifiedSince != null ? ifUnmodifiedSince : evaluateIfModifiedSince(lastModified);
     }
 
-    private Response.ResponseBuilder evaluateIfModifiedSince(Date lastModified) {
+    private Response.@Nullable ResponseBuilder evaluateIfModifiedSince(Date lastModified) {
         long lastModifiedSeconds = lastModified.getTime() / 1000;
         Long ifModifiedMillis = muRequest.headers().getTimeMillis(HeaderNames.IF_MODIFIED_SINCE);
         if (ifModifiedMillis == null || lastModifiedSeconds > (ifModifiedMillis / 1000)) {
@@ -282,7 +283,7 @@ class JaxRSRequest implements Request, ContainerRequestContext, ReaderIntercepto
             return isGetOrHead() ? Response.notModified() : null;
         }
     }
-    private Response.ResponseBuilder evaluateIfUnmodifiedSince(Date lastModified) {
+    private Response.@Nullable ResponseBuilder evaluateIfUnmodifiedSince(Date lastModified) {
         long lastModifiedSeconds = lastModified.getTime() / 1000;
         Long ifUnmodifiedSince = muRequest.headers().getTimeMillis(HeaderNames.IF_UNMODIFIED_SINCE);
         if (ifUnmodifiedSince == null || lastModifiedSeconds <= (ifUnmodifiedSince / 1000)) {
@@ -295,7 +296,7 @@ class JaxRSRequest implements Request, ContainerRequestContext, ReaderIntercepto
 
 
     @Override
-    public Response.ResponseBuilder evaluatePreconditions(Date lastModified, EntityTag eTag) {
+    public Response.@Nullable ResponseBuilder evaluatePreconditions(Date lastModified, EntityTag eTag) {
         if (lastModified == null) {
             throw new IllegalArgumentException("lastModified is null");
         }
@@ -323,7 +324,7 @@ class JaxRSRequest implements Request, ContainerRequestContext, ReaderIntercepto
     }
 
     @Override
-    public Response.ResponseBuilder evaluatePreconditions() {
+    public Response.@Nullable ResponseBuilder evaluatePreconditions() {
         return muRequest.headers().get(HeaderNames.IF_MATCH) == null ? null
             : Response.status(Response.Status.PRECONDITION_FAILED).entity(new ClientErrorException("Precondition failed: if-match", 412));
     }
@@ -397,17 +398,17 @@ class JaxRSRequest implements Request, ContainerRequestContext, ReaderIntercepto
     }
 
     @Override
-    public String getHeaderString(String name) {
+    public @Nullable String getHeaderString(String name) {
         return jaxHeaders.getHeaderString(name);
     }
 
     @Override
-    public Date getDate() {
+    public @Nullable Date getDate() {
         return jaxHeaders.getDate();
     }
 
     @Override
-    public Locale getLanguage() {
+    public @Nullable Locale getLanguage() {
         return jaxHeaders.getLanguage();
     }
 
@@ -417,7 +418,7 @@ class JaxRSRequest implements Request, ContainerRequestContext, ReaderIntercepto
     }
 
     @Override
-    public MediaType getMediaType() {
+    public @Nullable MediaType getMediaType() {
         return jaxHeaders.getMediaType();
     }
 
@@ -488,7 +489,7 @@ class JaxRSRequest implements Request, ContainerRequestContext, ReaderIntercepto
         }
     }
 
-    Response getAbortResponse() {
+    @Nullable Response getAbortResponse() {
         return abortResponse;
     }
 
@@ -526,21 +527,21 @@ class JaxRSRequest implements Request, ContainerRequestContext, ReaderIntercepto
 
     private static class MuResourceInfo implements ResourceInfo {
 
-        private final Class<?> clazz;
-        private final java.lang.reflect.Method method;
+        private final @Nullable Class<?> clazz;
+        private final java.lang.reflect.@Nullable Method method;
 
-        private MuResourceInfo(Class<?> clazz, java.lang.reflect.Method method) {
+        private MuResourceInfo(@Nullable Class<?> clazz, java.lang.reflect.@Nullable Method method) {
             this.clazz = clazz;
             this.method = method;
         }
 
         @Override
-        public java.lang.reflect.Method getResourceMethod() {
+        public java.lang.reflect.@Nullable Method getResourceMethod() {
             return method;
         }
 
         @Override
-        public Class<?> getResourceClass() {
+        public @Nullable Class<?> getResourceClass() {
             return clazz;
         }
     }

--- a/src/main/java/io/muserver/rest/JaxRSRequest.java
+++ b/src/main/java/io/muserver/rest/JaxRSRequest.java
@@ -29,7 +29,7 @@ class JaxRSRequest implements Request, ContainerRequestContext, ReaderIntercepto
     private final JaxRsHttpHeadersAdapter jaxHeaders;
     private UriInfo uriInfo;
     private RequestMatcher.@Nullable MatchedMethod matchedMethod;
-    private SecurityContext securityContext;
+    private @Nullable SecurityContext securityContext;
     private Annotation[] annotations = JaxRSResponse.Builder.EMPTY_ANNOTATIONS;
     private @Nullable Class<?> type;
     private @Nullable Type genericType;
@@ -106,7 +106,7 @@ class JaxRSRequest implements Request, ContainerRequestContext, ReaderIntercepto
     }
 
     @Override
-    public void setProperty(String name, Object object) {
+    public void setProperty(String name, @Nullable Object object) {
         if (object == null) {
             removeProperty(name);
         } else {
@@ -133,22 +133,22 @@ class JaxRSRequest implements Request, ContainerRequestContext, ReaderIntercepto
     }
 
     @Override
-    public Class<?> getType() {
-        return Objects.requireNonNull(type, "The request entity type has not been set");
+    public @Nullable Class<?> getType() {
+        return type;
     }
 
     @Override
-    public void setType(Class<?> type) {
+    public void setType(@Nullable Class<?> type) {
         this.type = type;
     }
 
     @Override
-    public Type getGenericType() {
-        return Objects.requireNonNull(genericType, "The request entity generic type has not been set");
+    public @Nullable Type getGenericType() {
+        return genericType;
     }
 
     @Override
-    public void setGenericType(Type genericType) {
+    public void setGenericType(@Nullable Type genericType) {
         this.genericType = genericType;
     }
 
@@ -369,8 +369,8 @@ class JaxRSRequest implements Request, ContainerRequestContext, ReaderIntercepto
         }
 
         // 2. Identify the Java type of the parameter whose value will be mapped from the entity body.
-        Class<?> type = getType();
-        Type genericType = getGenericType();
+        Class<?> type = Objects.requireNonNull(getType(), "The request entity type has not been set");
+        Type genericType = Objects.requireNonNull(getGenericType(), "The request entity generic type has not been set");
         Annotation[] annotations = getAnnotations();
 
         // 3 & 4: Select a reader that supports the media type of the request and isReadable
@@ -389,7 +389,7 @@ class JaxRSRequest implements Request, ContainerRequestContext, ReaderIntercepto
 
     @Override
     public void setInputStream(InputStream is) {
-        setEntityStream(is);
+        setEntityStream(Objects.requireNonNull(is, "is"));
     }
 
     @Override
@@ -423,7 +423,7 @@ class JaxRSRequest implements Request, ContainerRequestContext, ReaderIntercepto
     }
 
     @Override
-    public void setMediaType(MediaType mediaType) {
+    public void setMediaType(@Nullable MediaType mediaType) {
         if (mediaType == null) {
             jaxHeaders.getMutableRequestHeaders().remove("content-type");
         } else {
@@ -459,16 +459,16 @@ class JaxRSRequest implements Request, ContainerRequestContext, ReaderIntercepto
     @Override
     public void setEntityStream(InputStream input) {
         ensureNotInResponseFilter("setEntityStream");
-        this.inputStream = input;
+        this.inputStream = Objects.requireNonNull(input, "input");
     }
 
     @Override
-    public SecurityContext getSecurityContext() {
+    public @Nullable SecurityContext getSecurityContext() {
         return securityContext;
     }
 
     @Override
-    public void setSecurityContext(SecurityContext context) {
+    public void setSecurityContext(@Nullable SecurityContext context) {
         ensureNotInResponseFilter("setSecurityContext");
         this.securityContext = context;
     }

--- a/src/main/java/io/muserver/rest/JaxRSResponse.java
+++ b/src/main/java/io/muserver/rest/JaxRSResponse.java
@@ -10,6 +10,7 @@ import jakarta.ws.rs.ext.MessageBodyReader;
 import jakarta.ws.rs.ext.RuntimeDelegate;
 import jakarta.ws.rs.ext.WriterInterceptor;
 import jakarta.ws.rs.ext.WriterInterceptorContext;
+import org.jspecify.annotations.Nullable;
 
 import java.io.*;
 import java.lang.annotation.Annotation;
@@ -34,15 +35,15 @@ class JaxRSResponse extends Response implements ContainerResponseContext, Writer
     private final NewCookie[] cookies;
     private final List<Link> links;
     private Annotation[] annotations;
-    private OutputStream outputStream;
+    private @Nullable OutputStream outputStream;
 
-    private JaxRSRequest requestContext;
-    private List<WriterInterceptor> writerInterceptors;
+    private @Nullable JaxRSRequest requestContext;
+    private @Nullable List<WriterInterceptor> writerInterceptors;
     private int nextWriter = 0;
 
     private boolean isClosed = false;
 
-    private ByteArrayInputStream inputStreamBuffer;
+    private @Nullable ByteArrayInputStream inputStreamBuffer;
 
     JaxRSResponse(StatusType status, MultivaluedMap<String, Object> headers, ObjWithType entity, NewCookie[] cookies, List<Link> links, Annotation[] annotations) {
         this.status = status;
@@ -86,7 +87,7 @@ class JaxRSResponse extends Response implements ContainerResponseContext, Writer
 
     @Override
     public Class<?> getType() {
-        return objWithType.type;
+        return Objects.requireNonNull(objWithType.type, "The response entity type has not been set");
     }
 
     @Override
@@ -96,7 +97,7 @@ class JaxRSResponse extends Response implements ContainerResponseContext, Writer
 
     @Override
     public Type getGenericType() {
-        return objWithType.genericType;
+        return Objects.requireNonNull(objWithType.genericType, "The response entity generic type has not been set");
     }
 
     @Override
@@ -125,7 +126,7 @@ class JaxRSResponse extends Response implements ContainerResponseContext, Writer
     }
 
     @Override
-    public Object getEntity() {
+    public @Nullable Object getEntity() {
         return objWithType.entity;
     }
 
@@ -140,7 +141,7 @@ class JaxRSResponse extends Response implements ContainerResponseContext, Writer
     }
 
     @Override
-    public void setEntity(Object entity) {
+    public void setEntity(@Nullable Object entity) {
         objWithType = ObjWithType.objType(entity);
         if (entity instanceof Response) {
             Response resp = (Response) entity;
@@ -150,7 +151,7 @@ class JaxRSResponse extends Response implements ContainerResponseContext, Writer
 
     @Override
     public OutputStream getOutputStream() {
-        return outputStream;
+        return requiredOutputStream();
     }
 
     @Override
@@ -159,7 +160,7 @@ class JaxRSResponse extends Response implements ContainerResponseContext, Writer
     }
 
     @Override
-    public void setEntity(Object entity, Annotation[] annotations, MediaType mediaType) {
+    public void setEntity(@Nullable Object entity, Annotation @Nullable [] annotations, @Nullable MediaType mediaType) {
         setEntity(entity);
         setAnnotations(annotations == null ? Builder.EMPTY_ANNOTATIONS : annotations);
         setMediaType(mediaType);
@@ -172,7 +173,7 @@ class JaxRSResponse extends Response implements ContainerResponseContext, Writer
 
     @Override
     public OutputStream getEntityStream() {
-        return outputStream;
+        return requiredOutputStream();
     }
 
     @Override
@@ -185,19 +186,22 @@ class JaxRSResponse extends Response implements ContainerResponseContext, Writer
         return readEntity0(entityType, null, new Annotation[0]);
     }
 
-    private <T> T readEntity0(Class<T> entityType, Type genericType, Annotation[] annotations) {
-        if (inputStreamBuffer == null && !(InputStream.class.isAssignableFrom(getEntity().getClass()))) {
-            throw new IllegalStateException("The entity is not an input stream, it is " + getEntity().getClass());
+    private <T> T readEntity0(Class<T> entityType, @Nullable Type genericType, Annotation[] annotations) {
+        Object entity = Objects.requireNonNull(getEntity(), "The response has no entity");
+        if (inputStreamBuffer == null && !(entity instanceof InputStream)) {
+            throw new IllegalStateException("The entity is not an input stream, it is " + entity.getClass());
         }
         if (isClosed) throw new IllegalStateException("Cannot read entity; the response is closed");
-        InputStream toRead = inputStreamBuffer != null ? inputStreamBuffer : (InputStream) getEntity();
+        InputStream toRead = inputStreamBuffer != null ? inputStreamBuffer : (InputStream) entity;
+        Type typeToRead = genericType == null ? entityType : genericType;
+        MediaType mediaType = getMediaType() == null ? MediaType.APPLICATION_OCTET_STREAM_TYPE : getMediaType();
         EntityProviders ep = new EntityProviders(EntityProviders.builtInReaders(), emptyList());
-        MessageBodyReader<T> reader = (MessageBodyReader<T>) ep.selectReader(entityType, genericType, annotations, getMediaType());
+        MessageBodyReader<T> reader = (MessageBodyReader<T>) ep.selectReader(entityType, typeToRead, annotations, mediaType);
         if (reader == null) {
             throw new ProcessingException("Cannot read this entity type");
         }
         try {
-            T result = reader.readFrom(entityType, genericType, annotations, getMediaType(), getStringHeaders(), toRead);
+            T result = reader.readFrom(entityType, typeToRead, annotations, mediaType, getStringHeaders(), toRead);
             if (inputStreamBuffer != null) {
                 inputStreamBuffer.reset();
             } else {
@@ -276,13 +280,13 @@ class JaxRSResponse extends Response implements ContainerResponseContext, Writer
     }
 
     @Override
-    public MediaType getMediaType() {
+    public @Nullable MediaType getMediaType() {
         String h = getHeaderString("content-type");
         return h == null ? null : MediaTypeParser.fromString(h);
     }
 
     @Override
-    public void setMediaType(MediaType mediaType) {
+    public void setMediaType(@Nullable MediaType mediaType) {
         if (mediaType == null) {
             headers.remove("content-type");
         } else {
@@ -291,7 +295,7 @@ class JaxRSResponse extends Response implements ContainerResponseContext, Writer
     }
 
     @Override
-    public Locale getLanguage() {
+    public @Nullable Locale getLanguage() {
         String h = getHeaderString(HeaderNames.CONTENT_LANGUAGE.toString());
         if (h == null) return null;
         return Locale.forLanguageTag(h);
@@ -327,23 +331,23 @@ class JaxRSResponse extends Response implements ContainerResponseContext, Writer
     }
 
     @Override
-    public Date getDate() {
+    public @Nullable Date getDate() {
         return dateFromHeader("date");
     }
 
-    private Date dateFromHeader(String name) {
+    private @Nullable Date dateFromHeader(String name) {
         Object date = headers.getFirst(name);
         if (date == null || date.getClass().isAssignableFrom(Date.class)) return (Date)date;
         return Mutils.fromHttpDate(date.toString());
     }
 
     @Override
-    public Date getLastModified() {
+    public @Nullable Date getLastModified() {
         return dateFromHeader("last-modified");
     }
 
     @Override
-    public URI getLocation() {
+    public @Nullable URI getLocation() {
         String s = getHeaderString("location");
         return s == null ? null : URI.create(s);
     }
@@ -359,12 +363,12 @@ class JaxRSResponse extends Response implements ContainerResponseContext, Writer
     }
 
     @Override
-    public Link getLink(String relation) {
+    public @Nullable Link getLink(String relation) {
         return links.stream().filter(link -> link.getRels().contains(relation)).findFirst().orElse(null);
     }
 
     @Override
-    public Link.Builder getLinkBuilder(String relation) {
+    public Link.@Nullable Builder getLinkBuilder(String relation) {
         Link link = getLink(relation);
         if (link == null) {
             return null;
@@ -401,11 +405,11 @@ class JaxRSResponse extends Response implements ContainerResponseContext, Writer
     }
 
     @Override
-    public String getHeaderString(String name) {
+    public @Nullable String getHeaderString(String name) {
         return headerValueToString(headers.getFirst(name));
     }
 
-    private static String headerValueToString(Object value) {
+    private static @Nullable String headerValueToString(@Nullable Object value) {
         if (value == null || value instanceof String) {
             return (String)value;
         }
@@ -428,11 +432,12 @@ class JaxRSResponse extends Response implements ContainerResponseContext, Writer
 
     @Override
     public void proceed() throws IOException, WebApplicationException {
-        while (nextWriter < writerInterceptors.size()) {
+        List<WriterInterceptor> interceptors = Objects.requireNonNull(writerInterceptors, "Writer interceptors have not been initialized");
+        while (nextWriter < interceptors.size()) {
             nextWriter++;
-            WriterInterceptor nextInterceptor = writerInterceptors.get(nextWriter - 1);
+            WriterInterceptor nextInterceptor = interceptors.get(nextWriter - 1);
             List<Class<? extends Annotation>> filterBindings = ResourceClass.getNameBindingAnnotations(nextInterceptor.getClass());
-            if (requestContext.methodHasAnnotations(filterBindings)) {
+            if (requiredRequestContext().methodHasAnnotations(filterBindings)) {
                 nextInterceptor.aroundWriteTo(this);
                 return;
             }
@@ -440,27 +445,35 @@ class JaxRSResponse extends Response implements ContainerResponseContext, Writer
     }
 
     @Override
-    public Object getProperty(String name) {
-        return requestContext.getProperty(name);
+    public @Nullable Object getProperty(String name) {
+        return requiredRequestContext().getProperty(name);
     }
 
     @Override
     public Collection<String> getPropertyNames() {
-        return requestContext.getPropertyNames();
+        return requiredRequestContext().getPropertyNames();
     }
 
     @Override
     public void setProperty(String name, Object object) {
-        requestContext.setProperty(name, object);
+        requiredRequestContext().setProperty(name, object);
     }
 
     @Override
     public void removeProperty(String name) {
-        requestContext.removeProperty(name);
+        requiredRequestContext().removeProperty(name);
     }
 
     public void setRequestContext(JaxRSRequest requestContext) {
         this.requestContext = requestContext;
+    }
+
+    private OutputStream requiredOutputStream() {
+        return Objects.requireNonNull(outputStream, "The response entity stream has not been set");
+    }
+
+    private JaxRSRequest requiredRequestContext() {
+        return Objects.requireNonNull(requestContext, "The response request context has not been set");
     }
 
     // End interceptor specific things
@@ -478,11 +491,11 @@ class JaxRSResponse extends Response implements ContainerResponseContext, Writer
 
         private final MultivaluedMap<String, Object> headers = new LowercasedMultivaluedHashMap<>();
         private final List<Link> linkHeaders = new ArrayList<>();
-        private StatusType status;
-        private Object entity;
+        private @Nullable StatusType status;
+        private @Nullable Object entity;
         private Annotation[] annotations = EMPTY_ANNOTATIONS;
         private NewCookie[] cookies = new NewCookie[0];
-        private MediaType type;
+        private @Nullable MediaType type;
 
         @Override
         public Response build() {
@@ -495,7 +508,7 @@ class JaxRSResponse extends Response implements ContainerResponseContext, Writer
             if (this.type != null) {
                 headers.putSingle(HeaderNames.CONTENT_TYPE.toString(), this.type.toString());
             }
-            return new JaxRSResponse(status, headers, ObjWithType.objType(entity), cookies, linkHeaders, annotations);
+            return new JaxRSResponse(Objects.requireNonNull(status), headers, ObjWithType.objType(entity), cookies, linkHeaders, annotations);
         }
 
         @Override
@@ -509,24 +522,24 @@ class JaxRSResponse extends Response implements ContainerResponseContext, Writer
         }
 
         @Override
-        public ResponseBuilder status(int code, String reasonPhrase) {
+        public ResponseBuilder status(int code, @Nullable String reasonPhrase) {
             if (code < 100 || code > 599) {
                 throw new IllegalArgumentException("Status must be between 100 and 599, but was " + code);
             }
             this.status = Status.fromStatusCode(code);
             if (this.status == null || reasonPhrase != null) {
-                this.status = new CustomStatus(Status.Family.familyOf(code), code, reasonPhrase);
+                this.status = new CustomStatus(Status.Family.familyOf(code), code, reasonPhrase == null ? "" : reasonPhrase);
             }
             return this;
         }
 
         @Override
-        public ResponseBuilder entity(Object entity) {
+        public ResponseBuilder entity(@Nullable Object entity) {
             return entity(entity, EMPTY_ANNOTATIONS);
         }
 
         @Override
-        public ResponseBuilder entity(Object entity, Annotation[] annotations) {
+        public ResponseBuilder entity(@Nullable Object entity, Annotation[] annotations) {
             this.entity = entity;
             this.annotations = annotations;
             return this;
@@ -542,7 +555,7 @@ class JaxRSResponse extends Response implements ContainerResponseContext, Writer
         }
 
         @Override
-        public ResponseBuilder allow(Set<String> methods) {
+        public ResponseBuilder allow(@Nullable Set<String> methods) {
             if (methods == null) {
                 return setHeader(HeaderNames.ALLOW, null, true);
             }
@@ -568,11 +581,11 @@ class JaxRSResponse extends Response implements ContainerResponseContext, Writer
         }
 
         @Override
-        public ResponseBuilder encoding(String encoding) {
+        public ResponseBuilder encoding(@Nullable String encoding) {
             return setHeader(HeaderNames.CONTENT_ENCODING, encoding, false);
         }
 
-        private ResponseBuilder setHeader(CharSequence name, Object value, boolean append) {
+        private ResponseBuilder setHeader(CharSequence name, @Nullable Object value, boolean append) {
             if (value instanceof Iterable) {
                 ((Iterable) value).forEach(v -> setHeader(name, v, append));
             } else {
@@ -606,23 +619,23 @@ class JaxRSResponse extends Response implements ContainerResponseContext, Writer
         }
 
         @Override
-        public ResponseBuilder language(String language) {
+        public ResponseBuilder language(@Nullable String language) {
             return setHeader(HeaderNames.CONTENT_LANGUAGE, language, false);
         }
 
         @Override
-        public ResponseBuilder language(Locale language) {
+        public ResponseBuilder language(@Nullable Locale language) {
             return language(language == null ? null : language.toLanguageTag());
         }
 
         @Override
-        public ResponseBuilder type(MediaType type) {
+        public ResponseBuilder type(@Nullable MediaType type) {
             this.type = type;
             return this;
         }
 
         @Override
-        public ResponseBuilder type(String type) {
+        public ResponseBuilder type(@Nullable String type) {
             if (type == null) {
                 this.type = null;
                 return this;
@@ -631,7 +644,7 @@ class JaxRSResponse extends Response implements ContainerResponseContext, Writer
         }
 
         @Override
-        public ResponseBuilder variant(Variant variant) {
+        public ResponseBuilder variant(@Nullable Variant variant) {
             language(variant == null ? null : variant.getLanguage());
             type(variant == null ? null : variant.getMediaType());
             encoding(variant == null ? null : variant.getEncoding());

--- a/src/main/java/io/muserver/rest/JaxRSResponse.java
+++ b/src/main/java/io/muserver/rest/JaxRSResponse.java
@@ -86,22 +86,22 @@ class JaxRSResponse extends Response implements ContainerResponseContext, Writer
     }
 
     @Override
-    public Class<?> getType() {
-        return Objects.requireNonNull(objWithType.type, "The response entity type has not been set");
+    public @Nullable Class<?> getType() {
+        return objWithType.type;
     }
 
     @Override
-    public void setType(Class<?> type) {
+    public void setType(@Nullable Class<?> type) {
         objWithType = new ObjWithType(type, objWithType.genericType, objWithType.response, objWithType.entity);
     }
 
     @Override
-    public Type getGenericType() {
-        return Objects.requireNonNull(objWithType.genericType, "The response entity generic type has not been set");
+    public @Nullable Type getGenericType() {
+        return objWithType.genericType;
     }
 
     @Override
-    public void setGenericType(Type genericType) {
+    public void setGenericType(@Nullable Type genericType) {
         objWithType = new ObjWithType(objWithType.type, genericType, objWithType.response, objWithType.entity);
     }
 
@@ -112,7 +112,13 @@ class JaxRSResponse extends Response implements ContainerResponseContext, Writer
 
     @Override
     public void setStatus(int code) {
-        this.status = Status.fromStatusCode(code);
+        if (code < 100 || code > 599) {
+            throw new IllegalArgumentException("Status must be between 100 and 599, but was " + code);
+        }
+        Status standardStatus = Status.fromStatusCode(code);
+        this.status = standardStatus == null
+            ? new CustomStatus(Status.Family.familyOf(code), code, "")
+            : standardStatus;
     }
 
     @Override
@@ -122,7 +128,7 @@ class JaxRSResponse extends Response implements ContainerResponseContext, Writer
 
     @Override
     public void setStatusInfo(StatusType statusInfo) {
-        this.status = statusInfo;
+        this.status = Objects.requireNonNull(statusInfo, "statusInfo");
     }
 
     @Override
@@ -131,12 +137,12 @@ class JaxRSResponse extends Response implements ContainerResponseContext, Writer
     }
 
     @Override
-    public Class<?> getEntityClass() {
+    public @Nullable Class<?> getEntityClass() {
         return getType();
     }
 
     @Override
-    public Type getEntityType() {
+    public @Nullable Type getEntityType() {
         return getGenericType();
     }
 
@@ -324,7 +330,7 @@ class JaxRSResponse extends Response implements ContainerResponseContext, Writer
     }
 
     @Override
-    public EntityTag getEntityTag() {
+    public @Nullable EntityTag getEntityTag() {
         Object first = headers.getFirst(HeaderNames.ETAG.toString());
         if (first == null || first instanceof  EntityTag) return (EntityTag)first;
         return MuRuntimeDelegate.entityTagDelegate.fromString(first.toString());
@@ -455,7 +461,7 @@ class JaxRSResponse extends Response implements ContainerResponseContext, Writer
     }
 
     @Override
-    public void setProperty(String name, Object object) {
+    public void setProperty(String name, @Nullable Object object) {
         requiredRequestContext().setProperty(name, object);
     }
 
@@ -541,12 +547,12 @@ class JaxRSResponse extends Response implements ContainerResponseContext, Writer
         @Override
         public ResponseBuilder entity(@Nullable Object entity, Annotation[] annotations) {
             this.entity = entity;
-            this.annotations = annotations;
+            this.annotations = Objects.requireNonNull(annotations, "annotations");
             return this;
         }
 
         @Override
-        public ResponseBuilder allow(String... methods) {
+        public ResponseBuilder allow(String @Nullable ... methods) {
             if (methods == null || (methods.length == 1 && methods[0] == null)) {
                 return allow((Set<String>) null);
             } else {
@@ -576,8 +582,9 @@ class JaxRSResponse extends Response implements ContainerResponseContext, Writer
 
 
         @Override
-        public ResponseBuilder cacheControl(CacheControl cacheControl) {
-            return setHeader(HeaderNames.CACHE_CONTROL, MuRuntimeDelegate.cacheControlHeaderDelegate.toString(cacheControl), false);
+        public ResponseBuilder cacheControl(@Nullable CacheControl cacheControl) {
+            return setHeader(HeaderNames.CACHE_CONTROL,
+                cacheControl == null ? null : MuRuntimeDelegate.cacheControlHeaderDelegate.toString(cacheControl), false);
         }
 
         @Override
@@ -603,12 +610,12 @@ class JaxRSResponse extends Response implements ContainerResponseContext, Writer
         }
 
         @Override
-        public ResponseBuilder header(String name, Object value) {
+        public ResponseBuilder header(String name, @Nullable Object value) {
             return setHeader(name, value, true); // TODO should this actually be false?
         }
 
         @Override
-        public ResponseBuilder replaceAll(MultivaluedMap<String, Object> headers) {
+        public ResponseBuilder replaceAll(@Nullable MultivaluedMap<String, Object> headers) {
             this.headers.clear();
             if (headers != null) {
                 for (Map.Entry<String, List<Object>> entry : headers.entrySet()) {
@@ -652,13 +659,13 @@ class JaxRSResponse extends Response implements ContainerResponseContext, Writer
         }
 
         @Override
-        public ResponseBuilder contentLocation(URI location) {
+        public ResponseBuilder contentLocation(@Nullable URI location) {
             return setHeader(HeaderNames.CONTENT_LOCATION, location, false);
         }
 
         @Override
-        public ResponseBuilder cookie(NewCookie... cookies) {
-            this.cookies = cookies;
+        public ResponseBuilder cookie(NewCookie @Nullable ... cookies) {
+            this.cookies = cookies == null ? new NewCookie[0] : cookies;
             if (cookies == null) {
                 headers.remove(HeaderNames.SET_COOKIE.toString());
             }
@@ -666,37 +673,41 @@ class JaxRSResponse extends Response implements ContainerResponseContext, Writer
         }
 
         @Override
-        public ResponseBuilder expires(Date expires) {
+        public ResponseBuilder expires(@Nullable Date expires) {
             return setHeader(HeaderNames.EXPIRES, expires, false);
         }
 
         @Override
-        public ResponseBuilder lastModified(Date lastModified) {
+        public ResponseBuilder lastModified(@Nullable Date lastModified) {
             return setHeader(HeaderNames.LAST_MODIFIED, lastModified, false);
         }
 
         @Override
-        public ResponseBuilder location(URI location) {
+        public ResponseBuilder location(@Nullable URI location) {
             return setHeader(HeaderNames.LOCATION, location, false);
         }
 
         @Override
-        public ResponseBuilder tag(EntityTag tag) {
+        public ResponseBuilder tag(@Nullable EntityTag tag) {
             return setHeader(HeaderNames.ETAG, tag, false);
         }
 
         @Override
-        public ResponseBuilder tag(String tag) {
-            return tag(new EntityTag(tag));
+        public ResponseBuilder tag(@Nullable String tag) {
+            return tag == null ? tag((EntityTag) null) : tag(new EntityTag(tag));
         }
 
         @Override
-        public ResponseBuilder variants(Variant... variants) {
-            return variants(asList(variants));
+        public ResponseBuilder variants(Variant @Nullable ... variants) {
+            return variants(variants == null ? null : asList(variants));
         }
 
         @Override
-        public ResponseBuilder variants(List<Variant> variants) {
+        public ResponseBuilder variants(@Nullable List<Variant> variants) {
+            if (variants == null) {
+                this.headers.remove("vary");
+                return this;
+            }
             for (Variant variant : variants) {
                 if (variant == null) {
                     this.headers.remove("vary");
@@ -720,7 +731,7 @@ class JaxRSResponse extends Response implements ContainerResponseContext, Writer
         }
 
         @Override
-        public ResponseBuilder links(Link... links) {
+        public ResponseBuilder links(Link @Nullable ... links) {
             if (links == null) {
                 linkHeaders.clear();
             } else {

--- a/src/main/java/io/muserver/rest/JaxRsHttpHeadersAdapter.java
+++ b/src/main/java/io/muserver/rest/JaxRsHttpHeadersAdapter.java
@@ -18,7 +18,7 @@ class JaxRsHttpHeadersAdapter implements HttpHeaders {
     private static final List<MediaType> WILDCARD_MEDIA_TYPES = Collections.singletonList(MediaType.WILDCARD_TYPE);
     private final Headers muHeaders;
     private final List<io.muserver.Cookie> muCookies;
-    private MultivaluedMap<String, String> copy;
+    private @Nullable MultivaluedMap<String, String> copy;
 
     JaxRsHttpHeadersAdapter(Headers headers, List<io.muserver.Cookie> cookies) {
         muHeaders = headers;
@@ -53,7 +53,7 @@ class JaxRsHttpHeadersAdapter implements HttpHeaders {
             }
             copy = c;
         }
-        return copy;
+        return Objects.requireNonNull(copy);
     }
 
     @Override
@@ -68,7 +68,7 @@ class JaxRsHttpHeadersAdapter implements HttpHeaders {
     @Override
     public List<Locale> getAcceptableLanguages() {
         try {
-            return getLocalesFromHeader(HeaderNames.ACCEPT_LANGUAGE, WILDCARD_LOCALES);
+            return Objects.requireNonNull(getLocalesFromHeader(HeaderNames.ACCEPT_LANGUAGE, WILDCARD_LOCALES));
         } catch (IllegalArgumentException e) {
             throw new BadRequestException("Invalid accept-language header");
         }

--- a/src/main/java/io/muserver/rest/JaxSseEventSinkImpl.java
+++ b/src/main/java/io/muserver/rest/JaxSseEventSinkImpl.java
@@ -9,6 +9,7 @@ import jakarta.ws.rs.core.MultivaluedMap;
 import jakarta.ws.rs.ext.MessageBodyWriter;
 import jakarta.ws.rs.sse.OutboundSseEvent;
 import jakarta.ws.rs.sse.SseEventSink;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -26,7 +27,7 @@ class JaxSseEventSinkImpl implements SseEventSink {
     private final AsyncSsePublisher ssePublisher;
     private final MuResponse response;
     private final EntityProviders entityProviders;
-    private volatile MultivaluedMap<String, Object> writerHeadersSnapshot;
+    private volatile @Nullable MultivaluedMap<String, Object> writerHeadersSnapshot;
 
     public JaxSseEventSinkImpl(AsyncSsePublisher ssePublisher, MuResponse response, EntityProviders entityProviders) {
         this.ssePublisher = ssePublisher;

--- a/src/main/java/io/muserver/rest/JaxSseEventSinkImpl.java
+++ b/src/main/java/io/muserver/rest/JaxSseEventSinkImpl.java
@@ -14,6 +14,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.ByteArrayOutputStream;
+import java.lang.reflect.Type;
+import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.TimeUnit;
@@ -46,6 +48,7 @@ class JaxSseEventSinkImpl implements SseEventSink {
 
     @Override
     public CompletionStage<?> send(OutboundSseEvent event) {
+        Objects.requireNonNull(event, "event");
         if (isClosed()) {
             throw new IllegalStateException("The SSE stream was already closed");
         }
@@ -62,14 +65,19 @@ class JaxSseEventSinkImpl implements SseEventSink {
             }
             Object data = event.getData();
             if (data != null) {
-                MessageBodyWriter messageBodyWriter = entityProviders.selectWriter(event.getType(), event.getGenericType(),
+                Class<?> dataType = Objects.requireNonNull(event.getType(), "An SSE event with data must have a raw type");
+                Type genericDataType = event.getGenericType();
+                if (genericDataType == null) {
+                    genericDataType = dataType;
+                }
+                MessageBodyWriter messageBodyWriter = entityProviders.selectWriter(dataType, genericDataType,
                     JaxRSResponse.Builder.EMPTY_ANNOTATIONS, event.getMediaType());
                 String dataString;
                 if (data instanceof String && messageBodyWriter instanceof StringEntityProviders.StringMessageReaderWriter) {
                     dataString = (String) data;
                 } else {
                     try (ByteArrayOutputStream out = new ByteArrayOutputStream()) {
-                        messageBodyWriter.writeTo(data, event.getType(), event.getGenericType(), JaxRSResponse.Builder.EMPTY_ANNOTATIONS,
+                        messageBodyWriter.writeTo(data, dataType, genericDataType, JaxRSResponse.Builder.EMPTY_ANNOTATIONS,
                             event.getMediaType(), new MultivaluedHashMap<>(writerHeaders), out);
                         dataString = out.toString(UTF_8);
                     }

--- a/src/main/java/io/muserver/rest/Jaxutils.java
+++ b/src/main/java/io/muserver/rest/Jaxutils.java
@@ -1,5 +1,6 @@
 package io.muserver.rest;
 
+import org.jspecify.annotations.Nullable;
 import java.io.ByteArrayOutputStream;
 import java.nio.ByteBuffer;
 import java.nio.charset.CharacterCodingException;
@@ -57,7 +58,7 @@ class Jaxutils {
         return decoded.toString();
     }
 
-    private static IllegalArgumentException invalid(String value, Exception cause) {
+    private static IllegalArgumentException invalid(String value, @Nullable Exception cause) {
         return new IllegalArgumentException("Invalid UTF-8 percent encoding in " + value, cause);
     }
 

--- a/src/main/java/io/muserver/rest/LazyAccessInputStream.java
+++ b/src/main/java/io/muserver/rest/LazyAccessInputStream.java
@@ -2,6 +2,7 @@ package io.muserver.rest;
 
 import io.muserver.EmptyInputStream;
 import io.muserver.MuRequest;
+import org.jspecify.annotations.Nullable;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -12,7 +13,7 @@ import java.io.InputStream;
 class LazyAccessInputStream extends InputStream {
 
     private final MuRequest request;
-    private InputStream inputStream;
+    private @Nullable InputStream inputStream;
 
     LazyAccessInputStream(MuRequest request) {
         this.request = request;
@@ -22,7 +23,7 @@ class LazyAccessInputStream extends InputStream {
         if (inputStream == null) {
             inputStream = request.inputStream().orElse(EmptyInputStream.INSTANCE);
         }
-        return inputStream;
+        return java.util.Objects.requireNonNull(inputStream);
     }
 
     @Override

--- a/src/main/java/io/muserver/rest/LazyAccessOutputStream.java
+++ b/src/main/java/io/muserver/rest/LazyAccessOutputStream.java
@@ -1,6 +1,7 @@
 package io.muserver.rest;
 
 import io.muserver.MuResponse;
+import org.jspecify.annotations.Nullable;
 
 import java.io.IOException;
 import java.io.OutputStream;
@@ -12,7 +13,7 @@ import java.util.Objects;
 class LazyAccessOutputStream extends OutputStream {
     private final MuResponse muResponse;
     private final Runnable beforeFirstWrite;
-    private OutputStream os;
+    private @Nullable OutputStream os;
     private boolean prepared;
 
     private OutputStream out() {
@@ -20,7 +21,7 @@ class LazyAccessOutputStream extends OutputStream {
             prepare();
             os = muResponse.outputStream();
         }
-        return os;
+        return Objects.requireNonNull(os);
     }
 
     LazyAccessOutputStream(MuResponse muResponse, Runnable beforeFirstWrite) {

--- a/src/main/java/io/muserver/rest/LinkHeaderDelegate.java
+++ b/src/main/java/io/muserver/rest/LinkHeaderDelegate.java
@@ -37,11 +37,19 @@ class LinkHeaderDelegate implements RuntimeDelegate.HeaderDelegate<Link> {
         }
 
         Map<String, String> parma = h.parameters();
-        Link.Builder builder = new MuLinkBuilder()
-            .uri(uri.substring(1, uri.length() - 1))
-            .rel(parma.get("rel"))
-            .title(parma.get("title"))
-            .type(parma.get("type"));
+        Link.Builder builder = new MuLinkBuilder().uri(uri.substring(1, uri.length() - 1));
+        String rel = parma.get("rel");
+        if (rel != null) {
+            builder.rel(rel);
+        }
+        String title = parma.get("title");
+        if (title != null) {
+            builder.title(title);
+        }
+        String type = parma.get("type");
+        if (type != null) {
+            builder.type(type);
+        }
 
         for (Map.Entry<String, String> entry : parma.entrySet()) {
             String key = entry.getKey();
@@ -56,6 +64,7 @@ class LinkHeaderDelegate implements RuntimeDelegate.HeaderDelegate<Link> {
 
     @Override
     public String toString(Link value) {
+        Mutils.notNull("value", value);
         StringBuilder sb = new StringBuilder();
         sb.append("<").append(value.getUri().toString()).append(">");
         if (value.getRels().size() > 0) {
@@ -138,7 +147,7 @@ class LinkHeaderDelegate implements RuntimeDelegate.HeaderDelegate<Link> {
         }
 
         @Override
-        public boolean equals(Object o) {
+        public boolean equals(@Nullable Object o) {
             if (this == o) return true;
             if (o == null || getClass() != o.getClass()) return false;
             MuLink muLink = (MuLink) o;
@@ -166,6 +175,7 @@ class LinkHeaderDelegate implements RuntimeDelegate.HeaderDelegate<Link> {
 
         @Override
         public Link.Builder link(Link link) {
+            Mutils.notNull("link", link);
             this.uri = link.getUriBuilder();
             this.rels = link.getRels();
             this.title = link.getTitle();
@@ -181,36 +191,42 @@ class LinkHeaderDelegate implements RuntimeDelegate.HeaderDelegate<Link> {
 
         @Override
         public Link.Builder uri(URI uri) {
+            Mutils.notNull("uri", uri);
             this.uri = UriBuilder.fromUri(uri);
             return this;
         }
 
         @Override
         public Link.Builder uri(String uri) {
+            Mutils.notNull("uri", uri);
             this.uri = UriBuilder.fromUri(uri);
             return this;
         }
 
         @Override
         public Link.Builder baseUri(URI uri) {
+            Mutils.notNull("uri", uri);
             this.baseUri = uri;
             return this;
         }
 
         @Override
         public Link.Builder baseUri(String uri) {
+            Mutils.notNull("uri", uri);
             return baseUri(URI.create(uri));
         }
 
         @Override
         public Link.Builder uriBuilder(UriBuilder uriBuilder) {
+            Mutils.notNull("uriBuilder", uriBuilder);
             this.uri = uriBuilder;
             return this;
         }
 
         @Override
         public Link.Builder rel(String rel) {
-            if (rel == null || rel.isEmpty()) {
+            Mutils.notNull("rel", rel);
+            if (rel.isEmpty()) {
                 return this;
             }
             if (rels == null) {
@@ -222,18 +238,22 @@ class LinkHeaderDelegate implements RuntimeDelegate.HeaderDelegate<Link> {
 
         @Override
         public Link.Builder title(String title) {
+            Mutils.notNull("title", title);
             this.title = title;
             return this;
         }
 
         @Override
         public Link.Builder type(String type) {
+            Mutils.notNull("type", type);
             this.type = type;
             return this;
         }
 
         @Override
         public Link.Builder param(String name, String value) {
+            Mutils.notNull("name", name);
+            Mutils.notNull("value", value);
             if (params == null) {
                 params = new HashMap<>();
             }
@@ -243,11 +263,16 @@ class LinkHeaderDelegate implements RuntimeDelegate.HeaderDelegate<Link> {
 
         @Override
         public Link build(Object... values) {
-            return buildRelativized(null, values);
+            return buildInternal(null, values);
         }
 
         @Override
-        public Link buildRelativized(@Nullable URI relativeTo, Object... values) {
+        public Link buildRelativized(URI relativeTo, Object... values) {
+            Mutils.notNull("relativeTo", relativeTo);
+            return buildInternal(relativeTo, values);
+        }
+
+        private Link buildInternal(@Nullable URI relativeTo, Object... values) {
             if (this.uri == null) {
                 throw new UriBuilderException("No URI has been set");
             }

--- a/src/main/java/io/muserver/rest/LinkHeaderDelegate.java
+++ b/src/main/java/io/muserver/rest/LinkHeaderDelegate.java
@@ -6,6 +6,7 @@ import jakarta.ws.rs.core.Link;
 import jakarta.ws.rs.core.UriBuilder;
 import jakarta.ws.rs.core.UriBuilderException;
 import jakarta.ws.rs.ext.RuntimeDelegate;
+import org.jspecify.annotations.Nullable;
 
 import java.net.URI;
 import java.util.*;
@@ -81,19 +82,19 @@ class LinkHeaderDelegate implements RuntimeDelegate.HeaderDelegate<Link> {
 
         private final URI uri;
         private final List<String> rels;
-        private final String title;
-        private final String type;
+        private final @Nullable String title;
+        private final @Nullable String type;
         private final Map<String, String> params;
 
-        MuLink(URI uri, List<String> rels, String title, String type, Map<String, String> params) {
+        MuLink(URI uri, List<String> rels, @Nullable String title, @Nullable String type, Map<String, String> params) {
             Mutils.notNull("uri", uri);
+            this.uri = java.util.Objects.requireNonNull(uri);
             Mutils.notNull("rels", rels);
-            Mutils.notNull("params", params);
-            this.uri = uri;
-            this.rels = rels;
+            this.rels = java.util.Objects.requireNonNull(rels);
             this.title = title;
             this.type = type;
-            this.params = params;
+            Mutils.notNull("params", params);
+            this.params = java.util.Objects.requireNonNull(params);
         }
 
         @Override
@@ -107,7 +108,7 @@ class LinkHeaderDelegate implements RuntimeDelegate.HeaderDelegate<Link> {
         }
 
         @Override
-        public String getRel() {
+        public @Nullable String getRel() {
             return rels.isEmpty() ? null : rels.get(0);
         }
 
@@ -117,12 +118,12 @@ class LinkHeaderDelegate implements RuntimeDelegate.HeaderDelegate<Link> {
         }
 
         @Override
-        public String getTitle() {
+        public @Nullable String getTitle() {
             return title;
         }
 
         @Override
-        public String getType() {
+        public @Nullable String getType() {
             return type;
         }
 
@@ -156,12 +157,12 @@ class LinkHeaderDelegate implements RuntimeDelegate.HeaderDelegate<Link> {
 
     static class MuLinkBuilder implements Link.Builder {
 
-        private UriBuilder uri;
-        private List<String> rels;
-        private String title;
-        private String type;
-        private Map<String, String> params;
-        private URI baseUri;
+        private @Nullable UriBuilder uri;
+        private @Nullable List<String> rels;
+        private @Nullable String title;
+        private @Nullable String type;
+        private @Nullable Map<String, String> params;
+        private @Nullable URI baseUri;
 
         @Override
         public Link.Builder link(Link link) {
@@ -246,7 +247,7 @@ class LinkHeaderDelegate implements RuntimeDelegate.HeaderDelegate<Link> {
         }
 
         @Override
-        public Link buildRelativized(URI relativeTo, Object... values) {
+        public Link buildRelativized(@Nullable URI relativeTo, Object... values) {
             if (this.uri == null) {
                 throw new UriBuilderException("No URI has been set");
             }
@@ -257,7 +258,9 @@ class LinkHeaderDelegate implements RuntimeDelegate.HeaderDelegate<Link> {
             if (relativeTo != null) {
                 built = relativeTo.relativize(built);
             }
-            return new MuLink(built, coalesce(rels, emptyList()), title, type, coalesce(params, emptyMap()));
+            List<String> relsToUse = rels == null ? emptyList() : rels;
+            Map<String, String> paramsToUse = params == null ? emptyMap() : params;
+            return new MuLink(built, relsToUse, title, type, paramsToUse);
         }
     }
 }

--- a/src/main/java/io/muserver/rest/LowercasedMultivaluedHashMap.java
+++ b/src/main/java/io/muserver/rest/LowercasedMultivaluedHashMap.java
@@ -24,12 +24,12 @@ class LowercasedMultivaluedHashMap<V> extends AbstractMultivaluedMap<String, V> 
      */
     private static class LowercasedHashMap<V> extends HashMap<String, V> {
         @Override
-        public @Nullable V get(Object key) {
+        public @Nullable V get(@Nullable Object key) {
             return super.get(toLower(key));
         }
 
         @Override
-        public boolean containsKey(Object key) {
+        public boolean containsKey(@Nullable Object key) {
             return super.containsKey(toLower(key));
         }
 
@@ -46,12 +46,12 @@ class LowercasedMultivaluedHashMap<V> extends AbstractMultivaluedMap<String, V> 
         }
 
         @Override
-        public @Nullable V remove(Object key) {
+        public @Nullable V remove(@Nullable Object key) {
             return super.remove(toLower(key));
         }
 
         @Override
-        public V getOrDefault(Object key, V defaultValue) {
+        public @Nullable V getOrDefault(@Nullable Object key, @Nullable V defaultValue) {
             return super.getOrDefault(toLower(key), defaultValue);
         }
 
@@ -61,7 +61,7 @@ class LowercasedMultivaluedHashMap<V> extends AbstractMultivaluedMap<String, V> 
         }
 
         @Override
-        public boolean remove(Object key, Object value) {
+        public boolean remove(@Nullable Object key, @Nullable Object value) {
             return super.remove(toLower(key), value);
         }
 
@@ -95,7 +95,7 @@ class LowercasedMultivaluedHashMap<V> extends AbstractMultivaluedMap<String, V> 
             return super.merge(key.toLowerCase(), value, remappingFunction);
         }
 
-        private static Object toLower(Object val) {
+        private static @Nullable Object toLower(@Nullable Object val) {
             if (val instanceof String) {
                 return ((String) val).toLowerCase();
             }

--- a/src/main/java/io/muserver/rest/LowercasedMultivaluedHashMap.java
+++ b/src/main/java/io/muserver/rest/LowercasedMultivaluedHashMap.java
@@ -1,6 +1,7 @@
 package io.muserver.rest;
 
 import jakarta.ws.rs.core.AbstractMultivaluedMap;
+import org.jspecify.annotations.Nullable;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -23,7 +24,7 @@ class LowercasedMultivaluedHashMap<V> extends AbstractMultivaluedMap<String, V> 
      */
     private static class LowercasedHashMap<V> extends HashMap<String, V> {
         @Override
-        public V get(Object key) {
+        public @Nullable V get(Object key) {
             return super.get(toLower(key));
         }
 
@@ -33,7 +34,7 @@ class LowercasedMultivaluedHashMap<V> extends AbstractMultivaluedMap<String, V> 
         }
 
         @Override
-        public V put(String key, V value) {
+        public @Nullable V put(String key, V value) {
             return super.put(key.toLowerCase(), value);
         }
 
@@ -45,7 +46,7 @@ class LowercasedMultivaluedHashMap<V> extends AbstractMultivaluedMap<String, V> 
         }
 
         @Override
-        public V remove(Object key) {
+        public @Nullable V remove(Object key) {
             return super.remove(toLower(key));
         }
 
@@ -55,7 +56,7 @@ class LowercasedMultivaluedHashMap<V> extends AbstractMultivaluedMap<String, V> 
         }
 
         @Override
-        public V putIfAbsent(String key, V value) {
+        public @Nullable V putIfAbsent(String key, V value) {
             return super.putIfAbsent(key.toLowerCase(), value);
         }
 
@@ -70,27 +71,27 @@ class LowercasedMultivaluedHashMap<V> extends AbstractMultivaluedMap<String, V> 
         }
 
         @Override
-        public V replace(String key, V value) {
+        public @Nullable V replace(String key, V value) {
             return super.replace(key.toLowerCase(), value);
         }
 
         @Override
-        public V computeIfAbsent(String key, Function<? super String, ? extends V> mappingFunction) {
+        public @Nullable V computeIfAbsent(String key, Function<? super String, ? extends V> mappingFunction) {
             return super.computeIfAbsent(key.toLowerCase(), mappingFunction);
         }
 
         @Override
-        public V computeIfPresent(String key, BiFunction<? super String, ? super V, ? extends V> remappingFunction) {
+        public @Nullable V computeIfPresent(String key, BiFunction<? super String, ? super V, ? extends V> remappingFunction) {
             return super.computeIfPresent(key.toLowerCase(), remappingFunction);
         }
 
         @Override
-        public V compute(String key, BiFunction<? super String, ? super V, ? extends V> remappingFunction) {
+        public @Nullable V compute(String key, BiFunction<? super String, ? super V, ? extends V> remappingFunction) {
             return super.compute(key.toLowerCase(), remappingFunction);
         }
 
         @Override
-        public V merge(String key, V value, BiFunction<? super V, ? super V, ? extends V> remappingFunction) {
+        public @Nullable V merge(String key, V value, BiFunction<? super V, ? super V, ? extends V> remappingFunction) {
             return super.merge(key.toLowerCase(), value, remappingFunction);
         }
 

--- a/src/main/java/io/muserver/rest/MediaTypeDeterminer.java
+++ b/src/main/java/io/muserver/rest/MediaTypeDeterminer.java
@@ -82,13 +82,13 @@ class MediaTypeDeterminer {
         // 8. For each member of M,m: • If m is a concrete type, set Mselected = m, finish.
         for (CombinedMediaType mediaType : m) {
             if (mediaType.isConcrete()) {
-                return new MediaType(mediaType.type, mediaType.subType, mediaType.charset);
+                return new MediaType(Objects.requireNonNull(mediaType.type), Objects.requireNonNull(mediaType.subType), mediaType.charset);
             }
         }
 
         // 9. If M contains ‘*/*’ or ‘application/*’, set Mselected = ‘application/octet-stream’, finish
         for (CombinedMediaType mediaType : m) {
-            if ((mediaType.isWildcardType || mediaType.type.equals("application")) && mediaType.isWildcardSubtype) {
+            if ((mediaType.isWildcardType || "application".equals(mediaType.type)) && mediaType.isWildcardSubtype) {
                 return MediaType.APPLICATION_OCTET_STREAM_TYPE;
             }
         }

--- a/src/main/java/io/muserver/rest/MediaTypeHeaderDelegate.java
+++ b/src/main/java/io/muserver/rest/MediaTypeHeaderDelegate.java
@@ -1,6 +1,7 @@
 package io.muserver.rest;
 
 import io.muserver.MediaTypeParser;
+import io.muserver.Mutils;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.ext.RuntimeDelegate;
 import org.jspecify.annotations.Nullable;
@@ -19,11 +20,13 @@ class MediaTypeHeaderDelegate implements RuntimeDelegate.HeaderDelegate<MediaTyp
 
     @Override
     public MediaType fromString(String value) {
+        Mutils.notNull("value", value);
         return MediaTypeParser.fromString(value);
     }
 
     @Override
     public String toString(MediaType mediaType) {
+        Mutils.notNull("mediaType", mediaType);
         return MediaTypeParser.toString(mediaType);
     }
 

--- a/src/main/java/io/muserver/rest/MediaTypeHeaderDelegate.java
+++ b/src/main/java/io/muserver/rest/MediaTypeHeaderDelegate.java
@@ -3,6 +3,7 @@ package io.muserver.rest;
 import io.muserver.MediaTypeParser;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.ext.RuntimeDelegate;
+import org.jspecify.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -26,7 +27,7 @@ class MediaTypeHeaderDelegate implements RuntimeDelegate.HeaderDelegate<MediaTyp
         return MediaTypeParser.toString(mediaType);
     }
 
-    static List<MediaType> fromStrings(List<String> accepts) {
+    static List<MediaType> fromStrings(@Nullable List<String> accepts) {
         if (accepts == null || accepts.isEmpty()) {
             return Collections.emptyList();
         }
@@ -39,7 +40,7 @@ class MediaTypeHeaderDelegate implements RuntimeDelegate.HeaderDelegate<MediaTyp
         return results;
     }
 
-    static boolean atLeastOneCompatible(List<MediaType> providerProduces, List<MediaType> consumerAccepts, String checkParameter) {
+    static boolean atLeastOneCompatible(List<MediaType> providerProduces, List<MediaType> consumerAccepts, @Nullable String checkParameter) {
         for (MediaType clientAccept : consumerAccepts) {
             for (MediaType produce : providerProduces) {
                 boolean compatible = produce.isCompatible(clientAccept);
@@ -47,7 +48,7 @@ class MediaTypeHeaderDelegate implements RuntimeDelegate.HeaderDelegate<MediaTyp
                     if (checkParameter != null) {
                         String clientParam = clientAccept.getParameters().get(checkParameter);
                         if (clientParam != null) {
-                            String serverParam = produce.getParameters().get(checkParameter);
+                            @Nullable String serverParam = produce.getParameters().get(checkParameter);
                             compatible = clientParam.equalsIgnoreCase(serverParam);
                         }
                     }

--- a/src/main/java/io/muserver/rest/MuPathSegment.java
+++ b/src/main/java/io/muserver/rest/MuPathSegment.java
@@ -4,6 +4,7 @@ import io.muserver.Mutils;
 import jakarta.ws.rs.core.MultivaluedHashMap;
 import jakarta.ws.rs.core.MultivaluedMap;
 import jakarta.ws.rs.core.PathSegment;
+import org.jspecify.annotations.Nullable;
 
 import java.util.*;
 import java.util.function.Function;
@@ -58,7 +59,7 @@ class MuPathSegment implements PathSegment {
     }
 
     @Override
-    public boolean equals(Object o) {
+    public boolean equals(@Nullable Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         MuPathSegment that = (MuPathSegment) o;

--- a/src/main/java/io/muserver/rest/MuPathSegment.java
+++ b/src/main/java/io/muserver/rest/MuPathSegment.java
@@ -95,7 +95,7 @@ class MuPathSegment implements PathSegment {
     }
 
     public List<MuPathSegment> resolve(String name, String value, boolean encodeSlashInPath) {
-        String newPath = MuUriBuilder.resolve(path, name, value);
+        String newPath = Objects.requireNonNull(MuUriBuilder.resolve(path, name, value));
         MultivaluedMap<String, String> newParams = new MultivaluedHashMap<>();
         for (Map.Entry<String, List<String>> matrixParam : params.entrySet()) {
             newParams.put(MuUriBuilder.resolve(matrixParam.getKey(), name, value), matrixParam.getValue().stream()

--- a/src/main/java/io/muserver/rest/MuRuntimeDelegate.java
+++ b/src/main/java/io/muserver/rest/MuRuntimeDelegate.java
@@ -11,6 +11,7 @@ import jakarta.ws.rs.core.*;
 import jakarta.ws.rs.ext.RuntimeDelegate;
 import jakarta.ws.rs.sse.Sse;
 import jakarta.ws.rs.sse.SseBroadcaster;
+import org.jspecify.annotations.Nullable;
 
 import java.net.URI;
 import java.util.*;
@@ -40,7 +41,7 @@ public class MuRuntimeDelegate extends RuntimeDelegate {
         headerDelegates.put(Date.class, new DateHeaderDelegate());
     }
 
-    private static MuRuntimeDelegate singleton;
+    private static @Nullable MuRuntimeDelegate singleton;
 
     /**
      * Registers the mu RuntimeDelegate with jax-rs, if it was not already.
@@ -51,7 +52,7 @@ public class MuRuntimeDelegate extends RuntimeDelegate {
             singleton = new MuRuntimeDelegate();
             RuntimeDelegate.setInstance(singleton);
         }
-        return singleton;
+        return Objects.requireNonNull(singleton);
     }
 
     /**

--- a/src/main/java/io/muserver/rest/MuRuntimeDelegate.java
+++ b/src/main/java/io/muserver/rest/MuRuntimeDelegate.java
@@ -129,6 +129,7 @@ public class MuRuntimeDelegate extends RuntimeDelegate {
     @Override
     @SuppressWarnings("unchecked")
     public <T> HeaderDelegate<T> createHeaderDelegate(Class<T> type) throws IllegalArgumentException {
+        Mutils.notNull("type", type);
         HeaderDelegate<T> headerDelegate = (HeaderDelegate<T>)headerDelegates.get(type);
         if (headerDelegate != null) {
             return headerDelegate;

--- a/src/main/java/io/muserver/rest/MuSeBootstrap.java
+++ b/src/main/java/io/muserver/rest/MuSeBootstrap.java
@@ -7,6 +7,7 @@ import io.muserver.MuServerBuilder;
 import jakarta.ws.rs.ApplicationPath;
 import jakarta.ws.rs.SeBootstrap;
 import jakarta.ws.rs.core.Application;
+import org.jspecify.annotations.Nullable;
 
 import javax.net.ssl.SSLContext;
 import java.lang.reflect.InvocationTargetException;
@@ -187,7 +188,7 @@ final class MuSeBootstrap {
         }
 
         @Override
-        public Object property(String name) {
+        public @Nullable Object property(String name) {
             return properties.get(name);
         }
     }
@@ -214,7 +215,7 @@ final class MuSeBootstrap {
             }
             return CompletableFuture.completedFuture(new StopResult() {
                 @Override
-                public <T> T unwrap(Class<T> nativeClass) {
+                public <T> @Nullable T unwrap(Class<T> nativeClass) {
                     return null;
                 }
             });

--- a/src/main/java/io/muserver/rest/MuSeBootstrap.java
+++ b/src/main/java/io/muserver/rest/MuSeBootstrap.java
@@ -133,7 +133,7 @@ final class MuSeBootstrap {
         }
 
         @Override
-        public SeBootstrap.Configuration.Builder property(String name, Object value) {
+        public SeBootstrap.Configuration.Builder property(String name, @Nullable Object value) {
             Objects.requireNonNull(name, "name");
             if (PROPERTY_TYPES.containsKey(name)) {
                 if (value == null) {

--- a/src/main/java/io/muserver/rest/MuSecurityContext.java
+++ b/src/main/java/io/muserver/rest/MuSecurityContext.java
@@ -1,17 +1,18 @@
 package io.muserver.rest;
 
 import jakarta.ws.rs.core.SecurityContext;
+import org.jspecify.annotations.Nullable;
 
 import java.security.Principal;
 
 class MuSecurityContext implements SecurityContext {
 
-    private final Principal principal;
+    private final @Nullable Principal principal;
     private final Authorizer authorizer;
     private final boolean isHttps;
-    private final String authenticationScheme;
+    private final @Nullable String authenticationScheme;
 
-    MuSecurityContext(Principal principal, Authorizer authorizer, boolean isHttps, String authenticationScheme) {
+    MuSecurityContext(@Nullable Principal principal, Authorizer authorizer, boolean isHttps, @Nullable String authenticationScheme) {
         this.principal = principal;
         this.authorizer = authorizer;
         this.isHttps = isHttps;
@@ -19,13 +20,13 @@ class MuSecurityContext implements SecurityContext {
     }
 
     @Override
-    public Principal getUserPrincipal() {
+    public @Nullable Principal getUserPrincipal() {
         return principal;
     }
 
     @Override
     public boolean isUserInRole(String role) {
-        return authorizer.isInRole(principal, role);
+        return principal != null && authorizer.isInRole(principal, role);
     }
 
     @Override
@@ -34,7 +35,7 @@ class MuSecurityContext implements SecurityContext {
     }
 
     @Override
-    public String getAuthenticationScheme() {
+    public @Nullable String getAuthenticationScheme() {
         return authenticationScheme;
     }
 

--- a/src/main/java/io/muserver/rest/MuUriBuilder.java
+++ b/src/main/java/io/muserver/rest/MuUriBuilder.java
@@ -26,21 +26,21 @@ class MuUriBuilder extends UriBuilder {
         MuRuntimeDelegate.ensureSet();
     }
 
-    private String scheme;
-    private String userInfo;
-    private String host;
+    private @Nullable String scheme;
+    private @Nullable String userInfo;
+    private @Nullable String host;
     private int port = -1;
     private List<MuPathSegment> pathSegments = new ArrayList<>();
     private MultivaluedMap<String, String> query = new MultivaluedHashMap<>();
-    private String fragment;
+    private @Nullable String fragment;
     private boolean hasPrecedingSlash = false;
     private boolean hasTrailingSlash = false;
 
     MuUriBuilder() {
     }
 
-    private MuUriBuilder(String scheme, String userInfo, String host, int port, List<MuPathSegment> pathSegments,
-                         boolean hasPrecedingSlash, boolean hasTrailingSlash, MultivaluedMap<String, String> query, String fragment) {
+    private MuUriBuilder(@Nullable String scheme, @Nullable String userInfo, @Nullable String host, int port, List<MuPathSegment> pathSegments,
+                         boolean hasPrecedingSlash, boolean hasTrailingSlash, MultivaluedMap<String, String> query, @Nullable String fragment) {
         this.scheme = scheme;
         this.userInfo = userInfo;
         this.host = host;
@@ -127,7 +127,7 @@ class MuUriBuilder extends UriBuilder {
     public UriBuilder path(String path) {
         Mutils.notNull("path", path);
         setSlashes(path);
-        this.pathSegments.addAll(MuUriInfo.pathStringToSegments(decode(path), false).collect(toList()));
+        this.pathSegments.addAll(MuUriInfo.pathStringToSegments(Objects.requireNonNull(decode(path)), false).collect(toList()));
         return this;
     }
 
@@ -184,7 +184,7 @@ class MuUriBuilder extends UriBuilder {
         Mutils.notNull("segments", segments);
         for (String segment : segments) {
             Mutils.notNull("segment", segment);
-            this.pathSegments.addAll(MuUriInfo.pathStringToSegments(decode(segment), true).collect(toList()));
+            this.pathSegments.addAll(MuUriInfo.pathStringToSegments(Objects.requireNonNull(decode(segment)), true).collect(toList()));
         }
         this.hasTrailingSlash = false;
         return this;
@@ -494,7 +494,7 @@ class MuUriBuilder extends UriBuilder {
         return map;
     }
 
-    private static void addTemplateNames(List<String> sorted, String value) {
+    private static void addTemplateNames(List<String> sorted, @Nullable String value) {
         if (value != null) {
             List<String> toAdd = UriPattern.uriTemplateToRegex(value).namedGroups();
             for (String s : toAdd) {
@@ -505,7 +505,7 @@ class MuUriBuilder extends UriBuilder {
         }
     }
 
-    private static String decode(Object value) {
+    private static @Nullable String decode(@Nullable Object value) {
         return value == null ? null : Jaxutils.leniantUrlDecode(value.toString());
     }
 

--- a/src/main/java/io/muserver/rest/MuUriBuilder.java
+++ b/src/main/java/io/muserver/rest/MuUriBuilder.java
@@ -61,6 +61,7 @@ class MuUriBuilder extends UriBuilder {
 
     @Override
     public UriBuilder uri(URI uri) {
+        Mutils.notNull("uri", uri);
         scheme(uri.getScheme());
         userInfo(uri.getUserInfo());
         host(uri.getHost());
@@ -89,6 +90,7 @@ class MuUriBuilder extends UriBuilder {
 
     @Override
     public UriBuilder schemeSpecificPart(String ssp) {
+        Mutils.notNull("ssp", ssp);
         MuUriBuilder builder = (MuUriBuilder) fromUri(URI.create(scheme + "://" + ssp));
         this.scheme = builder.scheme;
         this.userInfo = builder.userInfo;
@@ -100,19 +102,19 @@ class MuUriBuilder extends UriBuilder {
     }
 
     @Override
-    public UriBuilder scheme(String scheme) {
+    public UriBuilder scheme(@Nullable String scheme) {
         this.scheme = decode(scheme);
         return this;
     }
 
     @Override
-    public UriBuilder userInfo(String userInfo) {
+    public UriBuilder userInfo(@Nullable String userInfo) {
         this.userInfo = decode(userInfo);
         return this;
     }
 
     @Override
-    public UriBuilder host(String host) {
+    public UriBuilder host(@Nullable String host) {
         this.host = decode(host);
         return this;
     }
@@ -132,9 +134,11 @@ class MuUriBuilder extends UriBuilder {
     }
 
     @Override
-    public UriBuilder replacePath(String path) {
+    public UriBuilder replacePath(@Nullable String path) {
         this.pathSegments.clear();
-        return path(path);
+        this.hasPrecedingSlash = false;
+        this.hasTrailingSlash = false;
+        return path == null ? this : path(path);
     }
 
     @Override
@@ -191,7 +195,7 @@ class MuUriBuilder extends UriBuilder {
     }
 
     @Override
-    public UriBuilder replaceMatrix(String matrix) {
+    public UriBuilder replaceMatrix(@Nullable String matrix) {
         MultivaluedMap<String, String> params = getOrCreateCurrentSegment().getMatrixParameters();
         params.clear();
         if (matrix != null) {
@@ -221,12 +225,11 @@ class MuUriBuilder extends UriBuilder {
     }
 
     @Override
-    public UriBuilder replaceMatrixParam(String name, Object... values) {
+    public UriBuilder replaceMatrixParam(String name, Object @Nullable ... values) {
         Mutils.notNull("name", name);
-        Mutils.notNull("values", values);
         MultivaluedMap<String, String> params = getOrCreateCurrentSegment().getMatrixParameters();
-        params.replace(name, Stream.of(values).map(Object::toString).collect(toList()));
-        return this;
+        params.remove(name);
+        return values == null || values.length == 0 ? this : matrixParam(name, values);
     }
 
     private MuPathSegment getOrCreateCurrentSegment() {
@@ -241,7 +244,7 @@ class MuUriBuilder extends UriBuilder {
     }
 
     @Override
-    public UriBuilder replaceQuery(String qs) {
+    public UriBuilder replaceQuery(@Nullable String qs) {
         if (qs == null) {
             this.query.clear();
         } else {
@@ -266,14 +269,14 @@ class MuUriBuilder extends UriBuilder {
     }
 
     @Override
-    public UriBuilder replaceQueryParam(String name, Object... values) {
+    public UriBuilder replaceQueryParam(String name, Object @Nullable ... values) {
         Mutils.notNull("name", name);
         query.remove(name);
         return values == null ? this : queryParam(name, values);
     }
 
     @Override
-    public UriBuilder fragment(String fragment) {
+    public UriBuilder fragment(@Nullable String fragment) {
         this.fragment = decode(fragment);
         return this;
     }

--- a/src/main/java/io/muserver/rest/MuUriInfo.java
+++ b/src/main/java/io/muserver/rest/MuUriInfo.java
@@ -3,6 +3,7 @@ package io.muserver.rest;
 import io.muserver.Mutils;
 import io.muserver.QueryString;
 import jakarta.ws.rs.core.*;
+import org.jspecify.annotations.Nullable;
 
 import java.net.URI;
 import java.util.ArrayList;
@@ -24,9 +25,9 @@ class MuUriInfo implements UriInfo {
     private final URI baseUri;
     private final URI requestUri;
     private final String encodedRelativePath;
-    private final RequestMatcher.MatchedMethod matchedMethod;
+    private final RequestMatcher.@Nullable MatchedMethod matchedMethod;
 
-    MuUriInfo(URI baseUri, URI requestUri, String encodedRelativePath, RequestMatcher.MatchedMethod matchedMethod) {
+    MuUriInfo(URI baseUri, URI requestUri, String encodedRelativePath, RequestMatcher.@Nullable MatchedMethod matchedMethod) {
         this.baseUri = baseUri;
         this.requestUri = requestUri;
         this.encodedRelativePath = encodedRelativePath;
@@ -168,7 +169,7 @@ class MuUriInfo implements UriInfo {
 
     @Override
     public List<String> getMatchedURIs(boolean decode) {
-        RequestMatcher.MatchedMethod mm = matchedMethod;
+        RequestMatcher.@Nullable MatchedMethod mm = matchedMethod;
         if (mm == null) {
             return Collections.emptyList();
         }
@@ -183,7 +184,8 @@ class MuUriInfo implements UriInfo {
 
     @Override
     public List<Object> getMatchedResources() {
-        return matchedMethod == null ? Collections.emptyList() : Collections.singletonList(matchedMethod.matchedClass.resourceClass.resourceInstance);
+        return matchedMethod == null ? Collections.emptyList()
+            : Collections.singletonList(matchedMethod.matchedClass.resourceClass.requiredResourceInstance());
     }
 
     @Override

--- a/src/main/java/io/muserver/rest/ObjWithType.java
+++ b/src/main/java/io/muserver/rest/ObjWithType.java
@@ -2,18 +2,19 @@ package io.muserver.rest;
 
 import jakarta.ws.rs.core.GenericEntity;
 import jakarta.ws.rs.core.Response;
+import org.jspecify.annotations.Nullable;
 
 import java.lang.reflect.Type;
 
 class ObjWithType {
     private static final ObjWithType EMPTY = new ObjWithType(null, null, null, null);
 
-    final Class type;
-    final Type genericType;
-    final JaxRSResponse response;
-    final Object entity;
+    final @Nullable Class type;
+    final @Nullable Type genericType;
+    final @Nullable JaxRSResponse response;
+    final @Nullable Object entity;
 
-    ObjWithType(Class type, Type genericType, JaxRSResponse response, Object entity) {
+    ObjWithType(@Nullable Class type, @Nullable Type genericType, @Nullable JaxRSResponse response, @Nullable Object entity) {
         this.type = type;
         this.genericType = genericType;
         this.response = response;
@@ -32,16 +33,16 @@ class ObjWithType {
         }
     }
 
-    static ObjWithType objType(Object valueFromMethod) {
+    static ObjWithType objType(@Nullable Object valueFromMethod) {
         return objType(valueFromMethod, null);
     }
 
-    static ObjWithType objType(Object valueFromMethod, Type resourceMethodReturnType) {
+    static ObjWithType objType(@Nullable Object valueFromMethod, @Nullable Type resourceMethodReturnType) {
         if (valueFromMethod == null) {
             return EMPTY;
         }
-        Object entity;
-        JaxRSResponse response;
+        @Nullable Object entity;
+        @Nullable JaxRSResponse response;
         if (valueFromMethod instanceof Response) {
             response = JaxRSResponse.from((Response) valueFromMethod);
             entity = response.getEntity();
@@ -49,8 +50,8 @@ class ObjWithType {
             response = null;
             entity = valueFromMethod;
         }
-        Class type;
-        Type genericType;
+        @Nullable Class type;
+        @Nullable Type genericType;
         if (entity instanceof GenericEntity) {
             GenericEntity ge = (GenericEntity) entity;
             entity = ge.getEntity();

--- a/src/main/java/io/muserver/rest/OpenApiDocumentor.java
+++ b/src/main/java/io/muserver/rest/OpenApiDocumentor.java
@@ -149,13 +149,14 @@ class OpenApiDocumentor implements MuHandler {
 
             String path = getPathWithoutRegex(root, method, parentResourcePath);
 
-            Map<String, OperationObject> operations;
+            PathItemObjectBuilder pathItem;
+            @Nullable Map<String, OperationObject> operations;
             if (pathItems.containsKey(path)) {
-                operations = pathItems.get(path).operations();
+                pathItem = Objects.requireNonNull(pathItems.get(path));
+                operations = pathItem.operations();
             } else {
                 operations = new LinkedHashMap<>();
-                PathItemObjectBuilder pathItem = pathItemObject()
-                    .withOperations(operations);
+                pathItem = pathItemObject().withOperations(operations);
                 pathItems.put(path, pathItem);
             }
             List<ParameterObject> parameters = method.paramsIncludingLocators().stream()
@@ -173,17 +174,23 @@ class OpenApiDocumentor implements MuHandler {
 
             String opIdPath = getPathWithoutRegex(root, method, parentResourcePath).replace("{", "_").replace("}", "_");
             String opPath = Mutils.trim(opIdPath, "/").replace("/", "_");
-            String opKey = method.httpMethod.name().toLowerCase();
-            OperationObject existing = operations.get(opKey);
+            String opKey = method.requiredHttpMethod().name().toLowerCase();
+            Map<String, OperationObject> configuredOperations = operations;
+            if (configuredOperations == null) {
+                configuredOperations = new LinkedHashMap<>();
+                pathItem.withOperations(configuredOperations);
+            }
+            OperationObject existing = configuredOperations.get(opKey);
             if (existing == null) {
                 existing = method.createOperationBuilder(customSchemas)
-                    .withOperationId(method.httpMethod.name() + "_" + opPath)
+                    .withOperationId(method.requiredHttpMethod().name() + "_" + opPath)
                     .withTags(singletonList(root.tag.name()))
                     .withParameters(parameters)
                     .build();
             } else {
                 OperationObject curOO = method.createOperationBuilder(customSchemas).build();
-                List<ParameterObject> combinedParams = new ArrayList<>(existing.parameters());
+                List<ParameterObject> combinedParams = new ArrayList<>(
+                    existing.parameters() == null ? Collections.emptyList() : existing.parameters());
                 for (ParameterObject po : parameters) {
                     // add to combinedParams if none with same name and in
                     if (combinedParams.stream().noneMatch(p -> p.name().equals(po.name()) &&
@@ -215,7 +222,7 @@ class OpenApiDocumentor implements MuHandler {
                 }
                 existing = operationObjectBuilder.build();
             }
-            operations.put(opKey, existing);
+            configuredOperations.put(opKey, existing);
         }
     }
 
@@ -230,17 +237,17 @@ class OpenApiDocumentor implements MuHandler {
 class SchemaReference {
     final String id;
     final Class<?> type;
-    final Type genericType;
+    final @Nullable Type genericType;
     final SchemaObject schema;
 
-    SchemaReference(String id, Class<?> type, Type genericType, SchemaObject schema) {
+    SchemaReference(String id, Class<?> type, @Nullable Type genericType, SchemaObject schema) {
         this.id = id;
         this.type = type;
         this.genericType = genericType;
         this.schema = schema;
     }
 
-    static @Nullable SchemaReference find(List<SchemaReference> references, Class<?> type, Type genericType) {
+    static @Nullable SchemaReference find(List<SchemaReference> references, Class<?> type, @Nullable Type genericType) {
         for (SchemaReference reference : references) {
             if (reference.type.equals(type)) {
                 return reference;

--- a/src/main/java/io/muserver/rest/ProblemDetailsException.java
+++ b/src/main/java/io/muserver/rest/ProblemDetailsException.java
@@ -1,6 +1,7 @@
 package io.muserver.rest;
 
 import jakarta.ws.rs.WebApplicationException;
+import org.jspecify.annotations.Nullable;
 
 import java.net.URI;
 import java.util.Collections;
@@ -13,12 +14,13 @@ import java.util.Map;
 public class ProblemDetailsException extends WebApplicationException {
     private final int status;
     private final String title;
-    private final String detail;
-    private final URI type;
+    private final @Nullable String detail;
+    private final @Nullable URI type;
     private final URI instance;
-    private final Map<String, Object> extensionMembers;
+    private final Map<String, @Nullable Object> extensionMembers;
 
-    ProblemDetailsException(int status, String title, String detail, URI type, URI instance, Map<String, Object> extensionMembers, Throwable cause) {
+    ProblemDetailsException(int status, String title, @Nullable String detail, @Nullable URI type, URI instance,
+                            Map<String, @Nullable Object> extensionMembers, @Nullable Throwable cause) {
         super(detail != null ? detail : title, cause, status);
         this.status = status;
         this.title = title;
@@ -45,14 +47,14 @@ public class ProblemDetailsException extends WebApplicationException {
     /**
      * @return The human-readable detail for the problem response, or {@code null}.
      */
-    public String getDetail() {
+    public @Nullable String getDetail() {
         return detail;
     }
 
     /**
      * @return The problem type URI.
      */
-    public URI getType() {
+    public @Nullable URI getType() {
         return type;
     }
 
@@ -66,7 +68,7 @@ public class ProblemDetailsException extends WebApplicationException {
     /**
      * @return Any RFC 9457 extension members.
      */
-    public Map<String, Object> getExtensionMembers() {
+    public Map<String, @Nullable Object> getExtensionMembers() {
         return extensionMembers;
     }
 

--- a/src/main/java/io/muserver/rest/ProblemDetailsExceptionBuilder.java
+++ b/src/main/java/io/muserver/rest/ProblemDetailsExceptionBuilder.java
@@ -1,5 +1,7 @@
 package io.muserver.rest;
 
+import org.jspecify.annotations.Nullable;
+
 import java.net.URI;
 import java.util.*;
 
@@ -17,12 +19,12 @@ public class ProblemDetailsExceptionBuilder {
     private static final String ABOUT_BLANK = "about:blank";
 
     private int status = 500;
-    private String title;
-    private String detail;
-    private URI type;
-    private URI instance;
-    private Throwable cause;
-    private final Map<String, Object> extensionMembers = new LinkedHashMap<>();
+    private @Nullable String title;
+    private @Nullable String detail;
+    private @Nullable URI type;
+    private @Nullable URI instance;
+    private @Nullable Throwable cause;
+    private final Map<String, @Nullable Object> extensionMembers = new LinkedHashMap<>();
 
     /**
      * Creates a builder with the default 500 status.
@@ -151,10 +153,10 @@ public class ProblemDetailsExceptionBuilder {
      * @param extensionMembers The extension members to use.
      * @return This builder.
      */
-    public ProblemDetailsExceptionBuilder withExtensionMembers(Map<String, Object> extensionMembers) {
+    public ProblemDetailsExceptionBuilder withExtensionMembers(Map<String, @Nullable Object> extensionMembers) {
         Objects.requireNonNull(extensionMembers, "extensionMembers");
         this.extensionMembers.clear();
-        for (Map.Entry<String, Object> entry : extensionMembers.entrySet()) {
+        for (Map.Entry<String, @Nullable Object> entry : extensionMembers.entrySet()) {
             addExtensionMember(entry.getKey(), entry.getValue());
         }
         return this;
@@ -171,7 +173,7 @@ public class ProblemDetailsExceptionBuilder {
      * @param value The extension member value.
      * @return This builder.
      */
-    public ProblemDetailsExceptionBuilder addExtensionMember(String name, Object value) {
+    public ProblemDetailsExceptionBuilder addExtensionMember(String name, @Nullable Object value) {
         validateExtensionName(name);
         extensionMembers.put(name, value);
         return this;
@@ -187,42 +189,42 @@ public class ProblemDetailsExceptionBuilder {
     /**
      * @return The title currently configured for the problem, or {@code null}.
      */
-    public String title() {
+    public @Nullable String title() {
         return title;
     }
 
     /**
      * @return The detail currently configured for the problem, or {@code null}.
      */
-    public String detail() {
+    public @Nullable String detail() {
         return detail;
     }
 
     /**
      * @return The cause currently configured for the problem, or {@code null}.
      */
-    public Throwable cause() {
+    public @Nullable Throwable cause() {
         return cause;
     }
 
     /**
      * @return The type URI currently configured for the problem, or {@code null}.
      */
-    public URI type() {
+    public @Nullable URI type() {
         return type;
     }
 
     /**
      * @return The instance URI currently configured for the problem, or {@code null}.
      */
-    public URI instance() {
+    public @Nullable URI instance() {
         return instance;
     }
 
     /**
      * @return The extension members currently configured for the problem.
      */
-    public Map<String, Object> extensionMembers() {
+    public Map<String, @Nullable Object> extensionMembers() {
         return Collections.unmodifiableMap(extensionMembers);
     }
 

--- a/src/main/java/io/muserver/rest/ProblemDetailsExceptionMapper.java
+++ b/src/main/java/io/muserver/rest/ProblemDetailsExceptionMapper.java
@@ -6,6 +6,7 @@ import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.ext.ExceptionMapper;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -129,8 +130,8 @@ public class ProblemDetailsExceptionMapper <E extends Throwable> implements Exce
         }
     }
 
-    private static Response toResponse(int status, String title, String detail, URI type, URI instance, Map<String, Object> extensionMembers) {
-        Map<String, Object> values = new LinkedHashMap<>();
+    private static Response toResponse(int status, String title, @Nullable String detail, @Nullable URI type, @Nullable URI instance, @Nullable Map<String, @Nullable Object> extensionMembers) {
+        Map<String, @Nullable Object> values = new LinkedHashMap<>();
         if (type != null) {
             values.put("type", type);
         }

--- a/src/main/java/io/muserver/rest/ReadOnlyMultivaluedMap.java
+++ b/src/main/java/io/muserver/rest/ReadOnlyMultivaluedMap.java
@@ -2,6 +2,7 @@ package io.muserver.rest;
 
 import jakarta.ws.rs.core.MultivaluedHashMap;
 import jakarta.ws.rs.core.MultivaluedMap;
+import org.jspecify.annotations.Nullable;
 
 import java.io.Serializable;
 import java.util.Collection;
@@ -97,7 +98,7 @@ class ReadOnlyMultivaluedMap<K, V> implements MultivaluedMap<K, V>, Serializable
         return actual.isEmpty();
     }
 
-    public List<V> get(Object key) {
+    public @Nullable List<V> get(Object key) {
         return actual.get(key);
     }
 

--- a/src/main/java/io/muserver/rest/ReadOnlyMultivaluedMap.java
+++ b/src/main/java/io/muserver/rest/ReadOnlyMultivaluedMap.java
@@ -50,7 +50,7 @@ class ReadOnlyMultivaluedMap<K, V> implements MultivaluedMap<K, V>, Serializable
         throw new NotImplementedException("Invalid access for readonly map");
     }
 
-    public V getFirst(K key) {
+    public @Nullable V getFirst(K key) {
         return actual.getFirst(key);
     }
 
@@ -66,7 +66,7 @@ class ReadOnlyMultivaluedMap<K, V> implements MultivaluedMap<K, V>, Serializable
         return actual.hashCode();
     }
 
-    public boolean equals(Object o) {
+    public boolean equals(@Nullable Object o) {
         return actual.equals(o);
     }
 
@@ -78,7 +78,7 @@ class ReadOnlyMultivaluedMap<K, V> implements MultivaluedMap<K, V>, Serializable
         return actual.size();
     }
 
-    public List<V> remove(Object key) {
+    public List<V> remove(@Nullable Object key) {
         throw new NotImplementedException("Invalid access for readonly map");
     }
 
@@ -98,7 +98,7 @@ class ReadOnlyMultivaluedMap<K, V> implements MultivaluedMap<K, V>, Serializable
         return actual.isEmpty();
     }
 
-    public @Nullable List<V> get(Object key) {
+    public @Nullable List<V> get(@Nullable Object key) {
         return actual.get(key);
     }
 
@@ -106,11 +106,11 @@ class ReadOnlyMultivaluedMap<K, V> implements MultivaluedMap<K, V>, Serializable
         return actual.entrySet();
     }
 
-    public boolean containsValue(Object value) {
+    public boolean containsValue(@Nullable Object value) {
         return actual.containsValue(value);
     }
 
-    public boolean containsKey(Object key) {
+    public boolean containsKey(@Nullable Object key) {
         return actual.containsKey(key);
     }
 

--- a/src/main/java/io/muserver/rest/RequestMatcher.java
+++ b/src/main/java/io/muserver/rest/RequestMatcher.java
@@ -9,6 +9,7 @@ import jakarta.ws.rs.NotSupportedException;
 import jakarta.ws.rs.ServerErrorException;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.PathSegment;
+import org.jspecify.annotations.Nullable;
 
 import java.net.URI;
 import java.util.*;
@@ -42,13 +43,13 @@ class RequestMatcher {
         String path = requestContext.relativePath();
         Set<MatchedMethod> candidateMethods = getMatchedMethodsForPath(path, subResourceLocator);
         MuRequest req = requestContext.muRequest;
-        String requestBodyContentType = req.headers().get(HeaderNames.CONTENT_TYPE);
+        @Nullable String requestBodyContentType = req.headers().get(HeaderNames.CONTENT_TYPE);
         return stepThreeIdentifyTheMethodThatWillHandleTheRequest(httpMethod, candidateMethods, requestBodyContentType, acceptHeaders);
     }
 
     Set<MatchedMethod> getMatchedMethodsForPath(String path, Function<MatchedMethod, ResourceClass> subResourceLocator) throws NotMatchedException {
         StepOneOutput stepOneOutput = stepOneIdentifyASetOfCandidateRootResourceClassesMatchingTheRequest(path);
-        URI methodURI = stepOneOutput.unmatchedGroup == null ? null : URI.create(UriPattern.trimSlashes(stepOneOutput.unmatchedGroup));
+        @Nullable URI methodURI = stepOneOutput.unmatchedGroup == null ? null : URI.create(UriPattern.trimSlashes(stepOneOutput.unmatchedGroup));
         return stepTwoObtainASetOfCandidateResourceMethodsForTheRequest(methodURI, stepOneOutput.candidates, subResourceLocator);
     }
 
@@ -82,7 +83,7 @@ class RequestMatcher {
         }
         // Set Rmatch to be the first member of E and set U to be the value of the final capturing group of Rmatch when matched against U
         UriPattern rMatch = candidates.get(0).resourceClass.pathPattern;
-        String u = rMatch.matcher(uri).lastGroup();
+        @Nullable String u = rMatch.matcher(uri).lastGroup();
 
         // Let C0 be the set of classes Z such that R(TZ) = Rmatch. By definition, all root resource classes in C0 must be annotated with the same URI path template modulo variable names
 
@@ -92,7 +93,7 @@ class RequestMatcher {
         return new StepOneOutput(u, c0);
     }
 
-    private Set<MatchedMethod> stepTwoObtainASetOfCandidateResourceMethodsForTheRequest(URI relativeUri, List<MatchedClass> candidateClasses, Function<MatchedMethod, ResourceClass> subResourceLocator) throws NotMatchedException {
+    private Set<MatchedMethod> stepTwoObtainASetOfCandidateResourceMethodsForTheRequest(@Nullable URI relativeUri, List<MatchedClass> candidateClasses, Function<MatchedMethod, ResourceClass> subResourceLocator) throws NotMatchedException {
         if (relativeUri == null) {
             // handle section 3.7.2 - 2(a)
             Set<MatchedMethod> candidates = getNonLocatorMethods(candidateClasses, false);
@@ -107,7 +108,7 @@ class RequestMatcher {
             for (ResourceMethod resourceMethod : candidateClass.resourceClass.resourceMethods) {
                 if (resourceMethod.isSubResource() || resourceMethod.isSubResourceLocator()) {
                     if (relativeUri != null) {
-                        PathMatch matcher = resourceMethod.pathPattern.matcher(relativeUri);
+                        PathMatch matcher = resourceMethod.requiredPathPattern().matcher(relativeUri);
                         // 2(c) add and 2(d) filter out
                         if (matcher.fullyMatches() || (resourceMethod.isSubResourceLocator() && matcher.prefixMatches())) {
                             Map<String, PathSegment> combinedParams = new HashMap<>(candidateClass.pathMatch.segments());
@@ -131,14 +132,14 @@ class RequestMatcher {
             ResourceMethod rm1 = o1.resourceMethod;
             ResourceMethod rm2 = o2.resourceMethod;
             // "Sort E using the number of literal characters4 in each member as the primary key (descending order)"
-            int c = Integer.compare(rm2.pathPattern.numberOfLiterals, rm1.pathPattern.numberOfLiterals);
+                int c = Integer.compare(rm2.requiredPathPattern().numberOfLiterals, rm1.requiredPathPattern().numberOfLiterals);
             if (c == 0) {
                 // "the number of capturing groups as a secondary key (descending order)"
-                c = Integer.compare(rm2.pathPattern.capturingGroupCount(), rm1.pathPattern.capturingGroupCount());
+                c = Integer.compare(rm2.requiredPathPattern().capturingGroupCount(), rm1.requiredPathPattern().capturingGroupCount());
             }
             if (c == 0) {
                 // " and the number of capturing groups with non-default regular expressions (i.e. not ‘([ˆ/]+?)’) as the tertiary key (descending order)"
-                c = Integer.compare(rm2.pathPattern.nonDefaultCapturingGroupCount(), rm1.pathPattern.nonDefaultCapturingGroupCount());
+                c = Integer.compare(rm2.requiredPathPattern().nonDefaultCapturingGroupCount(), rm1.requiredPathPattern().nonDefaultCapturingGroupCount());
             }
             if (c == 0) {
                 // "and the source of each member as quaternary key sorting those derived from sub-resource methods ahead of those derived from sub-resource locators"
@@ -149,11 +150,11 @@ class RequestMatcher {
         });
 
         // 2(g) Set Rmatch to be the first member of E
-        UriPattern matcher = candidates.get(0).resourceMethod.pathPattern;
+        UriPattern matcher = candidates.get(0).resourceMethod.requiredPathPattern();
 
         // 2(h) M = { subresource methods of all classes in C′ where R(T_method) = R_match (excluding sub-resource locators) }
         Set<MatchedMethod> m = candidates.stream()
-            .filter(rm -> !rm.resourceMethod.isSubResourceLocator() && rm.resourceMethod.pathPattern.equals(matcher))
+            .filter(rm -> !rm.resourceMethod.isSubResourceLocator() && rm.resourceMethod.requiredPathPattern().equals(matcher))
             .collect(toSet());
         if (!m.isEmpty()) {
             return m;
@@ -161,7 +162,7 @@ class RequestMatcher {
 
         // 2(i) Let L be a sub-resource locator such that Rmatch = R(TL)
         Set<MatchedMethod> l = candidates.stream()
-            .filter(rm -> rm.resourceMethod.isSubResourceLocator() && rm.resourceMethod.pathPattern.equals(matcher))
+            .filter(rm -> rm.resourceMethod.isSubResourceLocator() && rm.resourceMethod.requiredPathPattern().equals(matcher))
             .collect(toSet());
         if (l.isEmpty()) {
             throw new NotMatchedException();
@@ -240,7 +241,7 @@ class RequestMatcher {
                 '}';
         }
 
-        public String getPathParam(String key) {
+        public @Nullable String getPathParam(String key) {
             PathSegment segment = pathParams.get(key);
             return segment == null ? null : segment.getPath();
         }
@@ -254,10 +255,10 @@ class RequestMatcher {
         }
     }
 
-    private MatchedMethod stepThreeIdentifyTheMethodThatWillHandleTheRequest(Method method, Set<MatchedMethod> candidates, String requestBodyContentType, List<MediaType> acceptHeaders) throws NotAllowedException, NotAcceptableException, NotSupportedException {
+    private MatchedMethod stepThreeIdentifyTheMethodThatWillHandleTheRequest(Method method, Set<MatchedMethod> candidates, @Nullable String requestBodyContentType, List<MediaType> acceptHeaders) throws NotAllowedException, NotAcceptableException, NotSupportedException {
         List<MatchedMethod> result = candidates.stream().filter(rm -> rm.resourceMethod.httpMethod == method).collect(toList());
         if (result.isEmpty()) {
-            List<String> allowed = candidates.stream().map(c -> c.resourceMethod.httpMethod.name()).distinct().collect(toList());
+            List<String> allowed = candidates.stream().map(c -> c.resourceMethod.requiredHttpMethod().name()).distinct().collect(toList());
             throw new NotAllowedException(allowed.get(0), allowed.subList(1, allowed.size()).toArray(new String[0]));
         }
 
@@ -299,10 +300,10 @@ class RequestMatcher {
     }
 
     static class StepOneOutput {
-        final String unmatchedGroup;
+        final @Nullable String unmatchedGroup;
         final List<RequestMatcher.MatchedClass> candidates;
 
-        StepOneOutput(String unmatchedGroup, List<RequestMatcher.MatchedClass> candidates) {
+        StepOneOutput(@Nullable String unmatchedGroup, List<RequestMatcher.MatchedClass> candidates) {
             this.unmatchedGroup = unmatchedGroup;
             this.candidates = candidates;
         }

--- a/src/main/java/io/muserver/rest/ResourceClass.java
+++ b/src/main/java/io/muserver/rest/ResourceClass.java
@@ -8,6 +8,7 @@ import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.ext.ParamConverterProvider;
+import org.jspecify.annotations.Nullable;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.AnnotatedElement;
@@ -27,10 +28,11 @@ class ResourceClass {
 
     final UriPattern pathPattern;
     final Class<?> resourceClass;
-    final Object resourceInstance;
+    final @Nullable Object resourceInstance;
     final List<MediaType> produces;
     final List<MediaType> consumes;
-    List<ResourceMethod> resourceMethods;
+    List<ResourceMethod> resourceMethods = Collections.emptyList();
+    private boolean methodInfoSet;
     final String pathTemplate;
     final TagObject tag;
     final List<Class<? extends Annotation>> nameBindingAnnotations;
@@ -39,9 +41,9 @@ class ResourceClass {
     /**
      * If this class is sub-resource, then this is the locator method. Otherwise null.
      */
-    final ResourceMethod locatorMethod;
+    final @Nullable ResourceMethod locatorMethod;
 
-    private ResourceClass(UriPattern pathPattern, String pathTemplate, Class<?> resourceClass, Object resourceInstance, List<MediaType> consumes, List<MediaType> produces, TagObject tag, List<Class<? extends Annotation>> nameBindingAnnotations, SchemaObjectCustomizer schemaObjectCustomizer, ResourceMethod locatorMethod) {
+    private ResourceClass(UriPattern pathPattern, String pathTemplate, Class<?> resourceClass, @Nullable Object resourceInstance, List<MediaType> consumes, List<MediaType> produces, TagObject tag, List<Class<? extends Annotation>> nameBindingAnnotations, SchemaObjectCustomizer schemaObjectCustomizer, @Nullable ResourceMethod locatorMethod) {
         this.pathPattern = pathPattern;
         this.pathTemplate = pathTemplate;
         this.resourceClass = resourceClass;
@@ -67,7 +69,7 @@ class ResourceClass {
     }
 
     private void setupMethodInfo(List<ParamConverterProvider> paramConverterProviders) {
-        if (resourceMethods != null) {
+        if (methodInfoSet) {
             throw new IllegalStateException("Cannot call setupMethodInfo twice");
         }
 
@@ -78,7 +80,7 @@ class ResourceClass {
                 continue;
             }
             java.lang.reflect.Method annotationSource = JaxMethodLocator.getMethodThatHasJaxRSAnnotations(restMethod, resourceClass);
-            Method httpMethod = ResourceMethod.getMuMethod(annotationSource);
+            @Nullable Method httpMethod = ResourceMethod.getMuMethod(annotationSource);
             restMethod.setAccessible(true);
             Path methodPath = annotationSource.getAnnotation(Path.class);
             if (methodPath == null && httpMethod == null) {
@@ -87,7 +89,7 @@ class ResourceClass {
 
             List<Class<? extends Annotation>> methodNameBindingAnnotations = getNameBindingAnnotations(annotationSource);
 
-            UriPattern methodPattern = methodPath == null ? null : UriPattern.uriTemplateToRegex(methodPath.value());
+            @Nullable UriPattern methodPattern = methodPath == null ? null : UriPattern.uriTemplateToRegex(methodPath.value());
 
 
             List<MediaType> methodProduces = MediaTypeDeterminer.supportedProducesTypes(annotationSource);
@@ -100,11 +102,12 @@ class ResourceClass {
                 params.add(resourceMethodParam);
             }
             DescriptionData descriptionData = DescriptionData.fromAnnotation(restMethod, null);
-            String pathTemplate = methodPath == null ? null : methodPath.value();
+            @Nullable String pathTemplate = methodPath == null ? null : methodPath.value();
             boolean isDeprecated = annotationSource.isAnnotationPresent(Deprecated.class);
             resourceMethods.add(new ResourceMethod(this, methodPattern, restMethod, params, httpMethod, pathTemplate, methodProduces, methodConsumes, schemaObjectCustomizer, descriptionData, isDeprecated, methodNameBindingAnnotations, annotationSource.getAnnotations()));
         }
         this.resourceMethods = Collections.unmodifiableList(resourceMethods);
+        this.methodInfoSet = true;
     }
 
     static List<Class<? extends Annotation>> getNameBindingAnnotations(AnnotatedElement annotationSource) {
@@ -154,7 +157,7 @@ class ResourceClass {
         return resourceClass;
     }
 
-    private static List<MediaType> getProduces(List<MediaType> existing, Class<?> annotationSource) {
+    private static List<MediaType> getProduces(@Nullable List<MediaType> existing, Class<?> annotationSource) {
         Produces produces = annotationSource.getAnnotation(Produces.class);
         List<MediaType> producesList = new ArrayList<>(MediaTypeHeaderDelegate.fromStrings(produces == null ? null : asList(produces.value())));
         if (existing != null) {
@@ -163,7 +166,7 @@ class ResourceClass {
         return producesList;
     }
 
-    private static List<MediaType> getConsumes(List<MediaType> existing, Class<?> annotationSource) {
+    private static List<MediaType> getConsumes(@Nullable List<MediaType> existing, Class<?> annotationSource) {
         Consumes consumes = annotationSource.getAnnotation(Consumes.class);
         List<MediaType> consumesList = new ArrayList<>(MediaTypeHeaderDelegate.fromStrings(consumes == null ? null : asList(consumes.value())));
         if (existing != null) {
@@ -172,12 +175,16 @@ class ResourceClass {
         return consumesList;
     }
 
-    static ResourceClass forSubResourceLocator(ResourceMethod rm, Class<?> instanceClass, Object instance, SchemaObjectCustomizer schemaObjectCustomizer, List<ParamConverterProvider> paramConverterProviders) {
-        List<MediaType> existingConsumes = rm.effectiveConsumes.isEmpty() || (rm.directlyConsumes.isEmpty() && rm.effectiveConsumes.size() == 1 && rm.effectiveConsumes.get(0) == MediaType.WILDCARD_TYPE) ? null : rm.effectiveConsumes;
+    static ResourceClass forSubResourceLocator(ResourceMethod rm, Class<?> instanceClass, @Nullable Object instance, SchemaObjectCustomizer schemaObjectCustomizer, List<ParamConverterProvider> paramConverterProviders) {
+        @Nullable List<MediaType> existingConsumes = rm.effectiveConsumes.isEmpty() || (rm.directlyConsumes.isEmpty() && rm.effectiveConsumes.size() == 1 && rm.effectiveConsumes.get(0) == MediaType.WILDCARD_TYPE) ? null : rm.effectiveConsumes;
         List<MediaType> consumes = getConsumes(existingConsumes, instanceClass);
-        List<MediaType> existingProduces = rm.effectiveProduces.isEmpty() || (rm.directlyProduces.isEmpty() && rm.effectiveProduces.size() == 1 && rm.effectiveProduces.get(0) == MediaType.WILDCARD_TYPE) ? null : rm.effectiveProduces;
+        @Nullable List<MediaType> existingProduces = rm.effectiveProduces.isEmpty() || (rm.directlyProduces.isEmpty() && rm.effectiveProduces.size() == 1 && rm.effectiveProduces.get(0) == MediaType.WILDCARD_TYPE) ? null : rm.effectiveProduces;
         List<MediaType> produces = getProduces(existingProduces, instanceClass);
-        ResourceClass resourceClass = new ResourceClass(rm.pathPattern, rm.pathTemplate, instanceClass, instance, consumes, produces, rm.resourceClass.tag, rm.resourceClass.nameBindingAnnotations, schemaObjectCustomizer, rm);
+        ResourceClass resourceClass = new ResourceClass(
+            java.util.Objects.requireNonNull(rm.pathPattern, "Sub-resource locator had no path pattern"),
+            java.util.Objects.requireNonNull(rm.pathTemplate, "Sub-resource locator had no path template"),
+            instanceClass, instance, consumes, produces, rm.resourceClass.tag,
+            rm.resourceClass.nameBindingAnnotations, schemaObjectCustomizer, rm);
         resourceClass.setupMethodInfo(paramConverterProviders);
         return resourceClass;
     }
@@ -190,5 +197,9 @@ class ResourceClass {
 
     String resourceClassName() {
         return resourceClass.getName();
+    }
+
+    Object requiredResourceInstance() {
+        return java.util.Objects.requireNonNull(resourceInstance, "Resource instance is not available");
     }
 }

--- a/src/main/java/io/muserver/rest/ResourceMethod.java
+++ b/src/main/java/io/muserver/rest/ResourceMethod.java
@@ -27,11 +27,11 @@ import static java.util.stream.Collectors.toMap;
 
 class ResourceMethod {
     final ResourceClass resourceClass;
-    final UriPattern pathPattern;
+    final @Nullable UriPattern pathPattern;
     final java.lang.reflect.Method methodHandle;
     final @Nullable Type genericReturnType;
-    final Method httpMethod;
-    final String pathTemplate;
+    final @Nullable Method httpMethod;
+    final @Nullable String pathTemplate;
     final List<MediaType> effectiveConsumes;
     final List<MediaType> directlyConsumes;
     final List<MediaType> directlyProduces;
@@ -43,7 +43,7 @@ class ResourceMethod {
     private final List<Class<? extends Annotation>> nameBindingAnnotations;
     final Annotation[] methodAnnotations; // the annotations defined on the method to be passed to the message body writers
 
-    ResourceMethod(ResourceClass resourceClass, UriPattern pathPattern, java.lang.reflect.Method methodHandle, List<ResourceMethodParam> params, Method httpMethod, String pathTemplate, List<MediaType> produces, List<MediaType> consumes, SchemaObjectCustomizer schemaObjectCustomizer, DescriptionData descriptionData, boolean isDeprecated, List<Class<? extends Annotation>> nameBindingAnnotations, Annotation[] methodAnnotations) {
+    ResourceMethod(ResourceClass resourceClass, @Nullable UriPattern pathPattern, java.lang.reflect.Method methodHandle, List<ResourceMethodParam> params, @Nullable Method httpMethod, @Nullable String pathTemplate, List<MediaType> produces, List<MediaType> consumes, SchemaObjectCustomizer schemaObjectCustomizer, DescriptionData descriptionData, boolean isDeprecated, List<Class<? extends Annotation>> nameBindingAnnotations, Annotation[] methodAnnotations) {
         this.resourceClass = resourceClass;
         this.pathPattern = pathPattern;
         this.methodHandle = methodHandle;
@@ -89,11 +89,19 @@ class ResourceMethod {
         return httpMethod == null;
     }
 
-    Object invoke(Object... params) throws Exception {
+    UriPattern requiredPathPattern() {
+        return Objects.requireNonNull(pathPattern, "Resource method has no path pattern");
+    }
+
+    Method requiredHttpMethod() {
+        return Objects.requireNonNull(httpMethod, "Sub-resource locator has no HTTP method");
+    }
+
+    @Nullable Object invoke(@Nullable Object... params) throws Exception {
         try {
-            return methodHandle.invoke(resourceClass.resourceInstance, params);
+            return methodHandle.invoke(resourceClass.requiredResourceInstance(), params);
         } catch (InvocationTargetException e) {
-            Throwable cause = e.getCause();
+            @Nullable Throwable cause = e.getCause();
             if (cause instanceof Exception) {
                 throw (Exception) cause;
             }
@@ -109,14 +117,14 @@ class ResourceMethod {
         for (ApiResponseObj apiResponse : apiResponseList) {
             Class<?> responseClass = apiResponse.response;
 
-            Stream<MediaType> responseTypesStream = apiResponse.contentType.length != 0 ?
+            @Nullable Stream<MediaType> responseTypesStream = apiResponse.contentType.length != 0 ?
                 Stream.of(apiResponse.contentType).map(MediaType::valueOf)
                 : "204".equals(apiResponse.code) ? null : effectiveProduces.stream();
 
-            Map<String, MediaTypeObject> content = responseTypesStream == null ? null : responseTypesStream.collect(toMap(MediaType::toString,
+            @Nullable Map<String, MediaTypeObject> content = responseTypesStream == null ? null : responseTypesStream.collect(toMap(MediaType::toString,
                 mt -> {
-                    SchemaObject responseSchema;
-                    Object example = nullOrEmpty(apiResponse.example) ? null : apiResponse.example;
+                    @Nullable SchemaObject responseSchema;
+                    @Nullable Object example = nullOrEmpty(apiResponse.example) ? null : apiResponse.example;
 
                     if (void.class.isAssignableFrom(responseClass)) {
                         responseSchema = null;
@@ -150,7 +158,7 @@ class ResourceMethod {
 
         MediaType requestBodyMediaType = effectiveConsumes.get(0);
         String requestBodyMimeType = requestBodyMediaType.toString();
-        RequestBodyObject requestBody = params.stream()
+        @Nullable RequestBodyObject requestBody = params.stream()
             .filter(p -> p instanceof ResourceMethodParam.MessageBodyParam)
             .map(ResourceMethodParam.MessageBodyParam.class::cast)
             .map(messageBodyParam -> {
@@ -159,7 +167,7 @@ class ResourceMethod {
                 SchemaReference schemaReference = SchemaReference.find(customSchemas, bodyType, bodyParameterizedType);
                 SchemaObjectBuilder builder = schemaReference != null ? schemaReference.schema.toBuilder() :
                     schemaObjectFrom(bodyType, bodyParameterizedType, messageBodyParam.isRequired)
-                        .withTitle(messageBodyParam.descriptionData.summary)
+                        .withTitle(Objects.requireNonNull(messageBodyParam.descriptionData).summary)
                         .withDescription(messageBodyParam.descriptionData.description);
                 return requestBodyObject()
                     .withContent(singletonMap(requestBodyMimeType,
@@ -168,7 +176,7 @@ class ResourceMethod {
                                 schemaObjectCustomizer.customize(builder,
                                     schemaContext(SchemaObjectCustomizerTarget.REQUEST_BODY, null, bodyType, bodyParameterizedType, requestBodyMediaType))
                                     .build())
-                            .withExample(messageBodyParam.descriptionData.example)
+                            .withExample(Objects.requireNonNull(messageBodyParam.descriptionData).example)
                             .build()))
                     .withDescription(messageBodyParam.descriptionData.summaryAndDescription())
                     .withRequired(messageBodyParam.isRequired)
@@ -238,7 +246,7 @@ class ResourceMethod {
             ;
     }
 
-    private SchemaObjectCustomizerContext schemaContext(SchemaObjectCustomizerTarget target, String parameter, Class<?> type, Type parameterizedType, MediaType mediaType) {
+    private SchemaObjectCustomizerContext schemaContext(SchemaObjectCustomizerTarget target, @Nullable String parameter, Class<?> type, @Nullable Type parameterizedType, MediaType mediaType) {
         return new SchemaObjectCustomizerContext(target, type, parameterizedType, resourceClass.resourceInstance, methodHandle, parameter, mediaType);
     }
 
@@ -263,9 +271,9 @@ class ResourceMethod {
         return result;
     }
 
-    static Method getMuMethod(java.lang.reflect.Method restMethod) {
+    static @Nullable Method getMuMethod(java.lang.reflect.Method restMethod) {
         Annotation[] annotations = restMethod.getAnnotations();
-        Method value = null;
+        @Nullable Method value = null;
         for (Annotation annotation : annotations) {
             Class<? extends Annotation> anno = annotation.annotationType();
             HttpMethod httpMethodAnno = anno.getAnnotation(HttpMethod.class);

--- a/src/main/java/io/muserver/rest/ResourceMethodParam.java
+++ b/src/main/java/io/muserver/rest/ResourceMethodParam.java
@@ -27,6 +27,7 @@ import java.util.stream.Collectors;
 import static io.muserver.openapi.ParameterObjectBuilder.parameterObject;
 import static io.muserver.openapi.SchemaObjectBuilder.schemaObjectFrom;
 import static java.util.Collections.emptyList;
+import static java.util.Objects.requireNonNull;
 
 abstract class ResourceMethodParam {
 
@@ -36,10 +37,10 @@ abstract class ResourceMethodParam {
     final Type genericType;
     final Annotation[] annotations;
     final ValueSource source;
-    final DescriptionData descriptionData;
+    final @Nullable DescriptionData descriptionData;
     final boolean isRequired;
 
-    ResourceMethodParam(int index, ValueSource source, ResolvedParameter parameter, DescriptionData descriptionData, boolean isRequired) {
+    ResourceMethodParam(int index, ValueSource source, ResolvedParameter parameter, @Nullable DescriptionData descriptionData, boolean isRequired) {
         this.index = index;
         this.source = source;
         this.parameterHandle = parameter.handle;
@@ -50,16 +51,16 @@ abstract class ResourceMethodParam {
         this.isRequired = isRequired;
     }
 
-    static ResourceMethodParam fromParameter(int index, Parameter parameterHandle, List<ParamConverterProvider> paramConverterProviders, UriPattern methodPattern) {
+    static ResourceMethodParam fromParameter(int index, Parameter parameterHandle, List<ParamConverterProvider> paramConverterProviders, @Nullable UriPattern methodPattern) {
         return fromParameter(index, parameterHandle, parameterHandle,
             parameterHandle.getDeclaringExecutable().getDeclaringClass(), paramConverterProviders, methodPattern);
     }
 
     static ResourceMethodParam fromParameter(int index, Parameter parameterHandle, Parameter annotationSource, Class<?> concreteClass,
-                                             List<ParamConverterProvider> paramConverterProviders, UriPattern methodPattern) {
+                                             List<ParamConverterProvider> paramConverterProviders, @Nullable UriPattern methodPattern) {
 
         ResolvedParameter parameter = new ResolvedParameter(parameterHandle, annotationSource, concreteClass);
-        Pattern pattern = null;
+        @Nullable Pattern pattern = null;
         ValueSource source = getSource(annotationSource);
         boolean isRequired = source == ValueSource.PATH_PARAM || hasDeclared(annotationSource, Required.class);
         if (source == ValueSource.MESSAGE_BODY) {
@@ -76,7 +77,7 @@ abstract class ResourceMethodParam {
             ParamConverter<?> converter = getParamConverter(parameter, paramConverterProviders);
             boolean lazyDefaultValue = converter.getClass().getDeclaredAnnotation(ParamConverter.Lazy.class) != null;
             boolean explicitDefault = hasDeclared(annotationSource, DefaultValue.class);
-            Object defaultValue = getDefaultValue(parameter, annotationSource, converter, lazyDefaultValue, source, key);
+            @Nullable Object defaultValue = getDefaultValue(parameter, annotationSource, converter, lazyDefaultValue, source, key);
 
             isRequired |= (!explicitDefault && parameter.type.isPrimitive());
 
@@ -103,8 +104,9 @@ abstract class ResourceMethodParam {
 
         private ResolvedParameter(Parameter handle, Parameter annotationSource, Class<?> concreteClass) {
             this.handle = handle;
-            this.genericType = GenericTypeResolver.resolve(handle.getParameterizedType(), concreteClass,
+            Type resolvedType = GenericTypeResolver.resolve(handle.getParameterizedType(), concreteClass,
                 handle.getDeclaringExecutable().getDeclaringClass());
+            this.genericType = resolvedType == null ? handle.getParameterizedType() : resolvedType;
             Class<?> resolvedClass = GenericTypeResolver.rawClass(genericType);
             this.type = resolvedClass == null ? handle.getType() : resolvedClass;
             this.annotations = combinedAnnotations(handle, annotationSource);
@@ -134,22 +136,22 @@ abstract class ResourceMethodParam {
 
     static class RequestBasedParam extends ResourceMethodParam {
 
-        private final Object defaultValue;
+        private final @Nullable Object defaultValue;
         final boolean encodedRequested;
         private final boolean lazyDefaultValue;
         private final ParamConverter paramConverter;
         final String key;
         final boolean isDeprecated;
-        private final Pattern pattern;
+        private final @Nullable Pattern pattern;
         private final boolean explicitDefault;
 
         ParameterObjectBuilder createDocumentationBuilder() {
             ParameterObjectBuilder builder = parameterObject()
-                .withIn(source.openAPIIn)
+                .withIn(requireNonNull(source.openAPIIn, "Parameter source is not represented as an OpenAPI parameter"))
                 .withRequired(isRequired)
                 .withDeprecated(isDeprecated ? true : null)
                 .withName(key);
-            ExternalDocumentationObject externalDoc = null;
+            @Nullable ExternalDocumentationObject externalDoc = null;
             if (descriptionData != null) {
                 String desc = descriptionData.summaryAndDescription();
                 builder
@@ -157,7 +159,7 @@ abstract class ResourceMethodParam {
                     .withExample(descriptionData.example);
                 externalDoc = descriptionData.externalDocumentation;
             }
-            Pattern patternIfNotDefault = this.pattern == null || UriPattern.DEFAULT_CAPTURING_GROUP_PATTERN.equals(this.pattern.pattern()) ? null : this.pattern;
+            @Nullable Pattern patternIfNotDefault = this.pattern == null || UriPattern.DEFAULT_CAPTURING_GROUP_PATTERN.equals(this.pattern.pattern()) ? null : this.pattern;
             return builder.withSchema(
                 schemaObjectFrom(type, genericType, isRequired)
                     .withDefaultValue(source == ValueSource.PATH_PARAM || !hasExplicitDefault() ? null : defaultValue())
@@ -167,7 +169,7 @@ abstract class ResourceMethodParam {
             );
         }
 
-        RequestBasedParam(int index, ValueSource source, ResolvedParameter parameter, @Nullable Object defaultValue, boolean encodedRequested, boolean lazyDefaultValue, ParamConverter paramConverter, DescriptionData descriptionData, String key, boolean isDeprecated, boolean isRequired, Pattern pattern, boolean explicitDefault) {
+        RequestBasedParam(int index, ValueSource source, ResolvedParameter parameter, @Nullable Object defaultValue, boolean encodedRequested, boolean lazyDefaultValue, ParamConverter paramConverter, DescriptionData descriptionData, String key, boolean isDeprecated, boolean isRequired, @Nullable Pattern pattern, boolean explicitDefault) {
             super(index, source, parameter, descriptionData, isRequired);
             this.defaultValue = defaultValue;
             this.encodedRequested = encodedRequested;
@@ -188,7 +190,7 @@ abstract class ResourceMethodParam {
         }
 
 
-        public Object defaultValue() {
+        public @Nullable Object defaultValue() {
             boolean skipConverter = defaultValue != null && !lazyDefaultValue;
             return convertValue(parameterHandle, type, paramConverter, skipConverter, defaultValue, source, key);
         }
@@ -266,13 +268,13 @@ abstract class ResourceMethodParam {
                     : emptyList();
             boolean isSpecified = specifiedValue != null && !specifiedValue.isEmpty();
             if (encodedRequested && isSpecified) {
-                specifiedValue = specifiedValue.stream()
+                specifiedValue = requireNonNull(specifiedValue).stream()
                     .map(value -> source == ValueSource.FORM_PARAM ? FormUrlEncoder.formUrlEncode(value) : Mutils.urlEncode(value))
                     .collect(Collectors.toList());
             }
             if (collection != null) {
                 if (isSpecified) {
-                    for (String stringValue : specifiedValue) {
+                    for (String stringValue : requireNonNull(specifiedValue)) {
                         collection.add(ResourceMethodParam.convertValue(parameterHandle, type, paramConverter, false, stringValue, source, key));
                     }
                 } else if (hasExplicitDefault()) {
@@ -280,7 +282,7 @@ abstract class ResourceMethodParam {
                 }
                 return readOnly(collection);
             } else {
-                return isSpecified ? ResourceMethodParam.convertValue(parameterHandle, type, paramConverter, false, specifiedValue.get(0), source, key) : defaultValue();
+                return isSpecified ? ResourceMethodParam.convertValue(parameterHandle, type, paramConverter, false, requireNonNull(specifiedValue).get(0), source, key) : defaultValue();
             }
         }
 
@@ -301,8 +303,8 @@ abstract class ResourceMethodParam {
                 : Collections.unmodifiableCollection(collection);
         }
 
-        private List<String> getParamValues(MultivaluedMap<String, String> queryParameters, String key, CollectionParameterStrategy cps, boolean isCollectionType) {
-            List<String> values = queryParameters.get(key);
+        private @Nullable List<String> getParamValues(MultivaluedMap<String, String> queryParameters, String key, CollectionParameterStrategy cps, boolean isCollectionType) {
+            @Nullable List<String> values = queryParameters.get(key);
             if (isCollectionType && values != null && cps == CollectionParameterStrategy.SPLIT_ON_COMMA) {
                 List<String> copy = new ArrayList<>(values.size());
                 for (String value : values) {
@@ -334,7 +336,7 @@ abstract class ResourceMethodParam {
             return emptyList();
         }
 
-        static Collection<Object> createCollection(Class<?> collectionType) {
+        static @Nullable Collection<Object> createCollection(Class<?> collectionType) {
             if (SortedSet.class.equals(collectionType)) {
                 return new TreeSet<>();
             } else if (Set.class.equals(collectionType)) {
@@ -411,7 +413,7 @@ abstract class ResourceMethodParam {
         throw new MuException("Could not find a suitable ParamConverter for " + parameterizedType + " at " + parameter.handle.getDeclaringExecutable());
     }
 
-    private static Object getDefaultValue(ResolvedParameter parameter, Parameter annotationSource, ParamConverter<?> converter, boolean lazyDefaultValue, ValueSource source, String parameterName) {
+    private static @Nullable Object getDefaultValue(ResolvedParameter parameter, Parameter annotationSource, ParamConverter<?> converter, boolean lazyDefaultValue, ValueSource source, String parameterName) {
         DefaultValue annotation = annotationSource.getDeclaredAnnotation(DefaultValue.class);
         if (annotation == null) {
             return converter instanceof HasDefaultValue ? ((HasDefaultValue) converter).getDefault() : null;
@@ -419,7 +421,7 @@ abstract class ResourceMethodParam {
         return convertValue(parameter.handle, parameter.type, converter, lazyDefaultValue, annotation.value(), source, parameterName);
     }
 
-    private static Object convertValue(Parameter parameterHandle, Class<?> parameterType, ParamConverter<?> converter, boolean skipConverter, Object value, ValueSource source, String parameterName) {
+    private static @Nullable Object convertValue(Parameter parameterHandle, Class<?> parameterType, @Nullable ParamConverter<?> converter, boolean skipConverter, @Nullable Object value, ValueSource source, String parameterName) {
         if (converter == null || skipConverter) {
             return value;
         } else {
@@ -447,15 +449,15 @@ abstract class ResourceMethodParam {
     enum ValueSource {
         MESSAGE_BODY(null), QUERY_PARAM("query"), MATRIX_PARAM(null), PATH_PARAM("path"), COOKIE_PARAM("cookie"), HEADER_PARAM("header"), FORM_PARAM(null), CONTEXT(null), SUSPENDED(null);
 
-        final String openAPIIn;
+        final @Nullable String openAPIIn;
 
-        ValueSource(String openAPIIn) {
+        ValueSource(@Nullable String openAPIIn) {
             this.openAPIIn = openAPIIn;
         }
     }
 
     interface HasDefaultValue {
-        Object getDefault();
+        @Nullable Object getDefault();
     }
 
 }

--- a/src/main/java/io/muserver/rest/RestHandler.java
+++ b/src/main/java/io/muserver/rest/RestHandler.java
@@ -304,12 +304,14 @@ public class RestHandler implements MuHandler {
                         MediaType responseMediaType = Objects.requireNonNull(jaxRSResponse.getMediaType(),
                             "A response entity must have a media type");
 
-                        Class entityType = jaxRSResponse.getEntityClass();
-                        Type entityGenericType = jaxRSResponse.getEntityType();
+                        Class entityType = Objects.requireNonNull(jaxRSResponse.getEntityClass(),
+                            "A response entity must have a raw type");
+                        Type entityGenericType = Objects.requireNonNull(jaxRSResponse.getEntityType(),
+                            "A response entity must have a generic type");
                         MessageBodyWriter messageBodyWriter = entityProviders.selectWriter(entityType, entityGenericType, writerAnnontations, responseMediaType);
 
                         if (entityProviders.isBuiltInWriter(messageBodyWriter)) {
-                            long size = messageBodyWriter.getSize(jaxRSResponse.getEntity(), jaxRSResponse.getType(), jaxRSResponse.getGenericType(), writerAnnontations, responseMediaType);
+                            long size = messageBodyWriter.getSize(jaxRSResponse.getEntity(), entityType, entityGenericType, writerAnnontations, responseMediaType);
                             if (size >= 0) {
                                 jaxRSResponse.getHeaders().putSingle("content-length", Long.toString(size));
                             }
@@ -318,7 +320,7 @@ public class RestHandler implements MuHandler {
                         applyDefaultCharset(jaxRSResponse);
 
                         try {
-                            messageBodyWriter.writeTo(jaxRSResponse.getEntity(), jaxRSResponse.getType(), jaxRSResponse.getGenericType(), writerAnnontations,
+                            messageBodyWriter.writeTo(jaxRSResponse.getEntity(), entityType, entityGenericType, writerAnnontations,
                                 jaxRSResponse.getMediaType(), jaxRSResponse.getHeaders(), jaxRSResponse.getOutputStream());
                             out.prepare();
                         } catch (Exception e) {
@@ -374,7 +376,7 @@ public class RestHandler implements MuHandler {
         }
     }
 
-    private static Object getContextParam(JaxRSRequest requestContext, MuResponse muResponse, RequestMatcher.MatchedMethod mm, ResourceMethodParam param, EntityProviders providers) {
+    private static @Nullable Object getContextParam(JaxRSRequest requestContext, MuResponse muResponse, RequestMatcher.MatchedMethod mm, ResourceMethodParam param, EntityProviders providers) {
         MuRequest request = requestContext.muRequest;
         Object paramValue;
         Class<?> type = param.type;

--- a/src/main/java/io/muserver/rest/RestHandler.java
+++ b/src/main/java/io/muserver/rest/RestHandler.java
@@ -13,6 +13,7 @@ import jakarta.ws.rs.ext.ReaderInterceptor;
 import jakarta.ws.rs.ext.WriterInterceptor;
 import jakarta.ws.rs.sse.Sse;
 import jakarta.ws.rs.sse.SseEventSink;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -36,7 +37,7 @@ public class RestHandler implements MuHandler {
 
     private final RequestMatcher requestMatcher;
     private final EntityProviders entityProviders;
-    private final MuHandler documentor;
+    private final @Nullable MuHandler documentor;
     private final CustomExceptionMapper customExceptionMapper;
     private final FilterManagerThing filterManagerThing;
     private final CORSConfig corsConfig;
@@ -47,7 +48,7 @@ public class RestHandler implements MuHandler {
     private final List<WriterInterceptor> writerInterceptors;
     private final CollectionParameterStrategy collectionParameterStrategy;
 
-    RestHandler(EntityProviders entityProviders, List<ResourceClass> roots, MuHandler documentor, CustomExceptionMapper customExceptionMapper, FilterManagerThing filterManagerThing, CORSConfig corsConfig, List<ParamConverterProvider> paramConverterProviders, SchemaObjectCustomizer schemaObjectCustomizer, List<ReaderInterceptor> readerInterceptors, List<WriterInterceptor> writerInterceptors, CollectionParameterStrategy collectionParameterStrategy) {
+    RestHandler(EntityProviders entityProviders, List<ResourceClass> roots, @Nullable MuHandler documentor, CustomExceptionMapper customExceptionMapper, FilterManagerThing filterManagerThing, CORSConfig corsConfig, List<ParamConverterProvider> paramConverterProviders, SchemaObjectCustomizer schemaObjectCustomizer, List<ReaderInterceptor> readerInterceptors, List<WriterInterceptor> writerInterceptors, CollectionParameterStrategy collectionParameterStrategy) {
         this.requestMatcher = new RequestMatcher(roots);
         this.entityProviders = entityProviders;
         this.documentor = documentor;
@@ -86,12 +87,14 @@ public class RestHandler implements MuHandler {
             }
 
             Function<RequestMatcher.MatchedMethod,ResourceClass> subResourceLocator = matchedMethod -> {
-                Function<ResourceMethod, Object> onSuspended = resourceMethod -> {
+                Function<ResourceMethod, @Nullable Object> onSuspended = resourceMethod -> {
                     throw new MuException("Suspended is not supported on sub-resource locators. Method: " + resourceMethod.methodHandle);
                 };
                 ResourceMethod rm = matchedMethod.resourceMethod;
                 try {
-                    Object instance = invokeResourceMethod(requestContext, muResponse, matchedMethod, onSuspended, entityProviders, collectionParameterStrategy);
+                    Object instance = Objects.requireNonNull(
+                        invokeResourceMethod(requestContext, muResponse, matchedMethod, onSuspended, entityProviders, collectionParameterStrategy),
+                        "Sub-resource locator returned null");
                     return ResourceClass.forSubResourceLocator(rm, instance.getClass(), instance, schemaObjectCustomizer, paramConverterProviders);
                 } catch (WebApplicationException wae) {
                     throw wae;
@@ -123,7 +126,7 @@ public class RestHandler implements MuHandler {
             List<MediaType> produces = producesRef = mm.resourceMethod.resourceClass.produces;
             List<MediaType> directlyProduces = directlyProducesRef = mm.resourceMethod.directlyProduces;
             Annotation[] methodAnnotations = mm.resourceMethod.methodAnnotations;
-            Type methodReturnType = mm.resourceMethod.genericReturnType;
+            @Nullable Type methodReturnType = mm.resourceMethod.genericReturnType;
 
             filterManagerThing.onPostMatch(requestContext);
             if (requestContext.getAbortResponse() != null) {
@@ -131,7 +134,7 @@ public class RestHandler implements MuHandler {
                 return true;
             }
 
-            Function<ResourceMethod, Object> suspendedParamCallback = rm -> {
+            Function<ResourceMethod, @Nullable Object> suspendedParamCallback = rm -> {
                 if (muRequest.isAsync()) {
                     throw new MuException("A REST method can only have one @Suspended attribute. Error for " + rm);
                 }
@@ -140,7 +143,7 @@ public class RestHandler implements MuHandler {
             };
 
 
-            Object result = invokeResourceMethod(requestContext, muResponse, mm, suspendedParamCallback, entityProviders, collectionParameterStrategy);
+            @Nullable Object result = invokeResourceMethod(requestContext, muResponse, mm, suspendedParamCallback, entityProviders, collectionParameterStrategy);
 
             if (!muRequest.isAsync()) {
                 if (result instanceof CompletionStage) {
@@ -173,15 +176,15 @@ public class RestHandler implements MuHandler {
         return true;
     }
 
-    private static Type completionStageResultType(Type returnType) {
+    private static @Nullable Type completionStageResultType(@Nullable Type returnType) {
         return GenericTypeResolver.resolveTypeArgument(returnType, CompletionStage.class, 0);
     }
 
-    static Object invokeResourceMethod(JaxRSRequest requestContext, MuResponse muResponse, RequestMatcher.MatchedMethod mm, Function<ResourceMethod, Object> suspendedParamCallback, EntityProviders entityProviders, CollectionParameterStrategy collectionParameterStrategy) throws Exception {
+    static @Nullable Object invokeResourceMethod(JaxRSRequest requestContext, MuResponse muResponse, RequestMatcher.MatchedMethod mm, Function<ResourceMethod, @Nullable Object> suspendedParamCallback, EntityProviders entityProviders, CollectionParameterStrategy collectionParameterStrategy) throws Exception {
         ResourceMethod rm = mm.resourceMethod;
-        Object[] params = new Object[rm.methodHandle.getParameterCount()];
+        @Nullable Object[] params = new Object[rm.methodHandle.getParameterCount()];
         for (ResourceMethodParam param : rm.params) {
-            Object paramValue;
+            @Nullable Object paramValue;
             if (param.source == ResourceMethodParam.ValueSource.MESSAGE_BODY) {
                 paramValue = readRequestEntity(requestContext, param);
             } else if (param.source == ResourceMethodParam.ValueSource.CONTEXT) {
@@ -227,11 +230,11 @@ public class RestHandler implements MuHandler {
         }
     }
 
-    private void sendResponse(int nestingLevel, JaxRSRequest requestContext, MuResponse muResponse, List<MediaType> acceptHeaders, List<MediaType> produces, List<MediaType> directlyProduces, Annotation[] annotations, Object result) throws Exception {
+    private void sendResponse(int nestingLevel, JaxRSRequest requestContext, MuResponse muResponse, List<MediaType> acceptHeaders, List<MediaType> produces, List<MediaType> directlyProduces, Annotation[] annotations, @Nullable Object result) throws Exception {
         sendResponse(nestingLevel, requestContext, muResponse, acceptHeaders, produces, directlyProduces, annotations, result, null);
     }
 
-    private void sendResponse(int nestingLevel, JaxRSRequest requestContext, MuResponse muResponse, List<MediaType> acceptHeaders, List<MediaType> produces, List<MediaType> directlyProduces, Annotation[] annotations, Object result, Type resourceMethodReturnType) throws Exception {
+    private void sendResponse(int nestingLevel, JaxRSRequest requestContext, MuResponse muResponse, List<MediaType> acceptHeaders, List<MediaType> produces, List<MediaType> directlyProduces, Annotation[] annotations, @Nullable Object result, @Nullable Type resourceMethodReturnType) throws Exception {
         try {
             if (requestContext.hasEntity()) {
                 requestContext.getEntityStream().close();
@@ -296,7 +299,8 @@ public class RestHandler implements MuHandler {
                         MuRuntimeDelegate.writeResponseHeaders(requestContext.getUriInfo().getBaseUri(), jaxRSResponse, muResponse, isHttp1);
                     } else {
 
-                        MediaType responseMediaType = jaxRSResponse.getMediaType();
+                        MediaType responseMediaType = Objects.requireNonNull(jaxRSResponse.getMediaType(),
+                            "A response entity must have a media type");
 
                         Class entityType = jaxRSResponse.getEntityClass();
                         Type entityGenericType = jaxRSResponse.getEntityType();
@@ -399,7 +403,7 @@ public class RestHandler implements MuHandler {
         return paramValue;
     }
 
-    static MuUriInfo createUriInfo(String relativePath, RequestMatcher.MatchedMethod mm, URI baseUri, URI requestUri) {
+    static MuUriInfo createUriInfo(String relativePath, RequestMatcher.@Nullable MatchedMethod mm, URI baseUri, URI requestUri) {
         return new MuUriInfo(baseUri, requestUri, Mutils.trim(relativePath, "/"), mm);
     }
 

--- a/src/main/java/io/muserver/rest/RestHandlerBuilder.java
+++ b/src/main/java/io/muserver/rest/RestHandlerBuilder.java
@@ -120,7 +120,7 @@ public class RestHandlerBuilder implements MuHandlerBuilder<RestHandler> {
     public <P> RestHandlerBuilder addCustomParamConverter(Class<P> paramClass, ParamConverter<P> converter) {
         return addCustomParamConverterProvider(new ParamConverterProvider() {
             @Override
-            public <T> ParamConverter<T> getConverter(Class<T> rawType, Type genericType, Annotation[] annotations) {
+            public <T> @Nullable ParamConverter<T> getConverter(Class<T> rawType, Type genericType, Annotation[] annotations) {
                 if (!rawType.equals(paramClass)) {
                     return null;
                 }

--- a/src/main/java/io/muserver/rest/SchemaObjectCustomizerContext.java
+++ b/src/main/java/io/muserver/rest/SchemaObjectCustomizerContext.java
@@ -2,6 +2,7 @@ package io.muserver.rest;
 
 import io.muserver.openapi.SchemaObject;
 import jakarta.ws.rs.core.MediaType;
+import org.jspecify.annotations.Nullable;
 
 import java.lang.reflect.Method;
 import java.lang.reflect.Type;
@@ -16,13 +17,13 @@ public class SchemaObjectCustomizerContext {
 
     private final SchemaObjectCustomizerTarget target;
     private final Class<?> type;
-    private final Type parameterizedType;
-    private final Object resource;
+    private final @Nullable Type parameterizedType;
+    private final @Nullable Object resource;
     private final Method method;
-    private final String parameter;
+    private final @Nullable String parameter;
     private final MediaType mediaType;
 
-    SchemaObjectCustomizerContext(SchemaObjectCustomizerTarget target, Class<?> type, Type parameterizedType, Object resource, Method method, String parameter, MediaType mediaType) {
+    SchemaObjectCustomizerContext(SchemaObjectCustomizerTarget target, Class<?> type, @Nullable Type parameterizedType, @Nullable Object resource, Method method, @Nullable String parameter, MediaType mediaType) {
         this.target = requireNonNull(target, "target");
         this.type = requireNonNull(type, "type");
         this.parameterizedType = parameterizedType;
@@ -44,7 +45,7 @@ public class SchemaObjectCustomizerContext {
      * returned by a sub-resource-locator, this will be null.
      * @return The rest resource that creates or consumes the object being described
      */
-    public Object resource() {
+    public @Nullable Object resource() {
         return resource;
     }
 

--- a/src/main/java/io/muserver/rest/StringEntityProviders.java
+++ b/src/main/java/io/muserver/rest/StringEntityProviders.java
@@ -11,6 +11,7 @@ import jakarta.ws.rs.core.MultivaluedHashMap;
 import jakarta.ws.rs.core.MultivaluedMap;
 import jakarta.ws.rs.ext.MessageBodyReader;
 import jakarta.ws.rs.ext.MessageBodyWriter;
+import org.jspecify.annotations.Nullable;
 
 import java.io.*;
 import java.lang.annotation.Annotation;
@@ -155,7 +156,7 @@ class StringEntityProviders {
         }
 
         @Override
-        public T readFrom(Class<T> type, Type genericType, Annotation[] annotations, MediaType mediaType, MultivaluedMap<String, String> httpHeaders, InputStream entityStream) throws IOException, WebApplicationException {
+        public @Nullable T readFrom(Class<T> type, Type genericType, Annotation[] annotations, MediaType mediaType, MultivaluedMap<String, String> httpHeaders, InputStream entityStream) throws IOException, WebApplicationException {
             String s = new String(Mutils.toByteArray(entityStream, 512), EntityProviders.charsetFor(mediaType));
             if (Mutils.nullOrEmpty(s)) {
                 return null;

--- a/src/main/java/io/muserver/rest/UriParameterConversionException.java
+++ b/src/main/java/io/muserver/rest/UriParameterConversionException.java
@@ -2,6 +2,7 @@ package io.muserver.rest;
 
 import jakarta.ws.rs.MatrixParam;
 import jakarta.ws.rs.NotFoundException;
+import org.jspecify.annotations.Nullable;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.ext.ExceptionMapper;
@@ -26,10 +27,10 @@ import java.util.Objects;
  */
 public final class UriParameterConversionException extends NotFoundException {
     private final String parameterName;
-    private final String parameterValue;
+    private final @Nullable String parameterValue;
     private final Class<?> targetType;
 
-    UriParameterConversionException(String parameterName, String parameterValue, Class<?> targetType, Throwable cause) {
+    UriParameterConversionException(String parameterName, @Nullable String parameterValue, Class<?> targetType, Throwable cause) {
         super("Could not convert URI parameter \"" + parameterName + "\" with value \"" + parameterValue + "\" to " + targetType.getTypeName(), cause);
         this.parameterName = Objects.requireNonNull(parameterName, "parameterName");
         this.parameterValue = parameterValue;
@@ -46,7 +47,7 @@ public final class UriParameterConversionException extends NotFoundException {
     /**
      * @return the supplied parameter value, or {@code null} if no value was supplied
      */
-    public String getParameterValue() {
+    public @Nullable String getParameterValue() {
         return parameterValue;
     }
 

--- a/src/main/java/io/muserver/rest/UriPattern.java
+++ b/src/main/java/io/muserver/rest/UriPattern.java
@@ -8,6 +8,7 @@ import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import org.jspecify.annotations.Nullable;
 
 /**
  * A pattern representing a URI template, such as <code>/fruit</code> or <code>/fruit/{name}</code> etc.
@@ -39,7 +40,7 @@ public class UriPattern {
         this.pathWithoutRegex = pathWithoutRegex;
     }
 
-    String regexFor(String name) {
+    @Nullable String regexFor(String name) {
         int i = namedGroups.indexOf(name);
         if (i == -1) return null;
         return namedGroupRegexes.get(i);

--- a/src/main/java/io/muserver/rest/UriPattern.java
+++ b/src/main/java/io/muserver/rest/UriPattern.java
@@ -247,7 +247,7 @@ public class UriPattern {
     }
 
     @Override
-    public boolean equals(Object o) {
+    public boolean equals(@Nullable Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         UriPattern that = (UriPattern) o;

--- a/src/test/java/io/muserver/rest/JaxRSResponseTest.java
+++ b/src/test/java/io/muserver/rest/JaxRSResponseTest.java
@@ -293,6 +293,53 @@ public class JaxRSResponseTest {
     }
 
     @Test
+    public void nullableBuilderArgumentsRemovePreviouslyConfiguredMetadata() {
+        Response response = new JaxRSResponse.Builder()
+            .cacheControl(cacheControl())
+            .cacheControl(null)
+            .contentLocation(URI.create("/content"))
+            .contentLocation(null)
+            .cookie(new NewCookie("name", "value"))
+            .cookie((NewCookie[]) null)
+            .expires(new Date())
+            .expires(null)
+            .header("custom", "value")
+            .header("custom", null)
+            .lastModified(new Date())
+            .lastModified(null)
+            .location(URI.create("/location"))
+            .location(null)
+            .tag("tag")
+            .tag((String) null)
+            .variants(new Variant(MediaType.TEXT_PLAIN_TYPE, (Locale) null, null))
+            .variants((java.util.List<Variant>) null)
+            .links(Link.fromUri("/link").rel("related").build())
+            .links((Link[]) null)
+            .build();
+
+        assertThat(response.getHeaders(), anEmptyMap());
+        assertThat(response.getCookies(), anEmptyMap());
+        assertThat(response.getLinks(), empty());
+    }
+
+    @Test
+    public void customStatusCodesStillHaveNonNullStatusInfo() {
+        JaxRSResponse response = (JaxRSResponse) Response.ok().build();
+        response.setStatus(299);
+
+        assertThat(response.getStatus(), is(299));
+        assertThat(response.getStatusInfo(), notNullValue());
+    }
+
+    @Test
+    public void responseWithoutEntityHasNoEntityTypeInformation() {
+        JaxRSResponse response = (JaxRSResponse) Response.noContent().build();
+
+        assertThat(response.getEntityClass(), nullValue());
+        assertThat(response.getEntityType(), nullValue());
+    }
+
+    @Test
     public void canBufferInputStreams() throws IOException {
         AtomicInteger closeCount = new AtomicInteger(0);
         try (InputStream inputStream = new ByteArrayInputStream("Hello world".getBytes(StandardCharsets.UTF_8)) {

--- a/src/test/java/io/muserver/rest/JaxSseImplTest.java
+++ b/src/test/java/io/muserver/rest/JaxSseImplTest.java
@@ -2,6 +2,7 @@ package io.muserver.rest;
 
 
 import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.GenericType;
 import jakarta.ws.rs.sse.OutboundSseEvent;
 import org.junit.jupiter.api.Test;
 
@@ -21,7 +22,7 @@ public class JaxSseImplTest {
             .data("Not ignored")
             .name("Event name")
             .build();
-        assertThat(event.getGenericType(), is(nullValue()));
+        assertThat(event.getGenericType(), equalTo(String.class));
         assertThat(event.getMediaType(), is(MediaType.APPLICATION_SVG_XML_TYPE));
         assertThat(event.getComment(), is("A comment"));
         assertThat(event.getReconnectDelay(), is(1000L));
@@ -29,6 +30,19 @@ public class JaxSseImplTest {
         assertThat(event.getName(), is("Event name"));
         assertThat(event.getType(), equalTo(String.class));
         assertThat(event.getData(), is("Not ignored"));
+    }
+
+    @Test
+    public void replacingGenericDataKeepsRawAndGenericTypesConsistent() {
+        GenericType<java.util.List<String>> genericType = new GenericType<java.util.List<String>>() {
+        };
+        OutboundSseEvent event = new JaxSseImpl().newEventBuilder()
+            .data(String.class, "old")
+            .data(genericType, java.util.Collections.singletonList("new"))
+            .build();
+
+        assertThat(event.getType(), equalTo(java.util.List.class));
+        assertThat(event.getGenericType(), equalTo(genericType.getType()));
     }
 
 }

--- a/src/test/java/io/muserver/rest/MuUriBuilderTest.java
+++ b/src/test/java/io/muserver/rest/MuUriBuilderTest.java
@@ -204,6 +204,20 @@ public class MuUriBuilderTest {
     }
 
     @Test
+    public void nullableUriComponentsAreRemoved() {
+        URI uri = MuUriBuilder.fromUri(u("https://user@example.org/path;matrix=value?query=value#fragment"))
+            .scheme(null)
+            .userInfo(null)
+            .host(null)
+            .replacePath(null)
+            .replaceQuery(null)
+            .fragment(null)
+            .build();
+
+        assertThat(uri.toString(), equalTo(""));
+    }
+
+    @Test
     public void pathsAreAppended() {
         URI uri = MuUriBuilder.fromUri(u("http://example.org/blah"))
             .path("ha/har")
@@ -321,6 +335,16 @@ public class MuUriBuilderTest {
         uriBuilder.matrixParam("color", "black", "solid", "1px");
         uriBuilder.replaceMatrixParam("color", "orange", "bright");
         assertThat(uriBuilder.build().toString(), equalTo("/hello;color=red/blah;color=orange;color=bright"));
+    }
+
+    @Test
+    public void replacingMatrixParamWithNullRemovesIt() {
+        URI uri = UriBuilder.fromPath("/hello")
+            .matrixParam("color", "red")
+            .replaceMatrixParam("color", (Object[]) null)
+            .build();
+
+        assertThat(uri.toString(), equalTo("/hello"));
     }
 
     @Test

--- a/src/test/java/io/muserver/rest/RequestMatcherTest.java
+++ b/src/test/java/io/muserver/rest/RequestMatcherTest.java
@@ -471,7 +471,8 @@ public class RequestMatcherTest {
                 return emptyList();
             }
         };
-        InputStream inputStream = requestHasEntity ? new ByteArrayInputStream("Hello".getBytes(StandardCharsets.US_ASCII)) : null;
+        InputStream inputStream = new ByteArrayInputStream(
+            requestHasEntity ? "Hello".getBytes(StandardCharsets.US_ASCII) : new byte[0]);
         JaxRSRequest rc = new JaxRSRequest(request, null, inputStream, request.uri().getPath(), null, emptyList(), null);
         return rm.findResourceMethod(rc, method, acceptHeaders, null);
     }


### PR DESCRIPTION
## What changed

This is the `mu4` companion to #123.

- Adapted the shared JSpecify corrections from `master` while preserving the rewritten v4 server architecture.
- Audited all 290 v4 production sources with NullAway JSpecify mode.
- Applied the same standards-driven Jakarta REST contract pass using the 3.1 API sources/Javadocs, implementation behavior, and compatibility tests.
- Corrected additional v4-only nullable state in the HTTP/1 parser and body stream, HTTP/2 stream/HPACK handling, asynchronous request state, WebSocket framing, rejected requests, problem-details APIs, and SE bootstrap.
- Kept required public inputs non-null with runtime validation at external boundaries.
- Added no NullAway suppressions.
- Enabled NullAway 0.13.8 with Error Prone 2.50.0 in the Java 21 CI `verify` build; Java 11/17/25 and release builds remain unchanged.

## Jakarta REST findings

- Request/response interceptor type metadata is nullable during its lifecycle and required only at the provider call boundary.
- Entity streams remain non-null and public stream setters reject null.
- Documented null-to-remove/reset builder contracts are explicitly nullable and behave accordingly.
- Header delegates, async callbacks, SSE, link builders, and other required public inputs validate null at entry.
- SSE raw/generic types remain consistent, including a defensive raw-type fallback for third-party events.
- Shared fixes for response status/type/tag handling, cookie resets, URI/matrix replacement, and nullable map lookups were adapted to v4.

NullAway checks code flow; Jakarta API null contracts were classified independently from the official API documentation and runtime lifecycle.

## Impact

- CI treats NullAway findings as compilation errors on Java 21.
- Plain local and release builds activate NullAway only with `-Pnullaway`.
- Shared v3 changes were adapted rather than restoring classes deleted or rewritten in v4.

## Validation

After the latest `mu4` base (`6bf076e2`):

- `mvn -Pnullaway clean verify` on Java 21 — latest NullAway/Error Prone analysis compiled all production sources successfully
- `mvn verify` — 1,447 tests, 0 failures/errors, 5 skipped, 125.98 seconds locally
- focused Jakarta contract/SSE/URI/response tests — 116 tests, success
- `git diff --check` — clean