### PR TITLE
Enable more worthwhile Error Prone checks

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -404,7 +404,7 @@
                                 <arg>-XDcompilePolicy=simple</arg>
                                 <arg>-XDaddTypeAnnotationsToSymbol=true</arg>
                                 <arg>--should-stop=ifError=FLOW</arg>
-                                <arg>-Xplugin:ErrorProne -XepDisableAllChecks -Xep:NullAway:ERROR -Xep:BadInstanceof:ERROR -Xep:ByteBufferBackingArray:ERROR -Xep:DefaultLocale:ERROR -Xep:InterruptedExceptionSwallowed:ERROR -Xep:NarrowingCompoundAssignment:ERROR -Xep:ReturnValueIgnored:ERROR -Xep:StringCaseLocaleUsage:ERROR -Xep:WaitNotInLoop:ERROR -XepOpt:NullAway:OnlyNullMarked=true -XepOpt:NullAway:JSpecifyMode=true</arg>
+                                <arg>-Xplugin:ErrorProne -XepDisableAllChecks -Xep:NullAway:ERROR -Xep:ArrayEquals:ERROR -Xep:BadInstanceof:ERROR -Xep:ByteBufferBackingArray:ERROR -Xep:CollectionIncompatibleType:ERROR -Xep:DefaultCharset:ERROR -Xep:DefaultLocale:ERROR -Xep:EqualsHashCode:ERROR -Xep:InterruptedExceptionSwallowed:ERROR -Xep:LockNotBeforeTry:ERROR -Xep:MissingOverride:ERROR -Xep:NarrowingCompoundAssignment:ERROR -Xep:ReferenceEquality:ERROR -Xep:ReturnValueIgnored:ERROR -Xep:StringCaseLocaleUsage:ERROR -Xep:SynchronizeOnNonFinalField:ERROR -Xep:ThreadJoinLoop:ERROR -Xep:WaitNotInLoop:ERROR -XepOpt:NullAway:OnlyNullMarked=true -XepOpt:NullAway:JSpecifyMode=true</arg>
                             </compilerArgs>
                         </configuration>
                     </plugin>

--- a/src/main/java/io/muserver/ChunkedHttpOutputStream.java
+++ b/src/main/java/io/muserver/ChunkedHttpOutputStream.java
@@ -27,6 +27,7 @@ class ChunkedHttpOutputStream extends OutputStream {
         response.exchange().block(() -> response.writeAndFlush(Unpooled.wrappedBuffer(b, off, len)));
     }
 
+    @Override
     public void close() {
         isClosed = true;
     }

--- a/src/main/java/io/muserver/Cookie.java
+++ b/src/main/java/io/muserver/Cookie.java
@@ -83,14 +83,17 @@ public class Cookie {
         return nettyCookie.isHttpOnly();
     }
 
+    @Override
     public int hashCode() {
         return nettyCookie.hashCode();
     }
 
+    @Override
     public boolean equals(@Nullable Object o) {
         return (this == o) || ((o instanceof Cookie) && nettyCookie.equals(o));
     }
 
+    @Override
     public String toString() {
         return nettyCookie.toString();
     }

--- a/src/main/java/io/muserver/ForwardedHeader.java
+++ b/src/main/java/io/muserver/ForwardedHeader.java
@@ -229,6 +229,7 @@ public class ForwardedHeader {
      *
      * @return A String, such as "some-value" or "content-type:text/html;charset=UTF-8"
      */
+    @Override
     public String toString() {
         StringBuilder sb = new StringBuilder();
         appendString(sb, "by", by);

--- a/src/main/java/io/muserver/Headers.java
+++ b/src/main/java/io/muserver/Headers.java
@@ -134,6 +134,7 @@ public interface Headers extends Iterable<Map.Entry<String, String>> {
     /**
      * @return An iterator to iterate through the headers
      */
+    @Override
     Iterator<Map.Entry<String, String>> iterator();
 
     /**
@@ -383,6 +384,7 @@ public interface Headers extends Iterable<Map.Entry<String, String>> {
      * <p>If you wish to print all values or customize the header values that are hidden, use {@link #toString(Collection)}</p>
      * @return a string representation of these headers
      */
+    @Override
     String toString();
 
     /**

--- a/src/main/java/io/muserver/Http1Connection.java
+++ b/src/main/java/io/muserver/Http1Connection.java
@@ -74,6 +74,7 @@ class Http1Connection extends SimpleChannelInboundHandler<Object> implements Htt
         super.channelInactive(ctx);
     }
 
+    @Override
     protected void channelRead0(ChannelHandlerContext ctx, Object msg) {
         try {
             onChannelRead(ctx, msg);
@@ -98,7 +99,10 @@ class Http1Connection extends SimpleChannelInboundHandler<Object> implements Htt
                             nettyHandlerAdapter.onResponseComplete(exchange, serverStats, connectionStats);
                             ctx.channel().eventLoop().execute(() -> {
                                 if (exchange.state() != HttpExchangeState.UPGRADED) {
-                                    if (this.currentExchange != exchange) {
+                                    // Completion must belong to the exact exchange currently owning this connection.
+                                    @SuppressWarnings("ReferenceEquality")
+                                    boolean isCurrentExchange = this.currentExchange == exchange;
+                                    if (!isCurrentExchange) {
                                         throw new IllegalStateException("Expected current exchange to be " + exchange + " but was " + this.currentExchange);
                                     }
                                     this.currentExchange = null;

--- a/src/main/java/io/muserver/MuServerBuilder.java
+++ b/src/main/java/io/muserver/MuServerBuilder.java
@@ -784,6 +784,7 @@ public class MuServerBuilder {
             .channel(NioServerSocketChannel.class)
             .childHandler(new ChannelInitializer<SocketChannel>() {
 
+                @Override
                 protected void initChannel(SocketChannel socketChannel) {
                     ChannelPipeline p = socketChannel.pipeline();
                     p.addLast("idle", new IdleStateHandler(0, 0, idleTimeoutMills, TimeUnit.MILLISECONDS));

--- a/src/main/java/io/muserver/NettyRequestAdapter.java
+++ b/src/main/java/io/muserver/NettyRequestAdapter.java
@@ -62,6 +62,7 @@ class NettyRequestAdapter implements MuRequest {
         this.method = method;
     }
 
+    @Override
     public boolean isAsync() {
         return asyncHandle != null;
     }
@@ -109,21 +110,25 @@ class NettyRequestAdapter implements MuRequest {
         return exchange().startTime();
     }
 
+    @Override
     public Method method() {
         return method;
     }
 
 
+    @Override
     public URI uri() {
         return uri;
     }
 
 
+    @Override
     public URI serverURI() {
         return serverUri;
     }
 
 
+    @Override
     public Headers headers() {
         return headers;
     }
@@ -132,6 +137,7 @@ class NettyRequestAdapter implements MuRequest {
         return server().maxRequestSize();
     }
 
+    @Override
     public Optional<InputStream> inputStream() {
         if (!headers().hasBody()) {
             return Optional.empty();
@@ -158,6 +164,7 @@ class NettyRequestAdapter implements MuRequest {
         }
     }
 
+    @Override
     public String readBodyAsString() throws IOException {
         if (headers.hasBody()) {
             RequestBodyReader.StringRequestBodyReader reader = createStringRequestBodyReader(maxRequestBytes(), headers());
@@ -358,6 +365,7 @@ class NettyRequestAdapter implements MuRequest {
         }
     }
 
+    @Override
     public String toString() {
         return method().name() + " " + uri();
     }

--- a/src/main/java/io/muserver/NettyResponseAdaptor.java
+++ b/src/main/java/io/muserver/NettyResponseAdaptor.java
@@ -113,10 +113,12 @@ abstract class NettyResponseAdaptor implements MuResponse {
         this.headers.set(HeaderNames.DATE, Mutils.toHttpDate(new Date()));
     }
 
+    @Override
     public int status() {
         return status;
     }
 
+    @Override
     public void status(int value) {
         if (state != ResponseState.NOTHING && !state.completedWithError()) {
             throw new IllegalStateException("Cannot set the status after the headers have already been sent");
@@ -211,6 +213,7 @@ abstract class NettyResponseAdaptor implements MuResponse {
 
     abstract ChannelFuture writeAndFlushToChannel(boolean isLast, ByteBuf content);
 
+    @Override
     public void sendChunk(String text) {
         throwIfAsync();
         exchange().block(() -> {
@@ -228,14 +231,17 @@ abstract class NettyResponseAdaptor implements MuResponse {
         return Unpooled.copiedBuffer(text, charset);
     }
 
+    @Override
     public void redirect(String newLocation) {
         redirect(URI.create(newLocation));
     }
 
+    @Override
     public Headers headers() {
         return headers;
     }
 
+    @Override
     public void contentType(@Nullable CharSequence contentType) {
         if (contentType == null) {
             headers.remove(HeaderNames.CONTENT_TYPE);
@@ -244,6 +250,7 @@ abstract class NettyResponseAdaptor implements MuResponse {
         }
     }
 
+    @Override
     public void addCookie(Cookie cookie) {
         headers.add(HeaderNames.SET_COOKIE, ServerCookieEncoder.LAX.encode(cookie.nettyCookie));
     }
@@ -271,6 +278,7 @@ abstract class NettyResponseAdaptor implements MuResponse {
         }
     }
 
+    @Override
     public PrintWriter writer() {
         throwIfAsync();
         if (this.writer == null) {
@@ -353,6 +361,7 @@ abstract class NettyResponseAdaptor implements MuResponse {
 
     protected abstract ChannelFuture writeLastContentMarker();
 
+    @Override
     public final void redirect(URI newLocation) {
         HttpExchange exchange = exchange();
         if (!exchange.inLoop()) {

--- a/src/main/java/io/muserver/ParameterizedHeader.java
+++ b/src/main/java/io/muserver/ParameterizedHeader.java
@@ -165,6 +165,7 @@ public class ParameterizedHeader {
      *
      * @return A String, such as "some-value" or "content-type:text/html;charset=UTF-8"
      */
+    @Override
     public String toString() {
         StringBuilder sb = new StringBuilder();
         Map<String, @Nullable String> parameters = this.parameters();

--- a/src/main/java/io/muserver/ParameterizedHeaderWithValue.java
+++ b/src/main/java/io/muserver/ParameterizedHeaderWithValue.java
@@ -195,6 +195,7 @@ public class ParameterizedHeaderWithValue {
      *
      * @return A String, such as "some-value" or "content-type:text/html;charset=UTF-8"
      */
+    @Override
     public String toString() {
         StringBuilder sb = new StringBuilder(this.value());
         Map<String, String> parameters = this.parameters();

--- a/src/main/java/io/muserver/SSLInfoImpl.java
+++ b/src/main/java/io/muserver/SSLInfoImpl.java
@@ -54,10 +54,13 @@ class SSLInfoImpl implements SSLInfo {
         try {
             SSLContext ctx = SSLContext.getInstance("TLS");
             ctx.init(new KeyManager[0], new TrustManager[] {new X509TrustManager() {
+                    @Override
                     public void checkClientTrusted(X509Certificate[] x509Certificates, String s) {
                     }
+                    @Override
                     public void checkServerTrusted(X509Certificate[] x509Certificates, String s) {
                     }
+                    @Override
                     public X509Certificate[] getAcceptedIssuers() {
                         return new X509Certificate[0];
                     }

--- a/src/main/java/io/muserver/handlers/BytesRange.java
+++ b/src/main/java/io/muserver/handlers/BytesRange.java
@@ -61,6 +61,7 @@ class BytesRange {
         }
     }
 
+    @Override
     public String toString() {
         return "bytes " + from + "-" + to + "/" + total;
     }

--- a/src/main/java/io/muserver/handlers/ResourceHandlerBuilder.java
+++ b/src/main/java/io/muserver/handlers/ResourceHandlerBuilder.java
@@ -176,6 +176,7 @@ public class ResourceHandlerBuilder implements MuHandlerBuilder<ResourceHandler>
      * Creates the handler
      * @return The built handler
      */
+    @Override
     public ResourceHandler build() {
         if (resourceProviderFactory == null) {
             throw new IllegalStateException("No resourceProviderFactory has been set");

--- a/src/main/java/io/muserver/handlers/ResourceProvider.java
+++ b/src/main/java/io/muserver/handlers/ResourceProvider.java
@@ -147,29 +147,36 @@ class ClasspathCache implements ResourceProviderFactory {
     }
 
     private static final ResourceProvider nullProvider = new ResourceProvider() {
+        @Override
         public boolean exists() {
             return false;
         }
 
+        @Override
         public boolean isDirectory() {
             return false;
         }
 
+        @Override
         public @Nullable Long fileSize() {
             return null;
         }
 
+        @Override
         public @Nullable Date lastModified() {
             return null;
         }
 
+        @Override
         public boolean skipIfPossible(long bytes) {
             return false;
         }
 
+        @Override
         public void sendTo(MuRequest request, MuResponse response, boolean sendBody, long maxLen) {
         }
 
+        @Override
         public Stream<Path> listFiles() {
             return Stream.empty();
         }
@@ -194,6 +201,7 @@ class AsyncFileProvider implements ResourceProvider, CompletionHandler<Integer, 
         this.localPath = baseDirectory.resolve(relativePath);
     }
 
+    @Override
     public boolean exists() {
         return Files.exists(localPath);
     }
@@ -203,6 +211,7 @@ class AsyncFileProvider implements ResourceProvider, CompletionHandler<Integer, 
         return Files.isDirectory(localPath);
     }
 
+    @Override
     public @Nullable Long fileSize() {
         try {
             long size = Files.size(localPath);
@@ -331,6 +340,7 @@ class ClasspathResourceProvider implements ResourceProvider {
         return new ClasspathResourceProvider(exists, isDir, fileSize, lastModified, path, inputStream);
     }
 
+    @Override
     public boolean exists() {
         return exists;
     }

--- a/src/main/java/io/muserver/rest/BinaryEntityProviders.java
+++ b/src/main/java/io/muserver/rest/BinaryEntityProviders.java
@@ -35,22 +35,27 @@ class BinaryEntityProviders {
     @Produces("*/*")
     @Consumes("*/*")
     static class ByteArrayReaderWriter implements MessageBodyReader<byte[]>, MessageBodyWriter<byte[]> {
+        @Override
         public boolean isReadable(Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType) {
             return type.isArray() && type.getComponentType().equals(byte.class);
         }
 
+        @Override
         public byte[] readFrom(Class<byte[]> type, Type genericType, Annotation[] annotations, MediaType mediaType, MultivaluedMap<String, String> httpHeaders, InputStream entityStream) throws IOException, WebApplicationException {
             return Mutils.toByteArray(entityStream, 2048);
         }
 
+        @Override
         public boolean isWriteable(Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType) {
             return type.isArray() && type.getComponentType().equals(byte.class);
         }
 
+        @Override
         public long getSize(byte[] bytes, Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType) {
             return bytes.length;
         }
 
+        @Override
         public void writeTo(byte[] bytes, Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType, MultivaluedMap<String, Object> httpHeaders, OutputStream entityStream) throws IOException, WebApplicationException {
             entityStream.write(bytes);
         }
@@ -58,10 +63,12 @@ class BinaryEntityProviders {
 
     @Produces("*/*")
     static class StreamingOutputWriter implements MessageBodyWriter<StreamingOutput> {
+        @Override
         public boolean isWriteable(Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType) {
             return StreamingOutput.class.isAssignableFrom(type);
         }
 
+        @Override
         public void writeTo(StreamingOutput streamingOutput, Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType, MultivaluedMap<String, Object> httpHeaders, OutputStream entityStream) throws IOException, WebApplicationException {
             streamingOutput.write(entityStream);
         }
@@ -70,10 +77,12 @@ class BinaryEntityProviders {
 
     @Consumes("*/*")
     static class InputStreamReader implements MessageBodyReader<InputStream> {
+        @Override
         public boolean isReadable(Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType) {
             return InputStream.class.isAssignableFrom(type);
         }
 
+        @Override
         public InputStream readFrom(Class<InputStream> type, Type genericType, Annotation[] annotations, MediaType mediaType, MultivaluedMap<String, String> httpHeaders, InputStream entityStream) throws IOException, WebApplicationException {
             return entityStream;
         }

--- a/src/main/java/io/muserver/rest/BuiltInParamConverterProvider.java
+++ b/src/main/java/io/muserver/rest/BuiltInParamConverterProvider.java
@@ -23,9 +23,11 @@ import static java.util.Arrays.asList;
 class BuiltInParamConverterProvider implements ParamConverterProvider {
 
     private final ParamConverter<String> stringParamConverter = new ParamConverter<String>() {
+        @Override
         public String fromString(String value) {
             return value;
         }
+        @Override
         public String toString(String value) {
             return value;
         }
@@ -136,13 +138,16 @@ class BuiltInParamConverterProvider implements ParamConverterProvider {
             this.boxedClass = boxedClass;
             this.stringToValue = stringToValue;
         }
+        @Override
         public @Nullable T fromString(@Nullable String value) {
             if (Mutils.nullOrEmpty(value)) return null;
             return stringToValue.apply(java.util.Objects.requireNonNull(value));
         }
+        @Override
         public String toString(T value) {
             return String.valueOf(value);
         }
+        @Override
         public String toString() {
             return boxedClass.getSimpleName() + " param converter";
         }
@@ -158,18 +163,22 @@ class BuiltInParamConverterProvider implements ParamConverterProvider {
             this.primitiveClass = primitiveClass;
             this.stringToValue = stringToValue;
         }
+        @Override
         public T fromString(@Nullable String value) {
             if (value == null || value.isEmpty()) {
                 return defaultValue;
             }
             return stringToValue.apply(value);
         }
+        @Override
         public String toString(T value) {
             return String.valueOf(value);
         }
+        @Override
         public Object getDefault() {
             return defaultValue;
         }
+        @Override
         public String toString() {
             return primitiveClass.getSimpleName() + " param converter";
         }
@@ -187,12 +196,14 @@ class BuiltInParamConverterProvider implements ParamConverterProvider {
                 ? Stream.of(enumClass.getEnumConstants()).map(Enum::name).collect(Collectors.toList())
                 : java.util.Collections.emptyList();
         }
+        @Override
         public @Nullable E fromString(@Nullable String value) {
             if (Mutils.nullOrEmpty(value)) return null;
             if (fromStringConverter != null) return fromStringConverter.fromString(value);
             return Enum.valueOf(enumClass, value);
         }
 
+        @Override
         public String toString(E value) {
             return value.name();
         }
@@ -202,6 +213,7 @@ class BuiltInParamConverterProvider implements ParamConverterProvider {
             return allowedValues;
         }
 
+        @Override
         public String toString() {
             String validValues = Stream.of(enumClass.getEnumConstants()).map(Enum::name).collect(Collectors.joining(", "));
             return enumClass.getSimpleName() + " converter (valid values: " + validValues + ")";
@@ -213,6 +225,7 @@ class BuiltInParamConverterProvider implements ParamConverterProvider {
         private ConstructorConverter(Constructor<T> constructor) {
             this.constructor = constructor;
         }
+        @Override
         public @Nullable T fromString(@Nullable String value) {
             if (Mutils.nullOrEmpty(value)) return null;
             try {
@@ -221,9 +234,11 @@ class BuiltInParamConverterProvider implements ParamConverterProvider {
                 throw new IllegalArgumentException("Could not convert \"" + value + "\" to a " + constructor.getDeclaringClass().getSimpleName(), e);
             }
         }
+        @Override
         public String toString(T value) {
             return String.valueOf(value);
         }
+        @Override
         public String toString() {
             return "ConstructorConverter{" + constructor + '}';
         }
@@ -247,6 +262,7 @@ class BuiltInParamConverterProvider implements ParamConverterProvider {
         private StaticMethodConverter(Method staticMethod) {
             this.staticMethod = staticMethod;
         }
+        @Override
         public @Nullable T fromString(@Nullable String value) {
             if (Mutils.nullOrEmpty(value)) return null;
             try {
@@ -255,9 +271,11 @@ class BuiltInParamConverterProvider implements ParamConverterProvider {
                 throw new IllegalArgumentException("Could not convert \"" + value + "\" to a " + staticMethod.getDeclaringClass().getSimpleName() + " because " + e.getMessage(), e);
             }
         }
+        @Override
         public String toString(T value) {
             return String.valueOf(value);
         }
+        @Override
         public String toString() {
             return staticMethod.toString();
         }

--- a/src/main/java/io/muserver/rest/CombinedMediaType.java
+++ b/src/main/java/io/muserver/rest/CombinedMediaType.java
@@ -10,7 +10,7 @@ import java.util.Objects;
  */
 class CombinedMediaType implements Comparable<CombinedMediaType> {
 
-    public static CombinedMediaType NONMATCH = new CombinedMediaType(null, null, 1.0, 1.0, 0, null);
+    public static final CombinedMediaType NONMATCH = new CombinedMediaType(null, null, 1.0, 1.0, 0, null);
 
     public final @Nullable String type;
     public final @Nullable String subType;

--- a/src/main/java/io/muserver/rest/EmptyInputStream.java
+++ b/src/main/java/io/muserver/rest/EmptyInputStream.java
@@ -8,6 +8,7 @@ class EmptyInputStream extends InputStream {
     private EmptyInputStream() {
     }
 
+    @Override
     public int read() {
         return -1;
     }

--- a/src/main/java/io/muserver/rest/EntityProviders.java
+++ b/src/main/java/io/muserver/rest/EntityProviders.java
@@ -108,7 +108,12 @@ class EntityProviders {
     }
 
     boolean isBuiltInWriter(MessageBodyWriter<?> writer) {
-        return writers.stream().anyMatch(candidate -> candidate.provider == writer && candidate.isBuiltIn);
+        return writers.stream().anyMatch(candidate -> {
+            // Provider selection returns the exact instance held by its wrapper.
+            @SuppressWarnings("ReferenceEquality")
+            boolean sameProvider = candidate.provider == writer;
+            return sameProvider && candidate.isBuiltIn;
+        });
     }
 
     public static List<MessageBodyReader> builtInReaders() {

--- a/src/main/java/io/muserver/rest/GenericTypeResolver.java
+++ b/src/main/java/io/muserver/rest/GenericTypeResolver.java
@@ -130,7 +130,7 @@ final class GenericTypeResolver {
             Type resolvedOwner = owner == null ? null : resolve(owner, typeArguments);
             Type[] arguments = parameterizedType.getActualTypeArguments();
             Type[] resolvedArguments = resolve(arguments, typeArguments);
-            if (resolvedOwner == owner && Arrays.equals(arguments, resolvedArguments)) {
+            if (Objects.equals(resolvedOwner, owner) && Arrays.equals(arguments, resolvedArguments)) {
                 return type;
             }
             return new ResolvedParameterizedType(resolvedOwner, parameterizedType.getRawType(), resolvedArguments);

--- a/src/main/java/io/muserver/rest/HtmlDocumentor.java
+++ b/src/main/java/io/muserver/rest/HtmlDocumentor.java
@@ -454,6 +454,7 @@ class HtmlDocumentor {
             return this;
         }
 
+        @Override
         public void close() throws IOException {
             writer.write("</" + tag + ">");
         }

--- a/src/main/java/io/muserver/rest/JaxRSResponse.java
+++ b/src/main/java/io/muserver/rest/JaxRSResponse.java
@@ -76,6 +76,7 @@ class JaxRSResponse extends Response implements ContainerResponseContext, Writer
         );
     }
 
+    @Override
     public Annotation[] getAnnotations() {
         return annotations;
     }

--- a/src/main/java/io/muserver/rest/PrimitiveEntityProvider.java
+++ b/src/main/java/io/muserver/rest/PrimitiveEntityProvider.java
@@ -50,10 +50,12 @@ class PrimitiveEntityProvider<T> implements MessageBodyWriter<T>, MessageBodyRea
         this.stringToValue = stringToValue;
     }
 
+    @Override
     public boolean isReadable(Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType) {
         return primitiveClass.equals(type) || boxedClass.equals(type);
     }
 
+    @Override
     public T readFrom(Class<T> type, Type genericType, Annotation[] annotations, MediaType mediaType, MultivaluedMap<String, String> httpHeaders, InputStream entityStream) throws IOException, WebApplicationException {
         Charset charset = EntityProviders.charsetFor(mediaType);
         byte[] bytes = Mutils.toByteArray(entityStream, 2048);
@@ -64,14 +66,17 @@ class PrimitiveEntityProvider<T> implements MessageBodyWriter<T>, MessageBodyRea
         return stringToValue.apply(stringVal);
     }
 
+    @Override
     public boolean isWriteable(Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType) {
         return primitiveClass.equals(type) || boxedClass.equals(type);
     }
 
+    @Override
     public long getSize(T content, Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType) {
         return toBytes(content, mediaType).length;
     }
 
+    @Override
     public void writeTo(T content, Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType, MultivaluedMap<String, Object> httpHeaders, OutputStream entityStream) throws IOException, WebApplicationException {
         entityStream.write(toBytes(content, mediaType));
     }

--- a/src/main/java/io/muserver/rest/ReadOnlyMultivaluedMap.java
+++ b/src/main/java/io/muserver/rest/ReadOnlyMultivaluedMap.java
@@ -33,91 +33,113 @@ class ReadOnlyMultivaluedMap<K, V> implements MultivaluedMap<K, V>, Serializable
     }
 
 
+    @Override
     public void putSingle(K key, V value) {
         throw new NotImplementedException("Invalid access for readonly map");
     }
 
+    @Override
     public void add(K key, V value) {
         throw new NotImplementedException("Invalid access for readonly map");
     }
 
+    @Override
     @SafeVarargs
     public final void addAll(K key, V... newValues) {
         throw new NotImplementedException("Invalid access for readonly map");
     }
 
+    @Override
     public void addAll(K key, List<V> valueList) {
         throw new NotImplementedException("Invalid access for readonly map");
     }
 
+    @Override
     public @Nullable V getFirst(K key) {
         return actual.getFirst(key);
     }
 
+    @Override
     public void addFirst(K key, V value) {
         actual.addFirst(key, value);
     }
 
+    @Override
     public String toString() {
         return "Read Only: " + actual.toString();
     }
 
+    @Override
     public int hashCode() {
         return actual.hashCode();
     }
 
+    @Override
     public boolean equals(@Nullable Object o) {
         return actual.equals(o);
     }
 
+    @Override
     public Collection<List<V>> values() {
         return actual.values();
     }
 
+    @Override
     public int size() {
         return actual.size();
     }
 
+    @Override
     public List<V> remove(@Nullable Object key) {
         throw new NotImplementedException("Invalid access for readonly map");
     }
 
+    @Override
     public void putAll(Map<? extends K, ? extends List<V>> m) {
         throw new NotImplementedException("Invalid access for readonly map");
     }
 
+    @Override
     public List<V> put(K key, List<V> value) {
         throw new NotImplementedException("Invalid access for readonly map");
     }
 
+    @Override
     public Set<K> keySet() {
         return actual.keySet();
     }
 
+    @Override
     public boolean isEmpty() {
         return actual.isEmpty();
     }
 
+    @Override
     public @Nullable List<V> get(@Nullable Object key) {
         return actual.get(key);
     }
 
+    @Override
     public Set<Entry<K, List<V>>> entrySet() {
         return actual.entrySet();
     }
 
+    @Override
     public boolean containsValue(@Nullable Object value) {
         return actual.containsValue(value);
     }
 
+    @Override
     public boolean containsKey(@Nullable Object key) {
         return actual.containsKey(key);
     }
 
+    @Override
     public void clear() {
         throw new NotImplementedException("Invalid access for readonly map");
     }
 
+    @Override
     public boolean equalsIgnoreValueOrder(MultivaluedMap<K, V> omap) {
         return actual.equalsIgnoreValueOrder(omap);
     }

--- a/src/main/java/io/muserver/rest/RequestMatcher.java
+++ b/src/main/java/io/muserver/rest/RequestMatcher.java
@@ -295,8 +295,13 @@ class RequestMatcher {
     private static CombinedMediaType bestMediaType(List<MediaType> requestedTypes, List<MediaType> serverProvided) {
         return serverProvided.stream()
             .flatMap(serverType -> requestedTypes.stream().map(clientType -> CombinedMediaType.s(clientType, serverType)))
-            .filter(combined -> combined != CombinedMediaType.NONMATCH)
+            .filter(RequestMatcher::isMediaTypeMatch)
             .max(Comparator.naturalOrder()).get();
+    }
+
+    @SuppressWarnings("ReferenceEquality") // CombinedMediaType.s returns this sentinel for incompatible types.
+    private static boolean isMediaTypeMatch(CombinedMediaType combined) {
+        return combined != CombinedMediaType.NONMATCH;
     }
 
     static class StepOneOutput {

--- a/src/main/java/io/muserver/rest/ResourceClass.java
+++ b/src/main/java/io/muserver/rest/ResourceClass.java
@@ -176,9 +176,9 @@ class ResourceClass {
     }
 
     static ResourceClass forSubResourceLocator(ResourceMethod rm, Class<?> instanceClass, @Nullable Object instance, SchemaObjectCustomizer schemaObjectCustomizer, List<ParamConverterProvider> paramConverterProviders) {
-        @Nullable List<MediaType> existingConsumes = rm.effectiveConsumes.isEmpty() || (rm.directlyConsumes.isEmpty() && rm.effectiveConsumes.size() == 1 && rm.effectiveConsumes.get(0) == MediaType.WILDCARD_TYPE) ? null : rm.effectiveConsumes;
+        @Nullable List<MediaType> existingConsumes = rm.effectiveConsumes.isEmpty() || (rm.directlyConsumes.isEmpty() && rm.effectiveConsumes.size() == 1 && MediaType.WILDCARD_TYPE.equals(rm.effectiveConsumes.get(0))) ? null : rm.effectiveConsumes;
         List<MediaType> consumes = getConsumes(existingConsumes, instanceClass);
-        @Nullable List<MediaType> existingProduces = rm.effectiveProduces.isEmpty() || (rm.directlyProduces.isEmpty() && rm.effectiveProduces.size() == 1 && rm.effectiveProduces.get(0) == MediaType.WILDCARD_TYPE) ? null : rm.effectiveProduces;
+        @Nullable List<MediaType> existingProduces = rm.effectiveProduces.isEmpty() || (rm.directlyProduces.isEmpty() && rm.effectiveProduces.size() == 1 && MediaType.WILDCARD_TYPE.equals(rm.effectiveProduces.get(0))) ? null : rm.effectiveProduces;
         List<MediaType> produces = getProduces(existingProduces, instanceClass);
         ResourceClass resourceClass = new ResourceClass(
             java.util.Objects.requireNonNull(rm.pathPattern, "Sub-resource locator had no path pattern"),

--- a/src/main/java/io/muserver/rest/RestHandler.java
+++ b/src/main/java/io/muserver/rest/RestHandler.java
@@ -288,6 +288,8 @@ public class RestHandler implements MuHandler {
                     if (jaxRSResponse.hasEntity()) {
                         jaxRSResponse.executeInterceptors(writerInterceptors); // run the interceptors
                     }
+                    // Interceptors replace a stream by installing a different instance.
+                    @SuppressWarnings("ReferenceEquality")
                     boolean entityStreamReplaced = jaxRSResponse.getOutputStream() != originalEntityStream;
                     writerAnnontations = jaxRSResponse.getAnnotations();
                     Object entity = jaxRSResponse.getEntity();

--- a/src/main/java/io/muserver/rest/RestHandlerBuilder.java
+++ b/src/main/java/io/muserver/rest/RestHandlerBuilder.java
@@ -559,6 +559,7 @@ public class RestHandlerBuilder implements MuHandlerBuilder<RestHandler> {
     /**
      * @return The newly build {@link RestHandler}
      */
+    @Override
     public RestHandler build() {
         List<MessageBodyReader> readers = EntityProviders.builtInReaders();
         readers.addAll(customReaders);

--- a/src/main/java/io/muserver/rest/StringEntityProviders.java
+++ b/src/main/java/io/muserver/rest/StringEntityProviders.java
@@ -49,10 +49,12 @@ class StringEntityProviders {
 
         static final StringMessageReaderWriter INSTANCE = new StringMessageReaderWriter();
 
+        @Override
         public boolean isWriteable(Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType) {
             return String.class.equals(type);
         }
 
+        @Override
         public long getSize(String s, Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType) {
             if (s.length() > 100000) {
                 return -1;
@@ -65,14 +67,17 @@ class StringEntityProviders {
             return s.getBytes(charset).length;
         }
 
+        @Override
         public void writeTo(String s, Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType, MultivaluedMap<String, Object> httpHeaders, OutputStream entityStream) throws IOException, WebApplicationException {
             entityStream.write(s.getBytes(EntityProviders.charsetFor(mediaType)));
         }
 
+        @Override
         public boolean isReadable(Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType) {
             return String.class.equals(type);
         }
 
+        @Override
         public String readFrom(Class<String> type, Type genericType, Annotation[] annotations, MediaType mediaType, MultivaluedMap<String, String> httpHeaders, InputStream entityStream) throws IOException, WebApplicationException {
             return new String(Mutils.toByteArray(entityStream, 2048), EntityProviders.charsetFor(mediaType));
         }
@@ -193,10 +198,12 @@ class StringEntityProviders {
 
     @Consumes("*/*")
     static class ReaderEntityReader implements MessageBodyReader<Reader> {
+        @Override
         public boolean isReadable(Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType) {
             return Reader.class.isAssignableFrom(type);
         }
 
+        @Override
         public Reader readFrom(Class<Reader> type, Type genericType, Annotation[] annotations, MediaType mediaType, MultivaluedMap<String, String> httpHeaders, InputStream entityStream) throws IOException, WebApplicationException {
             return new InputStreamReader(entityStream, EntityProviders.charsetFor(mediaType));
         }

--- a/src/main/java/io/muserver/rest/UriPattern.java
+++ b/src/main/java/io/muserver/rest/UriPattern.java
@@ -109,6 +109,7 @@ public class UriPattern {
         }
     }
 
+    @Override
     public String toString() {
         return pattern.toString();
     }


### PR DESCRIPTION
## What changed

Enables these additional Error Prone checks as build-breaking production-source checks:

- `ArrayEquals`
- `CollectionIncompatibleType`
- `DefaultCharset`
- `EqualsHashCode`
- `LockNotBeforeTry`
- `MissingOverride`
- `ReferenceEquality`
- `SynchronizeOnNonFinalField`
- `ThreadJoinLoop`

The audit added the 110 missing `@Override` annotations reported by `MissingOverride`.

`ReferenceEquality` found several comparisons that needed individual review. This PR:

- uses value equality for Jakarta REST wildcard media types and resolved generic owner types;
- makes the internal non-match media-type sentinel final;
- keeps four intentional identity checks, with narrow suppressions and comments, for exchange ownership, provider instances, the media-type sentinel, and interceptor stream replacement.

The other seven newly enabled checks produced no current findings, but are retained because they catch concrete correctness or portability errors with low expected noise.

## Deliberately not enabled

`FutureReturnValueIgnored` reported 38 production call sites, overwhelmingly Netty asynchronous plumbing such as `write`, `writeAndFlush`, `close`, void promises, executor submission, and internal body-read futures. Enabling it would mostly require suppressions without improving error handling, so this PR leaves it disabled.

## Compatibility

The `@Override` and suppression annotations are source-only. The identity/value-equality fixes are internal implementation details and do not change public API or wire contracts. Treating equal wildcard `MediaType` instances as wildcard defaults removes an accidental dependency on singleton identity.

## Validation

- Java 21: `mvn -Pnullaway -DskipTests clean test-compile`
- Java 21 / Netty 4.2: `mvn -Pnullaway,netty-4.2 -DskipTests clean test-compile`
- Java 11 targeted REST tests: 69 passed
- Java 11: `mvn clean verify` — 968 tests passed; packaging, Javadocs, and dependency analysis succeeded
- `git diff --check`