### PR TITLE
Support RuntimeDelegate system property selection

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,5 +26,4 @@ jobs:
       - name: Build with Maven on JDK ${{ matrix.java }} and ${{ matrix.netty-profile }}
         run: mvn --batch-mode --update-snapshots -P${{ matrix.netty-profile }} verify
       - name: Verify RuntimeDelegate system-property selection in isolation
-        if: matrix.java == 11
         run: mvn --batch-mode -P${{ matrix.netty-profile }} -Dtest=RuntimeDelegateSystemPropertyTest test

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,5 +25,3 @@ jobs:
           cache: 'maven'
       - name: Build with Maven on JDK ${{ matrix.java }} and ${{ matrix.netty-profile }}
         run: mvn --batch-mode --update-snapshots -P${{ matrix.netty-profile }} verify
-      - name: Verify RuntimeDelegate system-property selection in isolation
-        run: mvn --batch-mode -P${{ matrix.netty-profile }} -Dtest=RuntimeDelegateSystemPropertyTest test

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,3 +25,6 @@ jobs:
           cache: 'maven'
       - name: Build with Maven on JDK ${{ matrix.java }} and ${{ matrix.netty-profile }}
         run: mvn --batch-mode --update-snapshots -P${{ matrix.netty-profile }} verify
+      - name: Verify RuntimeDelegate system-property selection in isolation
+        if: matrix.java == 11
+        run: mvn --batch-mode -P${{ matrix.netty-profile }} -Dtest=RuntimeDelegateSystemPropertyTest test

--- a/src/main/java/io/muserver/rest/LinkHeaderDelegate.java
+++ b/src/main/java/io/muserver/rest/LinkHeaderDelegate.java
@@ -15,12 +15,7 @@ import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
 
 class LinkHeaderDelegate implements RuntimeDelegate.HeaderDelegate<Link> {
-    private static final RuntimeDelegate.HeaderDelegate<Link> HEADER_DELEGATE;
-    static {
-        MuRuntimeDelegate.ensureSet();
-        HEADER_DELEGATE =
-            RuntimeDelegate.getInstance().createHeaderDelegate(Link.class);
-    }
+    private static final RuntimeDelegate.HeaderDelegate<Link> HEADER_DELEGATE = new LinkHeaderDelegate();
 
     @Override
     public Link fromString(String value) {

--- a/src/main/java/io/muserver/rest/MuRuntimeDelegate.java
+++ b/src/main/java/io/muserver/rest/MuRuntimeDelegate.java
@@ -26,6 +26,7 @@ public class MuRuntimeDelegate extends RuntimeDelegate {
 
     private static @Nullable MuRuntimeDelegate singleton;
     private static @Nullable MuRuntimeDelegate initializing;
+    private static boolean registeredByEnsureSet;
 
     /**
      * Registers the mu RuntimeDelegate with jax-rs, if it was not already.
@@ -37,7 +38,10 @@ public class MuRuntimeDelegate extends RuntimeDelegate {
         }
         if (singleton == null) {
             singleton = new MuRuntimeDelegate();
+        }
+        if (!registeredByEnsureSet) {
             RuntimeDelegate.setInstance(singleton);
+            registeredByEnsureSet = true;
         }
         return singleton;
     }

--- a/src/main/java/io/muserver/rest/MuRuntimeDelegate.java
+++ b/src/main/java/io/muserver/rest/MuRuntimeDelegate.java
@@ -25,12 +25,16 @@ import java.util.concurrent.CompletionStage;
 public class MuRuntimeDelegate extends RuntimeDelegate {
 
     private static @Nullable MuRuntimeDelegate singleton;
+    private static @Nullable MuRuntimeDelegate initializing;
 
     /**
      * Registers the mu RuntimeDelegate with jax-rs, if it was not already.
      * @return Returns the runtime delegate.
      */
     public static synchronized RuntimeDelegate ensureSet() {
+        if (initializing != null) {
+            return initializing;
+        }
         if (singleton == null) {
             singleton = new MuRuntimeDelegate();
             RuntimeDelegate.setInstance(singleton);
@@ -40,14 +44,36 @@ public class MuRuntimeDelegate extends RuntimeDelegate {
 
     private final Map<Class<?>, HeaderDelegate> headerDelegates = new HashMap<>();
 
-    private MuRuntimeDelegate() {
-        headerDelegates.put(MediaType.class, new MediaTypeHeaderDelegate());
-        headerDelegates.put(CacheControl.class, new CacheControlHeaderDelegate());
-        headerDelegates.put(NewCookie.class, new NewCookieHeaderDelegate());
-        headerDelegates.put(Cookie.class, new CookieHeaderDelegate());
-        headerDelegates.put(EntityTag.class, new EntityTagDelegate());
-        headerDelegates.put(Link.class, new LinkHeaderDelegate());
-        headerDelegates.put(Date.class, new DateHeaderDelegate());
+    /**
+     * Creates a runtime delegate.
+     * <p>This constructor is public so that Jakarta REST can instantiate this class when
+     * {@value RuntimeDelegate#JAXRS_RUNTIME_DELEGATE_PROPERTY} is set to
+     * {@code io.muserver.rest.MuRuntimeDelegate}. Applications should normally use
+     * {@link #ensureSet()} instead.</p>
+     */
+    public MuRuntimeDelegate() {
+        synchronized (MuRuntimeDelegate.class) {
+            boolean first = singleton == null && initializing == null;
+            if (first) {
+                initializing = this;
+            }
+            try {
+                headerDelegates.put(MediaType.class, new MediaTypeHeaderDelegate());
+                headerDelegates.put(CacheControl.class, new CacheControlHeaderDelegate());
+                headerDelegates.put(NewCookie.class, new NewCookieHeaderDelegate());
+                headerDelegates.put(Cookie.class, new CookieHeaderDelegate());
+                headerDelegates.put(EntityTag.class, new EntityTagDelegate());
+                headerDelegates.put(Link.class, new LinkHeaderDelegate());
+                headerDelegates.put(Date.class, new DateHeaderDelegate());
+                if (first) {
+                    singleton = this;
+                }
+            } finally {
+                if (first) {
+                    initializing = null;
+                }
+            }
+        }
     }
 
     /**

--- a/src/main/java/io/muserver/rest/README.md
+++ b/src/main/java/io/muserver/rest/README.md
@@ -381,7 +381,9 @@ Will not implement. Configuration should be handled by the user.
 - [ ] TLS client authentication through `SeBootstrap` is not supported.
 
 Mu Server does not advertise its `RuntimeDelegate` globally merely by being present on an application's classpath.
-Call `MuRuntimeDelegate.ensureSet()` once before the first `SeBootstrap` call to select Mu explicitly.
+Call `MuRuntimeDelegate.ensureSet()` once before the first `SeBootstrap` call to select Mu explicitly. When no
+`RuntimeDelegate` service provider takes precedence, the JVM system property can instead be used:
+`-Djakarta.ws.rs.ext.RuntimeDelegate=io.muserver.rest.MuRuntimeDelegate`.
 
 ## 12 Runtime Delegate
 

--- a/src/test/java/io/muserver/RequestBodyReaderStringTest.java
+++ b/src/test/java/io/muserver/RequestBodyReaderStringTest.java
@@ -194,7 +194,7 @@ public class RequestBodyReaderStringTest {
     @Test
     public void chineseWorks() throws Exception {
         server = ServerUtils.httpsServerForTest()
-            .withHttpsPort(8443)
+            .withHttpsPort(0)
             .addHandler((request, response) -> {
                 response.contentType(ContentTypes.TEXT_PLAIN_UTF8);
                 String requestBody = request.readBodyAsString();

--- a/src/test/java/io/muserver/rest/HeaderDelegateInitializationTest.java
+++ b/src/test/java/io/muserver/rest/HeaderDelegateInitializationTest.java
@@ -1,0 +1,90 @@
+package io.muserver.rest;
+
+import jakarta.ws.rs.core.Cookie;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.NewCookie;
+import jakarta.ws.rs.ext.RuntimeDelegate;
+import org.junit.Test;
+
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.concurrent.TimeUnit;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+public class HeaderDelegateInitializationTest {
+
+    @Test
+    public void mediaTypeDelegateSetsRuntimeWhenUsedDirectly() throws Exception {
+        runInFreshJvm("media-type");
+    }
+
+    @Test
+    public void cookieDelegateSetsRuntimeWhenUsedDirectly() throws Exception {
+        runInFreshJvm("cookie");
+    }
+
+    @Test
+    public void newCookieDelegateSetsRuntimeWhenUsedDirectly() throws Exception {
+        runInFreshJvm("new-cookie");
+    }
+
+    private static void runInFreshJvm(String delegate) throws Exception {
+        String java = System.getProperty("java.home") + File.separator + "bin" + File.separator + "java";
+        String classPath = System.getProperty("surefire.test.class.path", System.getProperty("java.class.path"));
+        Process process = new ProcessBuilder(
+            java,
+            "-cp",
+            classPath,
+            HeaderDelegateInitializationTest.class.getName(),
+            delegate)
+            .redirectErrorStream(true)
+            .start();
+
+        boolean finished = process.waitFor(30, TimeUnit.SECONDS);
+        if (!finished) {
+            process.destroyForcibly();
+        }
+        String output = new String(process.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
+
+        assertThat("Child JVM output:\n" + output, finished, is(true));
+        assertThat("Child JVM output:\n" + output, process.exitValue(), is(0));
+    }
+
+    public static void main(String[] args) {
+        if (args.length != 1) {
+            throw new AssertionError("Expected a header-delegate name");
+        }
+
+        switch (args[0]) {
+            case "media-type":
+                MediaType mediaType = MediaTypeHeaderDelegate
+                    .fromStrings(Collections.singletonList("text/plain"))
+                    .get(0);
+                if (!MediaType.TEXT_PLAIN_TYPE.equals(mediaType)) {
+                    throw new AssertionError("Media type delegate did not parse text/plain");
+                }
+                break;
+            case "cookie":
+                Cookie cookie = new CookieHeaderDelegate().fromString("session=abc");
+                if (!"abc".equals(cookie.getValue())) {
+                    throw new AssertionError("Cookie delegate did not parse the cookie");
+                }
+                break;
+            case "new-cookie":
+                NewCookie newCookie = new NewCookieHeaderDelegate().fromString("session=abc");
+                if (!"abc".equals(newCookie.getValue())) {
+                    throw new AssertionError("New-cookie delegate did not parse the cookie");
+                }
+                break;
+            default:
+                throw new AssertionError("Unknown header delegate " + args[0]);
+        }
+
+        if (RuntimeDelegate.getInstance().getClass() != MuRuntimeDelegate.class) {
+            throw new AssertionError("Direct header-delegate use did not select MuRuntimeDelegate");
+        }
+    }
+}

--- a/src/test/java/io/muserver/rest/RuntimeDelegateSystemPropertyTest.java
+++ b/src/test/java/io/muserver/rest/RuntimeDelegateSystemPropertyTest.java
@@ -7,6 +7,8 @@ import org.junit.Test;
 
 import java.io.File;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -16,15 +18,28 @@ public class RuntimeDelegateSystemPropertyTest {
 
     @Test
     public void systemPropertySelectsMuForSeBootstrap() throws Exception {
+        runInFreshJvm(true, "verify-system-property");
+    }
+
+    @Test
+    public void ensureSetRegistersAnInstanceThatWasConstructedDirectly() throws Exception {
+        runInFreshJvm(false, "verify-direct-construction");
+    }
+
+    private static void runInFreshJvm(boolean setSystemProperty, String childArgument) throws Exception {
         String java = System.getProperty("java.home") + File.separator + "bin" + File.separator + "java";
         String classPath = System.getProperty("surefire.test.class.path", System.getProperty("java.class.path"));
-        Process process = new ProcessBuilder(
-            java,
-            "-D" + RuntimeDelegate.JAXRS_RUNTIME_DELEGATE_PROPERTY + "=" + MuRuntimeDelegate.class.getName(),
-            "-cp",
-            classPath,
-            RuntimeDelegateSystemPropertyTest.class.getName(),
-            "verify-system-property")
+        List<String> command = new ArrayList<>();
+        command.add(java);
+        if (setSystemProperty) {
+            command.add("-D" + RuntimeDelegate.JAXRS_RUNTIME_DELEGATE_PROPERTY + "="
+                + MuRuntimeDelegate.class.getName());
+        }
+        command.add("-cp");
+        command.add(classPath);
+        command.add(RuntimeDelegateSystemPropertyTest.class.getName());
+        command.add(childArgument);
+        Process process = new ProcessBuilder(command)
             .redirectErrorStream(true)
             .start();
 
@@ -39,8 +54,22 @@ public class RuntimeDelegateSystemPropertyTest {
     }
 
     public static void main(String[] args) throws Exception {
-        if (args.length != 1 || !"verify-system-property".equals(args[0])) {
+        if (args.length != 1) {
             throw new AssertionError("Expected the child-process marker argument");
+        }
+
+        if ("verify-direct-construction".equals(args[0])) {
+            MuRuntimeDelegate constructed = new MuRuntimeDelegate();
+            if (MuRuntimeDelegate.ensureSet() != constructed) {
+                throw new AssertionError("ensureSet() did not retain the directly constructed instance");
+            }
+            if (RuntimeDelegate.getInstance() != constructed) {
+                throw new AssertionError("ensureSet() did not register the directly constructed instance");
+            }
+            return;
+        }
+        if (!"verify-system-property".equals(args[0])) {
+            throw new AssertionError("Unknown child-process marker argument " + args[0]);
         }
 
         SeBootstrap.Configuration configuration = SeBootstrap.Configuration.builder()

--- a/src/test/java/io/muserver/rest/RuntimeDelegateSystemPropertyTest.java
+++ b/src/test/java/io/muserver/rest/RuntimeDelegateSystemPropertyTest.java
@@ -1,0 +1,71 @@
+package io.muserver.rest;
+
+import jakarta.ws.rs.SeBootstrap;
+import jakarta.ws.rs.core.Application;
+import jakarta.ws.rs.ext.RuntimeDelegate;
+import org.junit.Test;
+
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.TimeUnit;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+public class RuntimeDelegateSystemPropertyTest {
+
+    @Test
+    public void systemPropertySelectsMuForSeBootstrap() throws Exception {
+        String java = System.getProperty("java.home") + File.separator + "bin" + File.separator + "java";
+        String classPath = System.getProperty("surefire.test.class.path", System.getProperty("java.class.path"));
+        Process process = new ProcessBuilder(
+            java,
+            "-D" + RuntimeDelegate.JAXRS_RUNTIME_DELEGATE_PROPERTY + "=" + MuRuntimeDelegate.class.getName(),
+            "-cp",
+            classPath,
+            RuntimeDelegateSystemPropertyTest.class.getName(),
+            "verify-system-property")
+            .redirectErrorStream(true)
+            .start();
+
+        boolean finished = process.waitFor(30, TimeUnit.SECONDS);
+        if (!finished) {
+            process.destroyForcibly();
+        }
+        String output = new String(process.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
+
+        assertThat("Child JVM output:\n" + output, finished, is(true));
+        assertThat("Child JVM output:\n" + output, process.exitValue(), is(0));
+    }
+
+    public static void main(String[] args) throws Exception {
+        if (args.length != 1 || !"verify-system-property".equals(args[0])) {
+            throw new AssertionError("Expected the child-process marker argument");
+        }
+
+        SeBootstrap.Configuration configuration = SeBootstrap.Configuration.builder()
+            .port(SeBootstrap.Configuration.FREE_PORT)
+            .build();
+        RuntimeDelegate selected = RuntimeDelegate.getInstance();
+
+        if (selected.getClass() != MuRuntimeDelegate.class) {
+            throw new AssertionError("Expected MuRuntimeDelegate but got " + selected.getClass().getName());
+        }
+        if (MuRuntimeDelegate.ensureSet() != selected) {
+            throw new AssertionError("ensureSet() did not retain the delegate selected by the system property");
+        }
+        if (!"HTTP".equals(configuration.protocol())) {
+            throw new AssertionError("Expected Mu's default HTTP configuration");
+        }
+
+        SeBootstrap.Instance instance = SeBootstrap.start(new Application() {
+        }, configuration).toCompletableFuture().get(10, TimeUnit.SECONDS);
+        try {
+            if (instance.configuration().port() <= 0) {
+                throw new AssertionError("Expected SeBootstrap to bind to a free port");
+            }
+        } finally {
+            instance.stop().toCompletableFuture().get(10, TimeUnit.SECONDS);
+        }
+    }
+}


### PR DESCRIPTION
## What changed

- Allow Jakarta REST to instantiate `MuRuntimeDelegate` when `jakarta.ws.rs.ext.RuntimeDelegate` names it.
- Preserve the singleton selected through the system-property lookup and remove recursive `LinkHeaderDelegate` initialization.
- Ensure a directly constructed delegate is still installed globally by a subsequent `ensureSet()` call.
- Add a child-JVM test that proves `SeBootstrap` can start without first calling `MuRuntimeDelegate.ensureSet()`; it remains deterministic when run in the normal test suite on every CI JDK.
- Add independent fresh-JVM coverage proving direct media-type, cookie, and new-cookie delegate use selects Mu before the Jakarta REST API needs a global delegate.
- Document the opt-in system property and its service-provider precedence caveat.
- Let `RequestBodyReaderStringTest.chineseWorks` use an ephemeral HTTPS port instead of hardcoding 8443.

## Why

Jakarta REST caches its `RuntimeDelegate` statically. It supports selecting an implementation from the `jakarta.ws.rs.ext.RuntimeDelegate` system property, but Mu's private constructor prevented the API factory from instantiating it. Fresh child JVMs are required to test lookup and direct initialization deterministically because another test may already have initialized the cached delegate.

## Validation

- `mvn --batch-mode -Pnetty-4.1 -Dtest=RuntimeDelegateSystemPropertyTest test`
- `mvn --batch-mode -Dtest=RuntimeDelegateSystemPropertyTest,HeaderDelegateInitializationTest,MuSeBootstrapTest,LinkHeaderDelegateTest test`
- `mvn --batch-mode -Dtest=RuntimeDelegateSystemPropertyTest,HeaderDelegateInitializationTest test` on Java 11, 17, 21, and 25
- `mvn --batch-mode -Dtest=RequestBodyReaderStringTest#chineseWorks test`
- `mvn --batch-mode -DskipTests verify`
- A full Java 11 `mvn verify` ran 944 tests; its sole error was the pre-existing hardcoded port 8443 already being occupied. The formerly failing test passes after switching it to port 0.