### PR TITLE
Add client certificate authentication modes

### DIFF
--- a/src/main/java/io/muserver/ClientCertificateAuthentication.java
+++ b/src/main/java/io/muserver/ClientCertificateAuthentication.java
@@ -1,0 +1,23 @@
+package io.muserver;
+
+/**
+ * Specifies how an HTTPS listener authenticates client certificates.
+ */
+public enum ClientCertificateAuthentication {
+    /**
+     * The server does not request a client certificate.
+     */
+    NONE,
+
+    /**
+     * The server requests a client certificate, but permits clients that do not provide one.
+     * A certificate that is provided must be accepted by the configured trust manager.
+     */
+    OPTIONAL,
+
+    /**
+     * The server requires a client certificate. Clients that do not provide a certificate, or that
+     * provide a certificate rejected by the configured trust manager, cannot complete the TLS handshake.
+     */
+    MANDATORY
+}

--- a/src/main/java/io/muserver/HttpConnection.java
+++ b/src/main/java/io/muserver/HttpConnection.java
@@ -2,7 +2,6 @@ package io.muserver;
 
 import org.jspecify.annotations.Nullable;
 
-import javax.net.ssl.TrustManager;
 import java.net.InetSocketAddress;
 import java.security.cert.Certificate;
 import java.time.Instant;
@@ -86,10 +85,11 @@ public interface HttpConnection {
      * <p>The returned certificate will be {@link Optional#empty()} when:</p>
      * <ul>
      *     <li>The client did not send a certificate, or</li>
-     *     <li>The client sent a certificate that failed verification with the client trust manager, or</li>
-     *     <li>No client trust manager was set with {@link HttpsConfigBuilder#withClientCertificateTrustManager(TrustManager)}, or</li>
+     *     <li>The server did not request client authentication, or</li>
      *     <li>The request was not sent over HTTPS</li>
      * </ul>
+     * <p>A client certificate that fails trust validation causes the TLS handshake to fail, so no request is
+     * delivered to a handler.</p>
      * @return The client certificate, or <code>empty</code> if no certificate is available
      */
     Optional<Certificate> clientCertificate();

--- a/src/main/java/io/muserver/HttpsConfigBuilder.java
+++ b/src/main/java/io/muserver/HttpsConfigBuilder.java
@@ -34,6 +34,7 @@ public class HttpsConfigBuilder {
     private @Nullable CipherSuiteFilter nettyCipherSuiteFilter;
     private @Nullable KeyManagerFactory keyManagerFactory;
     private @Nullable String defaultAlias;
+    private @Nullable ClientCertificateAuthentication clientCertificateAuthentication;
 
     /**
      * Only used by HttpsConfigBuilder
@@ -327,8 +328,9 @@ public class HttpsConfigBuilder {
     SslContext toNettySslContext(boolean http2) throws Exception {
         CipherSuiteFilter cipherFilter = nettyCipherSuiteFilter != null ? nettyCipherSuiteFilter : IdentityCipherSuiteFilter.INSTANCE;
 
+        validateClientCertificateAuthentication();
         SslContextBuilder builder;
-        ClientAuth clientAuthSetting = trustManager == null ? ClientAuth.NONE : ClientAuth.OPTIONAL;
+        ClientAuth clientAuthSetting = toNettyClientAuth(effectiveClientCertificateAuthentication());
         if (sslContext != null) {
             return new JdkSslContext(sslContext, false, null, cipherFilter, ApplicationProtocolConfig.DISABLED, clientAuthSetting, getHttpsProtocolsArray(), false);
         } else if (keystoreBytes != null) {
@@ -396,6 +398,44 @@ public class HttpsConfigBuilder {
             .build();
     }
 
+    private ClientCertificateAuthentication effectiveClientCertificateAuthentication() {
+        ClientCertificateAuthentication authentication = clientCertificateAuthentication;
+        if (authentication != null) {
+            return authentication;
+        }
+        return trustManager == null
+            ? ClientCertificateAuthentication.NONE
+            : ClientCertificateAuthentication.OPTIONAL;
+    }
+
+    private void validateClientCertificateAuthentication() {
+        ClientCertificateAuthentication authentication = clientCertificateAuthentication;
+        if (authentication == null) {
+            return;
+        }
+        if (authentication == ClientCertificateAuthentication.NONE && trustManager != null) {
+            throw new IllegalStateException(
+                "A client-certificate trust manager cannot be used when authentication is NONE");
+        }
+        if (sslContext == null
+            && authentication != ClientCertificateAuthentication.NONE
+            && trustManager == null) {
+            throw new IllegalStateException(
+                "A client-certificate trust manager is required when the SSLContext is built by mu-server");
+        }
+    }
+
+    private static ClientAuth toNettyClientAuth(ClientCertificateAuthentication authentication) {
+        switch (authentication) {
+            case OPTIONAL:
+                return ClientAuth.OPTIONAL;
+            case MANDATORY:
+                return ClientAuth.REQUIRE;
+            default:
+                return ClientAuth.NONE;
+        }
+    }
+
     private String[] getHttpsProtocolsArray() throws NoSuchAlgorithmException {
         List<String> supportedProtocols = asList(SSLContext.getDefault().getSupportedSSLParameters().getProtocols());
         List<String> protocolsToUse = new ArrayList<>();
@@ -426,16 +466,43 @@ public class HttpsConfigBuilder {
         return new HttpsConfigBuilder();
     }
 
+    /**
+     * Sets how HTTPS clients are authenticated with client certificates.
+     *
+     * <p>If this method is not called, setting a trust manager with
+     * {@link #withClientCertificateTrustManager(TrustManager)} enables optional authentication, preserving
+     * historical behaviour. An explicitly configured authentication policy takes precedence.</p>
+     *
+     * <p>When this builder creates the SSL context from a keystore or key manager factory, optional and
+     * mandatory authentication require a client-certificate trust manager. When
+     * {@link #withSSLContext(SSLContext)} is used, the pre-built context's embedded trust managers are used.</p>
+     * <p>{@link ClientCertificateAuthentication#NONE NONE} cannot be combined with a non-null
+     * client-certificate trust manager.</p>
+     *
+     * @param authentication The client-certificate authentication policy.
+     * @return This builder.
+     */
+    public HttpsConfigBuilder withClientCertificateAuthentication(
+        ClientCertificateAuthentication authentication) {
+        Mutils.notNull("authentication", authentication);
+        this.clientCertificateAuthentication = authentication;
+        return this;
+    }
+
 
     /**
      * Sets the trust manager that is used to validate client certificates.
-     * <p>Setting the trust manager will make client certificates optional. The trust manager should
-     * contain the public keys of certificate authorities that you want to allow client certificates
-     * from.
+     * <p>Unless an explicit policy is set with
+     * {@link #withClientCertificateAuthentication(ClientCertificateAuthentication)}, setting a non-null trust
+     * manager makes client certificates optional, preserving historical behaviour. The trust manager should
+     * contain the public keys of certificate authorities that you want to allow client certificates from.
      * Certificates will be available for request handlers at {@link HttpConnection#clientCertificate()}
      * (note that the connection of a request is available on {@link MuRequest#connection()}).</p>
      * <p><strong>Important note:</strong> if no certificate is set then the client certificate will be
      * <code>null</code>. If an invalid certificate is sent then the TLS connection will be rejected.</p>
+     * <p>When {@link #withSSLContext(SSLContext)} is used, that context's embedded trust managers perform
+     * validation. For compatibility, a non-null value supplied here still enables optional authentication when
+     * no explicit authentication policy is set.</p>
      * @param trustManager The trust manager to use to validate client certificates
      * @return This builder.
      */

--- a/src/main/java/io/muserver/rest/MuSeBootstrap.java
+++ b/src/main/java/io/muserver/rest/MuSeBootstrap.java
@@ -1,5 +1,6 @@
 package io.muserver.rest;
 
+import io.muserver.ClientCertificateAuthentication;
 import io.muserver.ContextHandlerBuilder;
 import io.muserver.HttpsConfigBuilder;
 import io.muserver.MuServer;
@@ -48,12 +49,11 @@ final class MuSeBootstrap {
             if ("HTTP".equalsIgnoreCase(protocol)) {
                 serverBuilder.withHttpPort(port);
             } else if ("HTTPS".equalsIgnoreCase(protocol)) {
-                if (requested.sslClientAuthentication()
-                    != SeBootstrap.Configuration.SSLClientAuthentication.NONE) {
-                    throw new UnsupportedOperationException("SEBootstrap TLS client authentication is not supported");
-                }
                 serverBuilder.withHttpsPort(port)
-                    .withHttpsConfig(new HttpsConfigBuilder().withSSLContext(requested.sslContext()));
+                    .withHttpsConfig(new HttpsConfigBuilder()
+                        .withSSLContext(requested.sslContext())
+                        .withClientCertificateAuthentication(clientCertificateAuthentication(
+                            requested.sslClientAuthentication())));
             } else {
                 throw new IllegalArgumentException("Unsupported protocol: " + protocol);
             }
@@ -76,6 +76,18 @@ final class MuSeBootstrap {
             CompletableFuture<SeBootstrap.Instance> failed = new CompletableFuture<>();
             failed.completeExceptionally(failure);
             return failed;
+        }
+    }
+
+    private static ClientCertificateAuthentication clientCertificateAuthentication(
+        SeBootstrap.Configuration.SSLClientAuthentication authentication) {
+        switch (authentication) {
+            case OPTIONAL:
+                return ClientCertificateAuthentication.OPTIONAL;
+            case MANDATORY:
+                return ClientCertificateAuthentication.MANDATORY;
+            default:
+                return ClientCertificateAuthentication.NONE;
         }
     }
 

--- a/src/main/java/io/muserver/rest/README.md
+++ b/src/main/java/io/muserver/rest/README.md
@@ -414,7 +414,7 @@ Will not implement. Configuration should be handled by the user.
 ## 11 Environment
 
 - [x] Java SE bootstrap with HTTP, HTTPS, root-path mounting, external configuration, dynamic ports, and shutdown.
-- [ ] TLS client authentication through `SeBootstrap` is not supported.
+- [x] TLS client authentication through `SeBootstrap`, including `NONE`, `OPTIONAL`, and `MANDATORY`.
 
 Mu Server does not advertise its `RuntimeDelegate` globally merely by being present on an application's classpath.
 Call `MuRuntimeDelegate.ensureSet()` once before the first `SeBootstrap` call to select Mu explicitly. When no

--- a/src/test/java/io/muserver/ClientCertTest.java
+++ b/src/test/java/io/muserver/ClientCertTest.java
@@ -10,14 +10,21 @@ import scaffolding.ServerUtils;
 
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.TrustManagerFactory;
+import javax.net.ssl.X509TrustManager;
+import java.io.IOException;
 import java.security.KeyStore;
 import java.security.cert.Certificate;
+import java.security.cert.CertificateException;
 import java.security.cert.CertificateExpiredException;
 import java.security.cert.X509Certificate;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static scaffolding.ClientCertificateTestUtils.clientForcingCertificate;
 import static scaffolding.ClientUtils.*;
 
 public class ClientCertTest {
@@ -108,6 +115,40 @@ public class ClientCertTest {
         OkHttpClient client = getClientWithCert("client.p12");
         try (Response resp = client.newCall(request(server.uri()).build()).execute()) {
             assertThat(resp.body().string(), equalTo("Cert is present? false"));
+        }
+    }
+
+    @Test
+    public void presentedUntrustedCertsAreRejected() throws Exception {
+        AtomicBoolean clientCertificateWasChecked = new AtomicBoolean();
+        X509TrustManager rejectingTrustManager = new X509TrustManager() {
+            @Override
+            public void checkClientTrusted(X509Certificate[] chain, String authType) throws CertificateException {
+                clientCertificateWasChecked.set(true);
+                throw new CertificateException("Client certificate is not trusted");
+            }
+
+            @Override
+            public void checkServerTrusted(X509Certificate[] chain, String authType) {
+            }
+
+            @Override
+            public X509Certificate[] getAcceptedIssuers() {
+                return new X509Certificate[0];
+            }
+        };
+        server = ServerUtils.httpsServerForTest()
+            .withHttpsConfig(HttpsConfigBuilder.unsignedLocalhost()
+                .withClientCertificateTrustManager(rejectingTrustManager))
+            .addHandler(Method.GET, "/", (request, response, pathParams) -> response.write("Should not be called"))
+            .start();
+
+        try (Response ignored = clientForcingCertificate("client.p12")
+            .newCall(request(server.uri()).build()).execute()) {
+            fail("Expected the TLS handshake to fail");
+        } catch (IOException expected) {
+            assertTrue("The server trust manager should have checked the offered certificate",
+                clientCertificateWasChecked.get());
         }
     }
 

--- a/src/test/java/io/muserver/ClientCertificateAuthenticationTest.java
+++ b/src/test/java/io/muserver/ClientCertificateAuthenticationTest.java
@@ -1,0 +1,250 @@
+package io.muserver;
+
+import okhttp3.ConnectionPool;
+import okhttp3.OkHttpClient;
+import okhttp3.Response;
+import org.junit.After;
+import org.junit.Test;
+import scaffolding.ClientUtils;
+import scaffolding.MuAssert;
+import scaffolding.ServerUtils;
+
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.X509TrustManager;
+import java.io.IOException;
+import java.io.InputStream;
+import java.security.KeyStore;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static io.muserver.ClientCertificateAuthentication.MANDATORY;
+import static io.muserver.ClientCertificateAuthentication.NONE;
+import static io.muserver.ClientCertificateAuthentication.OPTIONAL;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static scaffolding.ClientCertificateTestUtils.clientForcingCertificate;
+import static scaffolding.ClientCertificateTestUtils.clientWithCertificate;
+import static scaffolding.ClientUtils.call;
+import static scaffolding.ClientUtils.request;
+
+public class ClientCertificateAuthenticationTest {
+    private MuServer server;
+
+    @Test
+    public void explicitNoneCannotBeCombinedWithATrustManager() {
+        expectIllegalState(() -> HttpsConfigBuilder.unsignedLocalhost()
+            .withClientCertificateTrustManager(ClientUtils.veryTrustingTrustManager())
+            .withClientCertificateAuthentication(NONE)
+            .toNettySslContext(false));
+    }
+
+    @Test
+    public void muBuiltSslContextsRequireATrustManagerForClientAuthentication() {
+        expectIllegalState(() -> HttpsConfigBuilder.unsignedLocalhost()
+            .withClientCertificateAuthentication(OPTIONAL)
+            .toNettySslContext(false));
+        expectIllegalState(() -> HttpsConfigBuilder.unsignedLocalhost()
+            .withClientCertificateAuthentication(MANDATORY)
+            .toNettySslContext(false));
+    }
+
+    @Test
+    public void legacyTrustManagerStillEnablesOptionalAuthenticationWithASuppliedSslContext()
+        throws Exception {
+        AtomicBoolean embeddedTrustManagerWasCalled = new AtomicBoolean();
+        HttpsConfigBuilder httpsConfig = new HttpsConfigBuilder()
+            .withSSLContext(serverSslContext(acceptingTrustManager(embeddedTrustManagerWasCalled)))
+            .withClientCertificateTrustManager(ClientUtils.veryTrustingTrustManager());
+        server = serverWith(httpsConfig);
+
+        try (Response response = call(request(server.uri()))) {
+            assertThat(response.body().string(), equalTo("Client certificate present: false"));
+        }
+        try (Response response = clientForcingCertificate("client.p12")
+            .newCall(request(server.uri()).build()).execute()) {
+            assertThat(response.body().string(), equalTo("Client certificate present: true"));
+        }
+        assertTrue("The supplied SSLContext's trust manager should validate the certificate",
+            embeddedTrustManagerWasCalled.get());
+    }
+
+    @Test
+    public void noneDoesNotRequestAClientCertificate() throws Exception {
+        AtomicBoolean certificateWasRequested = new AtomicBoolean();
+        server = serverWith(NONE, null);
+
+        try (Response response = clientForcingCertificate(
+            "client.p12", certificateWasRequested).newCall(request(server.uri()).build()).execute()) {
+            assertThat(response.body().string(), equalTo("Client certificate present: false"));
+        }
+        assertFalse("The server should not have requested a client certificate",
+            certificateWasRequested.get());
+    }
+
+    @Test
+    public void optionalAcceptsMissingCertificatesAndExposesValidCertificates() throws Exception {
+        server = serverWith(OPTIONAL, ClientUtils.veryTrustingTrustManager());
+
+        try (Response response = call(request(server.uri()))) {
+            assertThat(response.body().string(), equalTo("Client certificate present: false"));
+        }
+        try (Response response = clientWithCertificate("client.p12")
+            .newCall(request(server.uri()).build()).execute()) {
+            assertThat(response.body().string(), equalTo("Client certificate present: true"));
+        }
+    }
+
+    @Test
+    public void mandatoryRejectsMissingCertificatesAndExposesValidCertificates() throws Exception {
+        server = serverWith(MANDATORY, ClientUtils.veryTrustingTrustManager());
+
+        assertConnectionFails(ClientUtils.client);
+        try (Response response = clientWithCertificate("client.p12")
+            .newCall(request(server.uri()).build()).execute()) {
+            assertThat(response.body().string(), equalTo("Client certificate present: true"));
+        }
+    }
+
+    @Test
+    public void optionalRejectsPresentedUntrustedCertificates() throws Exception {
+        assertPresentedUntrustedCertificateIsRejected(OPTIONAL);
+    }
+
+    @Test
+    public void mandatoryRejectsPresentedUntrustedCertificates() throws Exception {
+        assertPresentedUntrustedCertificateIsRejected(MANDATORY);
+    }
+
+    @Test
+    public void authenticationPolicyCanBeChangedForNewConnections() throws Exception {
+        X509TrustManager trustManager = ClientUtils.veryTrustingTrustManager();
+        server = serverWith(OPTIONAL, trustManager);
+        try (Response response = call(request(server.uri()))) {
+            assertThat(response.code(), equalTo(200));
+        }
+
+        server.changeHttpsConfig(httpsConfig(MANDATORY, trustManager));
+        OkHttpClient newConnection = ClientUtils.client.newBuilder()
+            .connectionPool(new ConnectionPool())
+            .build();
+        assertConnectionFails(newConnection);
+    }
+
+    private void assertPresentedUntrustedCertificateIsRejected(
+        ClientCertificateAuthentication authentication) throws Exception {
+        AtomicBoolean certificateWasChecked = new AtomicBoolean();
+        server = serverWith(authentication, rejectingTrustManager(certificateWasChecked));
+
+        assertConnectionFails(clientForcingCertificate("client.p12"));
+        assertTrue("The offered certificate should have been checked", certificateWasChecked.get());
+    }
+
+    private MuServer serverWith(ClientCertificateAuthentication authentication,
+                                X509TrustManager trustManager) {
+        return serverWith(httpsConfig(authentication, trustManager));
+    }
+
+    private MuServer serverWith(HttpsConfigBuilder httpsConfig) {
+        return ServerUtils.httpsServerForTest()
+            .withHttpsConfig(httpsConfig)
+            .addHandler(Method.GET, "/", (request, response, pathParams) ->
+                response.write("Client certificate present: "
+                    + request.connection().clientCertificate().isPresent()))
+            .start();
+    }
+
+    private static HttpsConfigBuilder httpsConfig(
+        ClientCertificateAuthentication authentication, X509TrustManager trustManager) {
+        HttpsConfigBuilder httpsConfig = HttpsConfigBuilder.unsignedLocalhost();
+        if (trustManager != null) {
+            httpsConfig.withClientCertificateTrustManager(trustManager);
+        }
+        httpsConfig.withClientCertificateAuthentication(authentication);
+        return httpsConfig;
+    }
+
+    private void assertConnectionFails(OkHttpClient client) throws Exception {
+        try (Response ignored = client.newCall(request(server.uri()).build()).execute()) {
+            fail("Expected the TLS handshake to fail");
+        } catch (IOException expected) {
+            // Expected: client authentication failed during the TLS handshake.
+        }
+    }
+
+    private static SSLContext serverSslContext(X509TrustManager trustManager) throws Exception {
+        char[] password = "Very5ecure".toCharArray();
+        KeyStore keyStore = KeyStore.getInstance("PKCS12");
+        try (InputStream inputStream = ClientCertificateAuthenticationTest.class.getResourceAsStream(
+            "/io/muserver/resources/localhost.p12")) {
+            keyStore.load(inputStream, password);
+        }
+        KeyManagerFactory factory = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
+        factory.init(keyStore, password);
+        SSLContext context = SSLContext.getInstance("TLS");
+        context.init(factory.getKeyManagers(), new X509TrustManager[]{trustManager}, null);
+        return context;
+    }
+
+    private static X509TrustManager acceptingTrustManager(AtomicBoolean certificateWasChecked) {
+        return new X509TrustManager() {
+            @Override
+            public void checkClientTrusted(X509Certificate[] chain, String authType) {
+                certificateWasChecked.set(true);
+            }
+
+            @Override
+            public void checkServerTrusted(X509Certificate[] chain, String authType) {
+            }
+
+            @Override
+            public X509Certificate[] getAcceptedIssuers() {
+                return new X509Certificate[0];
+            }
+        };
+    }
+
+    private static X509TrustManager rejectingTrustManager(AtomicBoolean certificateWasChecked) {
+        return new X509TrustManager() {
+            @Override
+            public void checkClientTrusted(X509Certificate[] chain, String authType)
+                throws CertificateException {
+                certificateWasChecked.set(true);
+                throw new CertificateException("Client certificate is not trusted");
+            }
+
+            @Override
+            public void checkServerTrusted(X509Certificate[] chain, String authType) {
+            }
+
+            @Override
+            public X509Certificate[] getAcceptedIssuers() {
+                return new X509Certificate[0];
+            }
+        };
+    }
+
+    private static void expectIllegalState(ThrowingRunnable action) {
+        try {
+            action.run();
+            fail("Expected IllegalStateException");
+        } catch (IllegalStateException expected) {
+            // Expected.
+        } catch (Exception e) {
+            throw new AssertionError("Expected IllegalStateException", e);
+        }
+    }
+
+    @After
+    public void stopIt() {
+        MuAssert.stopAndCheck(server);
+    }
+
+    private interface ThrowingRunnable {
+        void run() throws Exception;
+    }
+}

--- a/src/test/java/io/muserver/rest/MuSeBootstrapTest.java
+++ b/src/test/java/io/muserver/rest/MuSeBootstrapTest.java
@@ -6,19 +6,37 @@ import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.SeBootstrap;
 import jakarta.ws.rs.core.Application;
+import okhttp3.OkHttpClient;
 import okhttp3.Response;
 import org.junit.Test;
 import org.junit.BeforeClass;
+import scaffolding.ClientUtils;
 
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.X509TrustManager;
 import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.security.KeyStore;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 
+import static jakarta.ws.rs.SeBootstrap.Configuration.SSLClientAuthentication.MANDATORY;
+import static jakarta.ws.rs.SeBootstrap.Configuration.SSLClientAuthentication.NONE;
+import static jakarta.ws.rs.SeBootstrap.Configuration.SSLClientAuthentication.OPTIONAL;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static scaffolding.ClientCertificateTestUtils.clientForcingCertificate;
 import static scaffolding.ClientUtils.call;
 import static scaffolding.ClientUtils.request;
 
@@ -98,6 +116,155 @@ public class MuSeBootstrapTest {
         } finally {
             instance.stop().toCompletableFuture().get(10, TimeUnit.SECONDS);
         }
+    }
+
+    @Test
+    public void httpsNoneDoesNotRequestAClientCertificate() throws Exception {
+        AtomicBoolean certificateWasRequested = new AtomicBoolean();
+        AtomicBoolean certificateWasChecked = new AtomicBoolean();
+        SeBootstrap.Instance instance = startHttps(NONE, recordingTrustManager(certificateWasChecked, false));
+        try {
+            try (Response response = clientForcingCertificate("client.p12", certificateWasRequested)
+                .newCall(request(resourceUri(instance)).build()).execute()) {
+                assertThat(response.code(), is(200));
+            }
+            assertFalse("The server should not have requested a client certificate",
+                certificateWasRequested.get());
+            assertFalse("The server should not have checked a client certificate",
+                certificateWasChecked.get());
+        } finally {
+            stop(instance);
+        }
+    }
+
+    @Test
+    public void httpsOptionalAcceptsMissingCertificatesAndValidatesPresentedCertificates() throws Exception {
+        AtomicBoolean certificateWasChecked = new AtomicBoolean();
+        SeBootstrap.Instance instance = startHttps(
+            OPTIONAL, recordingTrustManager(certificateWasChecked, false));
+        try {
+            try (Response response = call(request(resourceUri(instance)))) {
+                assertThat(response.code(), is(200));
+            }
+            assertFalse(certificateWasChecked.get());
+
+            try (Response response = clientForcingCertificate("client.p12")
+                .newCall(request(resourceUri(instance)).build()).execute()) {
+                assertThat(response.code(), is(200));
+            }
+            assertTrue(certificateWasChecked.get());
+        } finally {
+            stop(instance);
+        }
+    }
+
+    @Test
+    public void httpsMandatoryRejectsMissingCertificatesAndAcceptsValidCertificates() throws Exception {
+        AtomicBoolean certificateWasChecked = new AtomicBoolean();
+        SeBootstrap.Instance instance = startHttps(
+            MANDATORY, recordingTrustManager(certificateWasChecked, false));
+        try {
+            assertConnectionFails(instance, ClientUtils.client);
+
+            try (Response response = clientForcingCertificate("client.p12")
+                .newCall(request(resourceUri(instance)).build()).execute()) {
+                assertThat(response.code(), is(200));
+            }
+            assertTrue(certificateWasChecked.get());
+        } finally {
+            stop(instance);
+        }
+    }
+
+    @Test
+    public void httpsOptionalRejectsPresentedUntrustedCertificates() throws Exception {
+        assertPresentedUntrustedCertificateIsRejected(OPTIONAL);
+    }
+
+    @Test
+    public void httpsMandatoryRejectsPresentedUntrustedCertificates() throws Exception {
+        assertPresentedUntrustedCertificateIsRejected(MANDATORY);
+    }
+
+    private static void assertPresentedUntrustedCertificateIsRejected(
+        SeBootstrap.Configuration.SSLClientAuthentication authentication) throws Exception {
+        AtomicBoolean certificateWasChecked = new AtomicBoolean();
+        SeBootstrap.Instance instance = startHttps(
+            authentication, recordingTrustManager(certificateWasChecked, true));
+        try {
+            assertConnectionFails(instance, clientForcingCertificate("client.p12"));
+            assertTrue("The offered certificate should have been checked", certificateWasChecked.get());
+        } finally {
+            stop(instance);
+        }
+    }
+
+    private static SeBootstrap.Instance startHttps(
+        SeBootstrap.Configuration.SSLClientAuthentication authentication,
+        X509TrustManager trustManager) throws Exception {
+        SeBootstrap.Configuration configuration = SeBootstrap.Configuration.builder()
+            .protocol("HTTPS")
+            .host("localhost")
+            .port(SeBootstrap.Configuration.FREE_PORT)
+            .sslContext(serverSslContext(trustManager))
+            .sslClientAuthentication(authentication)
+            .build();
+        return SeBootstrap.start(new TestApplication(), configuration)
+            .toCompletableFuture().get(10, TimeUnit.SECONDS);
+    }
+
+    private static SSLContext serverSslContext(X509TrustManager trustManager) throws Exception {
+        char[] password = "Very5ecure".toCharArray();
+        KeyStore keyStore = KeyStore.getInstance("PKCS12");
+        try (InputStream inputStream = MuSeBootstrapTest.class.getResourceAsStream(
+            "/io/muserver/resources/localhost.p12")) {
+            keyStore.load(inputStream, password);
+        }
+        KeyManagerFactory factory = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
+        factory.init(keyStore, password);
+        SSLContext context = SSLContext.getInstance("TLS");
+        context.init(factory.getKeyManagers(), new X509TrustManager[]{trustManager}, null);
+        return context;
+    }
+
+    private static X509TrustManager recordingTrustManager(
+        AtomicBoolean certificateWasChecked, boolean reject) {
+        return new X509TrustManager() {
+            @Override
+            public void checkClientTrusted(X509Certificate[] chain, String authType)
+                throws CertificateException {
+                certificateWasChecked.set(true);
+                if (reject) {
+                    throw new CertificateException("Client certificate is not trusted");
+                }
+            }
+
+            @Override
+            public void checkServerTrusted(X509Certificate[] chain, String authType) {
+            }
+
+            @Override
+            public X509Certificate[] getAcceptedIssuers() {
+                return new X509Certificate[0];
+            }
+        };
+    }
+
+    private static URI resourceUri(SeBootstrap.Instance instance) {
+        return instance.configuration().baseUriBuilder().path("application/resource").build();
+    }
+
+    private static void assertConnectionFails(SeBootstrap.Instance instance, OkHttpClient client)
+        throws Exception {
+        try (Response ignored = client.newCall(request(resourceUri(instance)).build()).execute()) {
+            fail("Expected the TLS handshake to fail");
+        } catch (IOException expected) {
+            // Expected: client authentication failed during the TLS handshake.
+        }
+    }
+
+    private static void stop(SeBootstrap.Instance instance) throws Exception {
+        instance.stop().toCompletableFuture().get(10, TimeUnit.SECONDS);
     }
 
     @ApplicationPath("application")

--- a/src/test/java/scaffolding/ClientCertificateTestUtils.java
+++ b/src/test/java/scaffolding/ClientCertificateTestUtils.java
@@ -1,0 +1,109 @@
+package scaffolding;
+
+import okhttp3.OkHttpClient;
+
+import javax.net.ssl.KeyManager;
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.X509KeyManager;
+import javax.net.ssl.X509TrustManager;
+import java.io.InputStream;
+import java.net.Socket;
+import java.security.KeyStore;
+import java.security.Principal;
+import java.security.PrivateKey;
+import java.security.cert.X509Certificate;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public final class ClientCertificateTestUtils {
+    private ClientCertificateTestUtils() {
+    }
+
+    public static OkHttpClient clientWithCertificate(String certFilename) throws Exception {
+        SSLContext sslContext = ClientUtils.getPKCS12Context(
+            "/client-certs/" + certFilename, "export password");
+        return new OkHttpClient.Builder()
+            .sslSocketFactory(sslContext.getSocketFactory(), ClientUtils.veryTrustingTrustManager())
+            .build();
+    }
+
+    public static OkHttpClient clientForcingCertificate(String certFilename) throws Exception {
+        return clientForcingCertificate(certFilename, new AtomicBoolean());
+    }
+
+    public static OkHttpClient clientForcingCertificate(
+        String certFilename, AtomicBoolean certificateWasRequested) throws Exception {
+        char[] password = "export password".toCharArray();
+        KeyStore keyStore = KeyStore.getInstance("PKCS12");
+        try (InputStream inputStream = ClientCertificateTestUtils.class.getResourceAsStream(
+            "/client-certs/" + certFilename)) {
+            keyStore.load(inputStream, password);
+        }
+        String alias = keyStore.aliases().nextElement();
+        KeyManagerFactory factory = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
+        factory.init(keyStore, password);
+        X509KeyManager delegate = null;
+        for (KeyManager keyManager : factory.getKeyManagers()) {
+            if (keyManager instanceof X509KeyManager) {
+                delegate = (X509KeyManager) keyManager;
+                break;
+            }
+        }
+        if (delegate == null) {
+            throw new IllegalStateException("No X509KeyManager was created");
+        }
+        X509KeyManager forcedKeyManager = new ForcedClientAliasKeyManager(
+            delegate, alias, certificateWasRequested);
+        SSLContext sslContext = SSLContext.getInstance("TLS");
+        sslContext.init(new KeyManager[]{forcedKeyManager},
+            new X509TrustManager[]{ClientUtils.veryTrustingTrustManager()}, null);
+        return new OkHttpClient.Builder()
+            .retryOnConnectionFailure(false)
+            .sslSocketFactory(sslContext.getSocketFactory(), ClientUtils.veryTrustingTrustManager())
+            .build();
+    }
+
+    private static class ForcedClientAliasKeyManager implements X509KeyManager {
+        private final X509KeyManager delegate;
+        private final String clientAlias;
+        private final AtomicBoolean certificateWasRequested;
+
+        private ForcedClientAliasKeyManager(X509KeyManager delegate, String clientAlias,
+                                            AtomicBoolean certificateWasRequested) {
+            this.delegate = delegate;
+            this.clientAlias = clientAlias;
+            this.certificateWasRequested = certificateWasRequested;
+        }
+
+        @Override
+        public String[] getClientAliases(String keyType, Principal[] issuers) {
+            return delegate.getClientAliases(keyType, issuers);
+        }
+
+        @Override
+        public String chooseClientAlias(String[] keyType, Principal[] issuers, Socket socket) {
+            certificateWasRequested.set(true);
+            return clientAlias;
+        }
+
+        @Override
+        public String[] getServerAliases(String keyType, Principal[] issuers) {
+            return delegate.getServerAliases(keyType, issuers);
+        }
+
+        @Override
+        public String chooseServerAlias(String keyType, Principal[] issuers, Socket socket) {
+            return delegate.chooseServerAlias(keyType, issuers, socket);
+        }
+
+        @Override
+        public X509Certificate[] getCertificateChain(String alias) {
+            return delegate.getCertificateChain(alias);
+        }
+
+        @Override
+        public PrivateKey getPrivateKey(String alias) {
+            return delegate.getPrivateKey(alias);
+        }
+    }
+}


### PR DESCRIPTION
## What changed

- add `ClientCertificateAuthentication` with `NONE`, `OPTIONAL`, and `MANDATORY`
- add `HttpsConfigBuilder.withClientCertificateAuthentication(...)`
- preserve legacy behavior where configuring a client trust manager alone enables optional authentication
- support explicit client-authentication modes when using either a Mu-built or prebuilt `SSLContext`
- make Jakarta REST `SeBootstrap.Configuration.sslClientAuthentication()` effective for all three standard values
- clarify that a presented certificate which fails validation aborts the TLS handshake

## Compatibility and behavior

- no explicit mode and no trust manager remains `NONE`
- no explicit mode with a trust manager remains `OPTIONAL`
- explicit `NONE` with a trust manager is rejected as contradictory
- `OPTIONAL` and `MANDATORY` without a separate trust manager are allowed with a supplied `SSLContext`, whose embedded trust managers validate certificates
- the historical supplied-`SSLContext` plus legacy trust-manager signaling behavior is preserved
- HTTPS configuration reload changes the policy for newly accepted connections

`OPTIONAL` follows standard JSSE/Netty want-client-auth semantics: clients may omit a certificate, but a certificate that is presented must validate.

## Validation

- existing `ClientCertTest` compatibility suite passed before and after the implementation
- new direct tests cover missing, valid, and presented-untrusted certificates for every mode
- SeBootstrap tests cover `NONE`, `OPTIONAL`, and `MANDATORY` with a supplied `SSLContext`
- focused TLS suites pass on Java 11
- full Mu test suite passes on Java 11
- `git diff --check` passes