### PR TITLE
Support Jakarta REST array parameters

### DIFF
--- a/src/main/java/io/muserver/rest/CollectionParameterStrategy.java
+++ b/src/main/java/io/muserver/rest/CollectionParameterStrategy.java
@@ -1,14 +1,14 @@
 package io.muserver.rest;
 
 /**
- * Specifies how to handle lists or sets in querystring parameters
- * <p>This can be used to allow clients to send lists of values in comma-separated values to query string parameters in JAX-RS methods.</p>
+ * Specifies how to handle collection or array query-string parameters.
+ * <p>This can be used to allow clients to send multiple values in a comma-separated query-string parameter to JAX-RS methods.</p>
  */
 public enum CollectionParameterStrategy {
 
     /**
-     * Splits parameter values on commas, for example <code>a,b,c</code> would result in a list of 3 strings.
-     * <p>With this option enabled, values are trimmed and empty values are removed, so <code>a,%20b,</code> would be a list with 2 values (&quot;a&quot; and &quot;b&quot;).</p>
+     * Splits parameter values on commas, for example <code>a,b,c</code> produces 3 strings.
+     * <p>With this option enabled, values are trimmed and empty values are removed, so <code>a,%20b,</code> produces 2 values (&quot;a&quot; and &quot;b&quot;).</p>
      */
     SPLIT_ON_COMMA,
 

--- a/src/main/java/io/muserver/rest/README.md
+++ b/src/main/java/io/muserver/rest/README.md
@@ -62,7 +62,7 @@ N/A Not applicable as only singletons supported
 - [x] Static valueOf method objects
 - [x] Single-string constructor objects
 - [x] `List<T>`, `Set<T>`, and `SortedSet<T>` for values satisfying above 3 cases. 
-- [ ] `T[]` parameters for `@CookieParam`, `@FormParam`, `@HeaderParam`, `@MatrixParam`, and `@QueryParam`
+- [x] `T[]` parameters for `@CookieParam`, `@FormParam`, `@HeaderParam`, `@MatrixParam`, and `@QueryParam`
 - [x] `@DefaultValue`
 - [x] `@Encoded`
 

--- a/src/main/java/io/muserver/rest/ResourceMethodParam.java
+++ b/src/main/java/io/muserver/rest/ResourceMethodParam.java
@@ -347,6 +347,13 @@ abstract class ResourceMethodParam {
                 }
             }
 
+            if (paramClass.equals(io.muserver.Cookie.class)) {
+                List<String> cookieValues = cookieValue(muRequest, key());
+                return cookieValues.isEmpty() ? null : new CookieBuilder()
+                    .withName(key())
+                    .withValue(cookieValues.get(0))
+                    .build();
+            }
             if (paramClass.isAssignableFrom(PathSegment.class)) {
                 PathSegment seg = matchedMethod.pathParams.get(key());
                 if (seg != null && encodedRequested()) {
@@ -587,11 +594,6 @@ abstract class ResourceMethodParam {
         if (source == ValueSource.COOKIE_PARAM && (value == null || value instanceof String)) {
             if (parameterType.equals(Cookie.class)) {
                 return value == null ? null : new Cookie(parameterName, (String) value);
-            } else if (parameterType.equals(io.muserver.Cookie.class)) {
-                return value == null ? null : new CookieBuilder()
-                    .withName(parameterName)
-                    .withValue((String) value)
-                    .build();
             }
         }
         if (converter == null || skipConverter) {

--- a/src/main/java/io/muserver/rest/ResourceMethodParam.java
+++ b/src/main/java/io/muserver/rest/ResourceMethodParam.java
@@ -424,7 +424,11 @@ abstract class ResourceMethodParam {
                     value = value.trim();
                     if (value.contains(",")) {
                         String[] bits = value.split("\\s*,\\s*");
-                        Collections.addAll(copy, bits);
+                        for (String bit : bits) {
+                            if (!bit.isEmpty()) {
+                                copy.add(bit);
+                            }
+                        }
                     } else if (!value.isEmpty()) {
                         copy.add(value.trim());
                     }

--- a/src/main/java/io/muserver/rest/ResourceMethodParam.java
+++ b/src/main/java/io/muserver/rest/ResourceMethodParam.java
@@ -259,11 +259,21 @@ abstract class ResourceMethodParam {
             @Nullable Pattern patternIfNotDefault = pattern == null || UriPattern.DEFAULT_CAPTURING_GROUP_PATTERN.equals(pattern.pattern()) ? null : pattern;
             return builder.withSchema(
                 schemaObjectFrom(type(), genericType(), isRequired())
-                    .withDefaultValue(source() == ValueSource.PATH_PARAM || !hasExplicitDefault() ? null : defaultValue())
+                    .withDefaultValue(documentationDefaultValue())
                     .withExternalDocs(externalDoc)
                     .withPattern(patternIfNotDefault)
                     .build()
             );
+        }
+
+        private @Nullable Object documentationDefaultValue() {
+            if (source() == ValueSource.PATH_PARAM || !hasExplicitDefault()) {
+                return null;
+            }
+            if (!array) {
+                return defaultValue();
+            }
+            return Collections.singletonList(defaultValue());
         }
 
         RequestBasedParam(Introspection introspection, Annotation[] annotations,

--- a/src/main/java/io/muserver/rest/ResourceMethodParam.java
+++ b/src/main/java/io/muserver/rest/ResourceMethodParam.java
@@ -304,7 +304,14 @@ abstract class ResourceMethodParam {
         public @Nullable Object getValue(JaxRSRequest jaxRequest, RequestMatcher.MatchedMethod matchedMethod, CollectionParameterStrategy cps) throws IOException {
             MuRequest muRequest = jaxRequest.muRequest;
             Class<?> paramClass = type();
-            if (UploadedFile.class.isAssignableFrom(paramClass)) {
+            if (array && UploadedFile.class.isAssignableFrom(convertedValueType)) {
+                List<UploadedFile> uploadedFiles = muRequest.uploadedFiles(key());
+                Object uploadedFileArray = Array.newInstance(convertedValueType, uploadedFiles.size());
+                for (int i = 0; i < uploadedFiles.size(); i++) {
+                    Array.set(uploadedFileArray, i, uploadedFiles.get(i));
+                }
+                return uploadedFileArray;
+            } else if (UploadedFile.class.isAssignableFrom(paramClass)) {
                 return muRequest.uploadedFile(key());
             } else if (File.class.isAssignableFrom(paramClass)) {
                 UploadedFile uf = muRequest.uploadedFile(key());

--- a/src/main/java/io/muserver/rest/ResourceMethodParam.java
+++ b/src/main/java/io/muserver/rest/ResourceMethodParam.java
@@ -161,6 +161,10 @@ abstract class ResourceMethodParam {
             } else if (source == ValueSource.SUSPENDED) {
                 return new SuspendedParam(this, boundAnnotations);
             } else {
+                if (type.isArray() && io.muserver.Cookie.class.isAssignableFrom(type.getComponentType())) {
+                    throw new MuException("io.muserver.Cookie[] is not supported for Jakarta REST parameters. "
+                        + "Use jakarta.ws.rs.core.Cookie[] with @CookieParam instead.");
+                }
                 ParamConverter<?> converter =
                     getParamConverter(this, boundAnnotations, paramConverterProviders);
                 boolean lazyDefaultValue = converter.getClass().getDeclaredAnnotation(ParamConverter.Lazy.class) != null;

--- a/src/main/java/io/muserver/rest/ResourceMethodParam.java
+++ b/src/main/java/io/muserver/rest/ResourceMethodParam.java
@@ -16,6 +16,8 @@ import org.jspecify.annotations.Nullable;
 import java.io.File;
 import java.io.IOException;
 import java.lang.annotation.Annotation;
+import java.lang.reflect.Array;
+import java.lang.reflect.GenericArrayType;
 import java.lang.reflect.Parameter;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
@@ -162,8 +164,9 @@ abstract class ResourceMethodParam {
                 ParamConverter<?> converter =
                     getParamConverter(this, boundAnnotations, paramConverterProviders);
                 boolean lazyDefaultValue = converter.getClass().getDeclaredAnnotation(ParamConverter.Lazy.class) != null;
+                Class<?> convertedValueType = convertedValueType(this);
                 @Nullable Object defaultValue = getDefaultValue(
-                    this, converter, lazyDefaultValue);
+                    this, convertedValueType, converter, lazyDefaultValue);
 
                 if (key.length() == 0) {
                     throw new WebApplicationException(
@@ -171,7 +174,7 @@ abstract class ResourceMethodParam {
                 }
 
                 return new RequestBasedParam(this, boundAnnotations, defaultValue,
-                    lazyDefaultValue, converter);
+                    lazyDefaultValue, convertedValueType, converter);
             }
         }
     }
@@ -218,6 +221,8 @@ abstract class ResourceMethodParam {
 
         private final @Nullable Object defaultValue;
         private final boolean lazyDefaultValue;
+        private final boolean array;
+        private final Class<?> convertedValueType;
         private final ParamConverter paramConverter;
 
         boolean encodedRequested() {
@@ -263,10 +268,12 @@ abstract class ResourceMethodParam {
 
         RequestBasedParam(Introspection introspection, Annotation[] annotations,
                           @Nullable Object defaultValue, boolean lazyDefaultValue,
-                          ParamConverter paramConverter) {
+                          Class<?> convertedValueType, ParamConverter paramConverter) {
             super(introspection, annotations);
             this.defaultValue = defaultValue;
             this.lazyDefaultValue = lazyDefaultValue;
+            this.array = isSupportedArray(introspection);
+            this.convertedValueType = convertedValueType;
             this.paramConverter = paramConverter;
         }
 
@@ -281,7 +288,7 @@ abstract class ResourceMethodParam {
 
         public @Nullable Object defaultValue() {
             boolean skipConverter = defaultValue != null && !lazyDefaultValue;
-            return convertValue(parameterHandle(), type(), paramConverter, skipConverter, defaultValue, source(), key());
+            return convertValue(parameterHandle(), convertedValueType, paramConverter, skipConverter, defaultValue, source(), key());
         }
 
         public @Nullable Object getValue(JaxRSRequest jaxRequest, RequestMatcher.MatchedMethod matchedMethod, CollectionParameterStrategy cps) throws IOException {
@@ -325,12 +332,6 @@ abstract class ResourceMethodParam {
                     return ((MuPathSegment) seg).toEncoded();
                 }
                 return seg;
-            } else if (paramClass.equals(Cookie.class)) {
-                List<String> cookieValues = cookieValue(muRequest, key());
-                return cookieValues.isEmpty() ? null : new Cookie(key(), cookieValues.get(0));
-            } else if (paramClass.equals(io.muserver.Cookie.class)) {
-                List<String> cookieValues = cookieValue(muRequest, key());
-                return cookieValues.isEmpty() ? null : new CookieBuilder().withName(key()).withValue(cookieValues.get(0)).build();
             }
             Collection<Object> collection = createCollection(paramClass);
             if (collection != null && source() == ValueSource.PATH_PARAM && isPathSegmentCollection()) {
@@ -349,8 +350,8 @@ abstract class ResourceMethodParam {
                 source() == ValueSource.PATH_PARAM ? (collection == null
                     ? (pathParam == null ? emptyList() : Collections.singletonList(pathParam))
                     : matchedMethod.getPathParams(key()))
-                    : source() == ValueSource.QUERY_PARAM ? getParamValues(jaxRequest.getUriInfo().getQueryParameters(), key(), cps, collection != null)
-                    : source() == ValueSource.HEADER_PARAM ? getParamValues(jaxRequest.getHeaders(), key(), cps, collection != null)
+                    : source() == ValueSource.QUERY_PARAM ? getParamValues(jaxRequest.getUriInfo().getQueryParameters(), key(), cps, collection != null || array)
+                    : source() == ValueSource.HEADER_PARAM ? getParamValues(jaxRequest.getHeaders(), key(), cps, collection != null || array)
                     : source() == ValueSource.FORM_PARAM ? muRequest.form().getAll(key())
                     : source() == ValueSource.COOKIE_PARAM ? cookieValue(muRequest, key())
                     : source() == ValueSource.MATRIX_PARAM ? matrixParamValue(key(), jaxRequest.relativePath())
@@ -361,7 +362,20 @@ abstract class ResourceMethodParam {
                     .map(value -> source() == ValueSource.FORM_PARAM ? FormUrlEncoder.formUrlEncode(value) : Mutils.urlEncode(value))
                     .collect(Collectors.toList());
             }
-            if (collection != null) {
+            if (array) {
+                int size = isSpecified ? requireNonNull(specifiedValue).size() : hasExplicitDefault() ? 1 : 0;
+                Object array = Array.newInstance(convertedValueType, size);
+                if (isSpecified) {
+                    for (int i = 0; i < size; i++) {
+                        Object converted = ResourceMethodParam.convertValue(parameterHandle(), convertedValueType,
+                            paramConverter, false, requireNonNull(specifiedValue).get(i), source(), key());
+                        Array.set(array, i, converted);
+                    }
+                } else if (hasExplicitDefault()) {
+                    Array.set(array, 0, defaultValue());
+                }
+                return array;
+            } else if (collection != null) {
                 if (isSpecified) {
                     for (String stringValue : requireNonNull(specifiedValue)) {
                         collection.add(ResourceMethodParam.convertValue(parameterHandle(), type(), paramConverter, false, stringValue, source(), key()));
@@ -478,7 +492,10 @@ abstract class ResourceMethodParam {
                                                        List<ParamConverterProvider> paramConverterProviders) {
         Class<?> paramType = parameter.type;
         Type parameterizedType = parameter.genericType;
-        if (Collection.class.isAssignableFrom(paramType) && parameterizedType instanceof ParameterizedType) {
+        if (isSupportedArray(parameter)) {
+            paramType = convertedValueType(parameter);
+            parameterizedType = arrayComponentType(parameter.genericType);
+        } else if (Collection.class.isAssignableFrom(paramType) && parameterizedType instanceof ParameterizedType) {
             Type possiblyWildcardType = ((ParameterizedType) parameterizedType).getActualTypeArguments()[0];
             Type type = (possiblyWildcardType instanceof WildcardType) ? ((WildcardType) possiblyWildcardType).getUpperBounds()[0] : possiblyWildcardType;
             if (type instanceof Class) {
@@ -507,16 +524,51 @@ abstract class ResourceMethodParam {
     }
 
     private static @Nullable Object getDefaultValue(Introspection parameter,
+                                                     Class<?> convertedValueType,
                                                      ParamConverter<?> converter,
                                                      boolean lazyDefaultValue) {
         if (!parameter.explicitDefault) {
             return converter instanceof HasDefaultValue ? ((HasDefaultValue) converter).getDefault() : null;
         }
-        return convertValue(parameter.parameterHandle, parameter.type, converter, lazyDefaultValue,
+        return convertValue(parameter.parameterHandle, convertedValueType, converter, lazyDefaultValue,
             parameter.explicitDefaultValue, parameter.source, parameter.key);
     }
 
+    private static boolean isSupportedArray(Introspection parameter) {
+        return parameter.source != ValueSource.PATH_PARAM
+            && parameter.type.isArray()
+            && !parameter.type.getComponentType().isPrimitive();
+    }
+
+    private static Class<?> convertedValueType(Introspection parameter) {
+        if (!isSupportedArray(parameter)) {
+            return parameter.type;
+        }
+        Class<?> componentClass = GenericTypeResolver.rawClass(arrayComponentType(parameter.genericType));
+        return componentClass == null ? parameter.type.getComponentType() : componentClass;
+    }
+
+    private static Type arrayComponentType(Type arrayType) {
+        if (arrayType instanceof Class && ((Class<?>) arrayType).isArray()) {
+            return ((Class<?>) arrayType).getComponentType();
+        }
+        if (arrayType instanceof GenericArrayType) {
+            return ((GenericArrayType) arrayType).getGenericComponentType();
+        }
+        throw new IllegalArgumentException("Not an array type: " + arrayType);
+    }
+
     private static @Nullable Object convertValue(Parameter parameterHandle, Class<?> parameterType, @Nullable ParamConverter<?> converter, boolean skipConverter, @Nullable Object value, ValueSource source, String parameterName) {
+        if (source == ValueSource.COOKIE_PARAM && (value == null || value instanceof String)) {
+            if (parameterType.equals(Cookie.class)) {
+                return value == null ? null : new Cookie(parameterName, (String) value);
+            } else if (parameterType.equals(io.muserver.Cookie.class)) {
+                return value == null ? null : new CookieBuilder()
+                    .withName(parameterName)
+                    .withValue((String) value)
+                    .build();
+            }
+        }
         if (converter == null || skipConverter) {
             return value;
         } else {

--- a/src/test/java/io/muserver/rest/FormUploadTest.java
+++ b/src/test/java/io/muserver/rest/FormUploadTest.java
@@ -212,6 +212,41 @@ public class FormUploadTest {
         }
     }
 
+    @Test
+    public void arraysOfFilesAreAllowed() throws IOException {
+        @Path("/images")
+        class ImageResource {
+            @POST
+            @Consumes(jakarta.ws.rs.core.MediaType.MULTIPART_FORM_DATA)
+            public String create(@FormParam("image") UploadedFile[] files) {
+                return files.length + " files: " + java.util.Arrays.stream(files)
+                    .map(UploadedFile::filename)
+                    .collect(Collectors.joining(", "));
+            }
+        }
+        server = ServerUtils.httpsServerForTest()
+            .addHandler(RestHandlerBuilder.restHandler(new ImageResource()))
+            .start();
+
+        try (Response resp = call(request(server.uri().resolve("/images"))
+            .post(new MultipartBody.Builder()
+                .setType(MultipartBody.FORM)
+                .addFormDataPart("Hello", "World")
+                .build()))) {
+            assertThat(resp.body().string(), is("0 files: "));
+        }
+        try (Response resp = call(request(server.uri().resolve("/images"))
+            .post(new MultipartBody.Builder()
+                .setType(MultipartBody.FORM)
+                .addPart(Headers.of("Content-Disposition", "form-data; name=\"image\"; filename=\"guangzhou.jpeg\""),
+                    RequestBody.create(guangzhou, MediaType.parse("image/jpeg")))
+                .addPart(Headers.of("Content-Disposition", "form-data; name=\"image\"; filename=\"friends.jpg\""),
+                    RequestBody.create(friends, MediaType.parse("image/jpeg")))
+                .build()))) {
+            assertThat(resp.body().string(), is("2 files: guangzhou.jpeg, friends.jpg"));
+        }
+    }
+
     @After
     public void stopIt() {
         scaffolding.MuAssert.stopAndCheck(server);

--- a/src/test/java/io/muserver/rest/ResourceMethodArrayParamTest.java
+++ b/src/test/java/io/muserver/rest/ResourceMethodArrayParamTest.java
@@ -438,7 +438,7 @@ public class ResourceMethodArrayParamTest {
         server = httpsServerForTest().addHandler(restHandler(new ArrayResource())
             .withCollectionParameterStrategy(CollectionParameterStrategy.SPLIT_ON_COMMA)).start();
 
-        try (Response response = call(request(server.uri().resolve("/arrays?value=one,%20two,")))) {
+        try (Response response = call(request(server.uri().resolve("/arrays?value=one,,%20two,")))) {
             assertThat(response.body().string(), is("one|two"));
         }
     }

--- a/src/test/java/io/muserver/rest/ResourceMethodArrayParamTest.java
+++ b/src/test/java/io/muserver/rest/ResourceMethodArrayParamTest.java
@@ -488,6 +488,25 @@ public class ResourceMethodArrayParamTest {
     }
 
     @Test
+    public void muCookieArraysRemainUnsupported() {
+        @Path("arrays")
+        class ArrayResource {
+            @GET
+            public String get(@CookieParam("value") io.muserver.Cookie[] ignored) {
+                return "unexpected";
+            }
+        }
+
+        try {
+            restHandler(new ArrayResource()).build();
+            Assert.fail("Should have rejected Mu Cookie arrays");
+        } catch (MuException expected) {
+            assertThat(expected.getMessage(), containsString("io.muserver.Cookie[] is not supported"));
+            assertThat(expected.getMessage(), containsString("jakarta.ws.rs.core.Cookie[]"));
+        }
+    }
+
+    @Test
     public void primitiveArraysRemainUnsupported() {
         @Path("arrays")
         class ArrayResource {

--- a/src/test/java/io/muserver/rest/ResourceMethodArrayParamTest.java
+++ b/src/test/java/io/muserver/rest/ResourceMethodArrayParamTest.java
@@ -17,6 +17,7 @@ import jakarta.ws.rs.ext.ParamConverter;
 import jakarta.ws.rs.ext.ParamConverterProvider;
 import okhttp3.FormBody;
 import okhttp3.Response;
+import org.json.JSONObject;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Test;
@@ -439,6 +440,32 @@ public class ResourceMethodArrayParamTest {
 
         try (Response response = call(request(server.uri().resolve("/arrays?value=one,%20two,")))) {
             assertThat(response.body().string(), is("one|two"));
+        }
+    }
+
+    @Test
+    public void openApiArrayDefaultsAreSingletonArrays() throws IOException {
+        @Path("arrays")
+        class ArrayResource {
+            @GET
+            public String get(@DefaultValue("42") @QueryParam("value") Integer[] values) {
+                return join(values);
+            }
+        }
+        server = httpsServerForTest().addHandler(restHandler(new ArrayResource())
+            .withOpenApiJsonUrl("/openapi.json")).start();
+
+        try (Response response = call(request(server.uri().resolve("/arrays")))) {
+            assertThat(response.body().string(), is("42"));
+        }
+        try (Response response = call(request(server.uri().resolve("/openapi.json")))) {
+            assertThat(response.code(), is(200));
+            JSONObject schema = (JSONObject) new JSONObject(response.body().string())
+                .query("/paths/~1arrays/get/parameters/0/schema");
+            assertThat(schema.getString("type"), is("array"));
+            assertThat(schema.getJSONObject("items").getString("type"), is("integer"));
+            assertThat(schema.getJSONArray("default").length(), is(1));
+            assertThat(schema.getJSONArray("default").getInt(0), is(42));
         }
     }
 

--- a/src/test/java/io/muserver/rest/ResourceMethodArrayParamTest.java
+++ b/src/test/java/io/muserver/rest/ResourceMethodArrayParamTest.java
@@ -1,0 +1,437 @@
+package io.muserver.rest;
+
+import io.muserver.MuException;
+import io.muserver.MuServer;
+import jakarta.ws.rs.CookieParam;
+import jakarta.ws.rs.DefaultValue;
+import jakarta.ws.rs.Encoded;
+import jakarta.ws.rs.FormParam;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.HeaderParam;
+import jakarta.ws.rs.MatrixParam;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.ext.ParamConverter;
+import jakarta.ws.rs.ext.ParamConverterProvider;
+import okhttp3.FormBody;
+import okhttp3.Response;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.Arrays;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
+
+import static io.muserver.rest.RestHandlerBuilder.restHandler;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static scaffolding.ClientUtils.call;
+import static scaffolding.ClientUtils.request;
+import static scaffolding.ServerUtils.httpsServerForTest;
+
+public class ResourceMethodArrayParamTest {
+
+    private MuServer server;
+
+    @Test
+    public void arraysReceiveValuesFromAllSupportedParameterAnnotations() throws IOException {
+        @Path("arrays")
+        class ArrayResource {
+            @GET
+            @Path("query")
+            public String query(@QueryParam("value") String[] values) {
+                return join(values);
+            }
+
+            @GET
+            @Path("header")
+            public String header(@HeaderParam("X-Value") String[] values) {
+                return join(values);
+            }
+
+            @GET
+            @Path("matrix")
+            public String matrix(@MatrixParam("value") String[] values) {
+                return join(values);
+            }
+
+            @POST
+            @Path("form")
+            public String form(@FormParam("value") String[] values) {
+                return join(values);
+            }
+
+            @GET
+            @Path("cookie")
+            public String cookie(@CookieParam("value") String[] values) {
+                return join(values);
+            }
+
+            @GET
+            @Path("cookie-object")
+            public String cookieObject(@CookieParam("value") jakarta.ws.rs.core.Cookie[] values) {
+                return Arrays.stream(values)
+                    .map(cookie -> cookie.getName() + "=" + cookie.getValue())
+                    .collect(Collectors.joining("|"));
+            }
+        }
+        server = httpsServerForTest().addHandler(restHandler(new ArrayResource())).start();
+
+        try (Response response = call(request(server.uri().resolve("/arrays/query?value=one&value=two")))) {
+            assertThat(response.body().string(), is("one|two"));
+        }
+        try (Response response = call(request(server.uri().resolve("/arrays/header"))
+            .addHeader("X-Value", "one")
+            .addHeader("X-Value", "two"))) {
+            assertThat(response.body().string(), is("one|two"));
+        }
+        try (Response response = call(request(server.uri().resolve("/arrays/matrix;value=one;value=two")))) {
+            assertThat(response.body().string(), is("one|two"));
+        }
+        try (Response response = call(request(server.uri().resolve("/arrays/form"))
+            .post(new FormBody.Builder().add("value", "one").add("value", "two").build()))) {
+            assertThat(response.body().string(), is("one|two"));
+        }
+        try (Response response = call(request(server.uri().resolve("/arrays/cookie"))
+            .header("Cookie", "value=one"))) {
+            assertThat(response.body().string(), is("one"));
+        }
+        try (Response response = call(request(server.uri().resolve("/arrays/cookie-object"))
+            .header("Cookie", "value=one"))) {
+            assertThat(response.body().string(), is("value=one"));
+        }
+    }
+
+    @Test
+    public void missingValuesProduceEmptyArraysAndDefaultsProduceSingletonArrays() throws IOException {
+        @Path("arrays")
+        class ArrayResource {
+            @POST
+            @Path("missing")
+            public String missing(@QueryParam("query") String[] query,
+                                  @HeaderParam("X-Value") String[] header,
+                                  @MatrixParam("matrix") String[] matrix,
+                                  @FormParam("form") String[] form,
+                                  @CookieParam("cookie") String[] cookie) {
+                return lengths(query, header, matrix, form, cookie);
+            }
+
+            @POST
+            @Path("defaults")
+            public String defaults(@DefaultValue("query-default") @QueryParam("query") String[] query,
+                                   @DefaultValue("header-default") @HeaderParam("X-Value") String[] header,
+                                   @DefaultValue("matrix-default") @MatrixParam("matrix") String[] matrix,
+                                   @DefaultValue("form-default") @FormParam("form") String[] form,
+                                   @DefaultValue("cookie-default") @CookieParam("cookie") jakarta.ws.rs.core.Cookie[] cookie,
+                                   @DefaultValue("scalar-cookie-default") @CookieParam("scalar-cookie") jakarta.ws.rs.core.Cookie scalarCookie) {
+                return join(query) + ";" + join(header) + ";" + join(matrix) + ";" + join(form) + ";"
+                    + cookie[0].getName() + "=" + cookie[0].getValue() + ";"
+                    + scalarCookie.getName() + "=" + scalarCookie.getValue();
+            }
+        }
+        server = httpsServerForTest().addHandler(restHandler(new ArrayResource())).start();
+
+        try (Response response = call(request(server.uri().resolve("/arrays/missing"))
+            .post(new FormBody.Builder().build()))) {
+            assertThat(response.body().string(), is("0|0|0|0|0"));
+        }
+        try (Response response = call(request(server.uri().resolve("/arrays/defaults"))
+            .post(new FormBody.Builder().build()))) {
+            assertThat(response.body().string(),
+                is("query-default;header-default;matrix-default;form-default;cookie=cookie-default;"
+                    + "scalar-cookie=scalar-cookie-default"));
+        }
+    }
+
+    @Test
+    public void encodedIsAppliedToEveryValueInUriAndFormArrays() throws IOException {
+        @Path("arrays")
+        class ArrayResource {
+            @POST
+            @Path("encoded")
+            public String encoded(@Encoded @QueryParam("query") String[] query,
+                                  @Encoded @MatrixParam("matrix") String[] matrix,
+                                  @Encoded @FormParam("form") String[] form) {
+                return join(query) + ";" + join(matrix) + ";" + join(form);
+            }
+        }
+        server = httpsServerForTest().addHandler(restHandler(new ArrayResource())).start();
+
+        try (Response response = call(request()
+            .url(server.uri().resolve("/arrays/encoded;matrix=one%20space%2F;matrix=two%20space%2F"
+                + "?query=one%20space%2F&query=two%20space%2F").toString())
+            .post(new FormBody.Builder().add("form", "one space/").add("form", "two space/").build()))) {
+            assertThat(response.body().string(),
+                is("one%20space%2F|two%20space%2F;"
+                    + "one%20space%2F|two%20space%2F;"
+                    + "one+space%2F|two+space%2F"));
+        }
+    }
+
+    @Test
+    public void builtInConvertersAreAppliedToArrayElements() throws IOException {
+        @Path("arrays")
+        class ArrayResource {
+            @GET
+            public String get(@QueryParam("number") Integer[] numbers) {
+                return Arrays.stream(numbers).map(number -> Integer.toString(number * 2))
+                    .collect(Collectors.joining("|"));
+            }
+        }
+        server = httpsServerForTest().addHandler(restHandler(new ArrayResource())).start();
+
+        try (Response response = call(request(server.uri().resolve("/arrays?number=10&number=21")))) {
+            assertThat(response.body().string(), is("20|42"));
+        }
+    }
+
+    @Test
+    public void applicationConvertersAreAskedToConvertTheArrayElementType() throws IOException {
+        AtomicReference<Class<?>> requestedRawType = new AtomicReference<>();
+        AtomicReference<Type> requestedGenericType = new AtomicReference<>();
+
+        class Converted {
+            private final String value;
+
+            private Converted(String value) {
+                this.value = value;
+            }
+        }
+        @Path("arrays")
+        class ArrayResource {
+            @GET
+            public String get(@QueryParam("value") Converted[] values) {
+                return Arrays.stream(values).map(value -> value.value).collect(Collectors.joining("|"));
+            }
+        }
+        ParamConverterProvider provider = new ParamConverterProvider() {
+            @Override
+            public <T> ParamConverter<T> getConverter(Class<T> rawType, Type genericType, Annotation[] annotations) {
+                if (!rawType.equals(Converted.class)) {
+                    return null;
+                }
+                requestedRawType.set(rawType);
+                requestedGenericType.set(genericType);
+                return new ParamConverter<T>() {
+                    @Override
+                    public T fromString(String value) {
+                        return rawType.cast(new Converted("converted-" + value));
+                    }
+
+                    @Override
+                    public String toString(T value) {
+                        return ((Converted) value).value;
+                    }
+                };
+            }
+        };
+        server = httpsServerForTest().addHandler(restHandler(new ArrayResource())
+            .addCustomParamConverterProvider(provider)).start();
+
+        try (Response response = call(request(server.uri().resolve("/arrays?value=one&value=two")))) {
+            assertThat(response.body().string(), is("converted-one|converted-two"));
+        }
+        assertThat(requestedRawType.get(), is(equalTo(Converted.class)));
+        assertThat(requestedGenericType.get(), is(equalTo(Converted.class)));
+    }
+
+    @Test
+    public void applicationConvertersReceiveGenericArrayElementTypes() throws IOException {
+        AtomicReference<Type> requestedGenericType = new AtomicReference<>();
+
+        class Holder<T> {
+            private final T value;
+
+            private Holder(T value) {
+                this.value = value;
+            }
+        }
+        @Path("arrays")
+        class ArrayResource {
+            @GET
+            public String get(@QueryParam("value") Holder<String>[] values) {
+                return Arrays.stream(values).map(value -> value.value).collect(Collectors.joining("|"));
+            }
+        }
+        ParamConverterProvider provider = new ParamConverterProvider() {
+            @Override
+            public <T> ParamConverter<T> getConverter(Class<T> rawType, Type genericType, Annotation[] annotations) {
+                if (!rawType.equals(Holder.class)) {
+                    return null;
+                }
+                requestedGenericType.set(genericType);
+                return new ParamConverter<T>() {
+                    @Override
+                    public T fromString(String value) {
+                        return rawType.cast(new Holder<>("converted-" + value));
+                    }
+
+                    @Override
+                    public String toString(T value) {
+                        return ((Holder<?>) value).value.toString();
+                    }
+                };
+            }
+        };
+        server = httpsServerForTest().addHandler(restHandler(new ArrayResource())
+            .addCustomParamConverterProvider(provider)).start();
+
+        try (Response response = call(request(server.uri().resolve("/arrays?value=one&value=two")))) {
+            assertThat(response.body().string(), is("converted-one|converted-two"));
+        }
+        assertThat(requestedGenericType.get(), is(org.hamcrest.Matchers.instanceOf(ParameterizedType.class)));
+        ParameterizedType genericType = (ParameterizedType) requestedGenericType.get();
+        assertThat(genericType.getRawType(), is(equalTo(Holder.class)));
+        assertThat(genericType.getActualTypeArguments(), is(equalTo(new Type[]{String.class})));
+    }
+
+    @Test
+    public void arrayElementConversionFailuresAreClientErrorsForAllSupportedAnnotations() throws IOException {
+        @Path("arrays")
+        class ArrayResource {
+            @GET
+            @Path("query")
+            public String query(@QueryParam("value") Integer[] ignored) {
+                return "unexpected";
+            }
+
+            @GET
+            @Path("header")
+            public String header(@HeaderParam("X-Value") Integer[] ignored) {
+                return "unexpected";
+            }
+
+            @GET
+            @Path("matrix")
+            public String matrix(@MatrixParam("value") Integer[] ignored) {
+                return "unexpected";
+            }
+
+            @POST
+            @Path("form")
+            public String form(@FormParam("value") Integer[] ignored) {
+                return "unexpected";
+            }
+
+            @GET
+            @Path("cookie")
+            public String cookie(@CookieParam("value") Integer[] ignored) {
+                return "unexpected";
+            }
+        }
+        server = httpsServerForTest().addHandler(restHandler(new ArrayResource())).start();
+
+        assertBadRequest("/arrays/query?value=not-a-number", null);
+        assertBadRequest("/arrays/header", request(server.uri().resolve("/arrays/header"))
+            .header("X-Value", "not-a-number"));
+        assertBadRequest("/arrays/matrix;value=not-a-number", null);
+        try (Response response = call(request(server.uri().resolve("/arrays/form"))
+            .post(new FormBody.Builder().add("value", "not-a-number").build()))) {
+            assertThat(response.code(), is(400));
+        }
+        assertBadRequest("/arrays/cookie", request(server.uri().resolve("/arrays/cookie"))
+            .header("Cookie", "value=not-a-number"));
+    }
+
+    @Test
+    public void inheritedGenericArrayElementTypesAreResolved() throws IOException {
+        class BaseResource<T> {
+            @GET
+            public String get(@QueryParam("value") T[] values) {
+                return values.getClass().getComponentType().getName() + ":" + join(values);
+            }
+        }
+        @Path("arrays")
+        class ArrayResource extends BaseResource<Integer> {
+        }
+        server = httpsServerForTest().addHandler(restHandler(new ArrayResource())).start();
+
+        try (Response response = call(request(server.uri().resolve("/arrays?value=10&value=20")))) {
+            assertThat(response.body().string(), is("java.lang.Integer:10|20"));
+        }
+    }
+
+    @Test
+    public void commaSplittingStrategyAppliesToArrays() throws IOException {
+        @Path("arrays")
+        class ArrayResource {
+            @GET
+            public String get(@QueryParam("value") String[] values) {
+                return join(values);
+            }
+        }
+        server = httpsServerForTest().addHandler(restHandler(new ArrayResource())
+            .withCollectionParameterStrategy(CollectionParameterStrategy.SPLIT_ON_COMMA)).start();
+
+        try (Response response = call(request(server.uri().resolve("/arrays?value=one,%20two,")))) {
+            assertThat(response.body().string(), is("one|two"));
+        }
+    }
+
+    @Test
+    public void pathParamArraysRemainUnsupported() {
+        @Path("arrays/{value}")
+        class ArrayResource {
+            @GET
+            public String get(@PathParam("value") String[] ignored) {
+                return "unexpected";
+            }
+        }
+
+        try {
+            restHandler(new ArrayResource()).build();
+            Assert.fail("Should have rejected @PathParam arrays");
+        } catch (MuException expected) {
+            assertThat(expected.getMessage(), containsString("Could not find a suitable ParamConverter"));
+        }
+    }
+
+    @Test
+    public void primitiveArraysRemainUnsupported() {
+        @Path("arrays")
+        class ArrayResource {
+            @GET
+            public String get(@QueryParam("value") int[] ignored) {
+                return "unexpected";
+            }
+        }
+
+        try {
+            restHandler(new ArrayResource()).build();
+            Assert.fail("Should have rejected primitive arrays");
+        } catch (MuException expected) {
+            assertThat(expected.getMessage(), containsString("Could not find a suitable ParamConverter"));
+        }
+    }
+
+    private void assertBadRequest(String path, okhttp3.Request.Builder requestBuilder) throws IOException {
+        okhttp3.Request.Builder actualRequest = requestBuilder == null
+            ? request(server.uri().resolve(path))
+            : requestBuilder;
+        try (Response response = call(actualRequest)) {
+            assertThat(response.code(), is(400));
+        }
+    }
+
+    private static String join(Object[] values) {
+        return Arrays.stream(values).map(String::valueOf).collect(Collectors.joining("|"));
+    }
+
+    private static String lengths(Object[]... arrays) {
+        return Arrays.stream(arrays).map(array -> Integer.toString(array.length)).collect(Collectors.joining("|"));
+    }
+
+    @After
+    public void stop() {
+        scaffolding.MuAssert.stopAndCheck(server);
+    }
+}

--- a/src/test/java/io/muserver/rest/ResourceMethodArrayParamTest.java
+++ b/src/test/java/io/muserver/rest/ResourceMethodArrayParamTest.java
@@ -42,6 +42,42 @@ public class ResourceMethodArrayParamTest {
 
     private MuServer server;
 
+    private enum ArrayEnum {
+        FIRST, SECOND
+    }
+
+    public static class ConstructedValue {
+        private final String value;
+
+        public ConstructedValue(String value) {
+            this.value = "constructor-" + value;
+        }
+    }
+
+    public static class FromStringValue {
+        private final String value;
+
+        private FromStringValue(String value) {
+            this.value = value;
+        }
+
+        public static FromStringValue fromString(String value) {
+            return new FromStringValue("fromString-" + value);
+        }
+    }
+
+    public static class ValueOfValue {
+        private final String value;
+
+        private ValueOfValue(String value) {
+            this.value = value;
+        }
+
+        public static ValueOfValue valueOf(String value) {
+            return new ValueOfValue("valueOf-" + value);
+        }
+    }
+
     @Test
     public void arraysReceiveValuesFromAllSupportedParameterAnnotations() throws IOException {
         @Path("arrays")
@@ -191,6 +227,35 @@ public class ResourceMethodArrayParamTest {
 
         try (Response response = call(request(server.uri().resolve("/arrays?number=10&number=21")))) {
             assertThat(response.body().string(), is("20|42"));
+        }
+    }
+
+    @Test
+    public void standardObjectConversionRulesAreAppliedToArrayElements() throws IOException {
+        @Path("arrays")
+        class ArrayResource {
+            @GET
+            public String get(@QueryParam("enum") ArrayEnum[] enums,
+                              @QueryParam("constructor") ConstructedValue[] constructed,
+                              @QueryParam("fromString") FromStringValue[] fromStrings,
+                              @QueryParam("valueOf") ValueOfValue[] valueOfs) {
+                return Arrays.stream(enums).map(Enum::name).collect(Collectors.joining("|")) + ";"
+                    + Arrays.stream(constructed).map(value -> value.value).collect(Collectors.joining("|")) + ";"
+                    + Arrays.stream(fromStrings).map(value -> value.value).collect(Collectors.joining("|")) + ";"
+                    + Arrays.stream(valueOfs).map(value -> value.value).collect(Collectors.joining("|"));
+            }
+        }
+        server = httpsServerForTest().addHandler(restHandler(new ArrayResource())).start();
+
+        try (Response response = call(request(server.uri().resolve("/arrays"
+            + "?enum=FIRST&enum=SECOND"
+            + "&constructor=one&constructor=two"
+            + "&fromString=one&fromString=two"
+            + "&valueOf=one&valueOf=two")))) {
+            assertThat(response.body().string(), is("FIRST|SECOND;"
+                + "constructor-one|constructor-two;"
+                + "fromString-one|fromString-two;"
+                + "valueOf-one|valueOf-two"));
         }
     }
 


### PR DESCRIPTION
## What changed

- support `T[]` resource-method parameters for `@CookieParam`, `@FormParam`, `@HeaderParam`, `@MatrixParam`, and `@QueryParam`
- apply built-in and application `ParamConverter`s to each array element, including enums, public string constructors, static `fromString`/`valueOf` methods, and generic or inherited element types
- preserve repeated values, empty-array semantics, `@DefaultValue`, `@Encoded`, conversion errors, and `CollectionParameterStrategy`, including filtering empty comma-separated elements
- describe array defaults in OpenAPI as singleton arrays while retaining scalar converted defaults for request injection
- route multipart `UploadedFile[]` parameters through the upload store, consistent with scalar and collection uploads
- keep `@PathParam` arrays and primitive arrays unsupported, as required by the Jakarta REST 3.1 API contracts
- preserve legacy scalar `@CookieParam io.muserver.Cookie` compatibility while rejecting `io.muserver.Cookie[]`; use the standard Jakarta `Cookie[]` type
- unify scalar and array conversion only for Jakarta `Cookie`, fixing scalar `@CookieParam Cookie` defaults along the way while leaving Mu Cookie conversion on its legacy scalar-only path
- update the JAX-RS support matrix and collection-strategy documentation

## Why

Jakarta REST 3.1 added `T[]` alongside `List<T>`, `Set<T>`, and `SortedSet<T>` for these five parameter annotations. Mu previously requested a converter for the array class itself and had no array materialization path, so handlers containing these parameters failed during construction.

The implementation resolves and caches the element type while binding resource metadata, asks providers for an element converter, and allocates one correctly typed array of the exact result size per request. OpenAPI documentation wraps an explicit converted array default only at the schema boundary, producing a valid JSON array without changing request injection.

## Validation

- tests were written first and observed failing before each implementation change
- `mise exec java@temurin-11 -- mvn -Dtest=ResourceMethodArrayParamTest,CookieTest,FormUploadTest,CollectionParameterStrategyTest,ResourceMethodParamTest,OpenApiDocumentorTest,SchemaObjectTest test` — 110 passed
- full Java 11 suite — 1,004 tests passed; one fixed-port test encountered an unrelated address-in-use error, and its isolated rerun passed
- `git diff --check`

No runtime dependencies or public signatures were added or changed.