### PR TITLE
Roll back partially constructed servers

### DIFF
--- a/src/main/java/io/muserver/ConnectionAcceptor.java
+++ b/src/main/java/io/muserver/ConnectionAcceptor.java
@@ -431,6 +431,7 @@ class ConnectionAcceptor {
             lastStopWasGraceful = false;
             return false;
         }
+        state = State.STOPPED;
         return lastStopWasGraceful;
     }
 
@@ -456,14 +457,23 @@ class ConnectionAcceptor {
         List<ContentEncoder> contentEncoders) throws IOException {
 
         ServerSocket socketServer = new ServerSocket(bindPort, ACCEPT_BACKLOG, address);
-        configureSocketOptions(socketServer);
+        try {
+            configureSocketOptions(socketServer);
 
-        String uriHost = address != null ? address.getHostName() : "localhost";
-        URI uri = URI.create("http" + (httpsConfig == null ? "" : "s") + "://" + uriHost + ":" + socketServer.getLocalPort());
+            String uriHost = address != null ? address.getHostName() : "localhost";
+            URI uri = URI.create("http" + (httpsConfig == null ? "" : "s") + "://" + uriHost + ":" + socketServer.getLocalPort());
 
-        return new ConnectionAcceptor(server, socketServer,
-            (InetSocketAddress) socketServer.getLocalSocketAddress(),
-            uri, httpsConfig, h2Config, handlerExecutor, connectionExecutor, http2WriterExecutor, contentEncoders);
+            return new ConnectionAcceptor(server, socketServer,
+                (InetSocketAddress) socketServer.getLocalSocketAddress(),
+                uri, httpsConfig, h2Config, handlerExecutor, connectionExecutor, http2WriterExecutor, contentEncoders);
+        } catch (IOException | RuntimeException | Error creationFailure) {
+            try {
+                socketServer.close();
+            } catch (IOException cleanupFailure) {
+                creationFailure.addSuppressed(cleanupFailure);
+            }
+            throw creationFailure;
+        }
     }
 
     private static void configureSocketOptions(ServerSocket socketServer) throws IOException {

--- a/src/main/java/io/muserver/Mu3ServerImpl.java
+++ b/src/main/java/io/muserver/Mu3ServerImpl.java
@@ -36,6 +36,8 @@ class Mu3ServerImpl implements MuServer {
     private final int maxHeadersSize;
     final List<RateLimiterImpl> rateLimiters;
     final Path tempDir;
+    private final ExecutorService handlerExecutor;
+    private final boolean ownsHandlerExecutor;
     private final ExecutorService connectionExecutor;
     private final boolean ownsConnectionExecutor;
     private final ExecutorService http2WriterExecutor;
@@ -46,7 +48,7 @@ class Mu3ServerImpl implements MuServer {
     private final boolean ownsTimerExecutor;
     private final Mu3StatsImpl statsImpl = new Mu3StatsImpl();
 
-    Mu3ServerImpl(List<ConnectionAcceptor> acceptors, List<MuHandler> handlers, List<ResponseCompleteListener> responseCompleteListeners, List<RequestRejectListener> requestRejectListeners, UnhandledExceptionHandler exceptionHandler, Long maxRequestBodySize, List<ContentEncoder> contentEncoders, Long requestIdleTimeoutMillis, Long idleTimeoutMillis, int maxUrlSize, int maxHeadersSize, List<RateLimiterImpl> rateLimiters, Path tempDir, ExecutorService connectionExecutor, boolean ownsConnectionExecutor, ExecutorService http2WriterExecutor, boolean ownsHttp2WriterExecutor, ExecutorService connectionMaintenanceExecutor, boolean ownsConnectionMaintenanceExecutor, ScheduledExecutorService timerExecutor, boolean ownsTimerExecutor) {
+    Mu3ServerImpl(List<ConnectionAcceptor> acceptors, List<MuHandler> handlers, List<ResponseCompleteListener> responseCompleteListeners, List<RequestRejectListener> requestRejectListeners, UnhandledExceptionHandler exceptionHandler, Long maxRequestBodySize, List<ContentEncoder> contentEncoders, Long requestIdleTimeoutMillis, Long idleTimeoutMillis, int maxUrlSize, int maxHeadersSize, List<RateLimiterImpl> rateLimiters, Path tempDir, ExecutorService handlerExecutor, boolean ownsHandlerExecutor, ExecutorService connectionExecutor, boolean ownsConnectionExecutor, ExecutorService http2WriterExecutor, boolean ownsHttp2WriterExecutor, ExecutorService connectionMaintenanceExecutor, boolean ownsConnectionMaintenanceExecutor, ScheduledExecutorService timerExecutor, boolean ownsTimerExecutor) {
         this.acceptors = acceptors;
         this.handlers = handlers;
         this.responseCompleteListeners = responseCompleteListeners;
@@ -60,6 +62,8 @@ class Mu3ServerImpl implements MuServer {
         this.maxHeadersSize = maxHeadersSize;
         this.rateLimiters = rateLimiters;
         this.tempDir = tempDir;
+        this.handlerExecutor = handlerExecutor;
+        this.ownsHandlerExecutor = ownsHandlerExecutor;
         this.connectionExecutor = connectionExecutor;
         this.ownsConnectionExecutor = ownsConnectionExecutor;
         this.http2WriterExecutor = http2WriterExecutor;
@@ -116,6 +120,9 @@ class Mu3ServerImpl implements MuServer {
         }
         if (ownsConnectionMaintenanceExecutor) {
             connectionMaintenanceExecutor.shutdown();
+        }
+        if (ownsHandlerExecutor) {
+            handlerExecutor.shutdown();
         }
         return stoppedCleanly;
     }
@@ -306,7 +313,32 @@ class Mu3ServerImpl implements MuServer {
     static MuServer start(MuServerBuilder builder) throws IOException {
 
         var exceptionHandler = UnhandledExceptionHandler.getDefault(builder.unhandledExceptionHandler());
+        var tempDir = builder.tempDirectory();
+        if (tempDir == null) {
+            tempDir = Files.createTempDirectory("muservertemp");
+        }
+
+        var acceptors = new ArrayList<ConnectionAcceptor>(2);
+
+        var actualHandlers = new ArrayList<MuHandler>();
+        actualHandlers.add(RequestVerifierHandler.INSTANCE);
+        if (builder.autoHandleExpectContinue()) {
+            actualHandlers.add(0, new ExpectContinueHandler(builder.maxRequestSize()));
+        }
+        actualHandlers.addAll(builder.handlers());
+
+        List<ContentEncoder> contentEncoders = builder.contentEncoders();
+        if (contentEncoders == null) {
+            contentEncoders = List.of(gzipEncoder().build());
+        }
+
+        List<RateLimiterImpl> limiters = builder.rateLimiters;
+        if (limiters == null) {
+            limiters = emptyList();
+        }
+
         ExecutorService handlerExecutor = builder.executor();
+        boolean ownsHandlerExecutor = handlerExecutor == null;
         if (handlerExecutor == null) {
             handlerExecutor = MuServerBuilder.defaultExecutor();
         }
@@ -330,29 +362,6 @@ class Mu3ServerImpl implements MuServer {
         if (timerExecutor == null) {
             timerExecutor = MuServerBuilder.defaultTimerExecutor();
         }
-        var acceptors = new ArrayList<ConnectionAcceptor>(2);
-
-        var actualHandlers = new ArrayList<MuHandler>();
-        actualHandlers.add(RequestVerifierHandler.INSTANCE);
-        if (builder.autoHandleExpectContinue()) {
-            actualHandlers.add(0, new ExpectContinueHandler(builder.maxRequestSize()));
-        }
-        actualHandlers.addAll(builder.handlers());
-
-        List<ContentEncoder> contentEncoders = builder.contentEncoders();
-        if (contentEncoders == null) {
-            contentEncoders = List.of(gzipEncoder().build());
-        }
-
-        var tempDir = builder.tempDirectory();
-        if (tempDir == null) {
-            tempDir = Files.createTempDirectory("muservertemp");
-        }
-
-        List<RateLimiterImpl> limiters = builder.rateLimiters;
-        if (limiters == null) {
-            limiters = emptyList();
-        }
 
         var impl = new Mu3ServerImpl(
             acceptors,
@@ -368,6 +377,8 @@ class Mu3ServerImpl implements MuServer {
             builder.maxHeadersSize(),
             limiters,
             tempDir,
+            handlerExecutor,
+            ownsHandlerExecutor,
             connectionExecutor,
             ownsConnectionExecutor,
             http2WriterExecutor,
@@ -378,59 +389,68 @@ class Mu3ServerImpl implements MuServer {
             ownsTimerExecutor
             );
 
-        var ih = builder.interfaceHost();
-        var address = ih == null ? null : InetAddress.getByName(ih);
+        try {
+            var ih = builder.interfaceHost();
+            var address = ih == null ? null : InetAddress.getByName(ih);
 
-        var configuredHttp2 = builder.http2Config();
-        Http2Config http2ConfigForHttp = configuredHttp2;
-        if (http2ConfigForHttp != null && http2ConfigForHttp.maxHeaderListSize() == -1) {
-            http2ConfigForHttp = http2ConfigForHttp.toBuilder().withMaxHeaderListSize(builder.maxHeadersSize()).build();
-        }
-
-        if (builder.httpsPort() >= 0) {
-            var http2Config = configuredHttp2;
-            if (http2Config == null) {
-                http2Config = Http2ConfigBuilder.http2Config().withMaxHeaderListSize(builder.maxHeadersSize()).build();
-            }
-            if (http2Config.maxHeaderListSize() == -1) {
-                http2Config = http2Config.toBuilder().withMaxHeaderListSize(builder.maxHeadersSize()).build();
+            var configuredHttp2 = builder.http2Config();
+            Http2Config http2ConfigForHttp = configuredHttp2;
+            if (http2ConfigForHttp != null && http2ConfigForHttp.maxHeaderListSize() == -1) {
+                http2ConfigForHttp = http2ConfigForHttp.toBuilder().withMaxHeaderListSize(builder.maxHeadersSize()).build();
             }
 
-            var httpsConfigBuilder = builder.httpsConfigBuilder();
-            if (httpsConfigBuilder == null) {
-                httpsConfigBuilder = HttpsConfigBuilder.unsignedLocalhost();
-            }
-            var httpsConfig = httpsConfigBuilder.build3();
+            if (builder.httpsPort() >= 0) {
+                var http2Config = configuredHttp2;
+                if (http2Config == null) {
+                    http2Config = Http2ConfigBuilder.http2Config().withMaxHeaderListSize(builder.maxHeadersSize()).build();
+                }
+                if (http2Config.maxHeaderListSize() == -1) {
+                    http2Config = http2Config.toBuilder().withMaxHeaderListSize(builder.maxHeadersSize()).build();
+                }
 
-            var acceptor = ConnectionAcceptor.create(
-                impl,
-                address,
-                builder.httpsPort(),
-                httpsConfig,
-                http2Config,
-                handlerExecutor,
-                connectionExecutor,
-                http2WriterExecutor,
-                contentEncoders
-            );
-            acceptors.add(acceptor);
-            httpsConfig.setHttpsUri(acceptor.uri());
+                var httpsConfigBuilder = builder.httpsConfigBuilder();
+                if (httpsConfigBuilder == null) {
+                    httpsConfigBuilder = HttpsConfigBuilder.unsignedLocalhost();
+                }
+                var httpsConfig = httpsConfigBuilder.build3();
+
+                var acceptor = ConnectionAcceptor.create(
+                    impl,
+                    address,
+                    builder.httpsPort(),
+                    httpsConfig,
+                    http2Config,
+                    handlerExecutor,
+                    connectionExecutor,
+                    http2WriterExecutor,
+                    contentEncoders
+                );
+                acceptors.add(acceptor);
+                httpsConfig.setHttpsUri(acceptor.uri());
+            }
+            if (builder.httpPort() >= 0) {
+                acceptors.add(ConnectionAcceptor.create(
+                    impl,
+                    address,
+                    builder.httpPort(),
+                    null,
+                    http2ConfigForHttp,
+                    handlerExecutor,
+                    connectionExecutor,
+                    http2WriterExecutor,
+                    contentEncoders
+                ));
+            }
+            impl.startListening();
+            return impl;
+        } catch (IOException | RuntimeException | Error startFailure) {
+            try {
+                impl.stop(0, TimeUnit.MILLISECONDS);
+            } catch (RuntimeException | Error cleanupFailure) {
+                startFailure.addSuppressed(cleanupFailure);
+            }
+            throw startFailure;
         }
-        if (builder.httpPort() >= 0) {
-            acceptors.add(ConnectionAcceptor.create(
-                impl,
-                address,
-                builder.httpPort(),
-                null,
-                http2ConfigForHttp,
-                handlerExecutor,
-                connectionExecutor,
-                http2WriterExecutor,
-                contentEncoders
-            ));
-        }
-        impl.startListening();
-        return impl;
     }
 
     ScheduledFuture<?> scheduleConnectionTask(Runnable task, long delay, TimeUnit unit) {

--- a/src/main/java/io/muserver/MuServerBuilder.java
+++ b/src/main/java/io/muserver/MuServerBuilder.java
@@ -203,8 +203,10 @@ public class MuServerBuilder {
 
     /**
      * Sets the thread executor service to run requests on. By default, a
-     * virtual-thread-per-task executor is used when the runtime supports virtual
-     * threads, otherwise {@link Executors#newCachedThreadPool()} is used.
+     * server-owned virtual-thread-per-task executor is used when the runtime supports
+     * virtual threads, otherwise {@link Executors#newCachedThreadPool()} is used. A
+     * caller-supplied executor remains owned by the caller and is not shut down when
+     * the server stops.
      *
      * @param executor The executor service to use to handle requests
      * @return The current Mu Server builder

--- a/src/test/java/io/muserver/ExecutionDomainsTest.java
+++ b/src/test/java/io/muserver/ExecutionDomainsTest.java
@@ -267,6 +267,26 @@ class ExecutionDomainsTest {
     }
 
     @Test
+    void serverOwnedExecutorsAreShutDownWithTheServer() throws Exception {
+        server = httpServer().start();
+        var serverImpl = (Mu3ServerImpl) server;
+        List<ExecutorService> serverOwnedExecutors = List.of(
+            getField(serverImpl, "handlerExecutor", ExecutorService.class),
+            getField(serverImpl, "connectionExecutor", ExecutorService.class),
+            getField(serverImpl, "http2WriterExecutor", ExecutorService.class),
+            getField(serverImpl, "connectionMaintenanceExecutor", ExecutorService.class),
+            getField(serverImpl, "timerExecutor", ExecutorService.class)
+        );
+
+        server.stop();
+        server = null;
+
+        for (ExecutorService executor : serverOwnedExecutors) {
+            assertThat(executor.isShutdown(), is(true));
+        }
+    }
+
+    @Test
     void rejectedTimerSchedulingRollsBackStartupWithoutTakingCallerExecutors() throws Exception {
         var handlerExecutor = track(Executors.newSingleThreadExecutor(namedThreads("handler-")));
         var connectionExecutor = track(Executors.newCachedThreadPool(namedThreads("connection-")));
@@ -290,6 +310,37 @@ class ExecutionDomainsTest {
         assertThat(writerExecutor.isShutdown(), is(false));
         assertThat(maintenanceExecutor.isShutdown(), is(false));
         try (var replacementListener = new ServerSocket(port)) {
+            assertThat(replacementListener.isBound(), is(true));
+        }
+    }
+
+    @Test
+    void listenerCreationFailureRollsBackEarlierListenersWithoutTakingCallerExecutors() throws Exception {
+        var handlerExecutor = track(Executors.newSingleThreadExecutor(namedThreads("handler-")));
+        var connectionExecutor = track(Executors.newCachedThreadPool(namedThreads("connection-")));
+        var writerExecutor = track(Executors.newCachedThreadPool(namedThreads("h2-writer-")));
+        var maintenanceExecutor = track(Executors.newCachedThreadPool(namedThreads("maintenance-")));
+        var timerExecutor = track(Executors.newSingleThreadScheduledExecutor(namedThreads("timer-")));
+        int firstPort = availablePort();
+
+        try (var occupiedListener = new ServerSocket(0)) {
+            assertThrows(MuException.class, () -> MuServerBuilder.muServer()
+                .withHttpsPort(firstPort)
+                .withHttpPort(occupiedListener.getLocalPort())
+                .withHandlerExecutor(handlerExecutor)
+                .withConnectionExecutor(connectionExecutor)
+                .withHttp2WriterExecutor(writerExecutor)
+                .withConnectionMaintenanceExecutor(maintenanceExecutor)
+                .withTimerExecutor(timerExecutor)
+                .start());
+        }
+
+        assertThat(handlerExecutor.isShutdown(), is(false));
+        assertThat(connectionExecutor.isShutdown(), is(false));
+        assertThat(writerExecutor.isShutdown(), is(false));
+        assertThat(maintenanceExecutor.isShutdown(), is(false));
+        assertThat(timerExecutor.isShutdown(), is(false));
+        try (var replacementListener = new ServerSocket(firstPort)) {
             assertThat(replacementListener.isBound(), is(true));
         }
     }
@@ -351,6 +402,12 @@ class ExecutionDomainsTest {
     private static java.util.concurrent.ThreadFactory namedThreads(String prefix) {
         var count = new AtomicInteger();
         return runnable -> new Thread(runnable, prefix + count.incrementAndGet());
+    }
+
+    private static <T> T getField(Object target, String name, Class<T> type) throws Exception {
+        var field = target.getClass().getDeclaredField(name);
+        field.setAccessible(true);
+        return type.cast(field.get(target));
     }
 
     @AfterEach


### PR DESCRIPTION
## Summary
- make server startup transactional across listener creation and listener startup
- close a `ServerSocket` when acceptor construction fails after binding
- consistently shut down every server-owned executor, including the default handler executor, while preserving caller ownership
- make stopping a constructed-but-never-started acceptor idempotent

## Why
If the HTTPS listener bound successfully and creation of the HTTP listener then failed, startup threw without returning a server but left the first listening socket open. The same partial-startup paths could also leak executors created by the server. This makes the ownership boundary explicit and rolls all constructed server resources back together.

## Tests
- deterministic occupied-second-port test proves the earlier listener can be rebound and configured executors remain caller-owned
- server stop test verifies all five default executor domains are shut down
- Java 11 targeted concurrency, lifecycle, TLS, WebSocket, async, HTTP/2 GOAWAY and WINDOW_UPDATE tests
- Java 25 targeted lifecycle, TLS, and HTTP/2 tests
- Java 21 full `mvn -q -Pnullaway verify`