### PR TITLE
Add JAX-RS XML Source entity providers

### DIFF
--- a/src/main/java/io/muserver/rest/CombinedMediaType.java
+++ b/src/main/java/io/muserver/rest/CombinedMediaType.java
@@ -28,7 +28,7 @@ class CombinedMediaType implements Comparable<CombinedMediaType> {
         this.qs = qs;
         this.d = d;
         this.isWildcardType = "*".equals(type);
-        this.isWildcardSubtype = "*".equals(subType);
+        this.isWildcardSubtype = subType != null && MediaTypeHeaderDelegate.isWildcardSubtype(subType);
         this.charset = charset;
     }
 
@@ -37,18 +37,21 @@ class CombinedMediaType implements Comparable<CombinedMediaType> {
     }
 
     public static CombinedMediaType s(MediaType clientType, MediaType serverType) {
-        if (!clientType.isCompatible(serverType)) {
+        if (!MediaTypeHeaderDelegate.isCompatible(clientType, serverType)) {
             return NONMATCH;
         }
         String type = clientType.isWildcardType() ? serverType.getType() : clientType.getType();
-        String sub = clientType.isWildcardSubtype() ? serverType.getSubtype() : clientType.getSubtype();
+        String sub = MediaTypeHeaderDelegate.isWildcardSubtype(clientType.getSubtype())
+            ? serverType.getSubtype()
+            : clientType.getSubtype();
         double q = Double.parseDouble(clientType.getParameters().getOrDefault("q", "1.0"));
         double qs = Double.parseDouble(serverType.getParameters().getOrDefault("qs", "1.0"));
         int d = 0;
         if (clientType.isWildcardType() ^ serverType.isWildcardType()) {
             d++;
         }
-        if (clientType.isWildcardSubtype() ^ serverType.isWildcardSubtype()) {
+        if (MediaTypeHeaderDelegate.isWildcardSubtype(clientType.getSubtype())
+            ^ MediaTypeHeaderDelegate.isWildcardSubtype(serverType.getSubtype())) {
             d++;
         }
         return new CombinedMediaType(type, sub, q, qs, d, serverType.getParameters().get("charset"));

--- a/src/main/java/io/muserver/rest/EntityProviders.java
+++ b/src/main/java/io/muserver/rest/EntityProviders.java
@@ -48,10 +48,16 @@ class EntityProviders {
 
     private static int mediaTypeSpecificity(ProviderWrapper<?> provider, MediaType requestedType) {
         return provider.mediaTypes.stream()
-            .filter(mediaType -> mediaType.isCompatible(requestedType))
-            .mapToInt(mediaType -> mediaType.isWildcardType() ? 2 : mediaType.isWildcardSubtype() ? 1 : 0)
+            .filter(mediaType -> MediaTypeHeaderDelegate.isCompatible(mediaType, requestedType))
+            .mapToInt(EntityProviders::mediaTypeSpecificity)
             .min()
             .orElse(2);
+    }
+
+    private static int mediaTypeSpecificity(MediaType mediaType) {
+        return mediaType.isWildcardType()
+            ? 2
+            : MediaTypeHeaderDelegate.isWildcardSubtype(mediaType.getSubtype()) ? 1 : 0;
     }
 
     private static Class<?> box(Class<?> type) {
@@ -89,8 +95,8 @@ class EntityProviders {
                 }
 
                 // and a secondary key of media type
-                Integer min1 = o1.mediaTypes.stream().map(mt -> mt.isWildcardType() ? 2 : mt.isWildcardSubtype() ? 1 : 0).min(Comparator.naturalOrder()).orElse(2);
-                Integer min2 = o2.mediaTypes.stream().map(mt -> mt.isWildcardType() ? 2 : mt.isWildcardSubtype() ? 1 : 0).min(Comparator.naturalOrder()).orElse(2);
+                Integer min1 = o1.mediaTypes.stream().map(EntityProviders::mediaTypeSpecificity).min(Comparator.naturalOrder()).orElse(2);
+                Integer min2 = o2.mediaTypes.stream().map(EntityProviders::mediaTypeSpecificity).min(Comparator.naturalOrder()).orElse(2);
                 int mtCompare = min1.compareTo(min2);
                 if (mtCompare != 0) {
                     return mtCompare;

--- a/src/main/java/io/muserver/rest/EntityProviders.java
+++ b/src/main/java/io/muserver/rest/EntityProviders.java
@@ -121,6 +121,7 @@ class EntityProviders {
         readers.addAll(StringEntityProviders.stringEntityReaders);
         readers.addAll(PrimitiveEntityProvider.primitiveEntryProviders);
         readers.addAll(BinaryEntityProviders.binaryEntityReaders);
+        readers.addAll(SourceEntityProviders.sourceEntityReaders);
         return readers;
     }
     public static List<MessageBodyWriter> builtInWriters() {
@@ -128,6 +129,7 @@ class EntityProviders {
         writers.addAll(StringEntityProviders.stringEntityWriters);
         writers.addAll(PrimitiveEntityProvider.primitiveEntryProviders);
         writers.addAll(BinaryEntityProviders.binaryEntityWriters);
+        writers.addAll(SourceEntityProviders.sourceEntityWriters);
         return writers;
     }
 

--- a/src/main/java/io/muserver/rest/MediaTypeDeterminer.java
+++ b/src/main/java/io/muserver/rest/MediaTypeDeterminer.java
@@ -65,7 +65,7 @@ class MediaTypeDeterminer {
             for (MediaType mediaTypeP : p) {
                 //  If a is compatible with p, add S(a,p) to M, where the function S returns the most specific media
                 //  type of the pair with the q-value of a and server-side qs-value of p.
-                if (mediaTypeA.isCompatible(mediaTypeP)) {
+                if (MediaTypeHeaderDelegate.isCompatible(mediaTypeA, mediaTypeP)) {
                     m.add(CombinedMediaType.s(mediaTypeA, mediaTypeP));
                 }
             }
@@ -88,7 +88,7 @@ class MediaTypeDeterminer {
 
         // 9. If M contains ‘*/*’ or ‘application/*’, set Mselected = ‘application/octet-stream’, finish
         for (CombinedMediaType mediaType : m) {
-            if ((mediaType.isWildcardType || "application".equals(mediaType.type)) && mediaType.isWildcardSubtype) {
+            if ((mediaType.isWildcardType || "application".equals(mediaType.type)) && "*".equals(mediaType.subType)) {
                 return MediaType.APPLICATION_OCTET_STREAM_TYPE;
             }
         }

--- a/src/main/java/io/muserver/rest/MediaTypeHeaderDelegate.java
+++ b/src/main/java/io/muserver/rest/MediaTypeHeaderDelegate.java
@@ -43,10 +43,36 @@ class MediaTypeHeaderDelegate implements RuntimeDelegate.HeaderDelegate<MediaTyp
         return results;
     }
 
+    // MediaType only treats a bare "*" subtype as a wildcard, while the standard XML entity providers
+    // are required to support media types of the form application/*+xml.
+    static boolean isCompatible(MediaType first, MediaType second) {
+        if (first.isCompatible(second)) {
+            return true;
+        }
+        boolean typesCompatible = first.getType().equalsIgnoreCase(second.getType())
+            || first.isWildcardType()
+            || second.isWildcardType();
+        return typesCompatible
+            && (suffixWildcardMatches(first.getSubtype(), second.getSubtype())
+            || suffixWildcardMatches(second.getSubtype(), first.getSubtype()));
+    }
+
+    static boolean isWildcardSubtype(String subtype) {
+        return "*".equals(subtype) || (subtype.length() > 2 && subtype.startsWith("*+"));
+    }
+
+    private static boolean suffixWildcardMatches(String pattern, String concrete) {
+        return pattern.length() > 2
+            && pattern.startsWith("*+")
+            && concrete.length() > pattern.length() - 1
+            && concrete.regionMatches(true, concrete.length() - pattern.length() + 1,
+            pattern, 1, pattern.length() - 1);
+    }
+
     static boolean atLeastOneCompatible(List<MediaType> providerProduces, List<MediaType> consumerAccepts, @Nullable String checkParameter) {
         for (MediaType clientAccept : consumerAccepts) {
             for (MediaType produce : providerProduces) {
-                boolean compatible = produce.isCompatible(clientAccept);
+                boolean compatible = isCompatible(produce, clientAccept);
                 if (compatible) {
                     if (checkParameter != null) {
                         String clientParam = clientAccept.getParameters().get(checkParameter);

--- a/src/main/java/io/muserver/rest/MuVariantListBuilder.java
+++ b/src/main/java/io/muserver/rest/MuVariantListBuilder.java
@@ -131,7 +131,7 @@ class MuVariantListBuilder extends Variant.VariantListBuilder {
         List<CombinedMediaType> m = new ArrayList<>();
         for (MediaType clientAccepts : acceptableMediaTypes) {
             for (MediaType serverProduces : candidates) {
-                if (clientAccepts.isCompatible(serverProduces)) {
+                if (MediaTypeHeaderDelegate.isCompatible(clientAccepts, serverProduces)) {
                     CombinedMediaType combined = CombinedMediaType.s(clientAccepts, serverProduces);
                     combinedToServerType.put(combined, serverProduces);
                     m.add(combined);

--- a/src/main/java/io/muserver/rest/ProviderWrapper.java
+++ b/src/main/java/io/muserver/rest/ProviderWrapper.java
@@ -69,7 +69,7 @@ class ProviderWrapper<T> implements Comparable<ProviderWrapper<T>> {
     }
 
     public boolean supports(MediaType mediaType) {
-        return mediaTypes.isEmpty() || mediaTypes.stream().anyMatch(mt -> mt.isCompatible(mediaType));
+        return mediaTypes.isEmpty() || mediaTypes.stream().anyMatch(mt -> MediaTypeHeaderDelegate.isCompatible(mt, mediaType));
     }
 
     @Override

--- a/src/main/java/io/muserver/rest/README.md
+++ b/src/main/java/io/muserver/rest/README.md
@@ -197,7 +197,7 @@ No plan to implement as it would add another dependency.
 - [x] `java.io.Reader` All media types (*/*)
 - [x] `java.io.File` All media types (*/*)
 - [ ] `jakarta.activation.DataSource` Will not implement as Jakarta Activation is an optional dependency
-- [ ] `javax.xml.transform.Source` XML types (text/xml, application/xml and media types of the form application/*+xml)
+- [x] `javax.xml.transform.Source` XML types (text/xml, application/xml and media types of the form application/*+xml)
 - [ ] `jakarta.xml.bind.JAXBElement` and application-supplied JAXB classes XML types (text/xml and application/xml and media types of the form application/*+xml)
 - [x] `MultivaluedMap<String,String>` Form content (application/x-www-form-urlencoded)
 - [ ] `java.util.List<EntityPart>` multipart/form-data `MessageBodyReader` (not started)

--- a/src/main/java/io/muserver/rest/SourceEntityProviders.java
+++ b/src/main/java/io/muserver/rest/SourceEntityProviders.java
@@ -1,6 +1,7 @@
 package io.muserver.rest;
 
 import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.NotSupportedException;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.MediaType;
@@ -9,7 +10,7 @@ import jakarta.ws.rs.ext.MessageBodyReader;
 import jakarta.ws.rs.ext.MessageBodyWriter;
 
 import javax.xml.XMLConstants;
-import javax.xml.transform.Result;
+import javax.xml.transform.OutputKeys;
 import javax.xml.transform.Source;
 import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerException;
@@ -18,9 +19,14 @@ import javax.xml.transform.stream.StreamResult;
 import javax.xml.transform.stream.StreamSource;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.io.OutputStream;
+import java.io.PushbackInputStream;
+import java.io.Reader;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 import static java.util.Collections.singletonList;
@@ -30,33 +36,146 @@ class SourceEntityProviders {
     static final List<MessageBodyReader> sourceEntityReaders = singletonList(new SourceReader());
     static final List<MessageBodyWriter> sourceEntityWriters = singletonList(new SourceWriter());
 
-    @Consumes("*/*")
+    // MediaType only supports a full subtype wildcard, so isReadable narrows application/* to *+xml types.
+    @Consumes({"text/xml", "application/xml", "application/*"})
     static class SourceReader implements MessageBodyReader<Source> {
         @Override
         public boolean isReadable(Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType) {
-            return Source.class.isAssignableFrom(type) && isXml(mediaType);
+            return (type.equals(Source.class) || type.equals(StreamSource.class)) && isXml(mediaType);
         }
 
         @Override
         public Source readFrom(Class<Source> type, Type genericType, Annotation[] annotations, MediaType mediaType,
-                               MultivaluedMap<String, String> httpHeaders, InputStream entityStream) {
-            return new StreamSource(entityStream);
+                               MultivaluedMap<String, String> httpHeaders, InputStream entityStream) throws IOException {
+            String charsetName = mediaType.getParameters().get(MediaType.CHARSET_PARAMETER);
+            if (charsetName == null) {
+                return new StreamSource(entityStream);
+            }
+            return new StreamSource(new BomAwareReader(entityStream, charsetName));
+        }
+
+        private static final class BomAwareReader extends Reader {
+            private final PushbackInputStream input;
+            private final String declaredCharset;
+            private Reader delegate;
+
+            private BomAwareReader(InputStream input, String declaredCharset) {
+                this.input = new PushbackInputStream(input, 4);
+                this.declaredCharset = declaredCharset;
+            }
+
+            @Override
+            public int read(char[] chars, int offset, int length) throws IOException {
+                if (offset < 0 || length < 0 || length > chars.length - offset) {
+                    throw new IndexOutOfBoundsException();
+                }
+                if (length == 0) {
+                    return 0;
+                }
+                return delegate().read(chars, offset, length);
+            }
+
+            @Override
+            public void close() throws IOException {
+                if (delegate == null) {
+                    input.close();
+                } else {
+                    delegate.close();
+                }
+            }
+
+            private Reader delegate() throws IOException {
+                if (delegate == null) {
+                    byte[] prefix = new byte[4];
+                    int length = 0;
+                    while (length < prefix.length) {
+                        int read = input.read(prefix, length, prefix.length - length);
+                        if (read <= 0) {
+                            break;
+                        }
+                        length += read;
+                    }
+
+                    int bomLength = 0;
+                    Charset charset;
+                    if (startsWith(prefix, length, 0x00, 0x00, 0xfe, 0xff)) {
+                        bomLength = 4;
+                        charset = Charset.forName("UTF-32BE");
+                    } else if (startsWith(prefix, length, 0xff, 0xfe, 0x00, 0x00)) {
+                        bomLength = 4;
+                        charset = Charset.forName("UTF-32LE");
+                    } else if (startsWith(prefix, length, 0xef, 0xbb, 0xbf)) {
+                        bomLength = 3;
+                        charset = StandardCharsets.UTF_8;
+                    } else if (startsWith(prefix, length, 0xfe, 0xff)) {
+                        bomLength = 2;
+                        charset = StandardCharsets.UTF_16BE;
+                    } else if (startsWith(prefix, length, 0xff, 0xfe)) {
+                        bomLength = 2;
+                        charset = StandardCharsets.UTF_16LE;
+                    } else {
+                        try {
+                            charset = Charset.forName(declaredCharset);
+                        } catch (IllegalArgumentException e) {
+                            throw new NotSupportedException("Unsupported XML charset " + declaredCharset, e);
+                        }
+                    }
+                    if (length > bomLength) {
+                        input.unread(prefix, bomLength, length - bomLength);
+                    }
+                    delegate = new InputStreamReader(input, charset);
+                }
+                return delegate;
+            }
+
+            private static boolean startsWith(byte[] actual, int actualLength, int... expected) {
+                if (actualLength < expected.length) {
+                    return false;
+                }
+                for (int i = 0; i < expected.length; i++) {
+                    if ((actual[i] & 0xff) != expected[i]) {
+                        return false;
+                    }
+                }
+                return true;
+            }
         }
     }
 
-    @Produces("*/*")
+    // application/* makes structured-suffix types candidates; isWriteable performs the final XML-only check.
+    @Produces({"application/xml", "text/xml;qs=0.9", "application/*;qs=0.8"})
     static class SourceWriter implements MessageBodyWriter<Source> {
         @Override
         public boolean isWriteable(Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType) {
-            return Source.class.isAssignableFrom(type) && isXml(mediaType);
+            return Source.class.isAssignableFrom(type) && (mediaType.isWildcardType() || isXml(mediaType));
         }
 
         @Override
         public void writeTo(Source source, Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType,
                             MultivaluedMap<String, Object> httpHeaders, OutputStream entityStream) throws IOException, WebApplicationException {
             try {
-                newTransformer().transform(source, new StreamResult(entityStream));
+                Charset charset;
+                try {
+                    charset = EntityProviders.charsetFor(mediaType);
+                } catch (IllegalArgumentException e) {
+                    charset = StandardCharsets.UTF_8;
+                    httpHeaders.putSingle("content-type", mediaType.withCharset("utf-8"));
+                }
+                Transformer transformer = newTransformer();
+                transformer.setOutputProperty(OutputKeys.ENCODING, charset.name());
+                transformer.transform(source, new StreamResult(entityStream));
             } catch (TransformerException e) {
+                Throwable cause = e;
+                while (cause != null) {
+                    if (cause instanceof NotSupportedException) {
+                        throw (NotSupportedException) cause;
+                    }
+                    Throwable next = cause.getCause();
+                    if (next == cause) {
+                        break;
+                    }
+                    cause = next;
+                }
                 throw new IOException("Could not write XML source", e);
             }
         }
@@ -71,11 +190,13 @@ class SourceEntityProviders {
     }
 
     private static boolean isXml(MediaType mediaType) {
-        if ("text".equalsIgnoreCase(mediaType.getType()) && "xml".equalsIgnoreCase(mediaType.getSubtype())) {
+        String type = mediaType.getType();
+        String subtype = mediaType.getSubtype();
+        if ("text".equalsIgnoreCase(type) && "xml".equalsIgnoreCase(subtype)) {
             return true;
         }
-        return "application".equalsIgnoreCase(mediaType.getType())
-            && ("xml".equalsIgnoreCase(mediaType.getSubtype())
-            || mediaType.getSubtype().toLowerCase(java.util.Locale.ROOT).endsWith("+xml"));
+        return "application".equalsIgnoreCase(type)
+            && ("xml".equalsIgnoreCase(subtype)
+            || (subtype.length() > 4 && subtype.toLowerCase(java.util.Locale.ROOT).endsWith("+xml")));
     }
 }

--- a/src/main/java/io/muserver/rest/SourceEntityProviders.java
+++ b/src/main/java/io/muserver/rest/SourceEntityProviders.java
@@ -1,0 +1,81 @@
+package io.muserver.rest;
+
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.ext.MessageBodyReader;
+import jakarta.ws.rs.ext.MessageBodyWriter;
+
+import javax.xml.XMLConstants;
+import javax.xml.transform.Result;
+import javax.xml.transform.Source;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerException;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.stream.StreamResult;
+import javax.xml.transform.stream.StreamSource;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.util.List;
+
+import static java.util.Collections.singletonList;
+
+class SourceEntityProviders {
+
+    static final List<MessageBodyReader> sourceEntityReaders = singletonList(new SourceReader());
+    static final List<MessageBodyWriter> sourceEntityWriters = singletonList(new SourceWriter());
+
+    @Consumes("*/*")
+    static class SourceReader implements MessageBodyReader<Source> {
+        @Override
+        public boolean isReadable(Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType) {
+            return Source.class.isAssignableFrom(type) && isXml(mediaType);
+        }
+
+        @Override
+        public Source readFrom(Class<Source> type, Type genericType, Annotation[] annotations, MediaType mediaType,
+                               MultivaluedMap<String, String> httpHeaders, InputStream entityStream) {
+            return new StreamSource(entityStream);
+        }
+    }
+
+    @Produces("*/*")
+    static class SourceWriter implements MessageBodyWriter<Source> {
+        @Override
+        public boolean isWriteable(Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType) {
+            return Source.class.isAssignableFrom(type) && isXml(mediaType);
+        }
+
+        @Override
+        public void writeTo(Source source, Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType,
+                            MultivaluedMap<String, Object> httpHeaders, OutputStream entityStream) throws IOException, WebApplicationException {
+            try {
+                newTransformer().transform(source, new StreamResult(entityStream));
+            } catch (TransformerException e) {
+                throw new IOException("Could not write XML source", e);
+            }
+        }
+
+        private static Transformer newTransformer() throws TransformerException {
+            TransformerFactory factory = TransformerFactory.newInstance();
+            factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+            factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+            factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_STYLESHEET, "");
+            return factory.newTransformer();
+        }
+    }
+
+    private static boolean isXml(MediaType mediaType) {
+        if ("text".equalsIgnoreCase(mediaType.getType()) && "xml".equalsIgnoreCase(mediaType.getSubtype())) {
+            return true;
+        }
+        return "application".equalsIgnoreCase(mediaType.getType())
+            && ("xml".equalsIgnoreCase(mediaType.getSubtype())
+            || mediaType.getSubtype().toLowerCase(java.util.Locale.ROOT).endsWith("+xml"));
+    }
+}

--- a/src/main/java/io/muserver/rest/SourceEntityProviders.java
+++ b/src/main/java/io/muserver/rest/SourceEntityProviders.java
@@ -8,6 +8,7 @@ import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.MultivaluedMap;
 import jakarta.ws.rs.ext.MessageBodyReader;
 import jakarta.ws.rs.ext.MessageBodyWriter;
+import org.jspecify.annotations.Nullable;
 
 import javax.xml.XMLConstants;
 import javax.xml.transform.OutputKeys;
@@ -28,6 +29,7 @@ import java.lang.reflect.Type;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
+import java.util.Objects;
 
 import static java.util.Collections.singletonList;
 
@@ -56,7 +58,7 @@ class SourceEntityProviders {
         private static final class BomAwareReader extends Reader {
             private final PushbackInputStream input;
             private final String declaredCharset;
-            private Reader delegate;
+            private @Nullable Reader delegate;
 
             private BomAwareReader(InputStream input, String declaredCharset) {
                 this.input = new PushbackInputStream(input, 4);
@@ -76,15 +78,17 @@ class SourceEntityProviders {
 
             @Override
             public void close() throws IOException {
-                if (delegate == null) {
+                Reader current = delegate;
+                if (current == null) {
                     input.close();
                 } else {
-                    delegate.close();
+                    current.close();
                 }
             }
 
             private Reader delegate() throws IOException {
-                if (delegate == null) {
+                Reader current = delegate;
+                if (current == null) {
                     byte[] prefix = new byte[4];
                     int length = 0;
                     while (length < prefix.length) {
@@ -122,9 +126,10 @@ class SourceEntityProviders {
                     if (length > bomLength) {
                         input.unread(prefix, bomLength, length - bomLength);
                     }
-                    delegate = new InputStreamReader(input, charset);
+                    current = new InputStreamReader(input, charset);
+                    delegate = current;
                 }
-                return delegate;
+                return current;
             }
 
             private static boolean startsWith(byte[] actual, int actualLength, int... expected) {
@@ -169,7 +174,7 @@ class SourceEntityProviders {
                         throw (NotSupportedException) cause;
                     }
                     Throwable next = cause.getCause();
-                    if (next == cause) {
+                    if (Objects.equals(next, cause)) {
                         break;
                     }
                     cause = next;

--- a/src/main/java/io/muserver/rest/SourceEntityProviders.java
+++ b/src/main/java/io/muserver/rest/SourceEntityProviders.java
@@ -36,8 +36,7 @@ class SourceEntityProviders {
     static final List<MessageBodyReader> sourceEntityReaders = singletonList(new SourceReader());
     static final List<MessageBodyWriter> sourceEntityWriters = singletonList(new SourceWriter());
 
-    // MediaType only supports a full subtype wildcard, so isReadable narrows application/* to *+xml types.
-    @Consumes({"text/xml", "application/xml", "application/*"})
+    @Consumes({"text/xml", "application/xml", "application/*+xml"})
     static class SourceReader implements MessageBodyReader<Source> {
         @Override
         public boolean isReadable(Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType) {
@@ -142,8 +141,7 @@ class SourceEntityProviders {
         }
     }
 
-    // application/* makes structured-suffix types candidates; isWriteable performs the final XML-only check.
-    @Produces({"application/xml", "text/xml;qs=0.9", "application/*;qs=0.8"})
+    @Produces({"application/xml", "text/xml;qs=0.9", "application/*+xml;qs=0.8"})
     static class SourceWriter implements MessageBodyWriter<Source> {
         @Override
         public boolean isWriteable(Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType) {

--- a/src/test/java/io/muserver/rest/CombinedMediaTypeTest.java
+++ b/src/test/java/io/muserver/rest/CombinedMediaTypeTest.java
@@ -50,6 +50,27 @@ public class CombinedMediaTypeTest {
     }
 
     @Test
+    public void structuredSuffixWildcardMatchesAConcreteSubtype() {
+        CombinedMediaType combined = CombinedMediaType.s(
+            delegate.fromString("application/vnd.mu+xml"),
+            delegate.fromString("application/*+xml"));
+
+        assertThat(combined.type, equalTo("application"));
+        assertThat(combined.subType, equalTo("vnd.mu+xml"));
+        assertThat(combined.d, equalTo(1));
+        assertThat(combined.isConcrete(), equalTo(true));
+    }
+
+    @Test
+    public void structuredSuffixWildcardDoesNotMatchAnotherSubtype() {
+        CombinedMediaType combined = CombinedMediaType.s(
+            delegate.fromString("application/json"),
+            delegate.fromString("application/*+xml"));
+
+        assertThat(combined, sameInstance(CombinedMediaType.NONMATCH));
+    }
+
+    @Test
     public void specificIsABetterMatchThanAWildcard() {
         CombinedMediaType[] sample = new CombinedMediaType[]{
             t("*", "*", 0.5, 0.5, 0),

--- a/src/test/java/io/muserver/rest/EntityProvidersTest.java
+++ b/src/test/java/io/muserver/rest/EntityProvidersTest.java
@@ -75,11 +75,11 @@ public class EntityProvidersTest {
             @POST
             @Consumes({
                 "text/xml", "application/xml", "application/atom+xml",
-                "application/svg+xml", "application/vnd.mu+xml", "application/*+xml"
+                "application/svg+xml", "application/vnd.mu+xml"
             })
             @Produces({
                 "text/xml", "application/xml", "application/atom+xml",
-                "application/svg+xml", "application/vnd.mu+xml", "application/*+xml"
+                "application/svg+xml", "application/vnd.mu+xml"
             })
             public Source echo(Source source) {
                 return source;
@@ -95,7 +95,7 @@ public class EntityProvidersTest {
 
             @GET
             @Path("suffix")
-            @Produces("application/vnd.mu+xml")
+            @Produces("application/*+xml")
             public Source suffixXml() {
                 return new StreamSource(new StringReader("<message>suffix</message>"));
             }
@@ -105,7 +105,7 @@ public class EntityProvidersTest {
 
         for (String xmlMediaType : asList(
             "text/xml", "application/xml", "application/atom+xml",
-            "application/svg+xml", "application/vnd.mu+xml", "application/*+xml")) {
+            "application/svg+xml", "application/vnd.mu+xml")) {
             try (Response response = call(request()
                 .header("Accept", xmlMediaType)
                 .post(RequestBody.create("<message>echo</message>", MediaType.get(xmlMediaType)))
@@ -124,7 +124,8 @@ public class EntityProvidersTest {
             assertThat(response.body().string(), Matchers.containsString("<message>stream</message>"));
         }
 
-        try (Response response = call(request(server.uri().resolve("/source/suffix")))) {
+        try (Response response = call(request(server.uri().resolve("/source/suffix"))
+            .header("Accept", "application/vnd.mu+xml"))) {
             assertThat(response.code(), equalTo(200));
             assertThat(response.header("Content-Type"), equalTo("application/vnd.mu+xml"));
             assertThat(response.body().string(), Matchers.containsString("<message>suffix</message>"));
@@ -335,6 +336,11 @@ public class EntityProvidersTest {
             assertThat(response.code(), equalTo(200));
             assertThat(response.header("Content-Type"), equalTo("application/vnd.mu+xml"));
             assertThat(response.body().string(), Matchers.containsString("<message>default</message>"));
+        }
+
+        try (Response response = call(request(server.uri().resolve("/source"))
+            .header("Accept", "application/json"))) {
+            assertThat(response.code(), equalTo(406));
         }
     }
 

--- a/src/test/java/io/muserver/rest/EntityProvidersTest.java
+++ b/src/test/java/io/muserver/rest/EntityProvidersTest.java
@@ -32,10 +32,13 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 import javax.xml.transform.Source;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.sax.SAXSource;
 import javax.xml.transform.stream.StreamSource;
 
 import static io.muserver.Mutils.NEWLINE;
@@ -70,9 +73,23 @@ public class EntityProvidersTest {
         @Path("source")
         class Sample {
             @POST
+            @Consumes({
+                "text/xml", "application/xml", "application/atom+xml",
+                "application/svg+xml", "application/vnd.mu+xml", "application/*+xml"
+            })
+            @Produces({
+                "text/xml", "application/xml", "application/atom+xml",
+                "application/svg+xml", "application/vnd.mu+xml", "application/*+xml"
+            })
+            public Source echo(Source source) {
+                return source;
+            }
+
+            @POST
+            @Path("stream")
             @Consumes("application/xml")
             @Produces("application/xml")
-            public Source echo(Source source) {
+            public Source echoStreamSource(StreamSource source) {
                 return source;
             }
 
@@ -86,18 +103,280 @@ public class EntityProvidersTest {
 
         startServer(new Sample());
 
+        for (String xmlMediaType : asList(
+            "text/xml", "application/xml", "application/atom+xml",
+            "application/svg+xml", "application/vnd.mu+xml", "application/*+xml")) {
+            try (Response response = call(request()
+                .header("Accept", xmlMediaType)
+                .post(RequestBody.create("<message>echo</message>", MediaType.get(xmlMediaType)))
+                .url(server.uri().resolve("/source").toString()))) {
+                assertThat(xmlMediaType, response.code(), equalTo(200));
+                String expectedContentType = xmlMediaType.equals("text/xml") ? "text/xml;charset=utf-8" : xmlMediaType;
+                assertThat(xmlMediaType, response.header("Content-Type"), equalTo(expectedContentType));
+                assertThat(xmlMediaType, response.body().string(), Matchers.containsString("<message>echo</message>"));
+            }
+        }
+
         try (Response response = call(request()
-            .post(RequestBody.create("<message>echo</message>", MediaType.get("application/xml")))
-            .url(server.uri().resolve("/source").toString()))) {
+            .post(RequestBody.create("<message>stream</message>", MediaType.get("application/xml")))
+            .url(server.uri().resolve("/source/stream").toString()))) {
             assertThat(response.code(), equalTo(200));
-            assertThat(response.header("Content-Type"), equalTo("application/xml"));
-            assertThat(response.body().string(), Matchers.containsString("<message>echo</message>"));
+            assertThat(response.body().string(), Matchers.containsString("<message>stream</message>"));
         }
 
         try (Response response = call(request(server.uri().resolve("/source/suffix")))) {
             assertThat(response.code(), equalTo(200));
             assertThat(response.header("Content-Type"), equalTo("application/vnd.mu+xml"));
             assertThat(response.body().string(), Matchers.containsString("<message>suffix</message>"));
+        }
+    }
+
+    @Test
+    public void unsupportedSourceSubtypeIsRejectedBeforeResourceInvocation() throws Exception {
+        AtomicBoolean invoked = new AtomicBoolean();
+        @Path("source")
+        class Sample {
+            @POST
+            @Consumes("application/xml")
+            public String read(DOMSource source) {
+                invoked.set(true);
+                return "unexpected";
+            }
+        }
+        startServer(new Sample());
+
+        try (Response response = call(request()
+            .post(RequestBody.create("<message>dom</message>", MediaType.get("application/xml")))
+            .url(server.uri().resolve("/source").toString()))) {
+            assertThat(response.code(), equalTo(415));
+            assertThat(invoked.get(), Matchers.is(false));
+        }
+    }
+
+    @Test
+    public void sourceReaderHonorsTheRequestCharset() throws Exception {
+        @Path("source")
+        class Sample {
+            @POST
+            @Consumes("application/xml")
+            @Produces("application/xml")
+            public Source echo(Source source) {
+                return source;
+            }
+        }
+        startServer(new Sample());
+        byte[] body = "<message>café</message>".getBytes(StandardCharsets.ISO_8859_1);
+
+        try (Response response = call(request()
+            .post(RequestBody.create(body, MediaType.get("application/xml;charset=ISO-8859-1")))
+            .url(server.uri().resolve("/source").toString()))) {
+            assertThat(response.code(), equalTo(200));
+            assertThat(response.body().string(), Matchers.containsString("<message>café</message>"));
+        }
+    }
+
+    @Test
+    public void sourceReaderLetsABomOverrideTheRequestCharset() throws Exception {
+        @Path("source")
+        class Sample {
+            @POST
+            @Consumes("application/xml")
+            @Produces("application/xml")
+            public Source echo(Source source) {
+                return source;
+            }
+        }
+        startServer(new Sample());
+        byte[] body = "<message>雪</message>".getBytes(StandardCharsets.UTF_16);
+
+        try (Response response = call(request()
+            .post(RequestBody.create(body, MediaType.get("application/xml;charset=ISO-8859-1")))
+            .url(server.uri().resolve("/source").toString()))) {
+            assertThat(response.code(), equalTo(200));
+            assertThat(response.body().string(), Matchers.containsString("<message>雪</message>"));
+        }
+    }
+
+    @Test
+    public void sourceReaderLetsABomOverrideAnUnsupportedRequestCharset() throws Exception {
+        @Path("source")
+        class Sample {
+            @POST
+            @Consumes("application/xml")
+            @Produces("application/xml")
+            public Source echo(Source source) {
+                return source;
+            }
+        }
+        startServer(new Sample());
+        byte[] body = "<message>雪</message>".getBytes(StandardCharsets.UTF_16);
+
+        try (Response response = call(request()
+            .post(RequestBody.create(body, MediaType.get("application/xml;charset=not-a-charset")))
+            .url(server.uri().resolve("/source").toString()))) {
+            assertThat(response.code(), equalTo(200));
+            assertThat(response.body().string(), Matchers.containsString("<message>雪</message>"));
+        }
+    }
+
+    @Test
+    public void sourceReaderRejectsAnUnsupportedRequestCharset() throws Exception {
+        @Path("source")
+        class Sample {
+            @POST
+            @Consumes("application/xml")
+            @Produces("application/xml")
+            public Source echo(Source source) {
+                return source;
+            }
+        }
+        startServer(new Sample());
+
+        try (Response response = call(request()
+            .post(RequestBody.create("<message/>".getBytes(StandardCharsets.UTF_8),
+                MediaType.get("application/xml;charset=not-a-charset")))
+            .url(server.uri().resolve("/source").toString()))) {
+            assertThat(response.code(), equalTo(415));
+        }
+    }
+
+    @Test
+    public void sourceWriterDoesNotResolveExternalEntities() throws Exception {
+        @Path("source")
+        class Sample {
+            @POST
+            @Consumes("application/xml")
+            @Produces("application/xml")
+            public Source echo(Source source) {
+                return source;
+            }
+        }
+        startServer(new Sample());
+        File externalEntity = new File("src/test/resources/something.txt");
+        String body = "<!DOCTYPE message [<!ENTITY xxe SYSTEM \"" + externalEntity.toURI()
+            + "\">]><message>&xxe;</message>";
+
+        try (Response response = call(request()
+            .post(RequestBody.create(body, MediaType.get("application/xml")))
+            .url(server.uri().resolve("/source").toString()))) {
+            assertThat(response.code(), equalTo(500));
+            assertThat(response.body().string(), Matchers.not(Matchers.containsString(
+                "This file exists for ResourceHandler tests.")));
+        }
+    }
+
+    @Test
+    public void sourceProviderAdvertisesOnlyTheTypesAndMediaTypesItCanHandle() {
+        Annotation[] noAnnotations = new Annotation[0];
+        SourceEntityProviders.SourceReader reader = new SourceEntityProviders.SourceReader();
+        SourceEntityProviders.SourceWriter writer = new SourceEntityProviders.SourceWriter();
+        jakarta.ws.rs.core.MediaType applicationXml = jakarta.ws.rs.core.MediaType.APPLICATION_XML_TYPE;
+
+        assertThat(reader.isReadable(Source.class, Source.class, noAnnotations, applicationXml), Matchers.is(true));
+        assertThat(reader.isReadable(StreamSource.class, StreamSource.class, noAnnotations, applicationXml), Matchers.is(true));
+        assertThat(reader.isReadable(DOMSource.class, DOMSource.class, noAnnotations, applicationXml), Matchers.is(false));
+        assertThat(reader.isReadable(SAXSource.class, SAXSource.class, noAnnotations, applicationXml), Matchers.is(false));
+
+        assertThat(writer.isWriteable(StreamSource.class, StreamSource.class, noAnnotations, applicationXml), Matchers.is(true));
+        assertThat(writer.isWriteable(DOMSource.class, DOMSource.class, noAnnotations, applicationXml), Matchers.is(true));
+        assertThat(writer.isWriteable(SAXSource.class, SAXSource.class, noAnnotations, applicationXml), Matchers.is(true));
+        assertThat(writer.isWriteable(StreamSource.class, StreamSource.class, noAnnotations,
+            jakarta.ws.rs.core.MediaType.WILDCARD_TYPE), Matchers.is(true));
+
+        for (String xmlMediaType : asList(
+            "text/xml", "application/xml", "application/vnd.mu+xml", "application/*+xml", "application/vnd.mu+XML")) {
+            String[] typeAndSubtype = xmlMediaType.split("/", 2);
+            jakarta.ws.rs.core.MediaType mediaType =
+                new jakarta.ws.rs.core.MediaType(typeAndSubtype[0], typeAndSubtype[1]);
+            assertThat(xmlMediaType, reader.isReadable(Source.class, Source.class, noAnnotations, mediaType), Matchers.is(true));
+            assertThat(xmlMediaType, writer.isWriteable(StreamSource.class, StreamSource.class, noAnnotations, mediaType), Matchers.is(true));
+        }
+        for (String nonXmlMediaType : asList("text/plain", "application/json", "image/svg+xml", "application/+xml")) {
+            String[] typeAndSubtype = nonXmlMediaType.split("/", 2);
+            jakarta.ws.rs.core.MediaType mediaType =
+                new jakarta.ws.rs.core.MediaType(typeAndSubtype[0], typeAndSubtype[1]);
+            assertThat(nonXmlMediaType, reader.isReadable(Source.class, Source.class, noAnnotations, mediaType), Matchers.is(false));
+            assertThat(nonXmlMediaType, writer.isWriteable(StreamSource.class, StreamSource.class, noAnnotations, mediaType), Matchers.is(false));
+        }
+    }
+
+    @Test
+    public void sourceReaderReturnsAnObjectForAZeroLengthEntity() throws Exception {
+        Source source = new SourceEntityProviders.SourceReader().readFrom(
+            Source.class,
+            Source.class,
+            new Annotation[0],
+            jakarta.ws.rs.core.MediaType.APPLICATION_XML_TYPE,
+            new jakarta.ws.rs.core.MultivaluedHashMap<>(),
+            new ByteArrayInputStream(new byte[0]));
+
+        assertThat(source, Matchers.instanceOf(StreamSource.class));
+    }
+
+    @Test
+    public void sourceWithoutProducesUsesTheWritersConcreteXmlMediaType() throws Exception {
+        @Path("source")
+        class Sample {
+            @GET
+            public Source get() {
+                return new StreamSource(new StringReader("<message>default</message>"));
+            }
+        }
+        startServer(new Sample());
+
+        try (Response response = call(request(server.uri().resolve("/source")))) {
+            assertThat(response.code(), equalTo(200));
+            assertThat(response.header("Content-Type"), equalTo("application/xml"));
+            assertThat(response.body().string(), Matchers.containsString("<message>default</message>"));
+        }
+
+        try (Response response = call(request(server.uri().resolve("/source"))
+            .header("Accept", "application/vnd.mu+xml"))) {
+            assertThat(response.code(), equalTo(200));
+            assertThat(response.header("Content-Type"), equalTo("application/vnd.mu+xml"));
+            assertThat(response.body().string(), Matchers.containsString("<message>default</message>"));
+        }
+    }
+
+    @Test
+    public void sourceWriterHonorsTheResponseCharset() throws Exception {
+        @Path("source")
+        class Sample {
+            @GET
+            @Produces("application/xml;charset=ISO-8859-1")
+            public Source get() {
+                return new StreamSource(new StringReader("<message>café</message>"));
+            }
+        }
+        startServer(new Sample());
+
+        try (Response response = call(request(server.uri().resolve("/source")))) {
+            assertThat(response.code(), equalTo(200));
+            assertThat(response.header("Content-Type"), equalTo("application/xml;charset=ISO-8859-1"));
+            String body = new String(response.body().bytes(), StandardCharsets.ISO_8859_1);
+            assertThat(body, Matchers.containsString("encoding=\"ISO-8859-1\""));
+            assertThat(body, Matchers.containsString("<message>café</message>"));
+        }
+    }
+
+    @Test
+    public void sourceWriterUsesUtf8WhenTheResponseCharsetIsUnsupported() throws Exception {
+        @Path("source")
+        class Sample {
+            @GET
+            @Produces("application/xml;charset=not-a-charset")
+            public Source get() {
+                return new StreamSource(new StringReader("<message>雪</message>"));
+            }
+        }
+        startServer(new Sample());
+
+        try (Response response = call(request(server.uri().resolve("/source")))) {
+            assertThat(response.code(), equalTo(200));
+            assertThat(response.header("Content-Type"), equalTo("application/xml;charset=utf-8"));
+            String body = new String(response.body().bytes(), StandardCharsets.UTF_8);
+            assertThat(body, Matchers.containsString("encoding=\"UTF-8\""));
+            assertThat(body, Matchers.containsString("<message>雪</message>"));
         }
     }
 

--- a/src/test/java/io/muserver/rest/EntityProvidersTest.java
+++ b/src/test/java/io/muserver/rest/EntityProvidersTest.java
@@ -35,6 +35,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
+import javax.xml.transform.Source;
+import javax.xml.transform.stream.StreamSource;
 
 import static io.muserver.Mutils.NEWLINE;
 import static io.muserver.rest.RestHandlerBuilder.restHandler;
@@ -61,6 +63,42 @@ public class EntityProvidersTest {
         }
         startServer(new Sample());
         stringCheck("text/plain", randomStringOfLength(128 * 1024), "text/plain;charset=utf-8", "/samples");
+    }
+
+    @Test
+    public void sourceEntitiesAreSupportedForXmlMediaTypes() throws Exception {
+        @Path("source")
+        class Sample {
+            @POST
+            @Consumes("application/xml")
+            @Produces("application/xml")
+            public Source echo(Source source) {
+                return source;
+            }
+
+            @GET
+            @Path("suffix")
+            @Produces("application/vnd.mu+xml")
+            public Source suffixXml() {
+                return new StreamSource(new StringReader("<message>suffix</message>"));
+            }
+        }
+
+        startServer(new Sample());
+
+        try (Response response = call(request()
+            .post(RequestBody.create("<message>echo</message>", MediaType.get("application/xml")))
+            .url(server.uri().resolve("/source").toString()))) {
+            assertThat(response.code(), equalTo(200));
+            assertThat(response.header("Content-Type"), equalTo("application/xml"));
+            assertThat(response.body().string(), Matchers.containsString("<message>echo</message>"));
+        }
+
+        try (Response response = call(request(server.uri().resolve("/source/suffix")))) {
+            assertThat(response.code(), equalTo(200));
+            assertThat(response.header("Content-Type"), equalTo("application/vnd.mu+xml"));
+            assertThat(response.body().string(), Matchers.containsString("<message>suffix</message>"));
+        }
     }
 
     @Test


### PR DESCRIPTION
## Summary

- add built-in `MessageBodyReader` and `MessageBodyWriter` support for `javax.xml.transform.Source`
- support `text/xml`, `application/xml`, and `application/*+xml` media types
- serialize using the JDK XML transformer with external DTD and stylesheet access disabled
- mark Source support in the JAX-RS README

## Why

Jakarta REST 3.1 requires Source providers. `Source` and the implementation used here are in the JDK `java.xml` module, so this adds no dependency.

## Validation

- `mise exec java@temurin-11 -- mvn -f pom.xml -Dtest=EntityProvidersTest test` (27 passed)
- Jakarta REST 3.1 focused suites: `spec/provider/standard,spec/provider/standardnotnull,jaxrs21/ee/sse/sseeventsink` (43 passed, 3 intentional unsupported providers, 3 field-injection blocks, 1 existing expected failure, no unexpected results)

The harness expectation updates were pushed directly to `mu-jaxrs-tck-harness` main in `b627086`.