### PR TITLE
Map URI conversion problems to bad requests

### DIFF
--- a/src/main/java/io/muserver/rest/BuiltInParamConverterProvider.java
+++ b/src/main/java/io/muserver/rest/BuiltInParamConverterProvider.java
@@ -174,21 +174,34 @@ class BuiltInParamConverterProvider implements ParamConverterProvider {
         }
     }
 
-    private static class EnumConverter<E extends Enum<E>>  implements ParamConverter<E> {
+    private static class EnumConverter<E extends Enum<E>> implements ParamConverter<E>, ResourceMethodParam.HasAllowedValues {
         private final Class<E> enumClass;
         private final StaticMethodConverter<E> fromStringConverter;
+        private final List<String> allowedValues;
+
         private EnumConverter(Class<E> enumClass) {
             this.enumClass = enumClass;
             this.fromStringConverter = StaticMethodConverter.tryToCreateFromString(enumClass);
+            this.allowedValues = fromStringConverter == null
+                ? Stream.of(enumClass.getEnumConstants()).map(Enum::name).collect(Collectors.toList())
+                : java.util.Collections.emptyList();
         }
+
         public E fromString(String value) {
             if (Mutils.nullOrEmpty(value)) return null;
             if (fromStringConverter != null) return fromStringConverter.fromString(value);
             return Enum.valueOf(enumClass, value);
         }
+
         public String toString(E value) {
             return value.name();
         }
+
+        @Override
+        public List<String> allowedValues() {
+            return allowedValues;
+        }
+
         public String toString() {
             String validValues = Stream.of(enumClass.getEnumConstants()).map(Enum::name).collect(Collectors.joining(", "));
             return enumClass.getSimpleName() + " converter (valid values: " + validValues + ")";

--- a/src/main/java/io/muserver/rest/ProblemDetailsExceptionMapper.java
+++ b/src/main/java/io/muserver/rest/ProblemDetailsExceptionMapper.java
@@ -29,6 +29,7 @@ import java.util.UUID;
  * </p>
  * <ul>
  *     <li>{@link ProblemDetailsException}: values are taken from the exception.</li>
+ *     <li>{@link UriParameterConversionException}: a 400 Bad Request problem-details body is created.</li>
  *     <li>{@link WebApplicationException} with no response entity and a 4xx/5xx status: a problem-details body is created.</li>
  *     <li>Any other exception: a generic 500 problem-details response is created.</li>
  * </ul>
@@ -72,20 +73,23 @@ public class ProblemDetailsExceptionMapper <E extends Throwable> implements Exce
             if (response.getEntity() != null) {
                 return response;
             }
-            Response.Status.Family family = Response.Status.Family.familyOf(response.getStatus());
+            int status = exception instanceof UriParameterConversionException
+                ? Response.Status.BAD_REQUEST.getStatusCode()
+                : response.getStatus();
+            Response.Status.Family family = Response.Status.Family.familyOf(status);
             if (family != Response.Status.Family.CLIENT_ERROR && family != Response.Status.Family.SERVER_ERROR) {
                 return response;
             }
 
             URI instance = newInstance();
-            if (shouldLogInstance(response.getStatus())) {
+            if (shouldLogInstance(status)) {
                 log.error("Sending a problem details response with instance={}", instance, exception);
             }
             String detail = exception.getMessage();
             if (Mutils.nullOrEmpty(detail)) {
-                detail = defaultTitle(response.getStatus());
+                detail = defaultTitle(status);
             }
-            return toResponse(response.getStatus(), defaultTitle(response.getStatus()), detail, null, instance, null);
+            return toResponse(status, defaultTitle(status), detail, null, instance, null);
         }
 
         return serverError(exception);

--- a/src/main/java/io/muserver/rest/ProblemDetailsExceptionMapper.java
+++ b/src/main/java/io/muserver/rest/ProblemDetailsExceptionMapper.java
@@ -29,7 +29,7 @@ import java.util.UUID;
  * </p>
  * <ul>
  *     <li>{@link ProblemDetailsException}: values are taken from the exception.</li>
- *     <li>{@link UriParameterConversionException}: a 400 Bad Request problem-details body is created.</li>
+ *     <li>{@link UriParameterConversionException}: a 400 Bad Request problem-details body with parameter metadata is created.</li>
  *     <li>{@link WebApplicationException} with no response entity and a 4xx/5xx status: a problem-details body is created.</li>
  *     <li>Any other exception: a generic 500 problem-details response is created.</li>
  * </ul>
@@ -64,6 +64,10 @@ public class ProblemDetailsExceptionMapper <E extends Throwable> implements Exce
             return toResponse(problem.getStatus(), problem.getTitle(), problem.getDetail(), problem.getType(), problem.getInstance(), problem.getExtensionMembers());
         }
 
+        if (exception instanceof UriParameterConversionException) {
+            return uriParameterConversionError((UriParameterConversionException) exception);
+        }
+
         if (exception instanceof WebApplicationException) {
             WebApplicationException webApplicationException = (WebApplicationException) exception;
             Response response = webApplicationException.getResponse();
@@ -73,26 +77,41 @@ public class ProblemDetailsExceptionMapper <E extends Throwable> implements Exce
             if (response.getEntity() != null) {
                 return response;
             }
-            int status = exception instanceof UriParameterConversionException
-                ? Response.Status.BAD_REQUEST.getStatusCode()
-                : response.getStatus();
-            Response.Status.Family family = Response.Status.Family.familyOf(status);
+            Response.Status.Family family = Response.Status.Family.familyOf(response.getStatus());
             if (family != Response.Status.Family.CLIENT_ERROR && family != Response.Status.Family.SERVER_ERROR) {
                 return response;
             }
 
             URI instance = newInstance();
-            if (shouldLogInstance(status)) {
+            if (shouldLogInstance(response.getStatus())) {
                 log.error("Sending a problem details response with instance={}", instance, exception);
             }
             String detail = exception.getMessage();
             if (Mutils.nullOrEmpty(detail)) {
-                detail = defaultTitle(status);
+                detail = defaultTitle(response.getStatus());
             }
-            return toResponse(status, defaultTitle(status), detail, null, instance, null);
+            return toResponse(response.getStatus(), defaultTitle(response.getStatus()), detail, null, instance, null);
         }
 
         return serverError(exception);
+    }
+
+    private Response uriParameterConversionError(UriParameterConversionException exception) {
+        int status = Response.Status.BAD_REQUEST.getStatusCode();
+        URI instance = newInstance();
+        if (shouldLogInstance(status)) {
+            log.error("Sending a problem details response with instance={}", instance, exception);
+        }
+        Map<String, Object> extensionMembers = new LinkedHashMap<>();
+        extensionMembers.put("parameter", exception.getParameterName());
+        if (exception.getParameterValue() != null) {
+            extensionMembers.put("suppliedValue", exception.getParameterValue());
+        }
+        if (!exception.getAllowedValues().isEmpty()) {
+            extensionMembers.put("allowedValues", exception.getAllowedValues());
+        }
+        String detail = "Invalid value for URI parameter \"" + exception.getParameterName() + "\".";
+        return toResponse(status, defaultTitle(status), detail, null, instance, extensionMembers);
     }
 
     private Response serverError(Throwable exception) {

--- a/src/main/java/io/muserver/rest/ResourceMethodParam.java
+++ b/src/main/java/io/muserver/rest/ResourceMethodParam.java
@@ -436,7 +436,10 @@ abstract class ResourceMethodParam {
                 throw e;
             } catch (Exception e) {
                 if (source == ValueSource.MATRIX_PARAM || source == ValueSource.QUERY_PARAM || source == ValueSource.PATH_PARAM) {
-                    throw new UriParameterConversionException(parameterName, (String) value, parameterType, e);
+                    List<String> allowedValues = converter instanceof HasAllowedValues
+                        ? ((HasAllowedValues) converter).allowedValues()
+                        : emptyList();
+                    throw new UriParameterConversionException(parameterName, (String) value, parameterType, allowedValues, e);
                 }
                 String message = "Could not convert String value \"" + value + "\" to a " + parameterType + " using " + converter + " on parameter " + parameterHandle;
                 throw new BadRequestException(message, e);
@@ -456,6 +459,10 @@ abstract class ResourceMethodParam {
 
     interface HasDefaultValue {
         Object getDefault();
+    }
+
+    interface HasAllowedValues {
+        List<String> allowedValues();
     }
 
 }

--- a/src/main/java/io/muserver/rest/UriParameterConversionException.java
+++ b/src/main/java/io/muserver/rest/UriParameterConversionException.java
@@ -6,6 +6,7 @@ import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.ext.ExceptionMapper;
 
+import java.util.List;
 import java.util.Objects;
 
 /**
@@ -22,18 +23,23 @@ import java.util.Objects;
  * response, for example to return a {@code 400 Bad Request} with an
  * application-specific validation message.
  *
+ * <p>When Mu's built-in enum converter is used, {@link #getAllowedValues()}
+ * contains the enum constant names accepted by that converter.
+ *
  * <p>The original conversion failure is available from {@link #getCause()}.
  */
 public final class UriParameterConversionException extends NotFoundException {
     private final String parameterName;
     private final String parameterValue;
     private final Class<?> targetType;
+    private final List<String> allowedValues;
 
-    UriParameterConversionException(String parameterName, String parameterValue, Class<?> targetType, Throwable cause) {
+    UriParameterConversionException(String parameterName, String parameterValue, Class<?> targetType, List<String> allowedValues, Throwable cause) {
         super("Could not convert URI parameter \"" + parameterName + "\" with value \"" + parameterValue + "\" to " + targetType.getTypeName(), cause);
         this.parameterName = Objects.requireNonNull(parameterName, "parameterName");
         this.parameterValue = parameterValue;
         this.targetType = Objects.requireNonNull(targetType, "targetType");
+        this.allowedValues = List.copyOf(Objects.requireNonNull(allowedValues, "allowedValues"));
     }
 
     /**
@@ -55,5 +61,14 @@ public final class UriParameterConversionException extends NotFoundException {
      */
     public Class<?> getTargetType() {
         return targetType;
+    }
+
+    /**
+     * Returns the values accepted by the parameter converter when they are known exactly.
+     *
+     * @return the allowed values, or an empty list when the converter does not declare a finite set
+     */
+    public List<String> getAllowedValues() {
+        return allowedValues;
     }
 }

--- a/src/test/java/io/muserver/rest/ProblemDetailsExceptionsTest.java
+++ b/src/test/java/io/muserver/rest/ProblemDetailsExceptionsTest.java
@@ -4,6 +4,7 @@ import io.muserver.MuServer;
 import jakarta.ws.rs.ClientErrorException;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
+import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.WebApplicationException;
 import okhttp3.Response;
 import org.json.JSONException;
@@ -28,6 +29,38 @@ import static scaffolding.ClientUtils.request;
 
 public class ProblemDetailsExceptionsTest {
     private MuServer server;
+
+    @Test
+    public void uriParameterConversionFailuresBecomeBadRequestProblems() throws Exception {
+        @Path("samples")
+        class Sample {
+            @GET
+            public String get(@QueryParam("breed") Breed breed) {
+                return breed.name();
+            }
+        }
+
+        this.server = ServerUtils.httpsServerForTest()
+            .addHandler(restHandler(new Sample())
+                .addExceptionMapper(Throwable.class, problemDetailsExceptionMapper()
+                    .withLog4xxProblemDetailsInstanceIds(false)
+                    .build()))
+            .start();
+
+        try (Response resp = call(request().url(server.uri().resolve("/samples?breed=BAD_DOG").toString()))) {
+            JSONObject json = new JSONObject(resp.body().string());
+            assertThat(resp.code(), is(400));
+            assertThat(resp.header("content-type"), is("application/problem+json"));
+            assertThat(json.getString("title"), is("Bad Request"));
+            assertThat(json.getInt("status"), is(400));
+            assertThat(json.getString("detail"), containsString("Could not convert URI parameter \"breed\""));
+            assertThat(json.getString("instance"), startsWith("urn:uuid:"));
+        }
+    }
+
+    private enum Breed {
+        CHIHUAHUA
+    }
 
     @Test
     public void problemDetailsExceptionsBecomeJson() throws Exception {

--- a/src/test/java/io/muserver/rest/ProblemDetailsExceptionsTest.java
+++ b/src/test/java/io/muserver/rest/ProblemDetailsExceptionsTest.java
@@ -14,7 +14,9 @@ import org.junit.Test;
 import scaffolding.ServerUtils;
 
 import java.net.URI;
+import java.util.Arrays;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
@@ -38,6 +40,18 @@ public class ProblemDetailsExceptionsTest {
             public String get(@QueryParam("breed") Breed breed) {
                 return breed.name();
             }
+
+            @GET
+            @Path("multiple")
+            public String getMultiple(@QueryParam("breed") List<Breed> breeds) {
+                return breeds.toString();
+            }
+
+            @GET
+            @Path("custom")
+            public String getCustom(@QueryParam("breed") CustomBreed breed) {
+                return breed.name();
+            }
         }
 
         this.server = ServerUtils.httpsServerForTest()
@@ -53,13 +67,42 @@ public class ProblemDetailsExceptionsTest {
             assertThat(resp.header("content-type"), is("application/problem+json"));
             assertThat(json.getString("title"), is("Bad Request"));
             assertThat(json.getInt("status"), is(400));
-            assertThat(json.getString("detail"), containsString("Could not convert URI parameter \"breed\""));
+            assertThat(json.getString("detail"), is("Invalid value for URI parameter \"breed\"."));
+            assertThat(json.getString("parameter"), is("breed"));
+            assertThat(json.getString("suppliedValue"), is("BAD_DOG"));
+            assertThat(json.getJSONArray("allowedValues").toList(), is(Arrays.asList("CHIHUAHUA", "YELPER")));
             assertThat(json.getString("instance"), startsWith("urn:uuid:"));
+        }
+
+        try (Response resp = call(request().url(server.uri().resolve("/samples/multiple?breed=BAD_DOG").toString()))) {
+            JSONObject json = new JSONObject(resp.body().string());
+            assertThat(resp.code(), is(400));
+            assertThat(json.getJSONArray("allowedValues").toList(), is(Arrays.asList("CHIHUAHUA", "YELPER")));
+        }
+
+        try (Response resp = call(request().url(server.uri().resolve("/samples/custom?breed=BAD_DOG").toString()))) {
+            JSONObject json = new JSONObject(resp.body().string());
+            assertThat(resp.code(), is(400));
+            assertThat(json.getString("parameter"), is("breed"));
+            assertThat(json.getString("suppliedValue"), is("BAD_DOG"));
+            assertThat(json.has("allowedValues"), is(false));
         }
     }
 
     private enum Breed {
-        CHIHUAHUA
+        CHIHUAHUA,
+        YELPER
+    }
+
+    private enum CustomBreed {
+        CHIHUAHUA;
+
+        public static CustomBreed fromString(String value) {
+            if ("small".equals(value)) {
+                return CHIHUAHUA;
+            }
+            throw new IllegalArgumentException("Invalid custom breed");
+        }
     }
 
     @Test

--- a/src/test/java/io/muserver/rest/ResourceMethodParamTest.java
+++ b/src/test/java/io/muserver/rest/ResourceMethodParamTest.java
@@ -399,13 +399,15 @@ public class ResourceMethodParamTest {
                     jakarta.ws.rs.core.Response.status(400)
                         .type(jakarta.ws.rs.core.MediaType.TEXT_PLAIN_TYPE)
                         .entity(exception.getParameterName() + "|" + exception.getParameterValue() + "|"
-                            + exception.getTargetType().getName() + "|" + (exception.getCause() != null))
+                            + exception.getTargetType().getName() + "|" + exception.getAllowedValues() + "|"
+                            + (exception.getCause() != null))
                         .build()))
             .start();
 
         try (Response resp = call(request(server.uri().resolve("/samples?breed=BAD_DOG")))) {
             assertThat(resp.code(), is(400));
-            assertThat(resp.body().string(), is("breed|BAD_DOG|" + Breed.class.getName() + "|true"));
+            assertThat(resp.body().string(), is("breed|BAD_DOG|" + Breed.class.getName()
+                + "|[CHIHUAHUA, BIG_HAIRY, YELPER]|true"));
         }
     }
 


### PR DESCRIPTION
## What changed

- Map `UriParameterConversionException` to a 400 Bad Request response when handled by `ProblemDetailsExceptionMapper`.
- Return client-safe parameter metadata instead of exposing the Java target class in the Problem Detail message.
- Include `parameter` and `suppliedValue` extension members.
- Include exact `allowedValues` for Mu's built-in enum conversion, including enum collection elements.
- Preserve the exception's default 404 response when the Problem Detail mapper is not registered, retaining Jakarta REST TCK behavior.

## Example

Given an endpoint with `@QueryParam("breed") Breed breed`, this request uses an invalid enum value:

```http
GET /dogs?breed=BAD_DOG
```

With `ProblemDetailsExceptionMapper` registered, the response is `400 Bad Request` with `Content-Type: application/problem+json`:

```json
{
  "title": "Bad Request",
  "status": 400,
  "detail": "Invalid value for URI parameter \"breed\".",
  "instance": "urn:uuid:12345678-1234-1234-1234-123456789abc",
  "parameter": "breed",
  "suppliedValue": "BAD_DOG",
  "allowedValues": [
    "CHIHUAHUA",
    "BIG_HAIRY",
    "YELPER"
  ]
}
```

The generated `instance` UUID differs for each response. `allowedValues` is omitted when a custom enum `fromString` method or application converter defines the accepted domain, because Mu cannot infer that domain accurately.

## Why

Jakarta REST requires URI parameter conversion failures to use 404 by default. Mu exposes these failures as `UriParameterConversionException` so applications can deliberately map them differently. The opt-in Problem Detail mapper previously treated the exception as an ordinary `NotFoundException` and returned 404 with an exception message that included the internal Java class name.

Applications using the mapper expect malformed client parameter values to be represented as 400 Bad Request problems. Structured extension members make the error actionable without exposing implementation class names.

## Compatibility and impact

- Default JAX-RS behavior and TCK compliance are unchanged.
- Only applications registering `ProblemDetailsExceptionMapper` for this exception, including through a catch-all mapper, change from 404 to 400.
- `UriParameterConversionException#getMessage()` remains unchanged for server logs and existing custom exception mappers.
- The additive `getAllowedValues()` API lets custom exception mappers use exact values when Mu's converter knows them.
- Custom converters and enums with custom `fromString` methods receive an empty allowed-values list rather than potentially incorrect metadata.

## Validation

- Test-first check: the new integration assertion failed before implementation because the detail exposed `ProblemDetailsExceptionsTest$Breed`.
- `mise exec java@temurin-11 -- mvn -Dtest=ProblemDetailsExceptionsTest,ResourceMethodParamTest test`: 33 tests passed.
- Full `mvn test`: 943 tests passed and one unrelated test errored because PID 305873 already occupied its hard-coded port 8443. The isolated retry failed for the same environmental bind conflict.