### PR TITLE
Warn about non-public JAX-RS methods

### DIFF
--- a/src/main/java/io/muserver/rest/README.md
+++ b/src/main/java/io/muserver/rest/README.md
@@ -51,7 +51,7 @@ N/A Not applicable as only singletons supported
 #### 3.3.1 Visibility 
 
 - [x] Implemented
-- [ ] Warn about mis-configured methods.
+- [x] Warn about mis-configured methods.
 
 #### 3.3.2 Parameters 
 

--- a/src/main/java/io/muserver/rest/ResourceClass.java
+++ b/src/main/java/io/muserver/rest/ResourceClass.java
@@ -86,8 +86,12 @@ class ResourceClass {
             throw new IllegalStateException("Cannot call setupMethodInfo twice");
         }
 
-        if (shouldLogVisibilityWarnings(resourceClass)) {
-            nonPublicResourceMethodWarnings(resourceClass).forEach(log::warn);
+        try {
+            if (shouldLogVisibilityWarnings(resourceClass)) {
+                nonPublicResourceMethodWarnings(resourceClass).forEach(log::warn);
+            }
+        } catch (LinkageError | RuntimeException ignored) {
+            // A best-effort diagnostic must not prevent an otherwise usable resource class from registering.
         }
         List<ResourceMethod> resourceMethods = new ArrayList<>();
         java.lang.reflect.Method[] methods = this.resourceClass.getMethods();

--- a/src/main/java/io/muserver/rest/ResourceClass.java
+++ b/src/main/java/io/muserver/rest/ResourceClass.java
@@ -3,15 +3,19 @@ package io.muserver.rest;
 import io.muserver.Method;
 import io.muserver.openapi.TagObject;
 import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.HttpMethod;
 import jakarta.ws.rs.NameBinding;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.ext.ParamConverterProvider;
 import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.AnnotatedElement;
+import java.lang.reflect.Modifier;
 import java.lang.reflect.Parameter;
 import java.net.URI;
 import java.util.ArrayList;
@@ -25,6 +29,8 @@ import static java.util.Arrays.asList;
 import static java.util.stream.Collectors.toList;
 
 class ResourceClass {
+
+    private static final Logger log = LoggerFactory.getLogger(ResourceClass.class);
 
     final UriPattern pathPattern;
     final Class<?> resourceClass;
@@ -73,6 +79,7 @@ class ResourceClass {
             throw new IllegalStateException("Cannot call setupMethodInfo twice");
         }
 
+        nonPublicResourceMethodWarnings(resourceClass).forEach(log::warn);
         List<ResourceMethod> resourceMethods = new ArrayList<>();
         java.lang.reflect.Method[] methods = this.resourceClass.getMethods();
         for (java.lang.reflect.Method restMethod : methods) {
@@ -108,6 +115,32 @@ class ResourceClass {
         }
         this.resourceMethods = Collections.unmodifiableList(resourceMethods);
         this.methodInfoSet = true;
+    }
+
+    static List<String> nonPublicResourceMethodWarnings(Class<?> resourceClass) {
+        List<String> warnings = new ArrayList<>();
+        for (Class<?> current = resourceClass; current != null && current != Object.class; current = current.getSuperclass()) {
+            for (java.lang.reflect.Method method : current.getDeclaredMethods()) {
+                if (!Modifier.isPublic(method.getModifiers()) && isResourceMethodOrLocator(method)) {
+                    warnings.add("The JAX-RS annotated method " + method.toGenericString()
+                        + " is ignored because only public methods may be exposed as resource methods or sub-resource locators.");
+                }
+            }
+        }
+        Collections.sort(warnings);
+        return warnings;
+    }
+
+    private static boolean isResourceMethodOrLocator(java.lang.reflect.Method method) {
+        if (method.isAnnotationPresent(Path.class)) {
+            return true;
+        }
+        for (Annotation annotation : method.getDeclaredAnnotations()) {
+            if (annotation.annotationType().isAnnotationPresent(HttpMethod.class)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     static List<Class<? extends Annotation>> getNameBindingAnnotations(AnnotatedElement annotationSource) {

--- a/src/main/java/io/muserver/rest/ResourceClass.java
+++ b/src/main/java/io/muserver/rest/ResourceClass.java
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -31,6 +32,12 @@ import static java.util.stream.Collectors.toList;
 class ResourceClass {
 
     private static final Logger log = LoggerFactory.getLogger(ResourceClass.class);
+    private static final ClassValue<AtomicBoolean> visibilityWarningsLogged = new ClassValue<AtomicBoolean>() {
+        @Override
+        protected AtomicBoolean computeValue(Class<?> type) {
+            return new AtomicBoolean();
+        }
+    };
 
     final UriPattern pathPattern;
     final Class<?> resourceClass;
@@ -79,7 +86,9 @@ class ResourceClass {
             throw new IllegalStateException("Cannot call setupMethodInfo twice");
         }
 
-        nonPublicResourceMethodWarnings(resourceClass).forEach(log::warn);
+        if (shouldLogVisibilityWarnings(resourceClass)) {
+            nonPublicResourceMethodWarnings(resourceClass).forEach(log::warn);
+        }
         List<ResourceMethod> resourceMethods = new ArrayList<>();
         java.lang.reflect.Method[] methods = this.resourceClass.getMethods();
         for (java.lang.reflect.Method restMethod : methods) {
@@ -123,12 +132,16 @@ class ResourceClass {
             for (java.lang.reflect.Method method : current.getDeclaredMethods()) {
                 if (!Modifier.isPublic(method.getModifiers()) && isResourceMethodOrLocator(method)) {
                     warnings.add("The JAX-RS annotated method " + method.toGenericString()
-                        + " is ignored because only public methods may be exposed as resource methods or sub-resource locators.");
+                        + " cannot itself be exposed as a resource method or sub-resource locator because only public methods may be exposed.");
                 }
             }
         }
         Collections.sort(warnings);
         return warnings;
+    }
+
+    static boolean shouldLogVisibilityWarnings(Class<?> resourceClass) {
+        return visibilityWarningsLogged.get(resourceClass).compareAndSet(false, true);
     }
 
     private static boolean isResourceMethodOrLocator(java.lang.reflect.Method method) {

--- a/src/test/java/io/muserver/rest/ResourceClassTest.java
+++ b/src/test/java/io/muserver/rest/ResourceClassTest.java
@@ -113,7 +113,7 @@ public class ResourceClassTest {
         assertThat(warnings.get(2), containsString("ResourceWithNonPublicMethods.protectedLocator()"));
         assertThat(warnings.get(3), containsString("ResourceWithNonPublicMethods.protectedSubResourceMethod()"));
         for (String warning : warnings) {
-            assertThat(warning, containsString("is ignored because only public methods may be exposed as resource methods or sub-resource locators."));
+            assertThat(warning, containsString("cannot itself be exposed as a resource method or sub-resource locator because only public methods may be exposed."));
         }
     }
 
@@ -126,6 +126,21 @@ public class ResourceClassTest {
     public void warnsAboutNonPublicAnnotatedMethodsOnSuperclasses() {
         assertThat(ResourceClass.nonPublicResourceMethodWarnings(ResourceWithInheritedVisibilityProblem.class),
             contains(containsString("BaseResourceWithVisibilityProblem.hidden()")));
+    }
+
+    @Test
+    public void warningDoesNotClaimInheritedAnnotationSourceIsIgnored() {
+        ResourceClass resourceClass = ResourceClass.fromObject(new ResourceWithPublicOverride(), ResourceMethodParamTest.BUILT_IN_PARAM_PROVIDERS, customizer);
+
+        assertThat(resourceClass.resourceMethods, hasSize(1));
+        assertThat(ResourceClass.nonPublicResourceMethodWarnings(ResourceWithPublicOverride.class),
+            contains(containsString("BaseResourceWithPublicOverride.inherited() cannot itself be exposed")));
+    }
+
+    @Test
+    public void onlyLogsVisibilityWarningsOncePerResourceClass() {
+        assertThat(ResourceClass.shouldLogVisibilityWarnings(ResourceForDeduplicationTest.class), equalTo(true));
+        assertThat(ResourceClass.shouldLogVisibilityWarnings(ResourceForDeduplicationTest.class), equalTo(false));
     }
 
     @Path("/api/fruits")
@@ -262,6 +277,23 @@ public class ResourceClassTest {
 
     @Path("/api/inherited-problem")
     private static class ResourceWithInheritedVisibilityProblem extends BaseResourceWithVisibilityProblem { }
+
+    private static class BaseResourceWithPublicOverride {
+        @GET
+        protected String inherited() {
+            return "";
+        }
+    }
+
+    @Path("/api/public-override")
+    private static class ResourceWithPublicOverride extends BaseResourceWithPublicOverride {
+        @Override
+        public String inherited() {
+            return "";
+        }
+    }
+
+    private static class ResourceForDeduplicationTest { }
 
     @Target(ElementType.METHOD)
     @Retention(RetentionPolicy.RUNTIME)

--- a/src/test/java/io/muserver/rest/ResourceClassTest.java
+++ b/src/test/java/io/muserver/rest/ResourceClassTest.java
@@ -1,17 +1,26 @@
 package io.muserver.rest;
 
 import jakarta.ws.rs.GET;
+import jakarta.ws.rs.HttpMethod;
 import jakarta.ws.rs.OPTIONS;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
 import org.junit.Test;
 
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 import java.util.Collections;
 import java.util.List;
 
 import static java.net.URI.create;
 import static java.util.Collections.emptyList;
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 
@@ -92,6 +101,31 @@ public class ResourceClassTest {
 
         assertThat(resourceClass.resourceMethods, hasSize(1));
         assertThat(resourceClass.resourceMethods.get(0).methodHandle.getDeclaringClass(), equalTo(UnannotatedImplementation.class));
+    }
+
+    @Test
+    public void warnsAboutNonPublicResourceMethodsAndLocators() {
+        List<String> warnings = ResourceClass.nonPublicResourceMethodWarnings(ResourceWithNonPublicMethods.class);
+
+        assertThat(warnings, hasSize(4));
+        assertThat(warnings.get(0), containsString("ResourceWithNonPublicMethods.packagePrivateResourceMethod()"));
+        assertThat(warnings.get(1), containsString("ResourceWithNonPublicMethods.privateResourceMethod()"));
+        assertThat(warnings.get(2), containsString("ResourceWithNonPublicMethods.protectedLocator()"));
+        assertThat(warnings.get(3), containsString("ResourceWithNonPublicMethods.protectedSubResourceMethod()"));
+        for (String warning : warnings) {
+            assertThat(warning, containsString("is ignored because only public methods may be exposed as resource methods or sub-resource locators."));
+        }
+    }
+
+    @Test
+    public void doesNotWarnAboutPublicOrUnrelatedAnnotatedMethods() {
+        assertThat(ResourceClass.nonPublicResourceMethodWarnings(ResourceWithoutVisibilityProblems.class), empty());
+    }
+
+    @Test
+    public void warnsAboutNonPublicAnnotatedMethodsOnSuperclasses() {
+        assertThat(ResourceClass.nonPublicResourceMethodWarnings(ResourceWithInheritedVisibilityProblem.class),
+            contains(containsString("BaseResourceWithVisibilityProblem.hidden()")));
     }
 
     @Path("/api/fruits")
@@ -181,5 +215,57 @@ public class ResourceClassTest {
 
     @Path("/api/inherited-implementation")
     private static class InterfaceResourceWithInheritedImplementation extends UnannotatedImplementation implements AnnotatedResourceMethod { }
+
+    @Path("/api/non-public")
+    private static class ResourceWithNonPublicMethods {
+        @GET
+        String packagePrivateResourceMethod() {
+            return "";
+        }
+
+        @GET
+        private String privateResourceMethod() {
+            return "";
+        }
+
+        @Path("locator")
+        protected Object protectedLocator() {
+            return new Object();
+        }
+
+        @CustomGET
+        @Path("custom")
+        protected String protectedSubResourceMethod() {
+            return "";
+        }
+    }
+
+    @Path("/api/public")
+    private static class ResourceWithoutVisibilityProblems {
+        @GET
+        public String publicResourceMethod() {
+            return "";
+        }
+
+        @Produces("text/plain")
+        private String helper() {
+            return "";
+        }
+    }
+
+    private static class BaseResourceWithVisibilityProblem {
+        @GET
+        protected String hidden() {
+            return "";
+        }
+    }
+
+    @Path("/api/inherited-problem")
+    private static class ResourceWithInheritedVisibilityProblem extends BaseResourceWithVisibilityProblem { }
+
+    @Target(ElementType.METHOD)
+    @Retention(RetentionPolicy.RUNTIME)
+    @HttpMethod(HttpMethod.GET)
+    private @interface CustomGET { }
 
 }


### PR DESCRIPTION
## Summary

- warn once per resource class for every non-public method carrying `@Path` or a request-method designator, including custom annotations meta-annotated with `@HttpMethod`
- inspect declarations on the concrete resource class and its superclasses
- deduplicate warnings for dynamically constructed sub-resources without retaining application classes or classloaders
- keep ignoring non-public methods themselves, as required by Jakarta REST 3.1 section 3.3.1
- mark the visibility-warning item complete in the JAX-RS support matrix

Mu already discovers callable endpoints with `Class.getMethods()`, which only returns public methods. This adds the diagnostic recommended by the specification. A public override may still inherit JAX-RS annotations from a non-public superclass declaration; the warning therefore describes only whether the annotated declaration can itself be exposed.

## Example

Given this misconfigured resource method:

```java
@Path("/orders")
public class OrdersResource {
    @GET
    private String list() {
        return "orders";
    }
}
```

SLF4J logs:

```text
WARN io.muserver.rest.ResourceClass - The JAX-RS annotated method private java.lang.String com.example.OrdersResource.list() cannot itself be exposed as a resource method or sub-resource locator because only public methods may be exposed.
```

A non-public `@Path`-only sub-resource locator is treated the same way:

```java
@Path("details")
protected Object details() {
    return new OrderDetailsResource();
}
```

```text
WARN io.muserver.rest.ResourceClass - The JAX-RS annotated method protected java.lang.Object com.example.OrdersResource.details() cannot itself be exposed as a resource method or sub-resource locator because only public methods may be exposed.
```

## Specification

Jakarta REST 3.1 section 3.3.1 says that only public methods may be exposed as resource methods and that implementations SHOULD warn when a non-public method carries a request-method designator or `@Path`.

## Validation

- `mise exec java@temurin-11 -- mvn -Dtest=ResourceClassTest test`
- `mise exec java@temurin-11 -- mvn test` — 973 tests passed
