### PR TITLE
Simplify buffering with Java 11 APIs

### DIFF
--- a/src/main/java/io/muserver/HttpsConfigBuilder.java
+++ b/src/main/java/io/muserver/HttpsConfigBuilder.java
@@ -107,10 +107,8 @@ public class HttpsConfigBuilder {
     protected void setKeystoreBytes(InputStream is, boolean closeAfter) {
         sslContext = null;
         keyManagerFactory = null;
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
         try {
-            Mutils.copy(is, baos, 8192);
-            this.keystoreBytes = baos.toByteArray();
+            this.keystoreBytes = is.readAllBytes();
         } catch (IOException e) {
             throw new MuException("Error while loading keystore", e);
         } finally {

--- a/src/main/java/io/muserver/MuServer.java
+++ b/src/main/java/io/muserver/MuServer.java
@@ -77,14 +77,11 @@ public interface MuServer {
     static String artifactVersion() {
         try {
             Properties props = new Properties();
-            InputStream in = MuServer.class.getResourceAsStream("/META-INF/maven/io.muserver/mu-server/pom.properties");
-            if (in == null) {
-                return "0.x";
-            }
-            try {
+            try (InputStream in = MuServer.class.getResourceAsStream("/META-INF/maven/io.muserver/mu-server/pom.properties")) {
+                if (in == null) {
+                    return "0.x";
+                }
                 props.load(in);
-            } finally {
-                in.close();
             }
             return props.getProperty("version");
         } catch (Exception ex) {

--- a/src/main/java/io/muserver/rest/JaxRSResponse.java
+++ b/src/main/java/io/muserver/rest/JaxRSResponse.java
@@ -251,10 +251,8 @@ class JaxRSResponse extends Response implements ContainerResponseContext, Writer
         }
         Object entity = getEntity();
         if (entity instanceof InputStream) {
-            try (InputStream in = (InputStream)entity;
-                ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
-                Mutils.copy(in, baos, 8192);
-                inputStreamBuffer = new ByteArrayInputStream(baos.toByteArray());
+            try (InputStream in = (InputStream)entity) {
+                inputStreamBuffer = new ByteArrayInputStream(in.readAllBytes());
                 setEntity(inputStreamBuffer);
             } catch (IOException e) {
                 throw new ProcessingException("Could not buffer entity input stream", e);


### PR DESCRIPTION
## What changed

- Use Java 11 `InputStream.readAllBytes()` for HTTPS keystore and JAX-RS response buffering.
- Use try-with-resources for MuServer artifact-version metadata loading.

## Why

The project now requires Java 11, so these paths can use standard Java 11 APIs and remove manual `ByteArrayOutputStream` and cleanup plumbing. Existing behavior is preserved: the affected paths already read the complete stream into memory, and stream ownership/closing behavior remains unchanged.

Protocol-sensitive parsing and SSE line handling were intentionally left unchanged.

## Validation

- Java 11: `mvn --batch-mode -Pnetty-4.1 verify`
- 968 tests passed
- Javadoc generation passed
- Dependency analysis passed
- Java 21: `mvn --batch-mode -Pnetty-4.1,nullaway -DskipTests verify`
- `git diff --check`