### PR TITLE
Isolate timed connection maintenance

### DIFF
--- a/src/main/java/io/muserver/Mu3ServerImpl.java
+++ b/src/main/java/io/muserver/Mu3ServerImpl.java
@@ -40,11 +40,13 @@ class Mu3ServerImpl implements MuServer {
     private final boolean ownsConnectionExecutor;
     private final ExecutorService http2WriterExecutor;
     private final boolean ownsHttp2WriterExecutor;
+    private final ExecutorService connectionMaintenanceExecutor;
+    private final boolean ownsConnectionMaintenanceExecutor;
     private final ScheduledExecutorService timerExecutor;
     private final boolean ownsTimerExecutor;
     private final Mu3StatsImpl statsImpl = new Mu3StatsImpl();
 
-    Mu3ServerImpl(List<ConnectionAcceptor> acceptors, List<MuHandler> handlers, List<ResponseCompleteListener> responseCompleteListeners, List<RequestRejectListener> requestRejectListeners, UnhandledExceptionHandler exceptionHandler, Long maxRequestBodySize, List<ContentEncoder> contentEncoders, Long requestIdleTimeoutMillis, Long idleTimeoutMillis, int maxUrlSize, int maxHeadersSize, List<RateLimiterImpl> rateLimiters, Path tempDir, ExecutorService connectionExecutor, boolean ownsConnectionExecutor, ExecutorService http2WriterExecutor, boolean ownsHttp2WriterExecutor, ScheduledExecutorService timerExecutor, boolean ownsTimerExecutor) {
+    Mu3ServerImpl(List<ConnectionAcceptor> acceptors, List<MuHandler> handlers, List<ResponseCompleteListener> responseCompleteListeners, List<RequestRejectListener> requestRejectListeners, UnhandledExceptionHandler exceptionHandler, Long maxRequestBodySize, List<ContentEncoder> contentEncoders, Long requestIdleTimeoutMillis, Long idleTimeoutMillis, int maxUrlSize, int maxHeadersSize, List<RateLimiterImpl> rateLimiters, Path tempDir, ExecutorService connectionExecutor, boolean ownsConnectionExecutor, ExecutorService http2WriterExecutor, boolean ownsHttp2WriterExecutor, ExecutorService connectionMaintenanceExecutor, boolean ownsConnectionMaintenanceExecutor, ScheduledExecutorService timerExecutor, boolean ownsTimerExecutor) {
         this.acceptors = acceptors;
         this.handlers = handlers;
         this.responseCompleteListeners = responseCompleteListeners;
@@ -62,6 +64,8 @@ class Mu3ServerImpl implements MuServer {
         this.ownsConnectionExecutor = ownsConnectionExecutor;
         this.http2WriterExecutor = http2WriterExecutor;
         this.ownsHttp2WriterExecutor = ownsHttp2WriterExecutor;
+        this.connectionMaintenanceExecutor = connectionMaintenanceExecutor;
+        this.ownsConnectionMaintenanceExecutor = ownsConnectionMaintenanceExecutor;
         this.timerExecutor = timerExecutor;
         this.ownsTimerExecutor = ownsTimerExecutor;
     }
@@ -109,6 +113,9 @@ class Mu3ServerImpl implements MuServer {
         }
         if (ownsHttp2WriterExecutor) {
             http2WriterExecutor.shutdown();
+        }
+        if (ownsConnectionMaintenanceExecutor) {
+            connectionMaintenanceExecutor.shutdown();
         }
         return stoppedCleanly;
     }
@@ -313,6 +320,11 @@ class Mu3ServerImpl implements MuServer {
         if (http2WriterExecutor == null) {
             http2WriterExecutor = MuServerBuilder.defaultExecutor();
         }
+        ExecutorService connectionMaintenanceExecutor = builder.connectionMaintenanceExecutor();
+        boolean ownsConnectionMaintenanceExecutor = connectionMaintenanceExecutor == null;
+        if (connectionMaintenanceExecutor == null) {
+            connectionMaintenanceExecutor = MuServerBuilder.defaultExecutor();
+        }
         ScheduledExecutorService timerExecutor = builder.timerExecutor();
         boolean ownsTimerExecutor = timerExecutor == null;
         if (timerExecutor == null) {
@@ -360,6 +372,8 @@ class Mu3ServerImpl implements MuServer {
             ownsConnectionExecutor,
             http2WriterExecutor,
             ownsHttp2WriterExecutor,
+            connectionMaintenanceExecutor,
+            ownsConnectionMaintenanceExecutor,
             timerExecutor,
             ownsTimerExecutor
             );
@@ -453,10 +467,10 @@ class Mu3ServerImpl implements MuServer {
 
     private boolean tryDispatchConnectionTask(Runnable task) {
         try {
-            connectionExecutor.execute(task);
+            connectionMaintenanceExecutor.execute(task);
             return true;
         } catch (RejectedExecutionException e) {
-            log.debug("Connection executor rejected timed work because the server is stopping or overloaded");
+            log.debug("Connection maintenance executor rejected timed work because the server is stopping or overloaded");
             return false;
         }
     }

--- a/src/main/java/io/muserver/MuServerBuilder.java
+++ b/src/main/java/io/muserver/MuServerBuilder.java
@@ -41,6 +41,7 @@ public class MuServerBuilder {
     private @Nullable ExecutorService executor;
     private @Nullable ExecutorService connectionExecutor;
     private @Nullable ExecutorService http2WriterExecutor;
+    private @Nullable ExecutorService connectionMaintenanceExecutor;
     private @Nullable ScheduledExecutorService timerExecutor;
     private long maxRequestSize = 24 * 1024 * 1024;
     private @Nullable List<ResponseCompleteListener> responseCompleteListeners;
@@ -261,11 +262,37 @@ public class MuServerBuilder {
     }
 
     /**
+     * Sets the executor used for timed connection maintenance, including idle timeout
+     * checks and automatic WebSocket pings.
+     *
+     * <p>Timer threads only determine when work is due and dispatch it to this executor.
+     * This executor must be independent from bounded executors containing long-lived
+     * connection tasks, otherwise those tasks can prevent timeouts and pings from
+     * running.</p>
+     *
+     * <p>By default, a server-owned virtual-thread-per-task executor is used when the
+     * runtime supports virtual threads, otherwise a cached thread pool is used. A
+     * caller-supplied executor remains owned by the caller and is not shut down when
+     * the server stops.</p>
+     *
+     * @param connectionMaintenanceExecutor The executor for timed connection work, or
+     *                                      <code>null</code> to use the default
+     * @return The current Mu Server builder
+     */
+    public MuServerBuilder withConnectionMaintenanceExecutor(
+        @Nullable ExecutorService connectionMaintenanceExecutor
+    ) {
+        this.connectionMaintenanceExecutor = connectionMaintenanceExecutor;
+        return this;
+    }
+
+    /**
      * Sets the executor used to schedule server connection timers.
      *
      * <p>Timer threads only determine when work is due. Connection work is dispatched
-     * to the executor configured by {@link #withConnectionExecutor(ExecutorService)}
-     * so that timer threads do not perform socket I/O or invoke application handlers.</p>
+     * to the executor configured by
+     * {@link #withConnectionMaintenanceExecutor(ExecutorService)}
+     * so that timer threads do not perform socket I/O or invoke application callbacks.</p>
      *
      * <p>The supplied scheduled executor must remain able to execute brief scheduling
      * callbacks promptly. It should not be shared with an executor that can be occupied
@@ -694,6 +721,15 @@ public class MuServerBuilder {
     }
 
     /**
+     * Gets the executor used for timed connection maintenance.
+     *
+     * @return The configured executor, or <code>null</code> if the default executor will be used.
+     */
+    public @Nullable ExecutorService connectionMaintenanceExecutor() {
+        return connectionMaintenanceExecutor;
+    }
+
+    /**
      * Gets the executor used to schedule server connection timers.
      *
      * @return The configured executor, or <code>null</code> if the default executor will be used.
@@ -812,6 +848,7 @@ public class MuServerBuilder {
             ", executor=" + executor +
             ", connectionExecutor=" + connectionExecutor +
             ", http2WriterExecutor=" + http2WriterExecutor +
+            ", connectionMaintenanceExecutor=" + connectionMaintenanceExecutor +
             ", timerExecutor=" + timerExecutor +
             ", maxRequestSize=" + maxRequestSize +
             ", responseCompleteListeners=" + responseCompleteListeners +

--- a/src/test/java/io/muserver/ExecutionDomainsTest.java
+++ b/src/test/java/io/muserver/ExecutionDomainsTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
+import java.io.EOFException;
 import java.io.IOException;
 import java.net.ServerSocket;
 import java.nio.ByteBuffer;
@@ -178,21 +179,47 @@ class ExecutionDomainsTest {
     }
 
     @Test
+    void idleTimeoutIsNotStarvedByAConnectionReader() throws Exception {
+        var connectionExecutor = track(Executors.newSingleThreadExecutor(namedThreads("connection-")));
+        var writerExecutor = track(Executors.newSingleThreadExecutor(namedThreads("h2-writer-")));
+        var maintenanceExecutor = track(Executors.newSingleThreadExecutor(namedThreads("maintenance-")));
+
+        server = httpServer()
+            .withHttp2Config(Http2ConfigBuilder.http2Enabled())
+            .withConnectionExecutor(connectionExecutor)
+            .withHttp2WriterExecutor(writerExecutor)
+            .withConnectionMaintenanceExecutor(maintenanceExecutor)
+            .withIdleTimeout(100, TimeUnit.MILLISECONDS)
+            .start();
+
+        try (var client = new H2Client();
+             var con = client.connectClearText(server)) {
+            con.handshake();
+            con.socket().setSoTimeout(2000);
+
+            assertThrows(EOFException.class, con::readLogicalFrame);
+        }
+    }
+
+    @Test
     void configuredExecutorsStayCallerOwnedAndHttp1UsesTheHandlerExecutor() throws Exception {
         var handlerExecutor = track(Executors.newSingleThreadExecutor(namedThreads("handler-")));
         var connectionExecutor = track(Executors.newCachedThreadPool(namedThreads("connection-")));
         var writerExecutor = track(Executors.newCachedThreadPool(namedThreads("h2-writer-")));
+        var maintenanceExecutor = track(Executors.newCachedThreadPool(namedThreads("maintenance-")));
         var timerExecutor = track(Executors.newSingleThreadScheduledExecutor(namedThreads("timer-")));
 
         var builder = httpServer()
             .withHandlerExecutor(handlerExecutor)
             .withConnectionExecutor(connectionExecutor)
             .withHttp2WriterExecutor(writerExecutor)
+            .withConnectionMaintenanceExecutor(maintenanceExecutor)
             .withTimerExecutor(timerExecutor)
             .addHandler(Method.GET, "/", (request, response, pathParams) ->
                 response.write(Thread.currentThread().getName()));
         assertThat(builder.connectionExecutor(), is(connectionExecutor));
         assertThat(builder.http2WriterExecutor(), is(writerExecutor));
+        assertThat(builder.connectionMaintenanceExecutor(), is(maintenanceExecutor));
         assertThat(builder.timerExecutor(), is(timerExecutor));
 
         server = builder.start();
@@ -205,6 +232,7 @@ class ExecutionDomainsTest {
         server = null;
         assertThat(connectionExecutor.isShutdown(), is(false));
         assertThat(writerExecutor.isShutdown(), is(false));
+        assertThat(maintenanceExecutor.isShutdown(), is(false));
         assertThat(handlerExecutor.isShutdown(), is(false));
         assertThat(timerExecutor.isShutdown(), is(false));
     }
@@ -214,6 +242,7 @@ class ExecutionDomainsTest {
         var handlerExecutor = track(Executors.newSingleThreadExecutor(namedThreads("handler-")));
         var connectionExecutor = track(Executors.newCachedThreadPool(namedThreads("connection-")));
         var writerExecutor = track(Executors.newCachedThreadPool(namedThreads("h2-writer-")));
+        var maintenanceExecutor = track(Executors.newCachedThreadPool(namedThreads("maintenance-")));
         var timerExecutor = track(Executors.newSingleThreadScheduledExecutor(namedThreads("timer-")));
         timerExecutor.shutdown();
         int port = availablePort();
@@ -223,12 +252,14 @@ class ExecutionDomainsTest {
             .withHandlerExecutor(handlerExecutor)
             .withConnectionExecutor(connectionExecutor)
             .withHttp2WriterExecutor(writerExecutor)
+            .withConnectionMaintenanceExecutor(maintenanceExecutor)
             .withTimerExecutor(timerExecutor)
             .start());
 
         assertThat(handlerExecutor.isShutdown(), is(false));
         assertThat(connectionExecutor.isShutdown(), is(false));
         assertThat(writerExecutor.isShutdown(), is(false));
+        assertThat(maintenanceExecutor.isShutdown(), is(false));
         try (var replacementListener = new ServerSocket(port)) {
             assertThat(replacementListener.isBound(), is(true));
         }
@@ -238,6 +269,7 @@ class ExecutionDomainsTest {
     void timedConnectionWorkIsNotStarvedByTheHandlerExecutor() throws Exception {
         var handlerExecutor = track(Executors.newSingleThreadExecutor(namedThreads("handler-")));
         var connectionExecutor = track(Executors.newCachedThreadPool(namedThreads("connection-")));
+        var maintenanceExecutor = track(Executors.newSingleThreadExecutor(namedThreads("maintenance-")));
         var pongReceived = new CountDownLatch(1);
         var serverSocket = new SimpleWebSocket() {
             @Override
@@ -258,6 +290,7 @@ class ExecutionDomainsTest {
         server = httpServer()
             .withHandlerExecutor(handlerExecutor)
             .withConnectionExecutor(connectionExecutor)
+            .withConnectionMaintenanceExecutor(maintenanceExecutor)
             .addHandler(webSocketHandler((request, responseHeaders) -> serverSocket)
                 .withPingInterval(10, TimeUnit.MILLISECONDS))
             .start();


### PR DESCRIPTION
## What changed

- add a separately configurable `withConnectionMaintenanceExecutor(...)` domain
- dispatch idle-timeout scans and automatic WebSocket pings there instead of the connection executor
- retain caller ownership and shut down server-owned maintenance executors
- clarify that timer threads schedule work but do not perform socket I/O or invoke application callbacks

## Why

The connection executor contains long-lived HTTP/2 reader tasks. With a bounded executor, readers can occupy every worker indefinitely, leaving timed maintenance queued behind them. In the regression case a single HTTP/2 reader parsed the connection normally, but its idle timeout never ran and the socket remained open.

Running maintenance on the timer thread would move socket operations and WebSocket timeout callbacks onto the scheduler, where one slow callback could delay unrelated deadlines. A separate maintenance domain preserves prompt scheduling without coupling it to long-lived connection readers.

## Validation

- deterministic HTTP/2 regression with independent single-thread connection, writer, and maintenance executors; before the change the idle socket timed out in the test client instead of reaching EOF
- executor getter, normal ownership, and startup-rollback coverage
- WebSocket automatic ping coverage on the configured maintenance executor
- Java 11 execution-domain, WebSocket, async, idle-timeout, shutdown, and WINDOW_UPDATE tests
- Java 25 execution-domain, WebSocket, and shutdown tests
- full `mvn -q -Pnullaway verify` on Java 21