### PR TITLE
Separate HTTP/1 connections from request handlers

### DIFF
--- a/src/main/java/io/muserver/ConnectionAcceptor.java
+++ b/src/main/java/io/muserver/ConnectionAcceptor.java
@@ -263,26 +263,8 @@ class ConnectionAcceptor {
 
         if (rejectDueToOverload) {
             handleOverload(socket);
-        } else if (httpVersion == HttpVersion.HTTP_2) {
-            handleRequest(socket, clientCert, startTime, httpVersion, inputStream);
         } else {
-            Socket requestSocket = socket;
-            Certificate requestClientCert = clientCert;
-            PushbackInputStream requestInputStream = inputStream;
-            HttpVersion requestHttpVersion = httpVersion;
-            try {
-                handlerExecutor.submit(() ->
-                    handleRequest(
-                        requestSocket,
-                        requestClientCert,
-                        startTime,
-                        requestHttpVersion,
-                        requestInputStream
-                    )
-                );
-            } catch (RejectedExecutionException e) {
-                handleOverload(requestSocket);
-            }
+            handleRequest(socket, clientCert, startTime, httpVersion, inputStream);
         }
     }
 
@@ -353,7 +335,15 @@ class ConnectionAcceptor {
                 http2WriterExecutor
             );
         } else {
-            con = new Http1Connection(server, this, socket, clientCert, startTime);
+            con = new Http1Connection(
+                server,
+                this,
+                socket,
+                clientCert,
+                startTime,
+                handlerExecutor,
+                handlerExecutor == connectionExecutor
+            );
         }
 
         connections.add(con);

--- a/src/main/java/io/muserver/ConnectionAcceptor.java
+++ b/src/main/java/io/muserver/ConnectionAcceptor.java
@@ -317,6 +317,7 @@ class ConnectionAcceptor {
         }
     }
 
+    @SuppressWarnings("ReferenceEquality") // Sharing is defined by the exact configured executor instance.
     private void handleRequest(Socket socket, @Nullable Certificate clientCert, Instant startTime, HttpVersion httpVersion, @Nullable InputStream providedInputStream) {
         BaseHttpConnection con;
         if (httpVersion == HttpVersion.HTTP_2) {

--- a/src/main/java/io/muserver/Http1Connection.java
+++ b/src/main/java/io/muserver/Http1Connection.java
@@ -14,7 +14,11 @@ import java.security.cert.Certificate;
 import java.time.Instant;
 import java.util.Queue;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -23,6 +27,8 @@ import static java.util.Collections.emptySet;
 class Http1Connection extends BaseHttpConnection {
 
     private static final Logger log = LoggerFactory.getLogger(Http1Connection.class);
+    private final ExecutorService handlerExecutor;
+    private final boolean handlersRunOnConnectionTask;
     private final Queue<HttpRequestTemp> requestPipeline = new ConcurrentLinkedQueue<>();
     // At most one active exchange exists on HTTP/1.1: either an HTTP request/response or a websocket takeover.
     private final AtomicReference<@Nullable ActiveExchange> activeExchange = new AtomicReference<>();
@@ -49,8 +55,12 @@ class Http1Connection extends BaseHttpConnection {
         }
     }
 
-    Http1Connection(Mu3ServerImpl server, ConnectionAcceptor creator, Socket clientSocket, @Nullable Certificate clientCertificate, Instant handshakeStartTime) {
+    Http1Connection(Mu3ServerImpl server, ConnectionAcceptor creator, Socket clientSocket,
+                    @Nullable Certificate clientCertificate, Instant handshakeStartTime,
+                    ExecutorService handlerExecutor, boolean handlersRunOnConnectionTask) {
         super(server, creator, clientSocket, clientCertificate, handshakeStartTime);
+        this.handlerExecutor = handlerExecutor;
+        this.handlersRunOnConnectionTask = handlersRunOnConnectionTask;
     }
 
     @Override
@@ -140,15 +150,22 @@ class Http1Connection extends BaseHttpConnection {
 
                     onRequestStarted(muRequest);
 
+                    boolean rejectedByHandlerExecutor = false;
                     try {
-                        handleExchange(muRequest, muResponse);
-                        closeConnection = cleanUpNicely(closeConnection, muResponse, muRequest);
+                        if (handleExchangeOnHandlerExecutor(muRequest, muResponse)) {
+                            closeConnection = cleanUpNicely(closeConnection, muResponse, muRequest);
+                        } else {
+                            rejectedByHandlerExecutor = true;
+                            closeConnection = rejectRequestDueToHandlerOverload(muRequest, outputStream);
+                        }
                     } catch (Throwable e) {
                         closeConnection = true;
                         log.warn("Unrecoverable error for " + muRequest, e);
                         muResponse.setState(ResponseState.ERRORED);
                     } finally {
-                        onExchangeEnded(muResponse);
+                        if (!rejectedByHandlerExecutor) {
+                            onExchangeEnded(muResponse);
+                        }
                         clientSocket.setSoTimeout(0);
                     }
                     var websocket = muResponse.getWebsocket();
@@ -168,6 +185,53 @@ class Http1Connection extends BaseHttpConnection {
             activeExchange.set(null);
             closeTransportQuietly();
         }
+    }
+
+    private boolean handleExchangeOnHandlerExecutor(Mu3Request request, Http1Response response) throws Throwable {
+        if (handlersRunOnConnectionTask) {
+            handleExchange(request, response);
+            return true;
+        }
+        CompletableFuture<@Nullable Void> completion = new CompletableFuture<>();
+        try {
+            handlerExecutor.execute(() -> {
+                try {
+                    handleExchange(request, response);
+                    completion.complete(null);
+                } catch (Throwable t) {
+                    completion.completeExceptionally(t);
+                }
+            });
+        } catch (RejectedExecutionException rejected) {
+            return false;
+        }
+        try {
+            completion.get();
+            return true;
+        } catch (ExecutionException e) {
+            throw e.getCause();
+        }
+    }
+
+    private boolean rejectRequestDueToHandlerOverload(Mu3Request request, OutputStream outputStream) throws IOException {
+        rejectedDueToOverload.incrementAndGet();
+        server.getStatsImpl().onRejectedDueToOverload();
+        server.onRequestSubmissionRejected(request);
+        activeExchange.updateAndGet(cur ->
+            cur != null && isSameRequest(cur.request, request) ? null : cur
+        );
+
+        String rejectionReason = "503 Service Unavailable";
+        outputStream.write(ConnectionAcceptor.serverUnavailableResponse);
+        outputStream.flush();
+        server.onRequestRejected(new RejectedRequestImpl(
+            HttpStatus.SERVICE_UNAVAILABLE_503.code(),
+            rejectionReason,
+            request.method().name(),
+            request.uri().toString(),
+            this
+        ));
+        return true;
     }
 
     private boolean cleanUpNicely(Boolean closeConnection, Http1Response muResponse, Mu3Request muRequest) {

--- a/src/main/java/io/muserver/MuServerBuilder.java
+++ b/src/main/java/io/muserver/MuServerBuilder.java
@@ -208,6 +208,12 @@ public class MuServerBuilder {
      * caller-supplied executor remains owned by the caller and is not shut down when
      * the server stops.
      *
+     * <p>Use an executor that is independent from the executor configured by
+     * {@link #withConnectionExecutor(ExecutorService)} to keep request handling isolated
+     * from long-lived connection tasks. If the same executor instance is supplied for
+     * both, HTTP/1 handlers run on their connection task to avoid submitting work back
+     * to an executor that may already be at capacity.</p>
+     *
      * @param executor The executor service to use to handle requests
      * @return The current Mu Server builder
      */
@@ -217,21 +223,26 @@ public class MuServerBuilder {
     }
 
     /**
-     * Sets the executor used for connection setup and HTTP/2 connection reads.
+     * Sets the executor used for connection setup and connection input processing.
      *
-     * <p>HTTP/2 uses one long-lived reader task per connection on this executor. HTTP/2
-     * writes use the executor configured by
+     * <p>HTTP/1 uses one long-lived keep-alive connection task and HTTP/2 uses one
+     * long-lived reader task per connection on this executor. Request handlers are
+     * submitted separately to the executor configured by
+     * {@link #withHandlerExecutor(ExecutorService)}. HTTP/2 writes use the executor configured by
      * {@link #withHttp2WriterExecutor(ExecutorService)} so a fixed-size connection pool
-     * cannot be occupied by readers while their writers wait in the same queue. Request
-     * handlers use the executor configured by
-     * {@link #withHandlerExecutor(ExecutorService)}.</p>
+     * cannot be occupied by readers while their writers wait in the same queue.</p>
+     *
+     * <p>Use an executor that is independent from the executor configured by
+     * {@link #withHandlerExecutor(ExecutorService)} to keep long-lived connection tasks
+     * from consuming handler capacity. If the same executor instance is supplied for
+     * both, HTTP/1 handlers run on their connection task to avoid self-deadlock.</p>
      *
      * <p>By default, a server-owned virtual-thread-per-task executor is used when the
      * runtime supports virtual threads, otherwise a cached thread pool is used. A
      * caller-supplied executor remains owned by the caller and is not shut down when
      * the server stops.</p>
      *
-     * @param connectionExecutor The executor for connection setup and HTTP/2 reads, or
+     * @param connectionExecutor The executor for connection setup and input processing, or
      *                           <code>null</code> to use the default
      * @return The current Mu Server builder
      */
@@ -710,7 +721,7 @@ public class MuServerBuilder {
     }
 
     /**
-     * Gets the executor used for connection setup and HTTP/2 connection reads.
+     * Gets the executor used for connection setup and connection input processing.
      *
      * @return The configured executor, or <code>null</code> if the default executor will be used.
      */

--- a/src/test/java/io/muserver/ExecutionDomainsTest.java
+++ b/src/test/java/io/muserver/ExecutionDomainsTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
+import scaffolding.Http1Client;
 
 import java.io.EOFException;
 import java.io.IOException;
@@ -175,6 +176,50 @@ class ExecutionDomainsTest {
             con.writeFrame(new Http2Ping(false, pingData)).flush();
 
             assertThat(con.readLogicalFrame(Http2Ping.class), equalTo(new Http2Ping(true, pingData)));
+        }
+    }
+
+    @Test
+    void anIdleHttp1ConnectionDoesNotRetainAHandlerWorker() throws Exception {
+        var handlerExecutor = track(Executors.newSingleThreadExecutor(namedThreads("handler-")));
+        var connectionExecutor = track(Executors.newCachedThreadPool(namedThreads("connection-")));
+        var clientExecutor = track(Executors.newSingleThreadExecutor(namedThreads("client-")));
+        server = httpServer()
+            .withHandlerExecutor(handlerExecutor)
+            .withConnectionExecutor(connectionExecutor)
+            .addHandler(Method.GET, "/", (request, response, pathParams) ->
+                response.write(Thread.currentThread().getName()))
+            .start();
+
+        try (var first = Http1Client.connect(server);
+             var second = Http1Client.connect(server)) {
+            first.writeRequestLine(Method.GET, "/").flushHeaders();
+            assertThat(first.readLine(), equalTo("HTTP/1.1 200 OK"));
+            assertThat(first.readBody(first.readHeaders()), startsWith("handler-"));
+
+            Future<String> secondResponse = clientExecutor.submit(() -> {
+                second.writeRequestLine(Method.GET, "/").flushHeaders();
+                assertThat(second.readLine(), equalTo("HTTP/1.1 200 OK"));
+                return second.readBody(second.readHeaders());
+            });
+            assertThat(secondResponse.get(2, TimeUnit.SECONDS), startsWith("handler-"));
+        }
+    }
+
+    @Test
+    void aSharedConnectionAndHandlerExecutorDoesNotSubmitBackToItself() throws Exception {
+        var sharedExecutor = track(Executors.newSingleThreadExecutor(namedThreads("shared-")));
+        server = httpServer()
+            .withHandlerExecutor(sharedExecutor)
+            .withConnectionExecutor(sharedExecutor)
+            .addHandler(Method.GET, "/", (request, response, pathParams) ->
+                response.write(Thread.currentThread().getName()))
+            .start();
+
+        try (var client = Http1Client.connect(server)) {
+            client.writeRequestLine(Method.GET, "/").flushHeaders();
+            assertThat(client.readLine(), equalTo("HTTP/1.1 200 OK"));
+            assertThat(client.readBody(client.readHeaders()), startsWith("shared-"));
         }
     }
 


### PR DESCRIPTION
## Summary
- keep HTTP/1 parsing and keep-alive reads on the connection executor
- submit only parsed request exchanges to the handler executor
- reject request-level handler saturation with the existing fixed HTTP/1 503 wire response
- avoid self-deadlock when callers deliberately supply the same executor instance for both domains
- document the HTTP/1 and HTTP/2 connection-task ownership model

## Why
An HTTP/1 connection previously moved its entire lifetime onto the handler executor after setup. After one response, an idle keep-alive connection therefore retained a handler worker while blocked reading the next request. A single idle connection could exhaust a bounded handler pool and starve unrelated requests.

The regression test opens two keep-alive connections with one handler worker. Before this change, the first idle connection retained `handler-1` and the second response timed out. Now each active request gets handler capacity while idle socket reads remain in the connection domain.

## Compatibility
- handler-executor rejection still sends the exact existing fixed 503 bytes and closes the connection
- overload response/statistics tests pass for HTTP, HTTPS, and HTTP/2
- if handler and connection executors are the same object, HTTP/1 runs the handler inline on its connection task rather than submitting back to a possibly saturated executor
- caller ownership and public signatures are unchanged

## Validation
- deterministic idle-connection regression and shared-single-thread executor regression
- Java 11 execution-domain, HTTP/1 shutdown, async, WebSocket, stop, and server tests
- Java 25 execution-domain, HTTP/1 shutdown, async, WebSocket, stop, and server tests
- full Java 21 `mvn -q -Pnullaway verify`