### PR TITLE
Cache class-derived JAX-RS resource metadata

### DIFF
--- a/src/main/java/io/muserver/rest/CORSConfig.java
+++ b/src/main/java/io/muserver/rest/CORSConfig.java
@@ -92,7 +92,7 @@ public class CORSConfig {
     }
 
     static String getAllowedMethods(Set<RequestMatcher.MatchedMethod> matchedMethodsForPath) {
-        Set<Method> methods = matchedMethodsForPath.stream().map(m -> m.resourceMethod.httpMethod).collect(toSet());
+        Set<Method> methods = matchedMethodsForPath.stream().map(m -> m.resourceMethod.httpMethod()).collect(toSet());
         return getAllowedString(methods);
     }
 

--- a/src/main/java/io/muserver/rest/JaxRSRequest.java
+++ b/src/main/java/io/muserver/rest/JaxRSRequest.java
@@ -86,7 +86,7 @@ class JaxRSRequest implements Request, ContainerRequestContext, ReaderIntercepto
             return muRequest;
         } else if (MuRuntimeDelegate.RESOURCE_INFO_PROPERTY.equals(name)) {
             @Nullable Class<?> resourceInstanceClass = (matchedMethod == null) ? null : matchedMethod.matchedClass.resourceClass.requiredResourceInstance().getClass();
-            java.lang.reflect.@Nullable Method resourceInstanceMethod = (matchedMethod == null) ? null : matchedMethod.resourceMethod.methodHandle;
+            java.lang.reflect.@Nullable Method resourceInstanceMethod = (matchedMethod == null) ? null : matchedMethod.resourceMethod.methodHandle();
             return new MuResourceInfo(resourceInstanceClass, resourceInstanceMethod);
         }
         return muRequest.attribute(name);

--- a/src/main/java/io/muserver/rest/OpenApiDocumentor.java
+++ b/src/main/java/io/muserver/rest/OpenApiDocumentor.java
@@ -129,7 +129,7 @@ class OpenApiDocumentor implements MuHandler {
 
         for (ResourceMethod method : root.resourceMethods) {
             if (method.isSubResourceLocator()) {
-                ResourceClass rc = ResourceClass.forSubResourceLocator(method, method.methodHandle.getReturnType(), null, schemaObjectCustomizer, paramConverterProviders);
+                ResourceClass rc = ResourceClass.forSubResourceLocator(method, method.methodHandle().getReturnType(), null, schemaObjectCustomizer, paramConverterProviders);
                 String newParentResourcePath = Mutils.join(parentResourcePath, "/", method.resourceClass.pathPattern.pathWithoutRegex);
                 addResourceClass(recursiveLevel + 1, newParentResourcePath, tags, pathItems, rc);
                 continue;
@@ -152,7 +152,7 @@ class OpenApiDocumentor implements MuHandler {
                 pathItems.put(path, pathItem);
             }
             List<ParameterObject> parameters = method.paramsIncludingLocators().stream()
-                .filter(p -> p.source.openAPIIn != null && p instanceof ResourceMethodParam.RequestBasedParam)
+                .filter(p -> p.source().openAPIIn != null && p instanceof ResourceMethodParam.RequestBasedParam)
                 .map(ResourceMethodParam.RequestBasedParam.class::cast)
                 .map(p -> p.createDocumentationBuilder().build())
                 .reduce(new ArrayList<>(), (parameterObjects, parameterObject) -> {
@@ -216,7 +216,7 @@ class OpenApiDocumentor implements MuHandler {
     static String getPathWithoutRegex(ResourceClass rc, ResourceMethod rm, String parentResourcePath) {
         return "/" + Mutils.trim(Mutils.join(parentResourcePath, "/",
             Mutils.join(rc.pathPattern == null ? null : rc.pathPattern.pathWithoutRegex,
-                "/", rm.pathPattern == null ? null : rm.pathPattern.pathWithoutRegex)), "/");
+                "/", rm.pathPattern() == null ? null : rm.pathPattern().pathWithoutRegex)), "/");
     }
 
 }

--- a/src/main/java/io/muserver/rest/RequestMatcher.java
+++ b/src/main/java/io/muserver/rest/RequestMatcher.java
@@ -256,7 +256,7 @@ class RequestMatcher {
     }
 
     private MatchedMethod stepThreeIdentifyTheMethodThatWillHandleTheRequest(Method method, Set<MatchedMethod> candidates, @Nullable String requestBodyContentType, List<MediaType> acceptHeaders) throws NotAllowedException, NotAcceptableException, NotSupportedException {
-        List<MatchedMethod> result = candidates.stream().filter(rm -> rm.resourceMethod.httpMethod == method).collect(toList());
+        List<MatchedMethod> result = candidates.stream().filter(rm -> rm.resourceMethod.httpMethod() == method).collect(toList());
         if (result.isEmpty()) {
             List<String> allowed = candidates.stream().map(c -> c.resourceMethod.requiredHttpMethod().name()).distinct().collect(toList());
             throw new NotAllowedException(allowed.get(0), allowed.subList(1, allowed.size()).toArray(new String[0]));

--- a/src/main/java/io/muserver/rest/ResourceClass.java
+++ b/src/main/java/io/muserver/rest/ResourceClass.java
@@ -1,6 +1,5 @@
 package io.muserver.rest;
 
-import io.muserver.Method;
 import io.muserver.openapi.TagObject;
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.NameBinding;
@@ -12,7 +11,6 @@ import org.jspecify.annotations.Nullable;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.AnnotatedElement;
-import java.lang.reflect.Parameter;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -37,6 +35,7 @@ class ResourceClass {
     final TagObject tag;
     final List<Class<? extends Annotation>> nameBindingAnnotations;
     private final SchemaObjectCustomizer schemaObjectCustomizer;
+    final ResourceClassIntrospection introspection;
 
     /**
      * If this class is sub-resource, then this is the locator method. Otherwise null.
@@ -54,6 +53,7 @@ class ResourceClass {
         this.nameBindingAnnotations = nameBindingAnnotations;
         this.schemaObjectCustomizer = schemaObjectCustomizer;
         this.locatorMethod = locatorMethod;
+        this.introspection = ResourceClassIntrospection.forClass(resourceClass);
     }
 
     public boolean matches(URI uri) {
@@ -74,37 +74,16 @@ class ResourceClass {
         }
 
         List<ResourceMethod> resourceMethods = new ArrayList<>();
-        java.lang.reflect.Method[] methods = this.resourceClass.getMethods();
-        for (java.lang.reflect.Method restMethod : methods) {
-            if (restMethod.isBridge()) {
-                continue;
-            }
-            java.lang.reflect.Method annotationSource = JaxMethodLocator.getMethodThatHasJaxRSAnnotations(restMethod, resourceClass);
-            @Nullable Method httpMethod = ResourceMethod.getMuMethod(annotationSource);
-            restMethod.setAccessible(true);
-            Path methodPath = annotationSource.getAnnotation(Path.class);
-            if (methodPath == null && httpMethod == null) {
-                continue; // after this, only methods that are (sub)resource-methods or resource locators are processed
-            }
-
-            List<Class<? extends Annotation>> methodNameBindingAnnotations = getNameBindingAnnotations(annotationSource);
-
-            @Nullable UriPattern methodPattern = methodPath == null ? null : UriPattern.uriTemplateToRegex(methodPath.value());
-
-
-            List<MediaType> methodProduces = MediaTypeDeterminer.supportedProducesTypes(annotationSource);
-            List<MediaType> methodConsumes = MediaTypeDeterminer.supportedConsumesTypes(annotationSource);
+        for (ResourceClassIntrospection.MethodInfo methodInfo : introspection.methods) {
+            methodInfo.methodHandle.setAccessible(true);
             List<ResourceMethodParam> params = new ArrayList<>();
-            Parameter[] annotationParameters = annotationSource.getParameters();
-            Parameter[] methodParameters = restMethod.getParameters();
-            for (int i = 0; i < annotationParameters.length; i++) {
-                ResourceMethodParam resourceMethodParam = ResourceMethodParam.fromParameter(i, methodParameters[i], annotationParameters[i], resourceClass, paramConverterProviders, methodPattern);
-                params.add(resourceMethodParam);
+            for (ResourceMethodParam.Introspection param : methodInfo.params) {
+                params.add(param.bind(paramConverterProviders));
             }
-            DescriptionData descriptionData = DescriptionData.fromAnnotation(restMethod, null);
-            @Nullable String pathTemplate = methodPath == null ? null : methodPath.value();
-            boolean isDeprecated = annotationSource.isAnnotationPresent(Deprecated.class);
-            resourceMethods.add(new ResourceMethod(this, methodPattern, restMethod, params, httpMethod, pathTemplate, methodProduces, methodConsumes, schemaObjectCustomizer, descriptionData, isDeprecated, methodNameBindingAnnotations, annotationSource.getAnnotations()));
+            DescriptionData descriptionData =
+                DescriptionData.fromAnnotation(methodInfo.methodHandle, null);
+            resourceMethods.add(new ResourceMethod(
+                this, methodInfo, params, schemaObjectCustomizer, descriptionData));
         }
         this.resourceMethods = Collections.unmodifiableList(resourceMethods);
         this.methodInfoSet = true;

--- a/src/main/java/io/muserver/rest/ResourceClass.java
+++ b/src/main/java/io/muserver/rest/ResourceClass.java
@@ -18,7 +18,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -28,12 +27,6 @@ import static java.util.stream.Collectors.toList;
 class ResourceClass {
 
     private static final Logger log = LoggerFactory.getLogger(ResourceClass.class);
-    private static final ClassValue<AtomicBoolean> visibilityWarningsLogged = new ClassValue<AtomicBoolean>() {
-        @Override
-        protected AtomicBoolean computeValue(Class<?> type) {
-            return new AtomicBoolean();
-        }
-    };
 
     final UriPattern pathPattern;
     final Class<?> resourceClass;
@@ -85,7 +78,7 @@ class ResourceClass {
         }
 
         try {
-            if (shouldLogVisibilityWarnings(resourceClass)) {
+            if (introspection.shouldLogVisibilityWarnings()) {
                 introspection.visibilityWarnings.forEach(log::warn);
             }
         } catch (LinkageError | RuntimeException ignored) {
@@ -98,10 +91,8 @@ class ResourceClass {
             for (ResourceMethodParam.Introspection param : methodInfo.params) {
                 params.add(param.bind(paramConverterProviders));
             }
-            DescriptionData descriptionData =
-                DescriptionData.fromAnnotation(methodInfo.methodHandle, null);
             resourceMethods.add(new ResourceMethod(
-                this, methodInfo, params, schemaObjectCustomizer, descriptionData));
+                this, methodInfo, params, schemaObjectCustomizer));
         }
         this.resourceMethods = Collections.unmodifiableList(resourceMethods);
         this.methodInfoSet = true;
@@ -112,7 +103,7 @@ class ResourceClass {
     }
 
     static boolean shouldLogVisibilityWarnings(Class<?> resourceClass) {
-        return visibilityWarningsLogged.get(resourceClass).compareAndSet(false, true);
+        return ResourceClassIntrospection.forClass(resourceClass).shouldLogVisibilityWarnings();
     }
 
     static List<Class<? extends Annotation>> getNameBindingAnnotations(AnnotatedElement annotationSource) {

--- a/src/main/java/io/muserver/rest/ResourceClass.java
+++ b/src/main/java/io/muserver/rest/ResourceClass.java
@@ -181,13 +181,13 @@ class ResourceClass {
     }
 
     static ResourceClass forSubResourceLocator(ResourceMethod rm, Class<?> instanceClass, @Nullable Object instance, SchemaObjectCustomizer schemaObjectCustomizer, List<ParamConverterProvider> paramConverterProviders) {
-        @Nullable List<MediaType> existingConsumes = rm.effectiveConsumes.isEmpty() || (rm.directlyConsumes.isEmpty() && rm.effectiveConsumes.size() == 1 && rm.effectiveConsumes.get(0) == MediaType.WILDCARD_TYPE) ? null : rm.effectiveConsumes;
+        @Nullable List<MediaType> existingConsumes = rm.effectiveConsumes.isEmpty() || (rm.directlyConsumes().isEmpty() && rm.effectiveConsumes.size() == 1 && rm.effectiveConsumes.get(0) == MediaType.WILDCARD_TYPE) ? null : rm.effectiveConsumes;
         List<MediaType> consumes = getConsumes(existingConsumes, instanceClass);
-        @Nullable List<MediaType> existingProduces = rm.effectiveProduces.isEmpty() || (rm.directlyProduces.isEmpty() && rm.effectiveProduces.size() == 1 && rm.effectiveProduces.get(0) == MediaType.WILDCARD_TYPE) ? null : rm.effectiveProduces;
+        @Nullable List<MediaType> existingProduces = rm.effectiveProduces.isEmpty() || (rm.directlyProduces().isEmpty() && rm.effectiveProduces.size() == 1 && rm.effectiveProduces.get(0) == MediaType.WILDCARD_TYPE) ? null : rm.effectiveProduces;
         List<MediaType> produces = getProduces(existingProduces, instanceClass);
         ResourceClass resourceClass = new ResourceClass(
-            java.util.Objects.requireNonNull(rm.pathPattern, "Sub-resource locator had no path pattern"),
-            java.util.Objects.requireNonNull(rm.pathTemplate, "Sub-resource locator had no path template"),
+            java.util.Objects.requireNonNull(rm.pathPattern(), "Sub-resource locator had no path pattern"),
+            java.util.Objects.requireNonNull(rm.pathTemplate(), "Sub-resource locator had no path template"),
             instanceClass, instance, consumes, produces, rm.resourceClass.tag,
             rm.resourceClass.nameBindingAnnotations, schemaObjectCustomizer, rm);
         resourceClass.setupMethodInfo(paramConverterProviders);

--- a/src/main/java/io/muserver/rest/ResourceClassIntrospection.java
+++ b/src/main/java/io/muserver/rest/ResourceClassIntrospection.java
@@ -1,19 +1,21 @@
 package io.muserver.rest;
 
 import io.muserver.Method;
+import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.HttpMethod;
 import jakarta.ws.rs.Path;
-import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.Produces;
 import org.jspecify.annotations.Nullable;
 
 import java.lang.annotation.Annotation;
+import java.lang.reflect.Modifier;
 import java.lang.reflect.Parameter;
 import java.lang.reflect.Type;
-import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * Immutable metadata that is derived solely from a concrete resource class.
@@ -28,6 +30,7 @@ final class ResourceClassIntrospection {
 
     final List<MethodInfo> methods;
     final List<String> visibilityWarnings;
+    private final AtomicBoolean visibilityWarningsLogged = new AtomicBoolean();
 
     private ResourceClassIntrospection(List<MethodInfo> methods, List<String> visibilityWarnings) {
         this.methods = Collections.unmodifiableList(new ArrayList<>(methods));
@@ -35,10 +38,11 @@ final class ResourceClassIntrospection {
     }
 
     static ResourceClassIntrospection forClass(Class<?> resourceClass) {
-        // Media type annotation processing uses Jakarta REST's RuntimeDelegate. Keep the
-        // one-time global delegate setup outside computeValue, which must stay side-effect free.
-        MuRuntimeDelegate.ensureSet();
         return CACHE.get(resourceClass);
+    }
+
+    boolean shouldLogVisibilityWarnings() {
+        return visibilityWarningsLogged.compareAndSet(false, true);
     }
 
     private static ResourceClassIntrospection introspect(Class<?> resourceClass) {
@@ -68,21 +72,29 @@ final class ResourceClassIntrospection {
 
             methods.add(new MethodInfo(
                 restMethod,
-                annotationSource,
                 methodPattern,
                 httpMethod,
                 pathTemplate,
-                MediaTypeDeterminer.supportedProducesTypes(annotationSource),
-                MediaTypeDeterminer.supportedConsumesTypes(annotationSource),
+                annotationValues(annotationSource.getAnnotation(Produces.class)),
+                annotationValues(annotationSource.getAnnotation(Consumes.class)),
                 params,
                 GenericTypeResolver.resolveConcrete(
                     restMethod.getGenericReturnType(), resourceClass, restMethod.getDeclaringClass()),
                 annotationSource.isAnnotationPresent(Deprecated.class),
                 ResourceClass.getNameBindingAnnotations(annotationSource),
-                Arrays.asList(annotationSource.getAnnotations())
+                Arrays.asList(annotationSource.getAnnotations()),
+                DescriptionData.fromAnnotation(restMethod, null)
             ));
         }
         return new ResourceClassIntrospection(methods, visibilityWarnings(resourceClass));
+    }
+
+    private static List<String> annotationValues(@Nullable Produces annotation) {
+        return annotation == null ? Collections.emptyList() : Arrays.asList(annotation.value());
+    }
+
+    private static List<String> annotationValues(@Nullable Consumes annotation) {
+        return annotation == null ? Collections.emptyList() : Arrays.asList(annotation.value());
     }
 
     private static List<String> visibilityWarnings(Class<?> resourceClass) {
@@ -120,32 +132,31 @@ final class ResourceClassIntrospection {
 
     static final class MethodInfo {
         final java.lang.reflect.Method methodHandle;
-        final java.lang.reflect.Method annotationSource;
         final @Nullable UriPattern pathPattern;
         final @Nullable Method httpMethod;
         final @Nullable String pathTemplate;
-        final List<MediaType> directlyProduces;
-        final List<MediaType> directlyConsumes;
+        final List<String> directlyProduces;
+        final List<String> directlyConsumes;
         final List<ResourceMethodParam.Introspection> params;
         final @Nullable Type genericReturnType;
         final boolean deprecated;
         final List<Class<? extends Annotation>> nameBindingAnnotations;
         final List<Annotation> methodAnnotations;
+        final DescriptionData descriptionData;
 
         private MethodInfo(java.lang.reflect.Method methodHandle,
-                           java.lang.reflect.Method annotationSource,
                            @Nullable UriPattern pathPattern,
                            @Nullable Method httpMethod,
                            @Nullable String pathTemplate,
-                           List<MediaType> directlyProduces,
-                           List<MediaType> directlyConsumes,
+                           List<String> directlyProduces,
+                           List<String> directlyConsumes,
                            List<ResourceMethodParam.Introspection> params,
                            @Nullable Type genericReturnType,
                            boolean deprecated,
                            List<Class<? extends Annotation>> nameBindingAnnotations,
-                           List<Annotation> methodAnnotations) {
+                           List<Annotation> methodAnnotations,
+                           DescriptionData descriptionData) {
             this.methodHandle = methodHandle;
-            this.annotationSource = annotationSource;
             this.pathPattern = pathPattern;
             this.httpMethod = httpMethod;
             this.pathTemplate = pathTemplate;
@@ -156,6 +167,7 @@ final class ResourceClassIntrospection {
             this.deprecated = deprecated;
             this.nameBindingAnnotations = immutableCopy(nameBindingAnnotations);
             this.methodAnnotations = immutableCopy(methodAnnotations);
+            this.descriptionData = descriptionData;
         }
 
         private static <T> List<T> immutableCopy(List<T> values) {

--- a/src/main/java/io/muserver/rest/ResourceClassIntrospection.java
+++ b/src/main/java/io/muserver/rest/ResourceClassIntrospection.java
@@ -1,0 +1,128 @@
+package io.muserver.rest;
+
+import io.muserver.Method;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.core.MediaType;
+import org.jspecify.annotations.Nullable;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Parameter;
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Immutable metadata that is derived solely from a concrete resource class.
+ */
+final class ResourceClassIntrospection {
+    private static final ClassValue<ResourceClassIntrospection> CACHE = new ClassValue<ResourceClassIntrospection>() {
+        @Override
+        protected ResourceClassIntrospection computeValue(Class<?> type) {
+            return introspect(type);
+        }
+    };
+
+    final List<MethodInfo> methods;
+
+    private ResourceClassIntrospection(List<MethodInfo> methods) {
+        this.methods = Collections.unmodifiableList(new ArrayList<>(methods));
+    }
+
+    static ResourceClassIntrospection forClass(Class<?> resourceClass) {
+        // Media type annotation processing uses Jakarta REST's RuntimeDelegate. Keep the
+        // one-time global delegate setup outside computeValue, which must stay side-effect free.
+        MuRuntimeDelegate.ensureSet();
+        return CACHE.get(resourceClass);
+    }
+
+    private static ResourceClassIntrospection introspect(Class<?> resourceClass) {
+        List<MethodInfo> methods = new ArrayList<>();
+        for (java.lang.reflect.Method restMethod : resourceClass.getMethods()) {
+            if (restMethod.isBridge()) {
+                continue;
+            }
+            java.lang.reflect.Method annotationSource =
+                JaxMethodLocator.getMethodThatHasJaxRSAnnotations(restMethod, resourceClass);
+            @Nullable Method httpMethod = ResourceMethod.getMuMethod(annotationSource);
+            Path methodPath = annotationSource.getAnnotation(Path.class);
+            if (methodPath == null && httpMethod == null) {
+                continue;
+            }
+
+            @Nullable String pathTemplate = methodPath == null ? null : methodPath.value();
+            @Nullable UriPattern methodPattern =
+                pathTemplate == null ? null : UriPattern.uriTemplateToRegex(pathTemplate);
+            Parameter[] annotationParameters = annotationSource.getParameters();
+            Parameter[] methodParameters = restMethod.getParameters();
+            List<ResourceMethodParam.Introspection> params = new ArrayList<>(annotationParameters.length);
+            for (int i = 0; i < annotationParameters.length; i++) {
+                params.add(ResourceMethodParam.introspect(
+                    i, methodParameters[i], annotationParameters[i], resourceClass, methodPattern));
+            }
+
+            methods.add(new MethodInfo(
+                restMethod,
+                annotationSource,
+                methodPattern,
+                httpMethod,
+                pathTemplate,
+                MediaTypeDeterminer.supportedProducesTypes(annotationSource),
+                MediaTypeDeterminer.supportedConsumesTypes(annotationSource),
+                params,
+                GenericTypeResolver.resolveConcrete(
+                    restMethod.getGenericReturnType(), resourceClass, restMethod.getDeclaringClass()),
+                annotationSource.isAnnotationPresent(Deprecated.class),
+                ResourceClass.getNameBindingAnnotations(annotationSource),
+                Arrays.asList(annotationSource.getAnnotations())
+            ));
+        }
+        return new ResourceClassIntrospection(methods);
+    }
+
+    static final class MethodInfo {
+        final java.lang.reflect.Method methodHandle;
+        final java.lang.reflect.Method annotationSource;
+        final @Nullable UriPattern pathPattern;
+        final @Nullable Method httpMethod;
+        final @Nullable String pathTemplate;
+        final List<MediaType> directlyProduces;
+        final List<MediaType> directlyConsumes;
+        final List<ResourceMethodParam.Introspection> params;
+        final @Nullable Type genericReturnType;
+        final boolean deprecated;
+        final List<Class<? extends Annotation>> nameBindingAnnotations;
+        final List<Annotation> methodAnnotations;
+
+        private MethodInfo(java.lang.reflect.Method methodHandle,
+                           java.lang.reflect.Method annotationSource,
+                           @Nullable UriPattern pathPattern,
+                           @Nullable Method httpMethod,
+                           @Nullable String pathTemplate,
+                           List<MediaType> directlyProduces,
+                           List<MediaType> directlyConsumes,
+                           List<ResourceMethodParam.Introspection> params,
+                           @Nullable Type genericReturnType,
+                           boolean deprecated,
+                           List<Class<? extends Annotation>> nameBindingAnnotations,
+                           List<Annotation> methodAnnotations) {
+            this.methodHandle = methodHandle;
+            this.annotationSource = annotationSource;
+            this.pathPattern = pathPattern;
+            this.httpMethod = httpMethod;
+            this.pathTemplate = pathTemplate;
+            this.directlyProduces = immutableCopy(directlyProduces);
+            this.directlyConsumes = immutableCopy(directlyConsumes);
+            this.params = immutableCopy(params);
+            this.genericReturnType = genericReturnType;
+            this.deprecated = deprecated;
+            this.nameBindingAnnotations = immutableCopy(nameBindingAnnotations);
+            this.methodAnnotations = immutableCopy(methodAnnotations);
+        }
+
+        private static <T> List<T> immutableCopy(List<T> values) {
+            return Collections.unmodifiableList(new ArrayList<>(values));
+        }
+    }
+}

--- a/src/main/java/io/muserver/rest/ResourceMethod.java
+++ b/src/main/java/io/muserver/rest/ResourceMethod.java
@@ -28,6 +28,8 @@ import static java.util.stream.Collectors.toMap;
 class ResourceMethod {
     final ResourceClass resourceClass;
     private final ResourceClassIntrospection.MethodInfo methodInfo;
+    private final List<MediaType> directlyConsumes;
+    private final List<MediaType> directlyProduces;
     final List<MediaType> effectiveConsumes;
     final List<MediaType> effectiveProduces;
     final List<ResourceMethodParam> params;
@@ -36,14 +38,17 @@ class ResourceMethod {
     final Annotation[] methodAnnotations; // the annotations defined on the method to be passed to the message body writers
 
     ResourceMethod(ResourceClass resourceClass, ResourceClassIntrospection.MethodInfo methodInfo,
-                   List<ResourceMethodParam> params, SchemaObjectCustomizer schemaObjectCustomizer,
-                   DescriptionData descriptionData) {
+                   List<ResourceMethodParam> params, SchemaObjectCustomizer schemaObjectCustomizer) {
         this.resourceClass = resourceClass;
         this.methodInfo = methodInfo;
         this.params = params;
         this.schemaObjectCustomizer = schemaObjectCustomizer;
-        this.descriptionData = descriptionData;
+        this.descriptionData = methodInfo.descriptionData;
         this.methodAnnotations = methodInfo.methodAnnotations.toArray(new Annotation[0]);
+        this.directlyProduces = Collections.unmodifiableList(
+            new ArrayList<>(MediaTypeHeaderDelegate.fromStrings(methodInfo.directlyProduces)));
+        this.directlyConsumes = Collections.unmodifiableList(
+            new ArrayList<>(MediaTypeHeaderDelegate.fromStrings(methodInfo.directlyConsumes)));
         this.effectiveProduces = !directlyProduces().isEmpty() ? directlyProduces() : (!resourceClass.produces.isEmpty() ? resourceClass.produces : RequestMatcher.WILDCARD_AS_LIST);
         this.effectiveConsumes = !directlyConsumes().isEmpty() ? directlyConsumes() : (!resourceClass.consumes.isEmpty() ? resourceClass.consumes : RequestMatcher.WILDCARD_AS_LIST);
     }
@@ -69,11 +74,11 @@ class ResourceMethod {
     }
 
     List<MediaType> directlyConsumes() {
-        return methodInfo.directlyConsumes;
+        return directlyConsumes;
     }
 
     List<MediaType> directlyProduces() {
-        return methodInfo.directlyProduces;
+        return directlyProduces;
     }
 
     boolean hasAll(List<Class<? extends Annotation>> annotations) {

--- a/src/main/java/io/muserver/rest/ResourceMethod.java
+++ b/src/main/java/io/muserver/rest/ResourceMethod.java
@@ -27,46 +27,58 @@ import static java.util.stream.Collectors.toMap;
 
 class ResourceMethod {
     final ResourceClass resourceClass;
-    final @Nullable UriPattern pathPattern;
-    final java.lang.reflect.Method methodHandle;
-    final @Nullable Type genericReturnType;
-    final @Nullable Method httpMethod;
-    final @Nullable String pathTemplate;
+    private final ResourceClassIntrospection.MethodInfo methodInfo;
     final List<MediaType> effectiveConsumes;
-    final List<MediaType> directlyConsumes;
-    final List<MediaType> directlyProduces;
     final List<MediaType> effectiveProduces;
     final List<ResourceMethodParam> params;
     private final SchemaObjectCustomizer schemaObjectCustomizer;
     private final DescriptionData descriptionData;
-    private final boolean isDeprecated;
-    private final List<Class<? extends Annotation>> nameBindingAnnotations;
     final Annotation[] methodAnnotations; // the annotations defined on the method to be passed to the message body writers
 
     ResourceMethod(ResourceClass resourceClass, ResourceClassIntrospection.MethodInfo methodInfo,
                    List<ResourceMethodParam> params, SchemaObjectCustomizer schemaObjectCustomizer,
                    DescriptionData descriptionData) {
         this.resourceClass = resourceClass;
-        this.pathPattern = methodInfo.pathPattern;
-        this.methodHandle = methodInfo.methodHandle;
-        this.genericReturnType = methodInfo.genericReturnType;
+        this.methodInfo = methodInfo;
         this.params = params;
-        this.httpMethod = methodInfo.httpMethod;
-        this.pathTemplate = methodInfo.pathTemplate;
-        this.directlyProduces = methodInfo.directlyProduces;
-        this.directlyConsumes = methodInfo.directlyConsumes;
         this.schemaObjectCustomizer = schemaObjectCustomizer;
         this.descriptionData = descriptionData;
-        this.isDeprecated = methodInfo.deprecated;
-        this.nameBindingAnnotations = methodInfo.nameBindingAnnotations;
         this.methodAnnotations = methodInfo.methodAnnotations.toArray(new Annotation[0]);
-        this.effectiveProduces = !directlyProduces.isEmpty() ? directlyProduces : (!resourceClass.produces.isEmpty() ? resourceClass.produces : RequestMatcher.WILDCARD_AS_LIST);
-        this.effectiveConsumes = !directlyConsumes.isEmpty() ? directlyConsumes : (!resourceClass.consumes.isEmpty() ? resourceClass.consumes : RequestMatcher.WILDCARD_AS_LIST);
+        this.effectiveProduces = !directlyProduces().isEmpty() ? directlyProduces() : (!resourceClass.produces.isEmpty() ? resourceClass.produces : RequestMatcher.WILDCARD_AS_LIST);
+        this.effectiveConsumes = !directlyConsumes().isEmpty() ? directlyConsumes() : (!resourceClass.consumes.isEmpty() ? resourceClass.consumes : RequestMatcher.WILDCARD_AS_LIST);
+    }
+
+    @Nullable UriPattern pathPattern() {
+        return methodInfo.pathPattern;
+    }
+
+    java.lang.reflect.Method methodHandle() {
+        return methodInfo.methodHandle;
+    }
+
+    @Nullable Type genericReturnType() {
+        return methodInfo.genericReturnType;
+    }
+
+    @Nullable Method httpMethod() {
+        return methodInfo.httpMethod;
+    }
+
+    @Nullable String pathTemplate() {
+        return methodInfo.pathTemplate;
+    }
+
+    List<MediaType> directlyConsumes() {
+        return methodInfo.directlyConsumes;
+    }
+
+    List<MediaType> directlyProduces() {
+        return methodInfo.directlyProduces;
     }
 
     boolean hasAll(List<Class<? extends Annotation>> annotations) {
         for (Class<? extends Annotation> annotation : annotations) {
-            if (!nameBindingAnnotations.contains(annotation) && !resourceClass.nameBindingAnnotations.contains(annotation)) {
+            if (!methodInfo.nameBindingAnnotations.contains(annotation) && !resourceClass.nameBindingAnnotations.contains(annotation)) {
                 return false;
             }
         }
@@ -83,24 +95,24 @@ class ResourceMethod {
     }
 
     boolean isSubResource() {
-        return pathPattern != null;
+        return pathPattern() != null;
     }
 
     boolean isSubResourceLocator() {
-        return httpMethod == null;
+        return httpMethod() == null;
     }
 
     UriPattern requiredPathPattern() {
-        return Objects.requireNonNull(pathPattern, "Resource method has no path pattern");
+        return Objects.requireNonNull(pathPattern(), "Resource method has no path pattern");
     }
 
     Method requiredHttpMethod() {
-        return Objects.requireNonNull(httpMethod, "Sub-resource locator has no HTTP method");
+        return Objects.requireNonNull(httpMethod(), "Sub-resource locator has no HTTP method");
     }
 
     @Nullable Object invoke(@Nullable Object... params) throws Exception {
         try {
-            return methodHandle.invoke(resourceClass.requiredResourceInstance(), params);
+            return methodHandle().invoke(resourceClass.requiredResourceInstance(), params);
         } catch (InvocationTargetException e) {
             @Nullable Throwable cause = e.getCause();
             if (cause instanceof Exception) {
@@ -111,7 +123,7 @@ class ResourceMethod {
     }
 
     OperationObjectBuilder createOperationBuilder(List<SchemaReference> customSchemas) {
-        List<ApiResponseObj> apiResponseList = getApiResponses(methodHandle);
+        List<ApiResponseObj> apiResponseList = getApiResponses(methodHandle());
 
         Map<String, ResponseObject> httpStatusCodes = new HashMap<>();
 
@@ -163,11 +175,11 @@ class ResourceMethod {
             .filter(p -> p instanceof ResourceMethodParam.MessageBodyParam)
             .map(ResourceMethodParam.MessageBodyParam.class::cast)
             .map(messageBodyParam -> {
-                Class<?> bodyType = messageBodyParam.type;
-                Type bodyParameterizedType = messageBodyParam.genericType;
+                Class<?> bodyType = messageBodyParam.type();
+                Type bodyParameterizedType = messageBodyParam.genericType();
                 SchemaReference schemaReference = SchemaReference.find(customSchemas, bodyType, bodyParameterizedType);
                 SchemaObjectBuilder builder = schemaReference != null ? schemaReference.schema.toBuilder() :
-                    schemaObjectFrom(bodyType, bodyParameterizedType, messageBodyParam.isRequired)
+                    schemaObjectFrom(bodyType, bodyParameterizedType, messageBodyParam.isRequired())
                         .withTitle(Objects.requireNonNull(messageBodyParam.descriptionData).summary)
                         .withDescription(messageBodyParam.descriptionData.description);
                 return requestBodyObject()
@@ -180,7 +192,7 @@ class ResourceMethod {
                             .withExample(Objects.requireNonNull(messageBodyParam.descriptionData).example)
                             .build()))
                     .withDescription(messageBodyParam.descriptionData.summaryAndDescription())
-                    .withRequired(messageBodyParam.isRequired)
+                    .withRequired(messageBodyParam.isRequired())
                     .build();
             })
             .findFirst().orElse(null);
@@ -189,7 +201,7 @@ class ResourceMethod {
             List<ResourceMethodParam.RequestBasedParam> formParams = params.stream()
                 .filter(p -> p instanceof ResourceMethodParam.RequestBasedParam)
                 .map(ResourceMethodParam.RequestBasedParam.class::cast)
-                .filter(p -> p.source == ResourceMethodParam.ValueSource.FORM_PARAM)
+                .filter(p -> p.source() == ResourceMethodParam.ValueSource.FORM_PARAM)
                 .collect(Collectors.toList());
             if (!formParams.isEmpty()) {
                 List<String> required = new ArrayList<>();
@@ -202,27 +214,27 @@ class ResourceMethod {
                                     .withRequired(required)
                                     .withProperties(
                                         formParams.stream().collect(
-                                            toMap(n -> n.key,
+                                            toMap(ResourceMethodParam.RequestBasedParam::key,
                                                 n -> {
-                                                    if (n.isRequired) {
-                                                        required.add(n.key);
+                                                    if (n.isRequired()) {
+                                                        required.add(n.key());
                                                     }
-                                                    Class<?> paramType = n.type;
-                                                    Type paramParameterizedType = n.genericType;
+                                                    Class<?> paramType = n.type();
+                                                    Type paramParameterizedType = n.genericType();
 
                                                     SchemaReference schemaReference = SchemaReference.find(customSchemas, paramType, paramParameterizedType);
-                                                    SchemaObjectBuilder schemaObjectBuilder = schemaReference != null ? schemaReference.schema.toBuilder() : schemaObjectFrom(paramType, paramParameterizedType, n.isRequired);
-                                                    schemaObjectBuilder.withDeprecated(n.isDeprecated ? true : null);
+                                                    SchemaObjectBuilder schemaObjectBuilder = schemaReference != null ? schemaReference.schema.toBuilder() : schemaObjectFrom(paramType, paramParameterizedType, n.isRequired());
+                                                    schemaObjectBuilder.withDeprecated(n.deprecated() ? true : null);
                                                     if (n.hasExplicitDefault()) {
                                                         schemaObjectBuilder.withDefaultValue(n.defaultValue());
                                                     }
                                                     if (n.descriptionData != null) {
                                                         String desc = n.descriptionData.summaryAndDescription();
                                                         schemaObjectBuilder.withExample(n.descriptionData.example)
-                                                            .withDescription(n.key.equals(desc) ? null : desc);
+                                                            .withDescription(n.key().equals(desc) ? null : desc);
                                                     }
                                                     return schemaObjectCustomizer
-                                                        .customize(schemaObjectBuilder, schemaContext(SchemaObjectCustomizerTarget.FORM_PARAM, n.key, paramType, paramParameterizedType, requestBodyMediaType))
+                                                        .customize(schemaObjectBuilder, schemaContext(SchemaObjectCustomizerTarget.FORM_PARAM, n.key(), paramType, paramParameterizedType, requestBodyMediaType))
                                                         .build();
                                                 }))
                                     )
@@ -238,7 +250,7 @@ class ResourceMethod {
             .withSummary(descriptionData.summary)
             .withDescription(descriptionData.description)
             .withExternalDocs(descriptionData.externalDocumentation)
-            .withDeprecated(isDeprecated ? true : null)
+            .withDeprecated(methodInfo.deprecated ? true : null)
             .withRequestBody(requestBody)
             .withResponses(
                 responsesObject()
@@ -248,7 +260,7 @@ class ResourceMethod {
     }
 
     private SchemaObjectCustomizerContext schemaContext(SchemaObjectCustomizerTarget target, @Nullable String parameter, Class<?> type, @Nullable Type parameterizedType, MediaType mediaType) {
-        return new SchemaObjectCustomizerContext(target, type, parameterizedType, resourceClass.resourceInstance, methodHandle, parameter, mediaType);
+        return new SchemaObjectCustomizerContext(target, type, parameterizedType, resourceClass.resourceInstance, methodHandle(), parameter, mediaType);
     }
 
     private static List<ApiResponseObj> getApiResponses(java.lang.reflect.Method methodHandle) {
@@ -290,7 +302,7 @@ class ResourceMethod {
 
     @Override
     public String toString() {
-        return "ResourceMethod{" + resourceClass.resourceClassName() + "#" + methodHandle.getName() + "}";
+        return "ResourceMethod{" + resourceClass.resourceClassName() + "#" + methodHandle().getName() + "}";
     }
 
     boolean canProduceFor(List<MediaType> clientAccepts) {

--- a/src/main/java/io/muserver/rest/ResourceMethod.java
+++ b/src/main/java/io/muserver/rest/ResourceMethod.java
@@ -43,24 +43,25 @@ class ResourceMethod {
     private final List<Class<? extends Annotation>> nameBindingAnnotations;
     final Annotation[] methodAnnotations; // the annotations defined on the method to be passed to the message body writers
 
-    ResourceMethod(ResourceClass resourceClass, @Nullable UriPattern pathPattern, java.lang.reflect.Method methodHandle, List<ResourceMethodParam> params, @Nullable Method httpMethod, @Nullable String pathTemplate, List<MediaType> produces, List<MediaType> consumes, SchemaObjectCustomizer schemaObjectCustomizer, DescriptionData descriptionData, boolean isDeprecated, List<Class<? extends Annotation>> nameBindingAnnotations, Annotation[] methodAnnotations) {
+    ResourceMethod(ResourceClass resourceClass, ResourceClassIntrospection.MethodInfo methodInfo,
+                   List<ResourceMethodParam> params, SchemaObjectCustomizer schemaObjectCustomizer,
+                   DescriptionData descriptionData) {
         this.resourceClass = resourceClass;
-        this.pathPattern = pathPattern;
-        this.methodHandle = methodHandle;
-        this.genericReturnType = GenericTypeResolver.resolveConcrete(methodHandle.getGenericReturnType(),
-            resourceClass.resourceClass, methodHandle.getDeclaringClass());
+        this.pathPattern = methodInfo.pathPattern;
+        this.methodHandle = methodInfo.methodHandle;
+        this.genericReturnType = methodInfo.genericReturnType;
         this.params = params;
-        this.httpMethod = httpMethod;
-        this.pathTemplate = pathTemplate;
-        this.directlyProduces = produces;
-        this.directlyConsumes = consumes;
+        this.httpMethod = methodInfo.httpMethod;
+        this.pathTemplate = methodInfo.pathTemplate;
+        this.directlyProduces = methodInfo.directlyProduces;
+        this.directlyConsumes = methodInfo.directlyConsumes;
         this.schemaObjectCustomizer = schemaObjectCustomizer;
         this.descriptionData = descriptionData;
-        this.isDeprecated = isDeprecated;
-        this.nameBindingAnnotations = nameBindingAnnotations;
-        this.methodAnnotations = methodAnnotations;
-        this.effectiveProduces = !produces.isEmpty() ? produces : (!resourceClass.produces.isEmpty() ? resourceClass.produces : RequestMatcher.WILDCARD_AS_LIST);
-        this.effectiveConsumes = !consumes.isEmpty() ? consumes : (!resourceClass.consumes.isEmpty() ? resourceClass.consumes : RequestMatcher.WILDCARD_AS_LIST);
+        this.isDeprecated = methodInfo.deprecated;
+        this.nameBindingAnnotations = methodInfo.nameBindingAnnotations;
+        this.methodAnnotations = methodInfo.methodAnnotations.toArray(new Annotation[0]);
+        this.effectiveProduces = !directlyProduces.isEmpty() ? directlyProduces : (!resourceClass.produces.isEmpty() ? resourceClass.produces : RequestMatcher.WILDCARD_AS_LIST);
+        this.effectiveConsumes = !directlyConsumes.isEmpty() ? directlyConsumes : (!resourceClass.consumes.isEmpty() ? resourceClass.consumes : RequestMatcher.WILDCARD_AS_LIST);
     }
 
     boolean hasAll(List<Class<? extends Annotation>> annotations) {

--- a/src/main/java/io/muserver/rest/ResourceMethodParam.java
+++ b/src/main/java/io/muserver/rest/ResourceMethodParam.java
@@ -35,10 +35,10 @@ abstract class ResourceMethodParam {
     final Annotation[] annotations;
     final @Nullable DescriptionData descriptionData;
 
-    ResourceMethodParam(Introspection introspection, ResolvedParameter parameter, @Nullable DescriptionData descriptionData) {
+    ResourceMethodParam(Introspection introspection, Annotation[] annotations) {
         this.introspection = introspection;
-        this.annotations = parameter.annotations;
-        this.descriptionData = descriptionData;
+        this.annotations = annotations;
+        this.descriptionData = introspection.descriptionData;
     }
 
     int index() {
@@ -88,7 +88,10 @@ abstract class ResourceMethodParam {
         boolean requestBased = source != ValueSource.MESSAGE_BODY
             && source != ValueSource.CONTEXT
             && source != ValueSource.SUSPENDED;
-        boolean isRequired = source == ValueSource.PATH_PARAM || hasDeclared(annotationSource, Required.class);
+        boolean isRequired = source == ValueSource.PATH_PARAM
+            || source == ValueSource.CONTEXT
+            || source == ValueSource.SUSPENDED
+            || hasDeclared(annotationSource, Required.class);
         boolean encodedRequested = requestBased && hasDeclared(annotationSource, Encoded.class);
         boolean isDeprecated = requestBased && hasDeclared(annotationSource, Deprecated.class);
         String key = requestBased ? parameterName(source, annotationSource) : "";
@@ -105,8 +108,11 @@ abstract class ResourceMethodParam {
         if (requestBased) {
             isRequired |= (!explicitDefault && parameter.type.isPrimitive());
         }
-        return new Introspection(index, source, parameter, annotationSource, isRequired,
-            encodedRequested, isDeprecated, key, pattern, explicitDefault, explicitDefaultValue);
+        @Nullable DescriptionData descriptionData = source == ValueSource.MESSAGE_BODY
+            ? DescriptionData.fromAnnotation(annotationSource, null)
+            : requestBased ? DescriptionData.fromAnnotation(annotationSource, key) : null;
+        return new Introspection(index, source, parameter, isRequired, encodedRequested,
+            isDeprecated, key, pattern, explicitDefault, explicitDefaultValue, descriptionData);
     }
 
     static final class Introspection {
@@ -116,7 +122,6 @@ abstract class ResourceMethodParam {
         private final Class<?> type;
         private final Type genericType;
         final List<Annotation> annotations;
-        private final Parameter annotationSource;
         final boolean isRequired;
         private final boolean encodedRequested;
         private final boolean deprecated;
@@ -124,12 +129,13 @@ abstract class ResourceMethodParam {
         private final @Nullable Pattern pattern;
         private final boolean explicitDefault;
         private final @Nullable String explicitDefaultValue;
+        private final @Nullable DescriptionData descriptionData;
 
         private Introspection(int index, ValueSource source, ResolvedParameter parameter,
-                              Parameter annotationSource, boolean isRequired,
-                              boolean encodedRequested, boolean deprecated, String key,
+                              boolean isRequired, boolean encodedRequested, boolean deprecated, String key,
                               @Nullable Pattern pattern, boolean explicitDefault,
-                              @Nullable String explicitDefaultValue) {
+                              @Nullable String explicitDefaultValue,
+                              @Nullable DescriptionData descriptionData) {
             this.index = index;
             this.source = source;
             this.parameterHandle = parameter.handle;
@@ -137,7 +143,6 @@ abstract class ResourceMethodParam {
             this.genericType = parameter.genericType;
             this.annotations = Collections.unmodifiableList(
                 Arrays.asList(parameter.annotations.clone()));
-            this.annotationSource = annotationSource;
             this.isRequired = isRequired;
             this.encodedRequested = encodedRequested;
             this.deprecated = deprecated;
@@ -145,34 +150,31 @@ abstract class ResourceMethodParam {
             this.pattern = pattern;
             this.explicitDefault = explicitDefault;
             this.explicitDefaultValue = explicitDefaultValue;
+            this.descriptionData = descriptionData;
         }
 
         ResourceMethodParam bind(List<ParamConverterProvider> paramConverterProviders) {
-            ResolvedParameter parameter = new ResolvedParameter(
-                parameterHandle, type, genericType, annotations.toArray(new Annotation[0]));
+            Annotation[] boundAnnotations = annotations.toArray(new Annotation[0]);
             if (source == ValueSource.MESSAGE_BODY) {
-                return new MessageBodyParam(this, parameter,
-                    DescriptionData.fromAnnotation(annotationSource, null));
+                return new MessageBodyParam(this, boundAnnotations);
             } else if (source == ValueSource.CONTEXT) {
-                return new ContextParam(this, parameter);
+                return new ContextParam(this, boundAnnotations);
             } else if (source == ValueSource.SUSPENDED) {
-                return new SuspendedParam(this, parameter);
+                return new SuspendedParam(this, boundAnnotations);
             } else {
-                ParamConverter<?> converter = getParamConverter(parameter, paramConverterProviders);
+                ParamConverter<?> converter =
+                    getParamConverter(this, boundAnnotations, paramConverterProviders);
                 boolean lazyDefaultValue = converter.getClass().getDeclaredAnnotation(ParamConverter.Lazy.class) != null;
                 @Nullable Object defaultValue = getDefaultValue(
-                    parameter, explicitDefault, explicitDefaultValue, converter,
-                    lazyDefaultValue, source, key);
+                    this, converter, lazyDefaultValue);
 
                 if (key.length() == 0) {
                     throw new WebApplicationException(
                         "No parameter specified for the " + source + " in " + parameterHandle);
                 }
 
-                DescriptionData descriptionData =
-                    DescriptionData.fromAnnotation(annotationSource, key);
-                return new RequestBasedParam(this, parameter, defaultValue,
-                    lazyDefaultValue, converter, descriptionData);
+                return new RequestBasedParam(this, boundAnnotations, defaultValue,
+                    lazyDefaultValue, converter);
             }
         }
     }
@@ -191,14 +193,6 @@ abstract class ResourceMethodParam {
             Class<?> resolvedClass = GenericTypeResolver.rawClass(genericType);
             this.type = resolvedClass == null ? handle.getType() : resolvedClass;
             this.annotations = combinedAnnotations(handle, annotationSource);
-        }
-
-        private ResolvedParameter(Parameter handle, Class<?> type, Type genericType,
-                                  Annotation[] annotations) {
-            this.handle = handle;
-            this.type = type;
-            this.genericType = genericType;
-            this.annotations = annotations;
         }
 
         private static Annotation[] combinedAnnotations(Parameter handle, Parameter annotationSource) {
@@ -270,10 +264,10 @@ abstract class ResourceMethodParam {
             );
         }
 
-        RequestBasedParam(Introspection introspection, ResolvedParameter parameter,
+        RequestBasedParam(Introspection introspection, Annotation[] annotations,
                           @Nullable Object defaultValue, boolean lazyDefaultValue,
-                          ParamConverter paramConverter, DescriptionData descriptionData) {
-            super(introspection, parameter, descriptionData);
+                          ParamConverter paramConverter) {
+            super(introspection, annotations);
             this.defaultValue = defaultValue;
             this.lazyDefaultValue = lazyDefaultValue;
             this.paramConverter = paramConverter;
@@ -448,20 +442,20 @@ abstract class ResourceMethodParam {
     }
 
     static class MessageBodyParam extends ResourceMethodParam {
-        MessageBodyParam(Introspection introspection, ResolvedParameter parameter, DescriptionData descriptionData) {
-            super(introspection, parameter, descriptionData);
+        MessageBodyParam(Introspection introspection, Annotation[] annotations) {
+            super(introspection, annotations);
         }
     }
 
     static class ContextParam extends ResourceMethodParam {
-        ContextParam(Introspection introspection, ResolvedParameter parameter) {
-            super(introspection, parameter, null);
+        ContextParam(Introspection introspection, Annotation[] annotations) {
+            super(introspection, annotations);
         }
     }
 
     static class SuspendedParam extends ResourceMethodParam {
-        SuspendedParam(Introspection introspection, ResolvedParameter parameter) {
-            super(introspection, parameter, null);
+        SuspendedParam(Introspection introspection, Annotation[] annotations) {
+            super(introspection, annotations);
         }
     }
 
@@ -482,7 +476,9 @@ abstract class ResourceMethodParam {
         return parameterHandle.getDeclaredAnnotation(annotationClass) != null;
     }
 
-    private static ParamConverter<?> getParamConverter(ResolvedParameter parameter, List<ParamConverterProvider> paramConverterProviders) {
+    private static ParamConverter<?> getParamConverter(Introspection parameter,
+                                                       Annotation[] annotations,
+                                                       List<ParamConverterProvider> paramConverterProviders) {
         Class<?> paramType = parameter.type;
         Type parameterizedType = parameter.genericType;
         if (Collection.class.isAssignableFrom(paramType) && parameterizedType instanceof ParameterizedType) {
@@ -493,7 +489,8 @@ abstract class ResourceMethodParam {
             }
         }
         for (ParamConverterProvider paramConverterProvider : paramConverterProviders) {
-            ParamConverter<?> converter = paramConverterProvider.getConverter(paramType, parameterizedType, parameter.annotations);
+            ParamConverter<?> converter =
+                paramConverterProvider.getConverter(paramType, parameterizedType, annotations);
             if (converter == null && RequestBasedParam.createCollection(paramType) != null && parameterizedType instanceof ParameterizedType) {
                 // Things like List<A> can be converted with just an 'A' param converter, so let's see if we have that
                 ParameterizedType pt = (ParameterizedType) parameterizedType;
@@ -502,24 +499,24 @@ abstract class ResourceMethodParam {
                     ParameterizedType type = (ParameterizedType) ata[0];
                     Type rawType = type.getRawType();
                     if (rawType instanceof Class) {
-                        converter = paramConverterProvider.getConverter((Class) rawType, type, parameter.annotations);
+                        converter =
+                            paramConverterProvider.getConverter((Class) rawType, type, annotations);
                     }
                 }
             }
             if (converter != null) return converter;
         }
-        throw new MuException("Could not find a suitable ParamConverter for " + parameterizedType + " at " + parameter.handle.getDeclaringExecutable());
+        throw new MuException("Could not find a suitable ParamConverter for " + parameterizedType + " at " + parameter.parameterHandle.getDeclaringExecutable());
     }
 
-    private static @Nullable Object getDefaultValue(ResolvedParameter parameter, boolean explicitDefault,
-                                                     @Nullable String explicitDefaultValue,
-                                                     ParamConverter<?> converter, boolean lazyDefaultValue,
-                                                     ValueSource source, String parameterName) {
-        if (!explicitDefault) {
+    private static @Nullable Object getDefaultValue(Introspection parameter,
+                                                     ParamConverter<?> converter,
+                                                     boolean lazyDefaultValue) {
+        if (!parameter.explicitDefault) {
             return converter instanceof HasDefaultValue ? ((HasDefaultValue) converter).getDefault() : null;
         }
-        return convertValue(parameter.handle, parameter.type, converter, lazyDefaultValue,
-            explicitDefaultValue, source, parameterName);
+        return convertValue(parameter.parameterHandle, parameter.type, converter, lazyDefaultValue,
+            parameter.explicitDefaultValue, parameter.source, parameter.key);
     }
 
     private static @Nullable Object convertValue(Parameter parameterHandle, Class<?> parameterType, @Nullable ParamConverter<?> converter, boolean skipConverter, @Nullable Object value, ValueSource source, String parameterName) {

--- a/src/main/java/io/muserver/rest/ResourceMethodParam.java
+++ b/src/main/java/io/muserver/rest/ResourceMethodParam.java
@@ -31,24 +31,42 @@ import static java.util.Objects.requireNonNull;
 
 abstract class ResourceMethodParam {
 
-    final int index;
-    final Parameter parameterHandle;
-    final Class<?> type;
-    final Type genericType;
+    private final Introspection introspection;
     final Annotation[] annotations;
-    final ValueSource source;
     final @Nullable DescriptionData descriptionData;
-    final boolean isRequired;
 
-    ResourceMethodParam(int index, ValueSource source, ResolvedParameter parameter, @Nullable DescriptionData descriptionData, boolean isRequired) {
-        this.index = index;
-        this.source = source;
-        this.parameterHandle = parameter.handle;
-        this.type = parameter.type;
-        this.genericType = parameter.genericType;
+    ResourceMethodParam(Introspection introspection, ResolvedParameter parameter, @Nullable DescriptionData descriptionData) {
+        this.introspection = introspection;
         this.annotations = parameter.annotations;
         this.descriptionData = descriptionData;
-        this.isRequired = isRequired;
+    }
+
+    int index() {
+        return introspection.index;
+    }
+
+    Parameter parameterHandle() {
+        return introspection.parameterHandle;
+    }
+
+    Class<?> type() {
+        return introspection.type;
+    }
+
+    Type genericType() {
+        return introspection.genericType;
+    }
+
+    ValueSource source() {
+        return introspection.source;
+    }
+
+    boolean isRequired() {
+        return introspection.isRequired;
+    }
+
+    final Introspection introspection() {
+        return introspection;
     }
 
     static ResourceMethodParam fromParameter(int index, Parameter parameterHandle, List<ParamConverterProvider> paramConverterProviders, @Nullable UriPattern methodPattern) {
@@ -133,12 +151,12 @@ abstract class ResourceMethodParam {
             ResolvedParameter parameter = new ResolvedParameter(
                 parameterHandle, type, genericType, annotations.toArray(new Annotation[0]));
             if (source == ValueSource.MESSAGE_BODY) {
-                return new MessageBodyParam(index, source, parameter,
-                    DescriptionData.fromAnnotation(annotationSource, null), isRequired);
+                return new MessageBodyParam(this, parameter,
+                    DescriptionData.fromAnnotation(annotationSource, null));
             } else if (source == ValueSource.CONTEXT) {
-                return new ContextParam(index, source, parameter);
+                return new ContextParam(this, parameter);
             } else if (source == ValueSource.SUSPENDED) {
-                return new SuspendedParam(index, source, parameter);
+                return new SuspendedParam(this, parameter);
             } else {
                 ParamConverter<?> converter = getParamConverter(parameter, paramConverterProviders);
                 boolean lazyDefaultValue = converter.getClass().getDeclaredAnnotation(ParamConverter.Lazy.class) != null;
@@ -153,10 +171,8 @@ abstract class ResourceMethodParam {
 
                 DescriptionData descriptionData =
                     DescriptionData.fromAnnotation(annotationSource, key);
-                return new RequestBasedParam(index, source, parameter, defaultValue,
-                    encodedRequested, lazyDefaultValue, converter,
-                    descriptionData, key, deprecated, isRequired,
-                    pattern, explicitDefault);
+                return new RequestBasedParam(this, parameter, defaultValue,
+                    lazyDefaultValue, converter, descriptionData);
             }
         }
     }
@@ -210,48 +226,57 @@ abstract class ResourceMethodParam {
     static class RequestBasedParam extends ResourceMethodParam {
 
         private final @Nullable Object defaultValue;
-        final boolean encodedRequested;
         private final boolean lazyDefaultValue;
         private final ParamConverter paramConverter;
-        final String key;
-        final boolean isDeprecated;
-        private final @Nullable Pattern pattern;
-        private final boolean explicitDefault;
+
+        boolean encodedRequested() {
+            return introspection().encodedRequested;
+        }
+
+        String key() {
+            return introspection().key;
+        }
+
+        boolean deprecated() {
+            return introspection().deprecated;
+        }
+
+        private @Nullable Pattern pattern() {
+            return introspection().pattern;
+        }
 
         ParameterObjectBuilder createDocumentationBuilder() {
             ParameterObjectBuilder builder = parameterObject()
-                .withIn(requireNonNull(source.openAPIIn, "Parameter source is not represented as an OpenAPI parameter"))
-                .withRequired(isRequired)
-                .withDeprecated(isDeprecated ? true : null)
-                .withName(key);
+                .withIn(requireNonNull(source().openAPIIn, "Parameter source is not represented as an OpenAPI parameter"))
+                .withRequired(isRequired())
+                .withDeprecated(deprecated() ? true : null)
+                .withName(key());
             @Nullable ExternalDocumentationObject externalDoc = null;
             if (descriptionData != null) {
                 String desc = descriptionData.summaryAndDescription();
                 builder
-                    .withDescription(key.equals(desc) ? null : desc)
+                    .withDescription(key().equals(desc) ? null : desc)
                     .withExample(descriptionData.example);
                 externalDoc = descriptionData.externalDocumentation;
             }
-            @Nullable Pattern patternIfNotDefault = this.pattern == null || UriPattern.DEFAULT_CAPTURING_GROUP_PATTERN.equals(this.pattern.pattern()) ? null : this.pattern;
+            @Nullable Pattern pattern = pattern();
+            @Nullable Pattern patternIfNotDefault = pattern == null || UriPattern.DEFAULT_CAPTURING_GROUP_PATTERN.equals(pattern.pattern()) ? null : pattern;
             return builder.withSchema(
-                schemaObjectFrom(type, genericType, isRequired)
-                    .withDefaultValue(source == ValueSource.PATH_PARAM || !hasExplicitDefault() ? null : defaultValue())
+                schemaObjectFrom(type(), genericType(), isRequired())
+                    .withDefaultValue(source() == ValueSource.PATH_PARAM || !hasExplicitDefault() ? null : defaultValue())
                     .withExternalDocs(externalDoc)
                     .withPattern(patternIfNotDefault)
                     .build()
             );
         }
 
-        RequestBasedParam(int index, ValueSource source, ResolvedParameter parameter, @Nullable Object defaultValue, boolean encodedRequested, boolean lazyDefaultValue, ParamConverter paramConverter, DescriptionData descriptionData, String key, boolean isDeprecated, boolean isRequired, @Nullable Pattern pattern, boolean explicitDefault) {
-            super(index, source, parameter, descriptionData, isRequired);
+        RequestBasedParam(Introspection introspection, ResolvedParameter parameter,
+                          @Nullable Object defaultValue, boolean lazyDefaultValue,
+                          ParamConverter paramConverter, DescriptionData descriptionData) {
+            super(introspection, parameter, descriptionData);
             this.defaultValue = defaultValue;
-            this.encodedRequested = encodedRequested;
             this.lazyDefaultValue = lazyDefaultValue;
             this.paramConverter = paramConverter;
-            this.key = key;
-            this.isDeprecated = isDeprecated;
-            this.pattern = pattern;
-            this.explicitDefault = explicitDefault;
         }
 
         /**
@@ -259,25 +284,25 @@ abstract class ResourceMethodParam {
          * using the {@link DefaultValue} annotation.
          */
         public boolean hasExplicitDefault() {
-            return explicitDefault;
+            return introspection().explicitDefault;
         }
 
 
         public @Nullable Object defaultValue() {
             boolean skipConverter = defaultValue != null && !lazyDefaultValue;
-            return convertValue(parameterHandle, type, paramConverter, skipConverter, defaultValue, source, key);
+            return convertValue(parameterHandle(), type(), paramConverter, skipConverter, defaultValue, source(), key());
         }
 
         public @Nullable Object getValue(JaxRSRequest jaxRequest, RequestMatcher.MatchedMethod matchedMethod, CollectionParameterStrategy cps) throws IOException {
             MuRequest muRequest = jaxRequest.muRequest;
-            Class<?> paramClass = type;
+            Class<?> paramClass = type();
             if (UploadedFile.class.isAssignableFrom(paramClass)) {
-                return muRequest.uploadedFile(key);
+                return muRequest.uploadedFile(key());
             } else if (File.class.isAssignableFrom(paramClass)) {
-                UploadedFile uf = muRequest.uploadedFile(key);
+                UploadedFile uf = muRequest.uploadedFile(key());
                 return uf == null ? null : uf.asFile();
             } else if (Collection.class.isAssignableFrom(paramClass)) {
-                Type t = genericType;
+                Type t = genericType();
                 if (t instanceof ParameterizedType) {
                     Type[] actualTypeArguments = ((ParameterizedType) t).getActualTypeArguments();
                     if (actualTypeArguments.length == 1) {
@@ -293,7 +318,7 @@ abstract class ResourceMethodParam {
                             }
                         }
                         if (isUploadedFileList) {
-                            List<UploadedFile> uploadedFiles = muRequest.uploadedFiles(key);
+                            List<UploadedFile> uploadedFiles = muRequest.uploadedFiles(key());
                             if (Set.class.isAssignableFrom(paramClass)) {
                                 return new HashSet<>(uploadedFiles);
                             }
@@ -304,64 +329,64 @@ abstract class ResourceMethodParam {
             }
 
             if (paramClass.isAssignableFrom(PathSegment.class)) {
-                PathSegment seg = matchedMethod.pathParams.get(key);
-                if (seg != null && encodedRequested) {
+                PathSegment seg = matchedMethod.pathParams.get(key());
+                if (seg != null && encodedRequested()) {
                     return ((MuPathSegment) seg).toEncoded();
                 }
                 return seg;
             } else if (paramClass.equals(Cookie.class)) {
-                List<String> cookieValues = cookieValue(muRequest, key);
-                return cookieValues.isEmpty() ? null : new Cookie(key, cookieValues.get(0));
+                List<String> cookieValues = cookieValue(muRequest, key());
+                return cookieValues.isEmpty() ? null : new Cookie(key(), cookieValues.get(0));
             } else if (paramClass.equals(io.muserver.Cookie.class)) {
-                List<String> cookieValues = cookieValue(muRequest, key);
-                return cookieValues.isEmpty() ? null : new CookieBuilder().withName(key).withValue(cookieValues.get(0)).build();
+                List<String> cookieValues = cookieValue(muRequest, key());
+                return cookieValues.isEmpty() ? null : new CookieBuilder().withName(key()).withValue(cookieValues.get(0)).build();
             }
             Collection<Object> collection = createCollection(paramClass);
-            if (collection != null && source == ValueSource.PATH_PARAM && isPathSegmentCollection()) {
-                List<PathSegment> pathSegments = matchedMethod.getPathSegments(key);
+            if (collection != null && source() == ValueSource.PATH_PARAM && isPathSegmentCollection()) {
+                List<PathSegment> pathSegments = matchedMethod.getPathSegments(key());
                 if (pathSegments.isEmpty() && hasExplicitDefault()) {
                     collection.add(defaultValue());
                 } else {
                     for (PathSegment segment : pathSegments) {
-                        collection.add(encodedRequested ? ((MuPathSegment) segment).toEncoded() : segment);
+                        collection.add(encodedRequested() ? ((MuPathSegment) segment).toEncoded() : segment);
                     }
                 }
                 return readOnly(collection);
             }
-            String pathParam = source == ValueSource.PATH_PARAM ? matchedMethod.getPathParam(key) : null;
+            String pathParam = source() == ValueSource.PATH_PARAM ? matchedMethod.getPathParam(key()) : null;
             List<String> specifiedValue =
-                source == ValueSource.PATH_PARAM ? (collection == null
+                source() == ValueSource.PATH_PARAM ? (collection == null
                     ? (pathParam == null ? emptyList() : Collections.singletonList(pathParam))
-                    : matchedMethod.getPathParams(key))
-                    : source == ValueSource.QUERY_PARAM ? getParamValues(jaxRequest.getUriInfo().getQueryParameters(), key, cps, collection != null)
-                    : source == ValueSource.HEADER_PARAM ? getParamValues(jaxRequest.getHeaders(), key, cps, collection != null)
-                    : source == ValueSource.FORM_PARAM ? muRequest.form().getAll(key)
-                    : source == ValueSource.COOKIE_PARAM ? cookieValue(muRequest, key)
-                    : source == ValueSource.MATRIX_PARAM ? matrixParamValue(key, jaxRequest.relativePath())
+                    : matchedMethod.getPathParams(key()))
+                    : source() == ValueSource.QUERY_PARAM ? getParamValues(jaxRequest.getUriInfo().getQueryParameters(), key(), cps, collection != null)
+                    : source() == ValueSource.HEADER_PARAM ? getParamValues(jaxRequest.getHeaders(), key(), cps, collection != null)
+                    : source() == ValueSource.FORM_PARAM ? muRequest.form().getAll(key())
+                    : source() == ValueSource.COOKIE_PARAM ? cookieValue(muRequest, key())
+                    : source() == ValueSource.MATRIX_PARAM ? matrixParamValue(key(), jaxRequest.relativePath())
                     : emptyList();
             boolean isSpecified = specifiedValue != null && !specifiedValue.isEmpty();
-            if (encodedRequested && isSpecified) {
+            if (encodedRequested() && isSpecified) {
                 specifiedValue = requireNonNull(specifiedValue).stream()
-                    .map(value -> source == ValueSource.FORM_PARAM ? FormUrlEncoder.formUrlEncode(value) : Mutils.urlEncode(value))
+                    .map(value -> source() == ValueSource.FORM_PARAM ? FormUrlEncoder.formUrlEncode(value) : Mutils.urlEncode(value))
                     .collect(Collectors.toList());
             }
             if (collection != null) {
                 if (isSpecified) {
                     for (String stringValue : requireNonNull(specifiedValue)) {
-                        collection.add(ResourceMethodParam.convertValue(parameterHandle, type, paramConverter, false, stringValue, source, key));
+                        collection.add(ResourceMethodParam.convertValue(parameterHandle(), type(), paramConverter, false, stringValue, source(), key()));
                     }
                 } else if (hasExplicitDefault()) {
                     collection.add(defaultValue());
                 }
                 return readOnly(collection);
             } else {
-                return isSpecified ? ResourceMethodParam.convertValue(parameterHandle, type, paramConverter, false, requireNonNull(specifiedValue).get(0), source, key) : defaultValue();
+                return isSpecified ? ResourceMethodParam.convertValue(parameterHandle(), type(), paramConverter, false, requireNonNull(specifiedValue).get(0), source(), key()) : defaultValue();
             }
         }
 
         private boolean isPathSegmentCollection() {
-            if (!(genericType instanceof ParameterizedType)) return false;
-            Type elementType = ((ParameterizedType) genericType).getActualTypeArguments()[0];
+            if (!(genericType() instanceof ParameterizedType)) return false;
+            Type elementType = ((ParameterizedType) genericType()).getActualTypeArguments()[0];
             if (elementType instanceof WildcardType) {
                 Type[] upperBounds = ((WildcardType) elementType).getUpperBounds();
                 elementType = upperBounds.length == 0 ? elementType : upperBounds[0];
@@ -423,20 +448,20 @@ abstract class ResourceMethodParam {
     }
 
     static class MessageBodyParam extends ResourceMethodParam {
-        MessageBodyParam(int index, ValueSource source, ResolvedParameter parameter, DescriptionData descriptionData, boolean isRequired) {
-            super(index, source, parameter, descriptionData, isRequired);
+        MessageBodyParam(Introspection introspection, ResolvedParameter parameter, DescriptionData descriptionData) {
+            super(introspection, parameter, descriptionData);
         }
     }
 
     static class ContextParam extends ResourceMethodParam {
-        ContextParam(int index, ValueSource source, ResolvedParameter parameter) {
-            super(index, source, parameter, null, true);
+        ContextParam(Introspection introspection, ResolvedParameter parameter) {
+            super(introspection, parameter, null);
         }
     }
 
     static class SuspendedParam extends ResourceMethodParam {
-        SuspendedParam(int index, ValueSource source, ResolvedParameter parameter) {
-            super(index, source, parameter, null, true);
+        SuspendedParam(Introspection introspection, ResolvedParameter parameter) {
+            super(introspection, parameter, null);
         }
     }
 

--- a/src/main/java/io/muserver/rest/ResourceMethodParam.java
+++ b/src/main/java/io/muserver/rest/ResourceMethodParam.java
@@ -58,41 +58,106 @@ abstract class ResourceMethodParam {
 
     static ResourceMethodParam fromParameter(int index, Parameter parameterHandle, Parameter annotationSource, Class<?> concreteClass,
                                              List<ParamConverterProvider> paramConverterProviders, @Nullable UriPattern methodPattern) {
+        return introspect(index, parameterHandle, annotationSource, concreteClass, methodPattern)
+            .bind(paramConverterProviders);
+    }
 
+    static Introspection introspect(int index, Parameter parameterHandle, Parameter annotationSource,
+                                    Class<?> concreteClass, @Nullable UriPattern methodPattern) {
         ResolvedParameter parameter = new ResolvedParameter(parameterHandle, annotationSource, concreteClass);
         @Nullable Pattern pattern = null;
         ValueSource source = getSource(annotationSource);
+        boolean requestBased = source != ValueSource.MESSAGE_BODY
+            && source != ValueSource.CONTEXT
+            && source != ValueSource.SUSPENDED;
         boolean isRequired = source == ValueSource.PATH_PARAM || hasDeclared(annotationSource, Required.class);
-        if (source == ValueSource.MESSAGE_BODY) {
-            DescriptionData descriptionData = DescriptionData.fromAnnotation(annotationSource, null);
-            return new MessageBodyParam(index, source, parameter, descriptionData, isRequired);
-        } else if (source == ValueSource.CONTEXT) {
-            return new ContextParam(index, source, parameter);
-        } else if (source == ValueSource.SUSPENDED) {
-            return new SuspendedParam(index, source, parameter);
-        } else {
-            boolean encodedRequested = hasDeclared(annotationSource, Encoded.class);
-            boolean isDeprecated = hasDeclared(annotationSource, Deprecated.class);
-            String key = parameterName(source, annotationSource);
-            ParamConverter<?> converter = getParamConverter(parameter, paramConverterProviders);
-            boolean lazyDefaultValue = converter.getClass().getDeclaredAnnotation(ParamConverter.Lazy.class) != null;
-            boolean explicitDefault = hasDeclared(annotationSource, DefaultValue.class);
-            @Nullable Object defaultValue = getDefaultValue(parameter, annotationSource, converter, lazyDefaultValue, source, key);
-
+        boolean encodedRequested = requestBased && hasDeclared(annotationSource, Encoded.class);
+        boolean isDeprecated = requestBased && hasDeclared(annotationSource, Deprecated.class);
+        String key = requestBased ? parameterName(source, annotationSource) : "";
+        boolean explicitDefault = requestBased && hasDeclared(annotationSource, DefaultValue.class);
+        @Nullable String explicitDefaultValue = explicitDefault
+            ? requireNonNull(annotationSource.getDeclaredAnnotation(DefaultValue.class)).value()
+            : null;
+        if (source == ValueSource.PATH_PARAM && methodPattern != null) {
+            String regex = methodPattern.regexFor(key);
+            if (regex != null) {
+                pattern = Pattern.compile(regex);
+            }
+        }
+        if (requestBased) {
             isRequired |= (!explicitDefault && parameter.type.isPrimitive());
+        }
+        return new Introspection(index, source, parameter, annotationSource, isRequired,
+            encodedRequested, isDeprecated, key, pattern, explicitDefault, explicitDefaultValue);
+    }
 
-            if (key.length() == 0) {
-                throw new WebApplicationException("No parameter specified for the " + source + " in " + parameterHandle);
-            }
-            if (source == ValueSource.PATH_PARAM && methodPattern != null) {
-                String regex = methodPattern.regexFor(key);
-                if (regex != null) {
-                    pattern = Pattern.compile(regex);
+    static final class Introspection {
+        final int index;
+        final ValueSource source;
+        private final Parameter parameterHandle;
+        private final Class<?> type;
+        private final Type genericType;
+        final List<Annotation> annotations;
+        private final Parameter annotationSource;
+        final boolean isRequired;
+        private final boolean encodedRequested;
+        private final boolean deprecated;
+        private final String key;
+        private final @Nullable Pattern pattern;
+        private final boolean explicitDefault;
+        private final @Nullable String explicitDefaultValue;
+
+        private Introspection(int index, ValueSource source, ResolvedParameter parameter,
+                              Parameter annotationSource, boolean isRequired,
+                              boolean encodedRequested, boolean deprecated, String key,
+                              @Nullable Pattern pattern, boolean explicitDefault,
+                              @Nullable String explicitDefaultValue) {
+            this.index = index;
+            this.source = source;
+            this.parameterHandle = parameter.handle;
+            this.type = parameter.type;
+            this.genericType = parameter.genericType;
+            this.annotations = Collections.unmodifiableList(
+                Arrays.asList(parameter.annotations.clone()));
+            this.annotationSource = annotationSource;
+            this.isRequired = isRequired;
+            this.encodedRequested = encodedRequested;
+            this.deprecated = deprecated;
+            this.key = key;
+            this.pattern = pattern;
+            this.explicitDefault = explicitDefault;
+            this.explicitDefaultValue = explicitDefaultValue;
+        }
+
+        ResourceMethodParam bind(List<ParamConverterProvider> paramConverterProviders) {
+            ResolvedParameter parameter = new ResolvedParameter(
+                parameterHandle, type, genericType, annotations.toArray(new Annotation[0]));
+            if (source == ValueSource.MESSAGE_BODY) {
+                return new MessageBodyParam(index, source, parameter,
+                    DescriptionData.fromAnnotation(annotationSource, null), isRequired);
+            } else if (source == ValueSource.CONTEXT) {
+                return new ContextParam(index, source, parameter);
+            } else if (source == ValueSource.SUSPENDED) {
+                return new SuspendedParam(index, source, parameter);
+            } else {
+                ParamConverter<?> converter = getParamConverter(parameter, paramConverterProviders);
+                boolean lazyDefaultValue = converter.getClass().getDeclaredAnnotation(ParamConverter.Lazy.class) != null;
+                @Nullable Object defaultValue = getDefaultValue(
+                    parameter, explicitDefault, explicitDefaultValue, converter,
+                    lazyDefaultValue, source, key);
+
+                if (key.length() == 0) {
+                    throw new WebApplicationException(
+                        "No parameter specified for the " + source + " in " + parameterHandle);
                 }
-            }
 
-            DescriptionData descriptionData = DescriptionData.fromAnnotation(annotationSource, key);
-            return new RequestBasedParam(index, source, parameter, defaultValue, encodedRequested, lazyDefaultValue, converter, descriptionData, key, isDeprecated, isRequired, pattern, explicitDefault);
+                DescriptionData descriptionData =
+                    DescriptionData.fromAnnotation(annotationSource, key);
+                return new RequestBasedParam(index, source, parameter, defaultValue,
+                    encodedRequested, lazyDefaultValue, converter,
+                    descriptionData, key, deprecated, isRequired,
+                    pattern, explicitDefault);
+            }
         }
     }
 
@@ -110,6 +175,14 @@ abstract class ResourceMethodParam {
             Class<?> resolvedClass = GenericTypeResolver.rawClass(genericType);
             this.type = resolvedClass == null ? handle.getType() : resolvedClass;
             this.annotations = combinedAnnotations(handle, annotationSource);
+        }
+
+        private ResolvedParameter(Parameter handle, Class<?> type, Type genericType,
+                                  Annotation[] annotations) {
+            this.handle = handle;
+            this.type = type;
+            this.genericType = genericType;
+            this.annotations = annotations;
         }
 
         private static Annotation[] combinedAnnotations(Parameter handle, Parameter annotationSource) {
@@ -413,12 +486,15 @@ abstract class ResourceMethodParam {
         throw new MuException("Could not find a suitable ParamConverter for " + parameterizedType + " at " + parameter.handle.getDeclaringExecutable());
     }
 
-    private static @Nullable Object getDefaultValue(ResolvedParameter parameter, Parameter annotationSource, ParamConverter<?> converter, boolean lazyDefaultValue, ValueSource source, String parameterName) {
-        DefaultValue annotation = annotationSource.getDeclaredAnnotation(DefaultValue.class);
-        if (annotation == null) {
+    private static @Nullable Object getDefaultValue(ResolvedParameter parameter, boolean explicitDefault,
+                                                     @Nullable String explicitDefaultValue,
+                                                     ParamConverter<?> converter, boolean lazyDefaultValue,
+                                                     ValueSource source, String parameterName) {
+        if (!explicitDefault) {
             return converter instanceof HasDefaultValue ? ((HasDefaultValue) converter).getDefault() : null;
         }
-        return convertValue(parameter.handle, parameter.type, converter, lazyDefaultValue, annotation.value(), source, parameterName);
+        return convertValue(parameter.handle, parameter.type, converter, lazyDefaultValue,
+            explicitDefaultValue, source, parameterName);
     }
 
     private static @Nullable Object convertValue(Parameter parameterHandle, Class<?> parameterType, @Nullable ParamConverter<?> converter, boolean skipConverter, @Nullable Object value, ValueSource source, String parameterName) {

--- a/src/main/java/io/muserver/rest/ResourceMethodParam.java
+++ b/src/main/java/io/muserver/rest/ResourceMethodParam.java
@@ -88,10 +88,7 @@ abstract class ResourceMethodParam {
         boolean requestBased = source != ValueSource.MESSAGE_BODY
             && source != ValueSource.CONTEXT
             && source != ValueSource.SUSPENDED;
-        boolean isRequired = source == ValueSource.PATH_PARAM
-            || source == ValueSource.CONTEXT
-            || source == ValueSource.SUSPENDED
-            || hasDeclared(annotationSource, Required.class);
+        boolean isRequired = source == ValueSource.PATH_PARAM || hasDeclared(annotationSource, Required.class);
         boolean encodedRequested = requestBased && hasDeclared(annotationSource, Encoded.class);
         boolean isDeprecated = requestBased && hasDeclared(annotationSource, Deprecated.class);
         String key = requestBased ? parameterName(source, annotationSource) : "";

--- a/src/main/java/io/muserver/rest/RestHandler.java
+++ b/src/main/java/io/muserver/rest/RestHandler.java
@@ -89,7 +89,7 @@ public class RestHandler implements MuHandler {
 
             Function<RequestMatcher.MatchedMethod,ResourceClass> subResourceLocator = matchedMethod -> {
                 Function<ResourceMethod, @Nullable Object> onSuspended = resourceMethod -> {
-                    throw new MuException("Suspended is not supported on sub-resource locators. Method: " + resourceMethod.methodHandle);
+                    throw new MuException("Suspended is not supported on sub-resource locators. Method: " + resourceMethod.methodHandle());
                 };
                 ResourceMethod rm = matchedMethod.resourceMethod;
                 try {
@@ -100,7 +100,7 @@ public class RestHandler implements MuHandler {
                 } catch (WebApplicationException wae) {
                     throw wae;
                 } catch (Exception e) {
-                    throw new MuException("Error creating instance returned by sub-resource-locator " + rm.methodHandle, e);
+                    throw new MuException("Error creating instance returned by sub-resource-locator " + rm.methodHandle(), e);
                 }
             };
 
@@ -125,9 +125,9 @@ public class RestHandler implements MuHandler {
             requestContext.setMatchedMethod(mm);
 
             List<MediaType> produces = producesRef = mm.resourceMethod.resourceClass.produces;
-            List<MediaType> directlyProduces = directlyProducesRef = mm.resourceMethod.directlyProduces;
+            List<MediaType> directlyProduces = directlyProducesRef = mm.resourceMethod.directlyProduces();
             Annotation[] methodAnnotations = mm.resourceMethod.methodAnnotations;
-            @Nullable Type methodReturnType = mm.resourceMethod.genericReturnType;
+            @Nullable Type methodReturnType = mm.resourceMethod.genericReturnType();
 
             filterManagerThing.onPostMatch(requestContext);
             if (requestContext.getAbortResponse() != null) {
@@ -183,20 +183,20 @@ public class RestHandler implements MuHandler {
 
     static @Nullable Object invokeResourceMethod(JaxRSRequest requestContext, MuResponse muResponse, RequestMatcher.MatchedMethod mm, Function<ResourceMethod, @Nullable Object> suspendedParamCallback, EntityProviders entityProviders, CollectionParameterStrategy collectionParameterStrategy) throws Exception {
         ResourceMethod rm = mm.resourceMethod;
-        @Nullable Object[] params = new Object[rm.methodHandle.getParameterCount()];
+        @Nullable Object[] params = new Object[rm.methodHandle().getParameterCount()];
         for (ResourceMethodParam param : rm.params) {
             @Nullable Object paramValue;
-            if (param.source == ResourceMethodParam.ValueSource.MESSAGE_BODY) {
+            if (param.source() == ResourceMethodParam.ValueSource.MESSAGE_BODY) {
                 paramValue = readRequestEntity(requestContext, param);
-            } else if (param.source == ResourceMethodParam.ValueSource.CONTEXT) {
+            } else if (param.source() == ResourceMethodParam.ValueSource.CONTEXT) {
                 paramValue = getContextParam(requestContext, muResponse, mm, param, entityProviders);
-            } else if (param.source == ResourceMethodParam.ValueSource.SUSPENDED) {
+            } else if (param.source() == ResourceMethodParam.ValueSource.SUSPENDED) {
                 paramValue = suspendedParamCallback.apply(rm);
             } else {
                 ResourceMethodParam.RequestBasedParam rbp = (ResourceMethodParam.RequestBasedParam) param;
                 paramValue = rbp.getValue(requestContext, mm, collectionParameterStrategy);
             }
-            params[param.index] = paramValue;
+            params[param.index()] = paramValue;
         }
         return rm.invoke(params);
     }
@@ -394,7 +394,7 @@ public class RestHandler implements MuHandler {
     private static @Nullable Object getContextParam(JaxRSRequest requestContext, MuResponse muResponse, RequestMatcher.MatchedMethod mm, ResourceMethodParam param, EntityProviders providers) {
         MuRequest request = requestContext.muRequest;
         Object paramValue;
-        Class<?> type = param.type;
+        Class<?> type = param.type();
         if (type.equals(UriInfo.class)) {
             paramValue = createUriInfo(requestContext.relativePath(), mm, request.uri().resolve(request.contextPath() + "/"), request.uri());
         } else if (type.equals(MuResponse.class)) {
@@ -406,7 +406,7 @@ public class RestHandler implements MuHandler {
         } else if (SecurityContext.class.isAssignableFrom(type)) {
             SecurityContext sc = requestContext.getSecurityContext();
             if (sc != null && !type.isAssignableFrom(sc.getClass())) {
-                throw new MuException("Invalid security context type: " + sc.getClass() + " being used for " + mm.resourceMethod.methodHandle);
+                throw new MuException("Invalid security context type: " + sc.getClass() + " being used for " + mm.resourceMethod.methodHandle());
             }
             return sc;
         } else if (type.equals(Sse.class)) {
@@ -428,8 +428,8 @@ public class RestHandler implements MuHandler {
 
     private static Object readRequestEntity(JaxRSRequest requestContext, ResourceMethodParam parameter) throws java.io.IOException {
         requestContext.setAnnotations(parameter.annotations);
-        requestContext.setType(parameter.type);
-        requestContext.setGenericType(parameter.genericType);
+        requestContext.setType(parameter.type());
+        requestContext.setGenericType(parameter.genericType());
         return requestContext.executeInterceptors();
     }
 

--- a/src/test/java/io/muserver/rest/RequestMatcherTest.java
+++ b/src/test/java/io/muserver/rest/RequestMatcherTest.java
@@ -178,9 +178,9 @@ public class RequestMatcherTest {
         ResourceClass resourcePeopleBelts = ResourceClass.fromObject(new Fruit(), paramConverterProviders, customizer);
         RequestMatcher rm = new RequestMatcher(singletonList(resourcePeopleBelts));
         ResourceMethod getAll = findResourceMethod(rm, Method.GET, "api/fruits", emptyList(), null).resourceMethod;
-        assertThat(getAll.methodHandle.getName(), equalTo("getAll"));
+        assertThat(getAll.methodHandle().getName(), equalTo("getAll"));
         RequestMatcher.MatchedMethod mm = findResourceMethod(rm, Method.GET, "api/fruits/orange", emptyList(), null);
-        assertThat(mm.resourceMethod.methodHandle.getName(), equalTo("get"));
+        assertThat(mm.resourceMethod.methodHandle().getName(), equalTo("get"));
         assertThat(mm.pathParams.get("name").getPath(), equalTo("orange"));
     }
 
@@ -204,7 +204,7 @@ public class RequestMatcherTest {
         }
 
         RequestMatcher rm = new RequestMatcher(singletonList(ResourceClass.fromObject(new OptionsDefault(), paramConverterProviders, customizer)));
-        assertThat(findResourceMethod(rm, Method.OPTIONS, "foo", emptyList(), null).resourceMethod.methodHandle.getName(), equalTo("options"));
+        assertThat(findResourceMethod(rm, Method.OPTIONS, "foo", emptyList(), null).resourceMethod.methodHandle().getName(), equalTo("options"));
 
         RequestMatcher rm2 = new RequestMatcher(asList(ResourceClass.fromObject(new Foo(), paramConverterProviders, customizer), ResourceClass.fromObject(new OptionsDefault(), paramConverterProviders, customizer)));
         try {
@@ -230,7 +230,7 @@ public class RequestMatcherTest {
 
         RequestMatcher rm = new RequestMatcher(singletonList(ResourceClass.fromObject(new Fruit(), paramConverterProviders, customizer)));
         RequestMatcher.MatchedMethod mm = findResourceMethod(rm, Method.GET, "api/citrus/orange", emptyList(), null);
-        assertThat(mm.resourceMethod.methodHandle.getName(), equalTo("get"));
+        assertThat(mm.resourceMethod.methodHandle().getName(), equalTo("get"));
         assertThat(mm.pathParams.get("fruitType").getPath(), equalTo("orange"));
         assertThat(mm.pathParams.get("fruitFamily").getPath(), equalTo("citrus"));
     }
@@ -254,7 +254,7 @@ public class RequestMatcherTest {
 
         RequestMatcher rm = new RequestMatcher(singletonList(ResourceClass.fromObject(new FruitImpl(), paramConverterProviders, customizer)));
         RequestMatcher.MatchedMethod mm = findResourceMethod(rm, Method.GET, "api/citrus/orange", emptyList(), null);
-        assertThat(mm.resourceMethod.methodHandle.getName(), equalTo("get"));
+        assertThat(mm.resourceMethod.methodHandle().getName(), equalTo("get"));
         assertThat(mm.pathParams.get("fruitType").getPath(), equalTo("orange"));
         assertThat(mm.pathParams.get("fruitFamily").getPath(), equalTo("citrus"));
     }
@@ -352,7 +352,7 @@ public class RequestMatcherTest {
         }
 
         RequestMatcher rm = new RequestMatcher(singletonList(ResourceClass.fromObject(new PictureThat(), paramConverterProviders, customizer)));
-        assertThat(findResourceMethod(rm, Method.POST, "pictures", emptyList(), null).resourceMethod.methodHandle.getName(), equalTo("text"));
+        assertThat(findResourceMethod(rm, Method.POST, "pictures", emptyList(), null).resourceMethod.methodHandle().getName(), equalTo("text"));
     }
 
     @Test
@@ -369,7 +369,7 @@ public class RequestMatcherTest {
 
         RequestMatcher rm = new RequestMatcher(singletonList(ResourceClass.fromObject(new PictureThat(), paramConverterProviders, customizer)));
         RequestMatcher.MatchedMethod match = findResourceMethod(rm, Method.POST, "pictures", emptyList(), null, true);
-        assertThat(match.resourceMethod.methodHandle.getName(), equalTo("html"));
+        assertThat(match.resourceMethod.methodHandle().getName(), equalTo("html"));
     }
 
     @Test
@@ -396,7 +396,7 @@ public class RequestMatcherTest {
         }
 
         RequestMatcher rm = new RequestMatcher(singletonList(ResourceClass.fromObject(new PictureThat(), paramConverterProviders, customizer)));
-        assertThat(findResourceMethod(rm, Method.POST, "pictures", emptyList(), null).resourceMethod.methodHandle.getName(), equalTo("concrete"));
+        assertThat(findResourceMethod(rm, Method.POST, "pictures", emptyList(), null).resourceMethod.methodHandle().getName(), equalTo("concrete"));
     }
 
     @Test
@@ -418,11 +418,11 @@ public class RequestMatcherTest {
         }
 
         RequestMatcher rm = new RequestMatcher(singletonList(ResourceClass.fromObject(new PictureThat(), paramConverterProviders, customizer)));
-        assertThat(findResourceMethod(rm, Method.POST, "pictures", emptyList(), null).resourceMethod.methodHandle.getName(), equalTo("concreteAndWildcard"));
+        assertThat(findResourceMethod(rm, Method.POST, "pictures", emptyList(), null).resourceMethod.methodHandle().getName(), equalTo("concreteAndWildcard"));
     }
 
     private static String nameOf(RequestMatcher rm, List<MediaType> acceptHeaders, String requestBodyContentType) throws NotMatchedException {
-        return findResourceMethod(rm, Method.GET, "pictures", acceptHeaders, requestBodyContentType).resourceMethod.methodHandle.getName();
+        return findResourceMethod(rm, Method.GET, "pictures", acceptHeaders, requestBodyContentType).resourceMethod.methodHandle().getName();
     }
 
     private static void assertNotAcceptable(RequestMatcher rm, List<MediaType> acceptHeaders, String requestBodyContentType) {

--- a/src/test/java/io/muserver/rest/ResourceClassTest.java
+++ b/src/test/java/io/muserver/rest/ResourceClassTest.java
@@ -1,5 +1,6 @@
 package io.muserver.rest;
 
+import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.HttpMethod;
 import jakarta.ws.rs.OPTIONS;
@@ -10,6 +11,7 @@ import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.ext.ParamConverter;
 import jakarta.ws.rs.ext.ParamConverterProvider;
+import jakarta.ws.rs.ext.RuntimeDelegate;
 import org.junit.Test;
 
 import java.lang.annotation.Annotation;
@@ -154,7 +156,7 @@ public class ResourceClassTest {
 
         assertThrows(UnsupportedOperationException.class, () -> model.methods.add(method));
         assertThrows(UnsupportedOperationException.class,
-            () -> method.directlyProduces.add(MediaType.APPLICATION_JSON_TYPE));
+            () -> method.directlyProduces.add(MediaType.APPLICATION_JSON));
         assertThrows(UnsupportedOperationException.class, () -> method.params.add(param));
         assertThrows(UnsupportedOperationException.class,
             () -> method.nameBindingAnnotations.add(Deprecated.class));
@@ -216,8 +218,37 @@ public class ResourceClassTest {
             ResourceClassIntrospection.forClass(StringLookupResource.class);
         assertThat(interfaceModel.methods.get(0).params.get(0).source,
             equalTo(ResourceMethodParam.ValueSource.PATH_PARAM));
-        assertThat(interfaceModel.methods.get(0).annotationSource.getDeclaringClass(),
-            equalTo(GenericLookupResource.class));
+    }
+
+    @Test
+    public void methodMediaTypesAreParsedForEachHandlerRuntimeDelegate() {
+        MuRuntimeDelegate.ensureSet();
+        RuntimeDelegate original = RuntimeDelegate.getInstance();
+        try {
+            RuntimeDelegate.setInstance(new MarkingRuntimeDelegate("first"));
+            ResourceClass first = ResourceClass.fromObject(new RuntimeDelegateMediaResource(),
+                ResourceMethodParamTest.BUILT_IN_PARAM_PROVIDERS, customizer);
+
+            RuntimeDelegate.setInstance(new MarkingRuntimeDelegate("second"));
+            ResourceClass second = ResourceClass.fromObject(new RuntimeDelegateMediaResource(),
+                ResourceMethodParamTest.BUILT_IN_PARAM_PROVIDERS, customizer);
+
+            assertSame(first.introspection, second.introspection);
+            assertThat(first.produces.get(0).getParameters().get("delegate"), equalTo("first"));
+            assertThat(second.produces.get(0).getParameters().get("delegate"), equalTo("second"));
+            assertThat(first.consumes.get(0).getParameters().get("delegate"), equalTo("first"));
+            assertThat(second.consumes.get(0).getParameters().get("delegate"), equalTo("second"));
+            assertThat(first.resourceMethods.get(0).directlyProduces().get(0)
+                .getParameters().get("delegate"), equalTo("first"));
+            assertThat(second.resourceMethods.get(0).directlyProduces().get(0)
+                .getParameters().get("delegate"), equalTo("second"));
+            assertThat(first.resourceMethods.get(0).directlyConsumes().get(0)
+                .getParameters().get("delegate"), equalTo("first"));
+            assertThat(second.resourceMethods.get(0).directlyConsumes().get(0)
+                .getParameters().get("delegate"), equalTo("second"));
+        } finally {
+            RuntimeDelegate.setInstance(original);
+        }
     }
 
     private static List<ParamConverterProvider> providersWithPrefix(String prefix) {
@@ -412,6 +443,47 @@ public class ResourceClassTest {
         @GET
         public String get() {
             return "ok";
+        }
+    }
+
+    @Path("/runtime-delegate-media")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    private static class RuntimeDelegateMediaResource {
+        @GET
+        @Consumes(MediaType.TEXT_PLAIN)
+        @Produces(MediaType.TEXT_PLAIN)
+        public String get() {
+            return "ok";
+        }
+    }
+
+    private static final class MarkingRuntimeDelegate extends MuRuntimeDelegate {
+        private final String marker;
+
+        private MarkingRuntimeDelegate(String marker) {
+            this.marker = marker;
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public <T> HeaderDelegate<T> createHeaderDelegate(Class<T> type) {
+            if (type != MediaType.class) {
+                return super.createHeaderDelegate(type);
+            }
+            return (HeaderDelegate<T>) new HeaderDelegate<MediaType>() {
+                @Override
+                public MediaType fromString(String value) {
+                    String[] typeAndSubtype = value.split("/", 2);
+                    return new MediaType(typeAndSubtype[0], typeAndSubtype[1],
+                        Collections.singletonMap("delegate", marker));
+                }
+
+                @Override
+                public String toString(MediaType value) {
+                    return value.getType() + "/" + value.getSubtype();
+                }
+            };
         }
     }
 

--- a/src/test/java/io/muserver/rest/ResourceClassTest.java
+++ b/src/test/java/io/muserver/rest/ResourceClassTest.java
@@ -80,8 +80,8 @@ public class ResourceClassTest {
 
         assertThat(resourceClass.resourceMethods, hasSize(1));
         ResourceMethod resourceMethod = resourceClass.resourceMethods.get(0);
-        assertThat(resourceMethod.methodHandle.isBridge(), equalTo(false));
-        assertThat(resourceMethod.genericReturnType.getTypeName(), equalTo("java.util.List<java.lang.String>"));
+        assertThat(resourceMethod.methodHandle().isBridge(), equalTo(false));
+        assertThat(resourceMethod.genericReturnType().getTypeName(), equalTo("java.util.List<java.lang.String>"));
     }
 
     @Test
@@ -90,9 +90,9 @@ public class ResourceClassTest {
 
         assertThat(resourceClass.resourceMethods, hasSize(1));
         ResourceMethod resourceMethod = resourceClass.resourceMethods.get(0);
-        assertThat(resourceMethod.methodHandle.isBridge(), equalTo(false));
-        assertThat(resourceMethod.methodHandle.getParameterTypes()[0], equalTo(String.class));
-        assertThat(resourceMethod.params.get(0).source, equalTo(ResourceMethodParam.ValueSource.PATH_PARAM));
+        assertThat(resourceMethod.methodHandle().isBridge(), equalTo(false));
+        assertThat(resourceMethod.methodHandle().getParameterTypes()[0], equalTo(String.class));
+        assertThat(resourceMethod.params.get(0).source(), equalTo(ResourceMethodParam.ValueSource.PATH_PARAM));
     }
 
     @Test
@@ -101,9 +101,9 @@ public class ResourceClassTest {
 
         assertThat(resourceClass.resourceMethods, hasSize(1));
         ResourceMethod resourceMethod = resourceClass.resourceMethods.get(0);
-        assertThat(resourceMethod.methodHandle.isBridge(), equalTo(false));
-        assertThat(resourceMethod.methodHandle.getParameterTypes()[0], equalTo(String.class));
-        assertThat(resourceMethod.params.get(0).source, equalTo(ResourceMethodParam.ValueSource.PATH_PARAM));
+        assertThat(resourceMethod.methodHandle().isBridge(), equalTo(false));
+        assertThat(resourceMethod.methodHandle().getParameterTypes()[0], equalTo(String.class));
+        assertThat(resourceMethod.params.get(0).source(), equalTo(ResourceMethodParam.ValueSource.PATH_PARAM));
     }
 
     @Test
@@ -111,7 +111,7 @@ public class ResourceClassTest {
         ResourceClass resourceClass = ResourceClass.fromObject(new InterfaceResourceWithInheritedImplementation(), ResourceMethodParamTest.BUILT_IN_PARAM_PROVIDERS, customizer);
 
         assertThat(resourceClass.resourceMethods, hasSize(1));
-        assertThat(resourceClass.resourceMethods.get(0).methodHandle.getDeclaringClass(), equalTo(UnannotatedImplementation.class));
+        assertThat(resourceClass.resourceMethods.get(0).methodHandle().getDeclaringClass(), equalTo(UnannotatedImplementation.class));
     }
 
     @Test

--- a/src/test/java/io/muserver/rest/ResourceClassTest.java
+++ b/src/test/java/io/muserver/rest/ResourceClassTest.java
@@ -4,16 +4,29 @@ import jakarta.ws.rs.GET;
 import jakarta.ws.rs.OPTIONS;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.ext.ParamConverter;
+import jakarta.ws.rs.ext.ParamConverterProvider;
 import org.junit.Test;
 
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 
 import static java.net.URI.create;
 import static java.util.Collections.emptyList;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
 
 public class ResourceClassTest {
 
@@ -92,6 +105,121 @@ public class ResourceClassTest {
 
         assertThat(resourceClass.resourceMethods, hasSize(1));
         assertThat(resourceClass.resourceMethods.get(0).methodHandle.getDeclaringClass(), equalTo(UnannotatedImplementation.class));
+    }
+
+    @Test
+    public void dynamicSubResourcesReuseIntrospectionButRemainBoundToTheirInstances() throws Exception {
+        ResourceClass root = ResourceClass.fromObject(new DynamicRoot(),
+            ResourceMethodParamTest.BUILT_IN_PARAM_PROVIDERS, customizer);
+        ResourceMethod locator = root.resourceMethods.get(0);
+
+        ResourceClass first = ResourceClass.forSubResourceLocator(locator, DynamicChild.class,
+            new DynamicChild("first"), customizer, ResourceMethodParamTest.BUILT_IN_PARAM_PROVIDERS);
+        ResourceClass second = ResourceClass.forSubResourceLocator(locator, DynamicChild.class,
+            new DynamicChild("second"), customizer, ResourceMethodParamTest.BUILT_IN_PARAM_PROVIDERS);
+
+        assertSame(first.introspection, second.introspection);
+        assertThat(first.resourceMethods.get(0).invoke(), equalTo("first"));
+        assertThat(second.resourceMethods.get(0).invoke(), equalTo("second"));
+    }
+
+    @Test
+    public void converterSelectionRemainsBoundToEachHandlerConfiguration() {
+        ResourceClass first = ResourceClass.fromObject(new ConverterResource(),
+            providersWithPrefix("first:"), customizer);
+        ResourceClass second = ResourceClass.fromObject(new ConverterResource(),
+            providersWithPrefix("second:"), customizer);
+
+        assertSame(first.introspection, second.introspection);
+        ResourceMethodParam.RequestBasedParam firstParam =
+            (ResourceMethodParam.RequestBasedParam) first.resourceMethods.get(0).params.get(0);
+        ResourceMethodParam.RequestBasedParam secondParam =
+            (ResourceMethodParam.RequestBasedParam) second.resourceMethods.get(0).params.get(0);
+        assertThat(firstParam.defaultValue(), equalTo(new ConvertedValue("first:value")));
+        assertThat(secondParam.defaultValue(), equalTo(new ConvertedValue("second:value")));
+    }
+
+    @Test
+    public void cachedCollectionsAreImmutable() {
+        ResourceClassIntrospection model = ResourceClassIntrospection.forClass(ConverterResource.class);
+        ResourceClassIntrospection.MethodInfo method = model.methods.get(0);
+        ResourceMethodParam.Introspection param = method.params.get(0);
+
+        assertThrows(UnsupportedOperationException.class, () -> model.methods.add(method));
+        assertThrows(UnsupportedOperationException.class,
+            () -> method.directlyProduces.add(MediaType.APPLICATION_JSON_TYPE));
+        assertThrows(UnsupportedOperationException.class, () -> method.params.add(param));
+        assertThrows(UnsupportedOperationException.class,
+            () -> method.nameBindingAnnotations.add(Deprecated.class));
+        assertThrows(UnsupportedOperationException.class,
+            () -> method.methodAnnotations.add(null));
+        assertThrows(UnsupportedOperationException.class,
+            () -> param.annotations.add(null));
+    }
+
+    @Test
+    public void concurrentInitialAccessReturnsOneCorrectModel() throws Exception {
+        int threadCount = 16;
+        ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch start = new CountDownLatch(1);
+        List<Future<ResourceClassIntrospection>> futures = new ArrayList<>();
+        try {
+            for (int i = 0; i < threadCount; i++) {
+                futures.add(executor.submit(() -> {
+                    start.await();
+                    return ResourceClassIntrospection.forClass(ConcurrentResource.class);
+                }));
+            }
+            start.countDown();
+            ResourceClassIntrospection expected = futures.get(0).get();
+            for (Future<ResourceClassIntrospection> future : futures) {
+                assertSame(expected, future.get());
+            }
+            assertThat(expected.methods, hasSize(1));
+            assertThat(expected.methods.get(0).httpMethod, equalTo(io.muserver.Method.GET));
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    @Test
+    public void cachedGenericTypesAreResolvedAgainstTheConcreteClass() {
+        ResourceClassIntrospection classModel =
+            ResourceClassIntrospection.forClass(StringListResource.class);
+        assertThat(classModel.methods.get(0).genericReturnType.getTypeName(),
+            equalTo("java.util.List<java.lang.String>"));
+
+        ResourceClassIntrospection interfaceModel =
+            ResourceClassIntrospection.forClass(StringLookupResource.class);
+        assertThat(interfaceModel.methods.get(0).params.get(0).source,
+            equalTo(ResourceMethodParam.ValueSource.PATH_PARAM));
+        assertThat(interfaceModel.methods.get(0).annotationSource.getDeclaringClass(),
+            equalTo(GenericLookupResource.class));
+    }
+
+    private static List<ParamConverterProvider> providersWithPrefix(String prefix) {
+        ParamConverterProvider provider = new ParamConverterProvider() {
+            @Override
+            @SuppressWarnings("unchecked")
+            public <T> ParamConverter<T> getConverter(Class<T> rawType, Type genericType,
+                                                       Annotation[] annotations) {
+                if (rawType != ConvertedValue.class) {
+                    return null;
+                }
+                return (ParamConverter<T>) new ParamConverter<ConvertedValue>() {
+                    @Override
+                    public ConvertedValue fromString(String value) {
+                        return new ConvertedValue(prefix + value);
+                    }
+
+                    @Override
+                    public String toString(ConvertedValue value) {
+                        return value.value;
+                    }
+                };
+            }
+        };
+        return Arrays.asList(provider, new BuiltInParamConverterProvider());
     }
 
     @Path("/api/fruits")
@@ -181,5 +309,61 @@ public class ResourceClassTest {
 
     @Path("/api/inherited-implementation")
     private static class InterfaceResourceWithInheritedImplementation extends UnannotatedImplementation implements AnnotatedResourceMethod { }
+
+    @Path("/dynamic")
+    private static class DynamicRoot {
+        @Path("{id}")
+        public DynamicChild child() {
+            return new DynamicChild("unused");
+        }
+    }
+
+    private static class DynamicChild {
+        private final String value;
+
+        private DynamicChild(String value) {
+            this.value = value;
+        }
+
+        @GET
+        public String get() {
+            return value;
+        }
+    }
+
+    private static final class ConvertedValue {
+        private final String value;
+
+        private ConvertedValue(String value) {
+            this.value = value;
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            return other instanceof ConvertedValue
+                && value.equals(((ConvertedValue) other).value);
+        }
+
+        @Override
+        public int hashCode() {
+            return value.hashCode();
+        }
+    }
+
+    @Path("/converter")
+    private static class ConverterResource {
+        @GET
+        public String get(@QueryParam("value") @jakarta.ws.rs.DefaultValue("value") ConvertedValue value) {
+            return value.value;
+        }
+    }
+
+    @Path("/concurrent")
+    private static class ConcurrentResource {
+        @GET
+        public String get() {
+            return "ok";
+        }
+    }
 
 }

--- a/src/test/java/io/muserver/rest/ResourceMethodParamTest.java
+++ b/src/test/java/io/muserver/rest/ResourceMethodParamTest.java
@@ -50,8 +50,6 @@ public class ResourceMethodParamTest {
                                           @MatrixParam("dummy2") @DefaultValue("Another Default") String defaultAndNotEncoded,
                                           @FormParam("dummy3") @Encoded String noDefaultButEncoded,
                                           @HeaderParam("dummy4") String noDefaultAndNoEncoded,
-                                          @jakarta.ws.rs.core.Context Object context,
-                                          @jakarta.ws.rs.container.Suspended Object suspended,
                                           String messageBasedParam) {
             }
         }
@@ -81,11 +79,7 @@ public class ResourceMethodParamTest {
         assertThat(noDefaultAndNoEncoded.encodedRequested(), is(false));
         assertThat(noDefaultAndNoEncoded.key(), equalTo("dummy4"));
 
-        assertThat(params.get(4), instanceOf(ResourceMethodParam.ContextParam.class));
-        assertThat(params.get(4).isRequired(), is(true));
-        assertThat(params.get(5), instanceOf(ResourceMethodParam.SuspendedParam.class));
-        assertThat(params.get(5).isRequired(), is(true));
-        assertThat(params.get(6), instanceOf(ResourceMethodParam.MessageBodyParam.class));
+        assertThat(params.get(4), instanceOf(ResourceMethodParam.MessageBodyParam.class));
     }
 
     @Test

--- a/src/test/java/io/muserver/rest/ResourceMethodParamTest.java
+++ b/src/test/java/io/muserver/rest/ResourceMethodParamTest.java
@@ -61,23 +61,23 @@ public class ResourceMethodParamTest {
 
         ResourceMethodParam.RequestBasedParam defaultAndEncoded = (ResourceMethodParam.RequestBasedParam) params.get(0);
         assertThat(defaultAndEncoded.defaultValue(), equalTo("A Default"));
-        assertThat(defaultAndEncoded.encodedRequested, is(true));
-        assertThat(defaultAndEncoded.key, equalTo("dummy1"));
+        assertThat(defaultAndEncoded.encodedRequested(), is(true));
+        assertThat(defaultAndEncoded.key(), equalTo("dummy1"));
 
         ResourceMethodParam.RequestBasedParam defaultAndNotEncoded = (ResourceMethodParam.RequestBasedParam) params.get(1);
         assertThat(defaultAndNotEncoded.defaultValue(), equalTo("Another Default"));
-        assertThat(defaultAndNotEncoded.encodedRequested, is(false));
-        assertThat(defaultAndNotEncoded.key, equalTo("dummy2"));
+        assertThat(defaultAndNotEncoded.encodedRequested(), is(false));
+        assertThat(defaultAndNotEncoded.key(), equalTo("dummy2"));
 
         ResourceMethodParam.RequestBasedParam noDefaultButEncoded = (ResourceMethodParam.RequestBasedParam) params.get(2);
         assertThat(noDefaultButEncoded.defaultValue(), is(nullValue()));
-        assertThat(noDefaultButEncoded.encodedRequested, is(true));
-        assertThat(noDefaultButEncoded.key, equalTo("dummy3"));
+        assertThat(noDefaultButEncoded.encodedRequested(), is(true));
+        assertThat(noDefaultButEncoded.key(), equalTo("dummy3"));
 
         ResourceMethodParam.RequestBasedParam noDefaultAndNoEncoded = (ResourceMethodParam.RequestBasedParam) params.get(3);
         assertThat(noDefaultAndNoEncoded.defaultValue(), is(nullValue()));
-        assertThat(noDefaultAndNoEncoded.encodedRequested, is(false));
-        assertThat(noDefaultAndNoEncoded.key, equalTo("dummy4"));
+        assertThat(noDefaultAndNoEncoded.encodedRequested(), is(false));
+        assertThat(noDefaultAndNoEncoded.key(), equalTo("dummy4"));
 
         assertThat(params.get(4), instanceOf(ResourceMethodParam.MessageBodyParam.class));
     }

--- a/src/test/java/io/muserver/rest/ResourceMethodParamTest.java
+++ b/src/test/java/io/muserver/rest/ResourceMethodParamTest.java
@@ -50,6 +50,8 @@ public class ResourceMethodParamTest {
                                           @MatrixParam("dummy2") @DefaultValue("Another Default") String defaultAndNotEncoded,
                                           @FormParam("dummy3") @Encoded String noDefaultButEncoded,
                                           @HeaderParam("dummy4") String noDefaultAndNoEncoded,
+                                          @jakarta.ws.rs.core.Context Object context,
+                                          @jakarta.ws.rs.container.Suspended Object suspended,
                                           String messageBasedParam) {
             }
         }
@@ -79,7 +81,11 @@ public class ResourceMethodParamTest {
         assertThat(noDefaultAndNoEncoded.encodedRequested(), is(false));
         assertThat(noDefaultAndNoEncoded.key(), equalTo("dummy4"));
 
-        assertThat(params.get(4), instanceOf(ResourceMethodParam.MessageBodyParam.class));
+        assertThat(params.get(4), instanceOf(ResourceMethodParam.ContextParam.class));
+        assertThat(params.get(4).isRequired(), is(true));
+        assertThat(params.get(5), instanceOf(ResourceMethodParam.SuspendedParam.class));
+        assertThat(params.get(5).isRequired(), is(true));
+        assertThat(params.get(6), instanceOf(ResourceMethodParam.MessageBodyParam.class));
     }
 
     @Test

--- a/src/test/java/io/muserver/rest/SubResourceLocatorTest.java
+++ b/src/test/java/io/muserver/rest/SubResourceLocatorTest.java
@@ -2,11 +2,15 @@ package io.muserver.rest;
 
 import io.muserver.MuServer;
 import jakarta.ws.rs.*;
+import jakarta.ws.rs.ext.ParamConverter;
+import jakarta.ws.rs.ext.ParamConverterProvider;
 import okhttp3.Response;
 import org.junit.After;
 import org.junit.Test;
 import scaffolding.MuAssert;
 
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
 import java.util.List;
 
 import static io.muserver.rest.RestHandlerBuilder.restHandler;
@@ -226,6 +230,112 @@ public class SubResourceLocatorTest {
             assertThat(resp.code(), is(200));
             assertThat(resp.header("content-type"), is("text/dog;charset=utf-8"));
             assertThat(resp.body().string(), equalTo("Oh, hi doggy"));
+        }
+    }
+
+    @Test
+    public void sameSubResourceClassRetainsEachLocatorsPathAndMediaTypeContext() throws Exception {
+        class Child {
+            @GET
+            public String get() {
+                return "child";
+            }
+        }
+        @Path("root")
+        class Root {
+            @Path("plain")
+            @Produces("text/plain")
+            public Child plain() {
+                return new Child();
+            }
+
+            @Path("json")
+            @Produces("application/json")
+            public Child json() {
+                return new Child();
+            }
+        }
+
+        server = httpsServerForTest()
+            .addHandler(restHandler(new Root()).build())
+            .start();
+
+        try (Response resp = call(request(server.uri().resolve("/root/plain")))) {
+            assertThat(resp.code(), is(200));
+            assertThat(resp.header("content-type"), is("text/plain;charset=utf-8"));
+            assertThat(resp.body().string(), is("child"));
+        }
+        try (Response resp = call(request(server.uri().resolve("/root/json")))) {
+            assertThat(resp.code(), is(200));
+            assertThat(resp.header("content-type"), is("application/json"));
+            assertThat(resp.body().string(), is("child"));
+        }
+    }
+
+    @Test
+    public void handlersWithDifferentConvertersForTheSameClassRemainIndependent() throws Exception {
+        MuServer first = httpsServerForTest()
+            .addHandler(restHandler(new HandlerConvertedResource())
+                .addCustomParamConverterProvider(prefixingProvider("first:"))
+                .build())
+            .start();
+        MuServer second = httpsServerForTest()
+            .addHandler(restHandler(new HandlerConvertedResource())
+                .addCustomParamConverterProvider(prefixingProvider("second:"))
+                .build())
+            .start();
+        try {
+            try (Response resp = call(request(first.uri().resolve("/convert?value=x")))) {
+                assertThat(resp.code(), is(200));
+                assertThat(resp.body().string(), is("first:x"));
+            }
+            try (Response resp = call(request(second.uri().resolve("/convert?value=x")))) {
+                assertThat(resp.code(), is(200));
+                assertThat(resp.body().string(), is("second:x"));
+            }
+        } finally {
+            MuAssert.stopAndCheck(first);
+            MuAssert.stopAndCheck(second);
+        }
+    }
+
+    private static ParamConverterProvider prefixingProvider(String prefix) {
+        return new ParamConverterProvider() {
+            @Override
+            @SuppressWarnings("unchecked")
+            public <T> ParamConverter<T> getConverter(Class<T> rawType, Type genericType,
+                                                       Annotation[] annotations) {
+                if (rawType != HandlerConvertedValue.class) {
+                    return null;
+                }
+                return (ParamConverter<T>) new ParamConverter<HandlerConvertedValue>() {
+                    @Override
+                    public HandlerConvertedValue fromString(String value) {
+                        return new HandlerConvertedValue(prefix + value);
+                    }
+
+                    @Override
+                    public String toString(HandlerConvertedValue value) {
+                        return value.value;
+                    }
+                };
+            }
+        };
+    }
+
+    private static final class HandlerConvertedValue {
+        private final String value;
+
+        private HandlerConvertedValue(String value) {
+            this.value = value;
+        }
+    }
+
+    @Path("convert")
+    private static final class HandlerConvertedResource {
+        @GET
+        public String get(@QueryParam("value") HandlerConvertedValue value) {
+            return value.value;
         }
     }
 


### PR DESCRIPTION
## Summary

- introduce an immutable `ResourceClassIntrospection` model cached with `ClassValue`
- reuse class-derived method, annotation, path, media-type, generic-type, parameter, name-binding, and visibility-warning metadata
- keep resource instances, locator context, effective media types, converter selection/default conversion, and schema customization bound to each `ResourceClass`
- make bound `ResourceMethod` and `ResourceMethodParam` objects delegate class-derived values to their cached descriptors instead of copying alias fields
- preserve the latest master visibility diagnostics by caching only their immutable descriptions and keeping guarded logging outside `ClassValue.computeValue`
- add focused coverage for dynamic sub-resource reuse, instance and handler isolation, locator context, generic inheritance, immutability, and concurrent access

## Motivation

Dynamic sub-resource locators can repeatedly return instances of the same concrete class. Previously every returned instance repeated public-method discovery, annotation-source resolution, annotation processing, URI-pattern compilation, and generic type resolution. This experiment evaluates whether strictly class-derived work can be reused without retaining application classes through an external static map or mixing handler/locator state into the cache.

## Impact

There is no public API or dependency change. Bound `ResourceClass`, `ResourceMethod`, and parameter objects remain independent for each resource instance, locator chain, and `RestHandler` configuration. They now retain references to cached descriptors for class-derived metadata, while mutable annotation arrays and binding-specific descriptions, converters, converted defaults, effective media types, instances, and schema customizers remain per binding.

No performance improvement is claimed yet; this needs a representative benchmark. The ownership boundary is clearer after removing duplicate descriptor fields, but the cache still adds an architectural layer overall. One diagnostic-order concern remains: if a resource class has multiple independent invalid definitions, class-wide introspection can encounter a class-derived error before a handler-specific converter error that construction previously encountered first. This affects which error is reported first, not whether invalid resources are accepted.

## Validation

- `mise exec java@temurin-11 -- mvn -Dtest=ResourceClassTest,JaxMethodLocatorTest,SubResourceLocatorTest,ResourceMethodParamTest,RequestMatcherTest,OpenApiDocumentorTest test` — 95 tests passed
- `mise exec java@temurin-11 -- mvn test` — 980 tests passed
- `git diff --check` — passed

The branch includes the latest `origin/master` commit `ce08f424`.