### PR TITLE
Preserve WebSocket write failure semantics

### DIFF
--- a/src/main/java/io/muserver/WebsocketConnection.java
+++ b/src/main/java/io/muserver/WebsocketConnection.java
@@ -347,6 +347,7 @@ class WebsocketConnection implements MuWebSocketSession {
     public void sendTextFragment(ByteBuffer fragment, boolean isLastFragment) throws IOException {
         writeLock.lock();
         try {
+            throwStoredWriteFailure();
             var payload = arrayBuffer(fragment);
             int off = payload.arrayOffset() + payload.position();
             int len = payload.remaining();
@@ -380,6 +381,7 @@ class WebsocketConnection implements MuWebSocketSession {
     public void sendBinaryFragment(ByteBuffer message, boolean isLastFragment) throws IOException {
         writeLock.lock();
         try {
+            throwStoredWriteFailure();
             if (isLastFragment && messageWritingState == MessageWritingState.NONE) {
                 // this is just a non-fragmented full message, so use the plain send
                 sendBinary(message);
@@ -476,9 +478,7 @@ class WebsocketConnection implements MuWebSocketSession {
         assert outputStream != null;
         writeLock.lock();
         try {
-            if (writeFailure != null) {
-                throw new IOException("Cannot write websocket messages after a previous write failed", writeFailure);
-            }
+            throwStoredWriteFailure();
             if (expectedState != null && messageWritingState != expectedState) {
                 throw new IllegalStateException("Expected state " + expectedState + " but was " + messageWritingState);
             }
@@ -507,6 +507,12 @@ class WebsocketConnection implements MuWebSocketSession {
             }
         } finally {
             writeLock.unlock();
+        }
+    }
+
+    private void throwStoredWriteFailure() throws IOException {
+        if (writeFailure != null) {
+            throw new IOException("Cannot write websocket messages after a previous write failed", writeFailure);
         }
     }
 

--- a/src/main/java/io/muserver/WebsocketConnection.java
+++ b/src/main/java/io/muserver/WebsocketConnection.java
@@ -322,6 +322,7 @@ class WebsocketConnection implements MuWebSocketSession {
 
 
     private MessageWritingState messageWritingState = MessageWritingState.NONE;
+    private @Nullable IOException writeFailure;
 
     void onTimeout() {
         try {
@@ -475,29 +476,35 @@ class WebsocketConnection implements MuWebSocketSession {
         assert outputStream != null;
         writeLock.lock();
         try {
+            if (writeFailure != null) {
+                throw new IOException("Cannot write websocket messages after a previous write failed", writeFailure);
+            }
             if (expectedState != null && messageWritingState != expectedState) {
                 throw new IllegalStateException("Expected state " + expectedState + " but was " + messageWritingState);
             }
             if (closeSent) {
                 throw new IllegalStateException("Cannot write websocket messages after close frame sent");
             }
-            outputStream.write(header, 0, header.length);
-            if (payloadLen > 0) {
-                outputStream.write(payload, payloadOffset, payloadLen);
-            }
-            outputStream.flush();
-            if (endState != null) {
-                messageWritingState = endState;
-            }
-        } catch (IOException e) {
-            messageWritingState = MessageWritingState.ERROR;
-            state = WebsocketSessionState.ERRORED;
             try {
-                webSocket.onError(e);
-            } catch (Exception userException) {
-                e.addSuppressed(userException);
+                outputStream.write(header, 0, header.length);
+                if (payloadLen > 0) {
+                    outputStream.write(payload, payloadOffset, payloadLen);
+                }
+                outputStream.flush();
+                if (endState != null) {
+                    messageWritingState = endState;
+                }
+            } catch (IOException e) {
+                writeFailure = e;
+                messageWritingState = MessageWritingState.ERROR;
+                state = WebsocketSessionState.ERRORED;
+                try {
+                    webSocket.onError(e);
+                } catch (Exception userException) {
+                    e.addSuppressed(userException);
+                }
+                throw e;
             }
-            throw e;
         } finally {
             writeLock.unlock();
         }

--- a/src/test/java/io/muserver/WebSocketsDeprecatedTest.java
+++ b/src/test/java/io/muserver/WebSocketsDeprecatedTest.java
@@ -12,7 +12,6 @@ import org.eclipse.jetty.websocket.api.Session;
 import org.eclipse.jetty.websocket.api.WebSocketAdapter;
 import org.eclipse.jetty.websocket.client.WebSocketClient;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.slf4j.Logger;
@@ -29,6 +28,7 @@ import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.*;
+import java.util.function.Consumer;
 
 import static io.muserver.MuServerBuilder.httpServer;
 import static io.muserver.WebSocketHandlerBuilder.webSocketHandler;
@@ -331,22 +331,27 @@ public class WebSocketsDeprecatedTest {
         MuWebSocketSession serverSession = sessionFuture.get(10, TimeUnit.SECONDS);
         clientSocket.cancel();
 
-        for (int i = 0; i < 100; i++) {
-            CompletableFuture<String> result = new CompletableFuture<>();
-            serverSession.sendText("This shouldn't work", error -> {
-                if (error == null) {
-                    result.complete("Success");
-                } else {
-                    result.completeExceptionally(error);
-                }
-            });
-            try {
-                result.get(10, TimeUnit.SECONDS);
-            } catch (ExecutionException e) {
-                return; // as expected
-            }
-        }
-        Assertions.fail("This should have failed");
+        assertEventually(() -> server.activeConnections(), empty());
+
+        asyncWriteFailure(done -> serverSession.sendText("This shouldn't work", done));
+        IOException repeatedFailure = asyncWriteFailure(done -> serverSession.sendText("Neither should this", done));
+        assertThat(repeatedFailure.getCause(), instanceOf(IOException.class));
+
+        IOException textFragmentFailure = asyncWriteFailure(
+            done -> serverSession.sendText("Text fragment", false, done));
+        assertThat(textFragmentFailure.getCause(), sameInstance(repeatedFailure.getCause()));
+
+        IOException binaryFragmentFailure = asyncWriteFailure(
+            done -> serverSession.sendBinary(Mutils.toByteBuffer("Binary fragment"), false, done));
+        assertThat(binaryFragmentFailure.getCause(), sameInstance(repeatedFailure.getCause()));
+    }
+
+    private static IOException asyncWriteFailure(Consumer<DoneCallback> send) throws Exception {
+        CompletableFuture<Throwable> result = new CompletableFuture<>();
+        send.accept(result::complete);
+        Throwable failure = result.get(10, TimeUnit.SECONDS);
+        assertThat(failure, instanceOf(IOException.class));
+        return (IOException) failure;
     }
 
     @Test

--- a/src/test/java/io/muserver/WebSocketsTest.java
+++ b/src/test/java/io/muserver/WebSocketsTest.java
@@ -40,6 +40,7 @@ import static io.muserver.WebSocketHandlerBuilder.webSocketHandler;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static scaffolding.ClientUtils.*;
 import static scaffolding.MuAssert.assertEventually;
@@ -919,6 +920,14 @@ public class WebSocketsTest {
         assertThrows(IOException.class, () -> serverSession.sendText("This shouldn't work"));
         IOException repeatedFailure = assertThrows(IOException.class, () -> serverSession.sendText("Neither should this"));
         assertThat(repeatedFailure.getCause(), instanceOf(IOException.class));
+        assertAll(
+            () -> assertThat(assertThrows(IOException.class,
+                () -> serverSession.sendTextFragment(Mutils.toByteBuffer("Text fragment"), false)).getCause(),
+                sameInstance(repeatedFailure.getCause())),
+            () -> assertThat(assertThrows(IOException.class,
+                () -> serverSession.sendBinaryFragment(Mutils.toByteBuffer("Binary fragment"), false)).getCause(),
+                sameInstance(repeatedFailure.getCause()))
+        );
     }
 
     @Test

--- a/src/test/java/io/muserver/WebSocketsTest.java
+++ b/src/test/java/io/muserver/WebSocketsTest.java
@@ -888,7 +888,7 @@ public class WebSocketsTest {
     }
 
     @Test
-    public void sendingMessagesAfterTheClientsCloseResultInFailureCallBacksForAsyncCalls() throws Exception {
+    public void sendingMessagesAfterClientDisconnectThrowIOExceptions() throws Exception {
         CompletableFuture<MuWebSocketSession> sessionFuture = new CompletableFuture<>();
         server = ServerUtils.httpsServerForTest()
             .addHandler(webSocketHandler((request, responseHeaders) -> new SimpleWebSocket() {
@@ -914,11 +914,11 @@ public class WebSocketsTest {
         MuWebSocketSession serverSession = sessionFuture.get(10, TimeUnit.SECONDS);
         clientSocket.cancel();
 
-        assertThrows(IOException.class, () -> {
-            for (int i = 0; i < 100; i++) {
-                serverSession.sendText("This shouldn't work");
-            }
-        });
+        assertEventually(() -> server.activeConnections(), empty());
+
+        assertThrows(IOException.class, () -> serverSession.sendText("This shouldn't work"));
+        IOException repeatedFailure = assertThrows(IOException.class, () -> serverSession.sendText("Neither should this"));
+        assertThat(repeatedFailure.getCause(), instanceOf(IOException.class));
     }
 
     @Test


### PR DESCRIPTION
## Summary

- preserve the original WebSocket write failure after the connection enters its write-error state
- report repeated writes as `IOException` instead of misclassifying the error state as an invalid fragmentation transition
- make the disconnect regression deterministic by waiting for server-side connection removal and checking consecutive failed writes

## Root cause

When client cancellation caused a close-frame write to fail, `WebsocketConnection` set `messageWritingState` to `ERROR`. The next send checked that value against the expected fragmentation state and threw `IllegalStateException`. Whether the test saw the original `IOException` or this later `IllegalStateException` depended on timing.

The `ERROR` state represents an I/O failure, not an invalid text/binary fragmentation sequence. The implementation now retains the original `IOException` and uses it as the cause of subsequent `IOException`s.

## Impact

Blocking WebSocket sends after a failed write now consistently follow the declared I/O failure contract, while genuine fragmentation-state mistakes continue to throw `IllegalStateException`.

This is Mu4-specific because master uses the older asynchronous session implementation and does not have `WebsocketConnection.MessageWritingState.ERROR`.

## Validation

- Java 11: reproduced the original failure on the latest `mu4`
- Java 11: 30 consecutive repetitions of the fixed regression test
- Java 11: `WebSocketsTest` and `WebSocketsDeprecatedTest` — 45 tests passed
- Java 11: full `mvn test` suite — 1,441 tests passed, 5 skipped
