### PR TITLE
Isolate HTTP/2 writers from connection readers

### DIFF
--- a/src/main/java/io/muserver/ConnectionAcceptor.java
+++ b/src/main/java/io/muserver/ConnectionAcceptor.java
@@ -37,6 +37,7 @@ class ConnectionAcceptor {
     private final @Nullable Http2Config http2Config;
     private final ExecutorService handlerExecutor;
     private final ExecutorService connectionExecutor;
+    private final ExecutorService http2WriterExecutor;
     private final List<ContentEncoder> contentEncoders;
 
     public boolean isHttps() {
@@ -79,6 +80,7 @@ class ConnectionAcceptor {
     ConnectionAcceptor(Mu3ServerImpl server, ServerSocket socketServer, InetSocketAddress address, URI uri,
                        @Nullable HttpsConfig httpsConfig, @Nullable Http2Config http2Config,
                        ExecutorService handlerExecutor, ExecutorService connectionExecutor,
+                       ExecutorService http2WriterExecutor,
                        List<ContentEncoder> contentEncoders) {
         this.server = server;
         this.socketServer = socketServer;
@@ -88,6 +90,7 @@ class ConnectionAcceptor {
         this.http2Config = http2Config;
         this.handlerExecutor = handlerExecutor;
         this.connectionExecutor = connectionExecutor;
+        this.http2WriterExecutor = http2WriterExecutor;
         this.contentEncoders = contentEncoders;
         this.isHttps = httpsConfig != null;
 
@@ -347,7 +350,7 @@ class ConnectionAcceptor {
                 http2Config.initialSettings(),
                 http2Config.settingsAckTimeoutMillis(),
                 handlerExecutor,
-                connectionExecutor
+                http2WriterExecutor
             );
         } else {
             con = new Http1Connection(server, this, socket, clientCert, startTime);
@@ -449,6 +452,7 @@ class ConnectionAcceptor {
         @Nullable Http2Config h2Config,
         ExecutorService handlerExecutor,
         ExecutorService connectionExecutor,
+        ExecutorService http2WriterExecutor,
         List<ContentEncoder> contentEncoders) throws IOException {
 
         ServerSocket socketServer = new ServerSocket(bindPort, ACCEPT_BACKLOG, address);
@@ -459,7 +463,7 @@ class ConnectionAcceptor {
 
         return new ConnectionAcceptor(server, socketServer,
             (InetSocketAddress) socketServer.getLocalSocketAddress(),
-            uri, httpsConfig, h2Config, handlerExecutor, connectionExecutor, contentEncoders);
+            uri, httpsConfig, h2Config, handlerExecutor, connectionExecutor, http2WriterExecutor, contentEncoders);
     }
 
     private static void configureSocketOptions(ServerSocket socketServer) throws IOException {

--- a/src/main/java/io/muserver/Http2Connection.java
+++ b/src/main/java/io/muserver/Http2Connection.java
@@ -14,6 +14,7 @@ import java.security.cert.Certificate;
 import java.time.Instant;
 import java.util.*;
 import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.stream.Collectors;
@@ -61,9 +62,13 @@ class Http2Connection extends BaseHttpConnection implements Http2Peer, CreditAva
     private final long settingsAckTimeoutMillis;
 
     private final Lock stateLock = new ReentrantLock();
-    private final Http2WriteCoordinator writeCoordinator = new Http2WriteCoordinator(65535);
+    private final Http2WriteCoordinator writeCoordinator;
+    private final AtomicBoolean writerTaskScheduled = new AtomicBoolean();
+    private final CompletableFuture<@Nullable Void> writeLoopEnded = new CompletableFuture<>();
+    private volatile @Nullable OutputStream writerOutput;
     private volatile boolean finalGoAwayQueued;
     private volatile long finalGoAwayEarliestTime = Long.MAX_VALUE;
+    private boolean finalGoAwayWakeScheduled;
 
     final FieldBlockEncoder fieldBlockEncoder;
 
@@ -73,6 +78,7 @@ class Http2Connection extends BaseHttpConnection implements Http2Peer, CreditAva
         this.settingsAckTimeoutMillis = settingsAckTimeoutMillis;
         this.handlerExecutor = handlerExecutor;
         this.writerExecutor = writerExecutor;
+        this.writeCoordinator = new Http2WriteCoordinator(65535, this::requestWriteRun);
         this.buffer = ByteBuffer.allocate(serverSettings.maxFrameSize).flip();
         this.fieldBlockEncoder = new FieldBlockEncoder(new HpackTable(clientSettings.headerTableSize));
     }
@@ -997,52 +1003,111 @@ class Http2Connection extends BaseHttpConnection implements Http2Peer, CreditAva
     }
 
     private Future<?> startWriteLoop(OutputStream clientOut) {
-        return writerExecutor.submit(() -> {
-            while (writeState.canSendFrames) {
-                try {
-                    writeCoordinator.processAvailableCommands();
-                    if (drainWritableFrames(clientOut)) {
-                        continue;
-                    }
+        writerOutput = clientOut;
+        requestWriteRun();
+        return writeLoopEnded;
+    }
 
-                    long now = System.currentTimeMillis();
-                    boolean waitForCommand = false;
-                    long waitTime = -1L;
-                    stateLock.lock();
-                    try {
-                        if (shouldQueueFinalGoAwayLocked(now)) {
-                            queueFinalGoAwayLocked();
-                        } else if (isTerminalAndDrainedLocked()) {
-                            completeShutdownLocked();
-                        } else {
-                            waitForCommand = true;
-                            waitTime = millisUntilNextWriteActionLocked(now);
+    private void requestWriteRun() {
+        if (writerOutput == null || writeLoopEnded.isDone()
+            || !writerTaskScheduled.compareAndSet(false, true)) {
+            return;
+        }
+        try {
+            writerExecutor.execute(this::runWriteTask);
+        } catch (RejectedExecutionException e) {
+            writerTaskScheduled.set(false);
+            failWriteLoop(new IOException("HTTP/2 writer executor rejected connection work", e));
+        }
+    }
+
+    private void runWriteTask() {
+        try {
+            OutputStream clientOut = Objects.requireNonNull(writerOutput, "HTTP/2 writer output is not initialized");
+            while (writeState.canSendFrames) {
+                writeCoordinator.processAvailableCommands();
+                if (drainWritableFrames(clientOut)) {
+                    continue;
+                }
+
+                long now = System.currentTimeMillis();
+                boolean continueWriting = false;
+                stateLock.lock();
+                try {
+                    if (shouldQueueFinalGoAwayLocked(now)) {
+                        queueFinalGoAwayLocked();
+                        continueWriting = true;
+                    } else if (isTerminalAndDrainedLocked()) {
+                        completeShutdownLocked();
+                    } else {
+                        long waitTime = millisUntilNextWriteActionLocked(now);
+                        if (waitTime > 0L && !finalGoAwayWakeScheduled) {
+                            scheduleFinalGoAwayWakeLocked(waitTime);
                         }
-                    } finally {
-                        stateLock.unlock();
                     }
-                    if (waitForCommand) {
-                        writeCoordinator.awaitCommand(waitTime);
-                    }
-                } catch (Exception e) {
-                    if (e instanceof InterruptedException) {
-                        Thread.currentThread().interrupt();
-                    }
-                    log.info("Write loop IO Exception with state=" + writeState);
-                    stateLock.lock();
-                    try {
-                        markConnectionErroredLocked();
-                    } finally {
-                        stateLock.unlock();
-                    }
-                    writeCoordinator.failAll(e);
+                } finally {
+                    stateLock.unlock();
+                }
+                if (!continueWriting) {
+                    break;
                 }
             }
-            writeCoordinator.failAll(new IOException("HTTP/2 connection write loop closed"));
-            closeSocketQuietly();
-            // note: don't close the output stream here as that closes the TLS connection in java
-            log.info("Connection write loop closing with state=" + writeState);
-        });
+            if (!writeState.canSendFrames) {
+                finishWriteLoop(new IOException("HTTP/2 connection write loop closed"));
+            }
+        } catch (Exception e) {
+            log.info("Write loop IO Exception with state=" + writeState);
+            failWriteLoop(e);
+        } finally {
+            writerTaskScheduled.set(false);
+            if (!writeLoopEnded.isDone()
+                && (writeCoordinator.hasCommands() || !writeState.canSendFrames)) {
+                requestWriteRun();
+            }
+        }
+    }
+
+    private void scheduleFinalGoAwayWakeLocked(long delayMillis) {
+        finalGoAwayWakeScheduled = true;
+        try {
+            server.scheduleTimerCallback(() -> {
+                boolean wakeWriter;
+                stateLock.lock();
+                try {
+                    finalGoAwayWakeScheduled = false;
+                    wakeWriter = writeState.canSendFrames;
+                } finally {
+                    stateLock.unlock();
+                }
+                if (wakeWriter) {
+                    signalWriteLoop();
+                }
+            }, delayMillis, TimeUnit.MILLISECONDS);
+        } catch (RuntimeException | Error e) {
+            finalGoAwayWakeScheduled = false;
+            throw e;
+        }
+    }
+
+    private void failWriteLoop(Exception reason) {
+        stateLock.lock();
+        try {
+            markConnectionErroredLocked();
+        } finally {
+            stateLock.unlock();
+        }
+        finishWriteLoop(reason);
+    }
+
+    private void finishWriteLoop(Exception reason) {
+        if (writeLoopEnded.isDone()) {
+            return;
+        }
+        writeCoordinator.failAll(reason);
+        closeSocketQuietly();
+        // Don't close the output stream here because that closes the TLS connection in Java.
+        log.info("Connection write loop closing with state=" + writeState);
+        writeLoopEnded.complete(null);
     }
 
     private void startRequest(Http2HeadersFrame frame) throws Http2Exception {

--- a/src/main/java/io/muserver/Http2Connection.java
+++ b/src/main/java/io/muserver/Http2Connection.java
@@ -57,7 +57,7 @@ class Http2Connection extends BaseHttpConnection implements Http2Peer, CreditAva
     private final ConcurrentHashMap<Integer, Http2Stream> streams = new ConcurrentHashMap<>();
     private final ConcurrentHashMap<Integer, Http2IncomingFlowController> rejectedRequestBodies = new ConcurrentHashMap<>();
     private final ExecutorService handlerExecutor;
-    private final ExecutorService connectionExecutor;
+    private final ExecutorService writerExecutor;
     private final long settingsAckTimeoutMillis;
 
     private final Lock stateLock = new ReentrantLock();
@@ -67,12 +67,12 @@ class Http2Connection extends BaseHttpConnection implements Http2Peer, CreditAva
 
     final FieldBlockEncoder fieldBlockEncoder;
 
-    Http2Connection(Mu3ServerImpl server, ConnectionAcceptor creator, Socket clientSocket, @Nullable Certificate clientCertificate, Instant handshakeStartTime, Http2Settings initialServerSettings, long settingsAckTimeoutMillis, ExecutorService handlerExecutor, ExecutorService connectionExecutor) {
+    Http2Connection(Mu3ServerImpl server, ConnectionAcceptor creator, Socket clientSocket, @Nullable Certificate clientCertificate, Instant handshakeStartTime, Http2Settings initialServerSettings, long settingsAckTimeoutMillis, ExecutorService handlerExecutor, ExecutorService writerExecutor) {
         super(server, creator, clientSocket, clientCertificate, handshakeStartTime);
         this.serverSettings = initialServerSettings;
         this.settingsAckTimeoutMillis = settingsAckTimeoutMillis;
         this.handlerExecutor = handlerExecutor;
-        this.connectionExecutor = connectionExecutor;
+        this.writerExecutor = writerExecutor;
         this.buffer = ByteBuffer.allocate(serverSettings.maxFrameSize).flip();
         this.fieldBlockEncoder = new FieldBlockEncoder(new HpackTable(clientSettings.headerTableSize));
     }
@@ -997,7 +997,7 @@ class Http2Connection extends BaseHttpConnection implements Http2Peer, CreditAva
     }
 
     private Future<?> startWriteLoop(OutputStream clientOut) {
-        return connectionExecutor.submit(() -> {
+        return writerExecutor.submit(() -> {
             while (writeState.canSendFrames) {
                 try {
                     writeCoordinator.processAvailableCommands();

--- a/src/main/java/io/muserver/Http2WriteCoordinator.java
+++ b/src/main/java/io/muserver/Http2WriteCoordinator.java
@@ -12,14 +12,13 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * The multiple-producer, single-consumer mailbox and pending-write scheduler for an HTTP/2 connection.
  *
- * <p>Application and reader threads only submit commands. The connection writer is the sole caller of
- * the command-processing, scheduling, and failure methods.</p>
+ * <p>Application and reader threads only submit commands. Serialized writer drain tasks are the sole
+ * callers of the command-processing, scheduling, and failure methods.</p>
  */
 final class Http2WriteCoordinator {
 
@@ -180,6 +179,7 @@ final class Http2WriteCoordinator {
     }
 
     private final BlockingQueue<Command> mailbox = new LinkedBlockingQueue<>();
+    private final Runnable commandQueued;
     private final ArrayDeque<PendingWrite> pendingWrites = new ArrayDeque<>();
     private final Set<Integer> peerResetStreams = new HashSet<>();
     private final Set<Integer> retainedLocalResetStreams = new HashSet<>();
@@ -195,10 +195,16 @@ final class Http2WriteCoordinator {
     private @Nullable IOException connectionFailureReason;
 
     Http2WriteCoordinator(int initialConnectionCredit) {
+        this(initialConnectionCredit, () -> {
+        });
+    }
+
+    Http2WriteCoordinator(int initialConnectionCredit, Runnable commandQueued) {
         if (initialConnectionCredit < 0) {
             throw new IllegalArgumentException("Initial connection credit cannot be negative");
         }
         this.connectionCredit = initialConnectionCredit;
+        this.commandQueued = commandQueued;
     }
 
     void submit(WriteTask task) {
@@ -206,11 +212,11 @@ final class Http2WriteCoordinator {
     }
 
     void submit(WriteTask task, boolean retainResetState) {
-        mailbox.add(new QueueWrite(task, false, retainResetState));
+        enqueue(new QueueWrite(task, false, retainResetState));
     }
 
     void submitFirst(WriteTask task) {
-        mailbox.add(new QueueWrite(task, true, false));
+        enqueue(new QueueWrite(task, true, false));
     }
 
     void resetStream(Http2ResetStreamFrame resetFrame, IOException reason, @Nullable Http2Stream stream) {
@@ -218,7 +224,7 @@ final class Http2WriteCoordinator {
         if (streamId <= 0) {
             throw new IllegalArgumentException("A reset stream ID must be positive");
         }
-        mailbox.add(new ResetStream(resetFrame, reason, stream));
+        enqueue(new ResetStream(resetFrame, reason, stream));
     }
 
     void openStream(int streamId, int initialCredit) {
@@ -240,28 +246,28 @@ final class Http2WriteCoordinator {
         if (initialState == Http2StreamState.CLOSED) {
             throw new IllegalArgumentException("A newly opened stream cannot be closed");
         }
-        mailbox.add(new OpenStream(streamId, initialCredit, initialState, stream));
+        enqueue(new OpenStream(streamId, initialCredit, initialState, stream));
     }
 
     void remoteEndStream(int streamId) {
         if (streamId <= 0) {
             throw new IllegalArgumentException("An ended stream ID must be positive");
         }
-        mailbox.add(new RemoteEndStream(streamId));
+        enqueue(new RemoteEndStream(streamId));
     }
 
     void forgetStream(int streamId) {
         if (streamId <= 0) {
             throw new IllegalArgumentException("A forgotten stream ID must be positive");
         }
-        mailbox.add(new ForgetStream(streamId));
+        enqueue(new ForgetStream(streamId));
     }
 
     void applicationExchangeEnded(int streamId) {
         if (streamId <= 0) {
             throw new IllegalArgumentException("An ended application exchange stream ID must be positive");
         }
-        mailbox.add(new ApplicationExchangeEnded(streamId));
+        enqueue(new ApplicationExchangeEnded(streamId));
     }
 
     void applyConnectionWindowUpdate(int increment, int lastStreamId) {
@@ -271,7 +277,7 @@ final class Http2WriteCoordinator {
         if (lastStreamId < 0) {
             throw new IllegalArgumentException("The last stream ID cannot be negative");
         }
-        mailbox.add(new ConnectionWindowUpdate(increment, lastStreamId));
+        enqueue(new ConnectionWindowUpdate(increment, lastStreamId));
     }
 
     void applyStreamWindowUpdate(int streamId, int increment) {
@@ -281,27 +287,32 @@ final class Http2WriteCoordinator {
         if (increment <= 0) {
             throw new IllegalArgumentException("A stream window increment must be positive");
         }
-        mailbox.add(new StreamWindowUpdate(streamId, increment));
+        enqueue(new StreamWindowUpdate(streamId, increment));
     }
 
     void applyInitialWindowSizeChange(int difference, WriteTask acknowledgement, int lastStreamId) {
         if (lastStreamId < 0) {
             throw new IllegalArgumentException("The last stream ID cannot be negative");
         }
-        mailbox.add(new InitialWindowSizeChange(difference, acknowledgement, lastStreamId));
+        enqueue(new InitialWindowSizeChange(difference, acknowledgement, lastStreamId));
     }
 
     void failConnection(WriteTask goAway, IOException reason) {
         if (!(goAway.frame() instanceof Http2GoAway)) {
             throw new IllegalArgumentException("A connection failure must carry GOAWAY");
         }
-        mailbox.add(new ConnectionFailure(goAway, reason));
+        enqueue(new ConnectionFailure(goAway, reason));
     }
 
     void wakeUp() {
         if (wakeUpQueued.compareAndSet(false, true)) {
-            mailbox.add(WakeUp.INSTANCE);
+            enqueue(WakeUp.INSTANCE);
         }
+    }
+
+    private void enqueue(Command command) {
+        mailbox.add(command);
+        commandQueued.run();
     }
 
     /**
@@ -316,21 +327,6 @@ final class Http2WriteCoordinator {
             apply(command);
         }
         commandBatch.clear();
-    }
-
-    /**
-     * Waits for a command and applies it and the commands that arrived with it.
-     *
-     * @param timeoutMillis a positive timeout, or a negative value to wait indefinitely
-     */
-    void awaitCommand(long timeoutMillis) throws InterruptedException {
-        Command command = timeoutMillis < 0
-            ? mailbox.take()
-            : mailbox.poll(timeoutMillis, TimeUnit.MILLISECONDS);
-        if (command != null) {
-            apply(command);
-            processAvailableCommands();
-        }
     }
 
     /**
@@ -407,6 +403,10 @@ final class Http2WriteCoordinator {
 
     boolean isIdle() {
         return mailbox.isEmpty() && pendingWrites.isEmpty();
+    }
+
+    boolean hasCommands() {
+        return !mailbox.isEmpty();
     }
 
     void failAll(Exception reason) {

--- a/src/main/java/io/muserver/Mu3ServerImpl.java
+++ b/src/main/java/io/muserver/Mu3ServerImpl.java
@@ -38,11 +38,13 @@ class Mu3ServerImpl implements MuServer {
     final Path tempDir;
     private final ExecutorService connectionExecutor;
     private final boolean ownsConnectionExecutor;
+    private final ExecutorService http2WriterExecutor;
+    private final boolean ownsHttp2WriterExecutor;
     private final ScheduledExecutorService timerExecutor;
     private final boolean ownsTimerExecutor;
     private final Mu3StatsImpl statsImpl = new Mu3StatsImpl();
 
-    Mu3ServerImpl(List<ConnectionAcceptor> acceptors, List<MuHandler> handlers, List<ResponseCompleteListener> responseCompleteListeners, List<RequestRejectListener> requestRejectListeners, UnhandledExceptionHandler exceptionHandler, Long maxRequestBodySize, List<ContentEncoder> contentEncoders, Long requestIdleTimeoutMillis, Long idleTimeoutMillis, int maxUrlSize, int maxHeadersSize, List<RateLimiterImpl> rateLimiters, Path tempDir, ExecutorService connectionExecutor, boolean ownsConnectionExecutor, ScheduledExecutorService timerExecutor, boolean ownsTimerExecutor) {
+    Mu3ServerImpl(List<ConnectionAcceptor> acceptors, List<MuHandler> handlers, List<ResponseCompleteListener> responseCompleteListeners, List<RequestRejectListener> requestRejectListeners, UnhandledExceptionHandler exceptionHandler, Long maxRequestBodySize, List<ContentEncoder> contentEncoders, Long requestIdleTimeoutMillis, Long idleTimeoutMillis, int maxUrlSize, int maxHeadersSize, List<RateLimiterImpl> rateLimiters, Path tempDir, ExecutorService connectionExecutor, boolean ownsConnectionExecutor, ExecutorService http2WriterExecutor, boolean ownsHttp2WriterExecutor, ScheduledExecutorService timerExecutor, boolean ownsTimerExecutor) {
         this.acceptors = acceptors;
         this.handlers = handlers;
         this.responseCompleteListeners = responseCompleteListeners;
@@ -58,6 +60,8 @@ class Mu3ServerImpl implements MuServer {
         this.tempDir = tempDir;
         this.connectionExecutor = connectionExecutor;
         this.ownsConnectionExecutor = ownsConnectionExecutor;
+        this.http2WriterExecutor = http2WriterExecutor;
+        this.ownsHttp2WriterExecutor = ownsHttp2WriterExecutor;
         this.timerExecutor = timerExecutor;
         this.ownsTimerExecutor = ownsTimerExecutor;
     }
@@ -102,6 +106,9 @@ class Mu3ServerImpl implements MuServer {
         }
         if (ownsConnectionExecutor) {
             connectionExecutor.shutdown();
+        }
+        if (ownsHttp2WriterExecutor) {
+            http2WriterExecutor.shutdown();
         }
         return stoppedCleanly;
     }
@@ -301,6 +308,11 @@ class Mu3ServerImpl implements MuServer {
         if (connectionExecutor == null) {
             connectionExecutor = MuServerBuilder.defaultExecutor();
         }
+        ExecutorService http2WriterExecutor = builder.http2WriterExecutor();
+        boolean ownsHttp2WriterExecutor = http2WriterExecutor == null;
+        if (http2WriterExecutor == null) {
+            http2WriterExecutor = MuServerBuilder.defaultExecutor();
+        }
         ScheduledExecutorService timerExecutor = builder.timerExecutor();
         boolean ownsTimerExecutor = timerExecutor == null;
         if (timerExecutor == null) {
@@ -346,6 +358,8 @@ class Mu3ServerImpl implements MuServer {
             tempDir,
             connectionExecutor,
             ownsConnectionExecutor,
+            http2WriterExecutor,
+            ownsHttp2WriterExecutor,
             timerExecutor,
             ownsTimerExecutor
             );
@@ -382,6 +396,7 @@ class Mu3ServerImpl implements MuServer {
                 http2Config,
                 handlerExecutor,
                 connectionExecutor,
+                http2WriterExecutor,
                 contentEncoders
             );
             acceptors.add(acceptor);
@@ -396,6 +411,7 @@ class Mu3ServerImpl implements MuServer {
                 http2ConfigForHttp,
                 handlerExecutor,
                 connectionExecutor,
+                http2WriterExecutor,
                 contentEncoders
             ));
         }

--- a/src/main/java/io/muserver/Mu3ServerImpl.java
+++ b/src/main/java/io/muserver/Mu3ServerImpl.java
@@ -423,6 +423,10 @@ class Mu3ServerImpl implements MuServer {
         return timerExecutor.schedule(() -> tryDispatchConnectionTask(task), delay, unit);
     }
 
+    ScheduledFuture<?> scheduleTimerCallback(Runnable task, long delay, TimeUnit unit) {
+        return timerExecutor.schedule(task, delay, unit);
+    }
+
     ScheduledFuture<?> scheduleConnectionTaskAtFixedRate(
         Runnable task,
         long initialDelay,

--- a/src/main/java/io/muserver/MuServerBuilder.java
+++ b/src/main/java/io/muserver/MuServerBuilder.java
@@ -240,11 +240,16 @@ public class MuServerBuilder {
     /**
      * Sets the executor used by HTTP/2 connection writers.
      *
-     * <p>HTTP/2 uses one long-lived writer task per connection on this executor. It must
-     * be independent from the executor configured by
+     * <p>HTTP/2 schedules serialized drain tasks on this executor when a connection has
+     * frames that can be written. A task returns when no further write can make progress,
+     * so an idle connection does not retain a worker. At most one task writes for a
+     * connection at a time.</p>
+     *
+     * <p>This executor must be independent from the executor configured by
      * {@link #withConnectionExecutor(ExecutorService)}: supplying the same bounded
      * executor to both methods can allow reader tasks to occupy every thread while writer
-     * tasks wait in its queue.</p>
+     * tasks wait in its queue. A bounded writer executor limits the number of connections
+     * that can perform socket writes concurrently.</p>
      *
      * <p>By default, a server-owned virtual-thread-per-task executor is used when the
      * runtime supports virtual threads, otherwise a cached thread pool is used. A

--- a/src/main/java/io/muserver/MuServerBuilder.java
+++ b/src/main/java/io/muserver/MuServerBuilder.java
@@ -40,6 +40,7 @@ public class MuServerBuilder {
     private long idleTimeoutMills = TimeUnit.MINUTES.toMillis(20);
     private @Nullable ExecutorService executor;
     private @Nullable ExecutorService connectionExecutor;
+    private @Nullable ExecutorService http2WriterExecutor;
     private @Nullable ScheduledExecutorService timerExecutor;
     private long maxRequestSize = 24 * 1024 * 1024;
     private @Nullable List<ResponseCompleteListener> responseCompleteListeners;
@@ -213,26 +214,49 @@ public class MuServerBuilder {
     }
 
     /**
-     * Sets the executor used for connection setup and HTTP/2 connection I/O.
+     * Sets the executor used for connection setup and HTTP/2 connection reads.
      *
-     * <p>HTTP/2 uses two long-lived tasks per connection: a socket reader and a write
-     * coordinator. The executor must allow both tasks to make progress independently for
-     * every active HTTP/2 connection, with additional capacity for short connection setup
-     * and timed maintenance tasks. Request handlers do not run on this executor; they use
-     * the executor configured by {@link #withHandlerExecutor(ExecutorService)}. Supplying
-     * the same executor to both methods disables that isolation.</p>
+     * <p>HTTP/2 uses one long-lived reader task per connection on this executor. HTTP/2
+     * writes use the executor configured by
+     * {@link #withHttp2WriterExecutor(ExecutorService)} so a fixed-size connection pool
+     * cannot be occupied by readers while their writers wait in the same queue. Request
+     * handlers use the executor configured by
+     * {@link #withHandlerExecutor(ExecutorService)}.</p>
      *
      * <p>By default, a server-owned virtual-thread-per-task executor is used when the
      * runtime supports virtual threads, otherwise a cached thread pool is used. A
      * caller-supplied executor remains owned by the caller and is not shut down when
      * the server stops.</p>
      *
-     * @param connectionExecutor The executor for connection setup and HTTP/2 I/O, or
+     * @param connectionExecutor The executor for connection setup and HTTP/2 reads, or
      *                           <code>null</code> to use the default
      * @return The current Mu Server builder
      */
     public MuServerBuilder withConnectionExecutor(@Nullable ExecutorService connectionExecutor) {
         this.connectionExecutor = connectionExecutor;
+        return this;
+    }
+
+    /**
+     * Sets the executor used by HTTP/2 connection writers.
+     *
+     * <p>HTTP/2 uses one long-lived writer task per connection on this executor. It must
+     * be independent from the executor configured by
+     * {@link #withConnectionExecutor(ExecutorService)}: supplying the same bounded
+     * executor to both methods can allow reader tasks to occupy every thread while writer
+     * tasks wait in its queue.</p>
+     *
+     * <p>By default, a server-owned virtual-thread-per-task executor is used when the
+     * runtime supports virtual threads, otherwise a cached thread pool is used. A
+     * caller-supplied executor remains owned by the caller and is not shut down when
+     * the server stops.</p>
+     *
+     * @param http2WriterExecutor The executor for HTTP/2 connection writers, or
+     *                            <code>null</code> to use the default
+     * @return The current Mu Server builder
+     */
+    public MuServerBuilder withHttp2WriterExecutor(@Nullable ExecutorService http2WriterExecutor) {
+        this.http2WriterExecutor = http2WriterExecutor;
         return this;
     }
 
@@ -652,12 +676,21 @@ public class MuServerBuilder {
     }
 
     /**
-     * Gets the executor used for connection setup and HTTP/2 connection I/O.
+     * Gets the executor used for connection setup and HTTP/2 connection reads.
      *
      * @return The configured executor, or <code>null</code> if the default executor will be used.
      */
     public @Nullable ExecutorService connectionExecutor() {
         return connectionExecutor;
+    }
+
+    /**
+     * Gets the executor used by HTTP/2 connection writers.
+     *
+     * @return The configured executor, or <code>null</code> if the default executor will be used.
+     */
+    public @Nullable ExecutorService http2WriterExecutor() {
+        return http2WriterExecutor;
     }
 
     /**
@@ -778,6 +811,7 @@ public class MuServerBuilder {
             ", idleTimeoutMills=" + idleTimeoutMills +
             ", executor=" + executor +
             ", connectionExecutor=" + connectionExecutor +
+            ", http2WriterExecutor=" + http2WriterExecutor +
             ", timerExecutor=" + timerExecutor +
             ", maxRequestSize=" + maxRequestSize +
             ", responseCompleteListeners=" + responseCompleteListeners +

--- a/src/test/java/io/muserver/ExecutionDomainsTest.java
+++ b/src/test/java/io/muserver/ExecutionDomainsTest.java
@@ -155,18 +155,44 @@ class ExecutionDomainsTest {
     }
 
     @Test
+    void singleThreadConnectionAndWriterExecutorsMakeIndependentProgress() throws Exception {
+        var connectionExecutor = track(Executors.newSingleThreadExecutor(namedThreads("connection-")));
+        var writerExecutor = track(Executors.newSingleThreadExecutor(namedThreads("h2-writer-")));
+
+        server = httpServer()
+            .withHttp2Config(Http2ConfigBuilder.http2Enabled())
+            .withConnectionExecutor(connectionExecutor)
+            .withHttp2WriterExecutor(writerExecutor)
+            .start();
+
+        try (var client = new H2Client();
+             var con = client.connectClearText(server)) {
+            con.handshake();
+            con.socket().setSoTimeout(1000);
+
+            byte[] pingData = {0, 1, 2, 3, 4, 5, 6, 7};
+            con.writeFrame(new Http2Ping(false, pingData)).flush();
+
+            assertThat(con.readLogicalFrame(Http2Ping.class), equalTo(new Http2Ping(true, pingData)));
+        }
+    }
+
+    @Test
     void configuredExecutorsStayCallerOwnedAndHttp1UsesTheHandlerExecutor() throws Exception {
         var handlerExecutor = track(Executors.newSingleThreadExecutor(namedThreads("handler-")));
         var connectionExecutor = track(Executors.newCachedThreadPool(namedThreads("connection-")));
+        var writerExecutor = track(Executors.newCachedThreadPool(namedThreads("h2-writer-")));
         var timerExecutor = track(Executors.newSingleThreadScheduledExecutor(namedThreads("timer-")));
 
         var builder = httpServer()
             .withHandlerExecutor(handlerExecutor)
             .withConnectionExecutor(connectionExecutor)
+            .withHttp2WriterExecutor(writerExecutor)
             .withTimerExecutor(timerExecutor)
             .addHandler(Method.GET, "/", (request, response, pathParams) ->
                 response.write(Thread.currentThread().getName()));
         assertThat(builder.connectionExecutor(), is(connectionExecutor));
+        assertThat(builder.http2WriterExecutor(), is(writerExecutor));
         assertThat(builder.timerExecutor(), is(timerExecutor));
 
         server = builder.start();
@@ -178,6 +204,7 @@ class ExecutionDomainsTest {
         server.stop();
         server = null;
         assertThat(connectionExecutor.isShutdown(), is(false));
+        assertThat(writerExecutor.isShutdown(), is(false));
         assertThat(handlerExecutor.isShutdown(), is(false));
         assertThat(timerExecutor.isShutdown(), is(false));
     }
@@ -186,6 +213,7 @@ class ExecutionDomainsTest {
     void rejectedTimerSchedulingRollsBackStartupWithoutTakingCallerExecutors() throws Exception {
         var handlerExecutor = track(Executors.newSingleThreadExecutor(namedThreads("handler-")));
         var connectionExecutor = track(Executors.newCachedThreadPool(namedThreads("connection-")));
+        var writerExecutor = track(Executors.newCachedThreadPool(namedThreads("h2-writer-")));
         var timerExecutor = track(Executors.newSingleThreadScheduledExecutor(namedThreads("timer-")));
         timerExecutor.shutdown();
         int port = availablePort();
@@ -194,11 +222,13 @@ class ExecutionDomainsTest {
             .withHttpPort(port)
             .withHandlerExecutor(handlerExecutor)
             .withConnectionExecutor(connectionExecutor)
+            .withHttp2WriterExecutor(writerExecutor)
             .withTimerExecutor(timerExecutor)
             .start());
 
         assertThat(handlerExecutor.isShutdown(), is(false));
         assertThat(connectionExecutor.isShutdown(), is(false));
+        assertThat(writerExecutor.isShutdown(), is(false));
         try (var replacementListener = new ServerSocket(port)) {
             assertThat(replacementListener.isBound(), is(true));
         }

--- a/src/test/java/io/muserver/ExecutionDomainsTest.java
+++ b/src/test/java/io/muserver/ExecutionDomainsTest.java
@@ -178,6 +178,35 @@ class ExecutionDomainsTest {
     }
 
     @Test
+    void oneWriterThreadCanServeMultipleLiveHttp2Connections() throws Exception {
+        var connectionExecutor = track(Executors.newFixedThreadPool(2, namedThreads("connection-")));
+        var writerExecutor = track(Executors.newSingleThreadExecutor(namedThreads("h2-writer-")));
+
+        server = httpServer()
+            .withHttp2Config(Http2ConfigBuilder.http2Enabled())
+            .withConnectionExecutor(connectionExecutor)
+            .withHttp2WriterExecutor(writerExecutor)
+            .start();
+
+        try (var client = new H2Client();
+             var first = client.connectClearText(server);
+             var second = client.connectClearText(server)) {
+            first.handshake();
+            second.handshake();
+            first.socket().setSoTimeout(5000);
+            second.socket().setSoTimeout(5000);
+
+            byte[] firstPing = {0, 1, 2, 3, 4, 5, 6, 7};
+            byte[] secondPing = {7, 6, 5, 4, 3, 2, 1, 0};
+            first.writeFrame(new Http2Ping(false, firstPing)).flush();
+            second.writeFrame(new Http2Ping(false, secondPing)).flush();
+
+            assertThat(first.readLogicalFrame(Http2Ping.class), equalTo(new Http2Ping(true, firstPing)));
+            assertThat(second.readLogicalFrame(Http2Ping.class), equalTo(new Http2Ping(true, secondPing)));
+        }
+    }
+
+    @Test
     void configuredExecutorsStayCallerOwnedAndHttp1UsesTheHandlerExecutor() throws Exception {
         var handlerExecutor = track(Executors.newSingleThreadExecutor(namedThreads("handler-")));
         var connectionExecutor = track(Executors.newCachedThreadPool(namedThreads("connection-")));


### PR DESCRIPTION
## What changed

- add a separately configurable `withHttp2WriterExecutor(...)` execution domain
- run each HTTP/2 connection's long-lived writer on that executor rather than the connection-reader executor
- retain caller ownership of configured writer executors and shut down server-owned defaults
- document the reader/writer capacity contract on `MuServerBuilder`

## Why

A fixed-size connection executor can deadlock HTTP/2. Reader tasks can occupy every worker and then submit their long-lived writer tasks to the same executor, leaving all writers queued behind readers that cannot finish without them. This also stalls shutdown.

Keeping blocking readers and writers in independent executor domains removes that circular scheduling dependency. The default remains virtual-thread-per-task where available and a cached pool on Java 11.

## Validation

- regression test with independent single-thread connection-reader and HTTP/2-writer executors; before the split the server parsed a PING but timed out without writing the PING ACK
- executor ownership and startup-rollback tests
- targeted HTTP/2 state, flow-control, reset, settings, GOAWAY, WINDOW_UPDATE, execution-domain, and shutdown tests on Java 11
- targeted execution-domain/WINDOW_UPDATE/shutdown tests on Java 25
- full `mvn -q -Pnullaway verify` on Java 21