### PR TITLE
Fix JAX-RS header and cookie serialization

### DIFF
--- a/src/main/java/io/muserver/rest/JaxRSResponse.java
+++ b/src/main/java/io/muserver/rest/JaxRSResponse.java
@@ -415,12 +415,11 @@ class JaxRSResponse extends Response implements ContainerResponseContext, Writer
         if (value == null || value instanceof String) {
             return (String)value;
         }
-        try {
-            RuntimeDelegate.HeaderDelegate headerDelegate = MuRuntimeDelegate.getInstance().createHeaderDelegate(value.getClass());
+        RuntimeDelegate.HeaderDelegate headerDelegate = MuRuntimeDelegate.getInstance().createHeaderDelegate(value.getClass());
+        if (headerDelegate != null) {
             return headerDelegate.toString(value);
-        } catch (MuException e) {
-            return value.toString();
         }
+        return value.toString();
     }
 
     private static String headerValueToNonNullString(Object value) {

--- a/src/main/java/io/muserver/rest/MuRuntimeDelegate.java
+++ b/src/main/java/io/muserver/rest/MuRuntimeDelegate.java
@@ -155,13 +155,13 @@ public class MuRuntimeDelegate extends RuntimeDelegate {
 
     @Override
     @SuppressWarnings("unchecked")
-    public <T> HeaderDelegate<T> createHeaderDelegate(Class<T> type) throws IllegalArgumentException {
+    public <T> @Nullable HeaderDelegate<T> createHeaderDelegate(Class<T> type) throws IllegalArgumentException {
         Mutils.notNull("type", type);
         HeaderDelegate<T> headerDelegate = headerDelegates.get(type);
         if (headerDelegate != null) {
             return (HeaderDelegate<T>) headerDelegate;
         }
-        throw new MuException("MuServer does not support converting " + type.getName());
+        return null;
     }
 
     @Override

--- a/src/main/java/io/muserver/rest/NewCookieHeaderDelegate.java
+++ b/src/main/java/io/muserver/rest/NewCookieHeaderDelegate.java
@@ -93,7 +93,16 @@ class NewCookieHeaderDelegate implements RuntimeDelegate.HeaderDelegate<NewCooki
         if (ss != null) {
             nettyCookie.setSameSite(toNetty(ss));
         }
-        return encoder.encode(nettyCookie);
+        String encoded = encoder.encode(nettyCookie);
+        String comment = cookie.getComment();
+        return comment == null ? encoded : encoded + "; Comment=\"" + escapeQuotedString(comment) + "\"";
+    }
+
+    private static String escapeQuotedString(String value) {
+        if (value.indexOf('\r') >= 0 || value.indexOf('\n') >= 0) {
+            throw new IllegalArgumentException("Cookie comments cannot contain CR or LF characters");
+        }
+        return value.replace("\\", "\\\\").replace("\"", "\\\"");
     }
 
     private CookieHeaderNames.SameSite toNetty(NewCookie.SameSite ss) {

--- a/src/test/java/io/muserver/rest/JaxRSResponseTest.java
+++ b/src/test/java/io/muserver/rest/JaxRSResponseTest.java
@@ -293,6 +293,14 @@ public class JaxRSResponseTest {
     }
 
     @Test
+    public void getHeaderStringFallsBackToToStringWhenNoHeaderDelegateExists() {
+        Response response = JaxRSResponse.ok().header("X-Value", new StringBuilder("value")).build();
+
+        assertThat(MuRuntimeDelegate.getInstance().createHeaderDelegate(StringBuilder.class), is(nullValue()));
+        assertThat(response.getHeaderString("X-Value"), is("value"));
+    }
+
+    @Test
     public void getHeaderStringTreatsAnEmptyValueListAsPresentWithoutAValue() {
         Response response = JaxRSResponse.ok().build();
         response.getHeaders().put("X-Empty", new java.util.ArrayList<>());

--- a/src/test/java/io/muserver/rest/NewCookieHeaderDelegateTest.java
+++ b/src/test/java/io/muserver/rest/NewCookieHeaderDelegateTest.java
@@ -17,7 +17,7 @@ public class NewCookieHeaderDelegateTest {
             .value("ha%20ha")
             .path("/what")
             .domain("example.org")
-            .comment("Comments are ignored")
+            .comment("Comments are serialized")
             .maxAge(1234567)
             .secure(true)
             .httpOnly(true)
@@ -25,7 +25,8 @@ public class NewCookieHeaderDelegateTest {
             .build();
         String headerValue = delegate.toString(newCookie);
         assertThat(headerValue, startsWith("Blah=ha%20ha; Max-Age=1234567; Expires="));
-        assertThat(headerValue, endsWith("; Path=/what; Domain=example.org; Secure; HTTPOnly; SameSite=Strict"));
+        assertThat(headerValue, containsString("; Path=/what; Domain=example.org; Secure; HTTPOnly; SameSite=Strict"));
+        assertThat(headerValue, containsString("; Comment=\"Comments are serialized\""));
         NewCookie recreated = delegate.fromString(headerValue);
         assertThat(recreated.getName(), equalTo("Blah"));
         assertThat(recreated.getValue(), equalTo("ha%20ha"));
@@ -37,6 +38,26 @@ public class NewCookieHeaderDelegateTest {
         assertThat(recreated.getComment(), is(nullValue()));
         assertThat(recreated.getVersion(), is(1));
         assertThat(recreated.getSameSite(), is(NewCookie.SameSite.STRICT));
+    }
+
+    @Test
+    public void quotesAndEscapesComments() {
+        NewCookie cookie = new NewCookie.Builder("name")
+            .value("value")
+            .comment("A \"quoted\" \\ comment")
+            .build();
+
+        assertThat(delegate.toString(cookie), is("name=value; Comment=\"A \\\"quoted\\\" \\\\ comment\""));
+    }
+
+    @Test
+    public void rejectsLineBreaksInComments() {
+        NewCookie cookie = new NewCookie.Builder("name")
+            .value("value")
+            .comment("unsafe\r\ncomment")
+            .build();
+
+        assertThrows(IllegalArgumentException.class, () -> delegate.toString(cookie));
     }
 
     @Test


### PR DESCRIPTION
## Summary

- return no `HeaderDelegate` for unsupported header-value types so Jakarta REST callers use `toString()`
- serialize `NewCookie` comments as safely quoted `Comment` attributes
- reject CR/LF in cookie comments to prevent response-header injection

## Root cause

`MuRuntimeDelegate#createHeaderDelegate` threw for unsupported types, preventing the API-required fallback. Netty's cookie encoder does not emit the JAX-RS `NewCookie` comment field.

## Validation

- `mise exec java@temurin-11 -- mvn -f pom.xml -Dtest=NewCookieHeaderDelegateTest,JaxRSResponseTest test`
- Jakarta REST 3.1 focused TCK: `core/headers,api/rs/core/newcookie` (35 passed; 6 expected field-injection blocks; no failures)

The corresponding harness expectations were updated directly on `mu-jaxrs-tck-harness` main (`98a1e4b`).