### PR TITLE
Own callback-based asynchronous I/O

### DIFF
--- a/src/main/java/io/muserver/BaseWebSocket.java
+++ b/src/main/java/io/muserver/BaseWebSocket.java
@@ -7,7 +7,9 @@ import java.net.SocketTimeoutException;
 import java.nio.ByteBuffer;
 import java.nio.charset.CharacterCodingException;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicLong;
@@ -79,19 +81,23 @@ public abstract class BaseWebSocket implements MuWebSocket {
         // This calls the old-style methods in a new thread and blocks until the done callback is invoked.
         // Overriders of this base class should just override this method and block until the data is finished with.
         CompletableFuture<@Nullable Void> result = new CompletableFuture<>();
-        CompletableFuture.runAsync(() -> {
-            try {
-                onText(message, true, error -> {
-                    if (error == null) {
-                        result.complete(null);
-                    } else {
-                        result.completeExceptionally(error);
-                    }
-                });
-            } catch (Exception e) {
-                result.completeExceptionally(e);
-            }
-        });
+        try {
+            CompletableFuture.runAsync(() -> {
+                try {
+                    onText(message, true, error -> {
+                        if (error == null) {
+                            result.complete(null);
+                        } else {
+                            result.completeExceptionally(error);
+                        }
+                    });
+                } catch (Exception e) {
+                    result.completeExceptionally(e);
+                }
+            }, asyncExecutor());
+        } catch (RuntimeException failure) {
+            result.completeExceptionally(failure);
+        }
         blockUntilDone(result);
     }
 
@@ -167,20 +173,31 @@ public abstract class BaseWebSocket implements MuWebSocket {
         // This calls the old-style methods in a new thread and blocks until the done callback is invoked.
         // Overriders of this base class should just override this method and block until the data is finished with.
         CompletableFuture<@Nullable Void> result = new CompletableFuture<>();
-        CompletableFuture.runAsync(() -> {
-            try {
-                onBinary(buffer, true, error -> {
-                    if (error == null) {
-                        result.complete(null);
-                    } else {
-                        result.completeExceptionally(error);
-                    }
-                }, () -> {});
-            } catch (Exception e) {
-                result.completeExceptionally(e);
-            }
-        });
+        try {
+            CompletableFuture.runAsync(() -> {
+                try {
+                    onBinary(buffer, true, error -> {
+                        if (error == null) {
+                            result.complete(null);
+                        } else {
+                            result.completeExceptionally(error);
+                        }
+                    }, () -> {});
+                } catch (Exception e) {
+                    result.completeExceptionally(e);
+                }
+            }, asyncExecutor());
+        } catch (RuntimeException failure) {
+            result.completeExceptionally(failure);
+        }
         blockUntilDone(result);
+    }
+
+    private Executor asyncExecutor() {
+        MuWebSocketSession currentSession = session;
+        return currentSession instanceof WebsocketConnection
+            ? ((WebsocketConnection) currentSession).asyncExecutor()
+            : ForkJoinPool.commonPool();
     }
 
     private static void blockUntilDone(CompletableFuture<@Nullable Void> result) throws Exception {

--- a/src/main/java/io/muserver/Mu3AsyncHandleImpl.java
+++ b/src/main/java/io/muserver/Mu3AsyncHandleImpl.java
@@ -3,10 +3,11 @@ package io.muserver;
 import org.jspecify.annotations.Nullable;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.ByteBuffer;
 import java.util.concurrent.*;
-import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
@@ -16,10 +17,12 @@ class Mu3AsyncHandleImpl implements AsyncHandle {
     private CompletableFuture<@Nullable Void> responseFuture = CompletableFuture.completedFuture(null);
     private final CompletableFuture<@Nullable Void> completionFuture = new CompletableFuture<>();
     private final Lock lock = new ReentrantLock();
+    private final ExecutorService asyncExecutor;
 
-    Mu3AsyncHandleImpl(Mu3Request request, BaseResponse response) {
+    Mu3AsyncHandleImpl(Mu3Request request, BaseResponse response, ExecutorService asyncExecutor) {
         this.request = request;
         this.response = response;
+        this.asyncExecutor = asyncExecutor;
     }
 
     public void waitForCompletion(long timeoutMillis) throws Throwable {
@@ -42,58 +45,106 @@ class Mu3AsyncHandleImpl implements AsyncHandle {
 
     @Override
     public void setReadListener(RequestBodyListener readListener) {
-        var requestFuture = CompletableFuture.runAsync(() -> {
-            AtomicReference<@Nullable Throwable> requestException = new AtomicReference<>();
-            try (var clientIn = request.body()) {
-                var buffer = new byte[8192];
-                int read;
-                while (requestException.get() == null) {
-                    try {
-                        read = clientIn.read(buffer);
-                    } catch (Throwable e) {
-                        requestException.set(e);
-                        readListener.onError(e);
-                        break;
-                    }
-                    if (read == -1) {
-                        break;
-                    }
-                    if (read > 0) {
-                        var latch = new CountDownLatch(1);
-                        DoneCallback dc = error -> {
-                            if (error != null) {
-                                requestException.set(error);
-                            }
-                            latch.countDown();
-                        };
-                        readListener.onDataReceived(ByteBuffer.wrap(buffer, 0, read), dc);
-                        // TODO set proper timeout
-                        if (!latch.await(24, TimeUnit.HOURS)) {
-                            requestException.set(new TimeoutException("Timed out in read callback " + readListener));
-                        }
-                    }
-                }
-                var toThrow = requestException.get();
-                if (toThrow != null) {
-                    throw toThrow;
-                } else {
-                    readListener.onComplete();
-                }
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-                requestException.set(e);
-            } catch (Throwable e) {
-                requestException.set(e);
+        new AsyncBodyReader(readListener).scheduleNextRead();
+    }
+
+    private final class AsyncBodyReader {
+        private final RequestBodyListener readListener;
+        private final byte[] buffer = new byte[8192];
+        private final AtomicBoolean finished = new AtomicBoolean();
+        private @Nullable InputStream clientIn;
+
+        private AsyncBodyReader(RequestBodyListener readListener) {
+            this.readListener = readListener;
+        }
+
+        private void scheduleNextRead() {
+            if (finished.get()) {
+                return;
             }
-            var e = requestException.get();
-            if (e != null) {
-                throw e instanceof RuntimeException ? (RuntimeException) e : new RuntimeException("Error while reading body", e);
+            try {
+                asyncExecutor.execute(this::readNext);
+            } catch (RuntimeException t) {
+                fail(t, false);
             }
-        });
-        requestFuture.exceptionally( t -> {
-            complete(t);
-            return null;
-        });
+        }
+
+        private void readNext() {
+            if (finished.get()) {
+                return;
+            }
+            InputStream input = clientIn;
+            if (input == null) {
+                try {
+                    input = request.body();
+                    clientIn = input;
+                } catch (Throwable t) {
+                    fail(t, false);
+                    return;
+                }
+            }
+
+            final int read;
+            try {
+                read = input.read(buffer);
+            } catch (Throwable t) {
+                fail(t, true);
+                return;
+            }
+            if (read == -1) {
+                finishReading();
+                return;
+            }
+            if (read == 0) {
+                scheduleNextRead();
+                return;
+            }
+
+            var callbackUsed = new AtomicBoolean();
+            try {
+                readListener.onDataReceived(ByteBuffer.wrap(buffer, 0, read), error -> {
+                    if (!callbackUsed.compareAndSet(false, true)) {
+                        return;
+                    }
+                    if (error == null) {
+                        scheduleNextRead();
+                    } else {
+                        fail(error, false);
+                    }
+                });
+            } catch (Throwable t) {
+                fail(t, false);
+            }
+        }
+
+        private void finishReading() {
+            if (!finished.compareAndSet(false, true)) {
+                return;
+            }
+            try {
+                readListener.onComplete();
+            } catch (Throwable t) {
+                complete(t);
+            } finally {
+                Mutils.closeSilently(clientIn);
+            }
+        }
+
+        private void fail(Throwable failure, boolean notifyListener) {
+            if (!finished.compareAndSet(false, true)) {
+                return;
+            }
+            try {
+                if (notifyListener) {
+                    readListener.onError(failure);
+                }
+            } catch (Throwable listenerFailure) {
+                addSuppressedIfDifferent(failure, listenerFailure);
+            } finally {
+                Mutils.closeSilently(clientIn);
+            }
+            complete(failure);
+        }
     }
 
     @Override
@@ -116,42 +167,87 @@ class Mu3AsyncHandleImpl implements AsyncHandle {
 
     @Override
     public void write(ByteBuffer data, DoneCallback callback) {
+        var taskStarted = new AtomicBoolean();
+        CompletableFuture<@Nullable Void> writeFuture;
         lock.lock();
         try {
             responseFuture = responseFuture.thenRunAsync(() -> {
+                taskStarted.set(true);
                 try {
                     copyBufferToResponseOutput(data);
-                    callback.onComplete(null);
                 } catch (Throwable e) {
                     try {
                         callback.onComplete(e);
-                    } catch (Exception ignored) {
+                    } catch (Throwable callbackFailure) {
+                        addSuppressedIfDifferent(e, callbackFailure);
                     }
                     complete(e);
                     throw e instanceof RuntimeException ? (RuntimeException) e : new RuntimeException("Error while writing body", e);
                 }
-            }).thenApply(ignored -> null);
+                try {
+                    callback.onComplete(null);
+                } catch (Throwable e) {
+                    complete(e);
+                    throw e instanceof RuntimeException ? (RuntimeException) e : new RuntimeException("Error in write callback", e);
+                }
+            }, asyncExecutor).thenApply(ignored -> null);
+            writeFuture = responseFuture;
         } finally {
             lock.unlock();
         }
+        writeFuture.whenComplete((ignored, failure) -> {
+            if (failure != null && !taskStarted.get()) {
+                Throwable cause = completionCause(failure);
+                try {
+                    callback.onComplete(cause);
+                } catch (Throwable callbackFailure) {
+                    addSuppressedIfDifferent(cause, callbackFailure);
+                }
+                complete(cause);
+            }
+        });
     }
 
     @Override
     public Future<@Nullable Void> write(ByteBuffer data) {
+        var taskStarted = new AtomicBoolean();
+        CompletableFuture<@Nullable Void> writeFuture;
         lock.lock();
         try {
-            CompletableFuture<@Nullable Void> writeFuture = responseFuture.thenRunAsync(() -> {
+            writeFuture = responseFuture.thenRunAsync(() -> {
+                taskStarted.set(true);
                 try {
                     copyBufferToResponseOutput(data);
                 } catch (Throwable e) {
                     complete(e);
                     throw e instanceof RuntimeException ? (RuntimeException) e : new RuntimeException("Error while writing body", e);
                 }
-            }).thenApply(ignored -> null);
+            }, asyncExecutor).thenApply(ignored -> null);
             responseFuture = writeFuture;
-            return writeFuture;
         } finally {
             lock.unlock();
+        }
+        writeFuture.whenComplete((ignored, failure) -> {
+            if (failure != null && !taskStarted.get()) {
+                complete(completionCause(failure));
+            }
+        });
+        return writeFuture;
+    }
+
+    private static Throwable completionCause(Throwable failure) {
+        Throwable cause = failure;
+        while ((cause instanceof CompletionException || cause instanceof ExecutionException)
+            && cause.getCause() != null) {
+            cause = cause.getCause();
+        }
+        return cause;
+    }
+
+    @SuppressWarnings("ReferenceEquality") // Throwable forbids suppressing itself; identity is required.
+    private static void addSuppressedIfDifferent(Throwable failure, Throwable suppressed) {
+        if (failure != suppressed) {
+            failure.addSuppressed(suppressed);
         }
     }
 

--- a/src/main/java/io/muserver/Mu3Request.java
+++ b/src/main/java/io/muserver/Mu3Request.java
@@ -254,7 +254,8 @@ class Mu3Request implements MuRequest {
     public synchronized AsyncHandle handleAsync() {
         if (asyncHandle == null) {
             asyncHandle = new Mu3AsyncHandleImpl(this,
-                Objects.requireNonNull(response, "The response has not been initialized"));
+                Objects.requireNonNull(response, "The response has not been initialized"),
+                ((Mu3ServerImpl) connection.server()).asyncExecutor());
         }
         if (clientCancelled) {
             asyncHandle.complete();

--- a/src/main/java/io/muserver/Mu3ServerImpl.java
+++ b/src/main/java/io/muserver/Mu3ServerImpl.java
@@ -38,6 +38,8 @@ class Mu3ServerImpl implements MuServer {
     final Path tempDir;
     private final ExecutorService handlerExecutor;
     private final boolean ownsHandlerExecutor;
+    private final ExecutorService asyncExecutor;
+    private final boolean ownsAsyncExecutor;
     private final ExecutorService connectionExecutor;
     private final boolean ownsConnectionExecutor;
     private final ExecutorService http2WriterExecutor;
@@ -48,7 +50,7 @@ class Mu3ServerImpl implements MuServer {
     private final boolean ownsTimerExecutor;
     private final Mu3StatsImpl statsImpl = new Mu3StatsImpl();
 
-    Mu3ServerImpl(List<ConnectionAcceptor> acceptors, List<MuHandler> handlers, List<ResponseCompleteListener> responseCompleteListeners, List<RequestRejectListener> requestRejectListeners, UnhandledExceptionHandler exceptionHandler, Long maxRequestBodySize, List<ContentEncoder> contentEncoders, Long requestIdleTimeoutMillis, Long idleTimeoutMillis, int maxUrlSize, int maxHeadersSize, List<RateLimiterImpl> rateLimiters, Path tempDir, ExecutorService handlerExecutor, boolean ownsHandlerExecutor, ExecutorService connectionExecutor, boolean ownsConnectionExecutor, ExecutorService http2WriterExecutor, boolean ownsHttp2WriterExecutor, ExecutorService connectionMaintenanceExecutor, boolean ownsConnectionMaintenanceExecutor, ScheduledExecutorService timerExecutor, boolean ownsTimerExecutor) {
+    Mu3ServerImpl(List<ConnectionAcceptor> acceptors, List<MuHandler> handlers, List<ResponseCompleteListener> responseCompleteListeners, List<RequestRejectListener> requestRejectListeners, UnhandledExceptionHandler exceptionHandler, Long maxRequestBodySize, List<ContentEncoder> contentEncoders, Long requestIdleTimeoutMillis, Long idleTimeoutMillis, int maxUrlSize, int maxHeadersSize, List<RateLimiterImpl> rateLimiters, Path tempDir, ExecutorService handlerExecutor, boolean ownsHandlerExecutor, ExecutorService asyncExecutor, boolean ownsAsyncExecutor, ExecutorService connectionExecutor, boolean ownsConnectionExecutor, ExecutorService http2WriterExecutor, boolean ownsHttp2WriterExecutor, ExecutorService connectionMaintenanceExecutor, boolean ownsConnectionMaintenanceExecutor, ScheduledExecutorService timerExecutor, boolean ownsTimerExecutor) {
         this.acceptors = acceptors;
         this.handlers = handlers;
         this.responseCompleteListeners = responseCompleteListeners;
@@ -64,6 +66,8 @@ class Mu3ServerImpl implements MuServer {
         this.tempDir = tempDir;
         this.handlerExecutor = handlerExecutor;
         this.ownsHandlerExecutor = ownsHandlerExecutor;
+        this.asyncExecutor = asyncExecutor;
+        this.ownsAsyncExecutor = ownsAsyncExecutor;
         this.connectionExecutor = connectionExecutor;
         this.ownsConnectionExecutor = ownsConnectionExecutor;
         this.http2WriterExecutor = http2WriterExecutor;
@@ -124,7 +128,14 @@ class Mu3ServerImpl implements MuServer {
         if (ownsHandlerExecutor) {
             handlerExecutor.shutdown();
         }
+        if (ownsAsyncExecutor) {
+            asyncExecutor.shutdown();
+        }
         return stoppedCleanly;
+    }
+
+    ExecutorService asyncExecutor() {
+        return asyncExecutor;
     }
 
     @Override
@@ -342,6 +353,11 @@ class Mu3ServerImpl implements MuServer {
         if (handlerExecutor == null) {
             handlerExecutor = MuServerBuilder.defaultExecutor();
         }
+        ExecutorService asyncExecutor = builder.asyncExecutor();
+        boolean ownsAsyncExecutor = asyncExecutor == null;
+        if (asyncExecutor == null) {
+            asyncExecutor = MuServerBuilder.defaultExecutor();
+        }
         ExecutorService connectionExecutor = builder.connectionExecutor();
         boolean ownsConnectionExecutor = connectionExecutor == null;
         if (connectionExecutor == null) {
@@ -379,6 +395,8 @@ class Mu3ServerImpl implements MuServer {
             tempDir,
             handlerExecutor,
             ownsHandlerExecutor,
+            asyncExecutor,
+            ownsAsyncExecutor,
             connectionExecutor,
             ownsConnectionExecutor,
             http2WriterExecutor,

--- a/src/main/java/io/muserver/MuServerBuilder.java
+++ b/src/main/java/io/muserver/MuServerBuilder.java
@@ -39,6 +39,7 @@ public class MuServerBuilder {
     private long requestReadTimeoutMillis = TimeUnit.MINUTES.toMillis(2);
     private long idleTimeoutMills = TimeUnit.MINUTES.toMillis(20);
     private @Nullable ExecutorService executor;
+    private @Nullable ExecutorService asyncExecutor;
     private @Nullable ExecutorService connectionExecutor;
     private @Nullable ExecutorService http2WriterExecutor;
     private @Nullable ExecutorService connectionMaintenanceExecutor;
@@ -219,6 +220,30 @@ public class MuServerBuilder {
      */
     public MuServerBuilder withHandlerExecutor(@Nullable ExecutorService executor) {
         this.executor = executor;
+        return this;
+    }
+
+    /**
+     * Sets the executor used for asynchronous request body reads, asynchronous response
+     * writes, and deprecated asynchronous WebSocket compatibility methods.
+     *
+     * <p>These operations adapt blocking I/O to callback-based APIs and must not use an
+     * executor whose workers can all be retained by connection readers, request handlers,
+     * HTTP/2 writers, or timed maintenance. A single-thread executor is supported:
+     * asynchronous request body delivery releases the worker while waiting for its
+     * {@link DoneCallback}.</p>
+     *
+     * <p>By default, a server-owned virtual-thread-per-task executor is used when the
+     * runtime supports virtual threads, otherwise a cached thread pool is used. A
+     * caller-supplied executor remains owned by the caller and is not shut down when
+     * the server stops.</p>
+     *
+     * @param asyncExecutor The executor for callback-based asynchronous I/O, or
+     *                      <code>null</code> to use the default
+     * @return The current Mu Server builder
+     */
+    public MuServerBuilder withAsyncExecutor(@Nullable ExecutorService asyncExecutor) {
+        this.asyncExecutor = asyncExecutor;
         return this;
     }
 
@@ -718,6 +743,15 @@ public class MuServerBuilder {
      */
     public @Nullable ExecutorService executor() {
         return executor;
+    }
+
+    /**
+     * Gets the executor used for callback-based asynchronous I/O.
+     *
+     * @return The configured executor, or <code>null</code> if the default executor will be used.
+     */
+    public @Nullable ExecutorService asyncExecutor() {
+        return asyncExecutor;
     }
 
     /**

--- a/src/main/java/io/muserver/MuWebSocketSession.java
+++ b/src/main/java/io/muserver/MuWebSocketSession.java
@@ -7,6 +7,8 @@ import java.net.InetSocketAddress;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -14,6 +16,20 @@ import java.util.concurrent.TimeUnit;
  * <p>The simplest way to get a reference to a session is to extend {@link BaseWebSocket} and use the {@link BaseWebSocket#session()} method.</p>
  */
 public interface MuWebSocketSession {
+
+    private void runAsync(Runnable task, DoneCallback doneCallback) {
+        Executor executor = this instanceof WebsocketConnection
+            ? ((WebsocketConnection) this).asyncExecutor()
+            : ForkJoinPool.commonPool();
+        try {
+            CompletableFuture.runAsync(task, executor);
+        } catch (RuntimeException failure) {
+            try {
+                doneCallback.onComplete(failure);
+            } catch (Exception ignored) {
+            }
+        }
+    }
 
     /**
      * Specifies whether a close frame sent from the client has been received
@@ -54,7 +70,7 @@ public interface MuWebSocketSession {
      */
     @Deprecated
     default void sendText(String message, DoneCallback doneCallback) {
-        CompletableFuture.runAsync(() -> {
+        runAsync(() -> {
             try {
                 sendText(message);
                 doneCallback.onComplete(null);
@@ -64,7 +80,7 @@ public interface MuWebSocketSession {
                 } catch (Exception ignored) {
                 }
             }
-        });
+        }, doneCallback);
     }
 
 
@@ -79,7 +95,7 @@ public interface MuWebSocketSession {
      */
     @Deprecated
     default void sendText(String message, boolean isLastFragment, DoneCallback doneCallback) {
-        CompletableFuture.runAsync(() -> {
+        runAsync(() -> {
             try {
                 sendTextFragment(ByteBuffer.wrap(message.getBytes(StandardCharsets.UTF_8)), isLastFragment);
                 doneCallback.onComplete(null);
@@ -89,7 +105,7 @@ public interface MuWebSocketSession {
                 } catch (Exception ignored) {
                 }
             }
-        });
+        }, doneCallback);
     }
 
 
@@ -111,7 +127,7 @@ public interface MuWebSocketSession {
      */
     @Deprecated
     default void sendBinary(ByteBuffer message, DoneCallback doneCallback) {
-        CompletableFuture.runAsync(() -> {
+        runAsync(() -> {
             try {
                 sendBinary(message);
                 doneCallback.onComplete(null);
@@ -121,7 +137,7 @@ public interface MuWebSocketSession {
                 } catch (Exception ignored) {
                 }
             }
-        });
+        }, doneCallback);
     }
 
     /**
@@ -144,7 +160,7 @@ public interface MuWebSocketSession {
      */
     @Deprecated
     default void sendBinary(ByteBuffer message, boolean isLastFragment, DoneCallback doneCallback) {
-        CompletableFuture.runAsync(() -> {
+        runAsync(() -> {
             try {
                 sendBinaryFragment(message, isLastFragment);
                 doneCallback.onComplete(null);
@@ -154,7 +170,7 @@ public interface MuWebSocketSession {
                 } catch (Exception ignored) {
                 }
             }
-        });
+        }, doneCallback);
     }
 
     /**
@@ -174,7 +190,7 @@ public interface MuWebSocketSession {
      */
     @Deprecated
     default void sendPing(ByteBuffer payload, DoneCallback doneCallback) {
-        CompletableFuture.runAsync(() -> {
+        runAsync(() -> {
             try {
                 sendPing(payload);
                 doneCallback.onComplete(null);
@@ -184,7 +200,7 @@ public interface MuWebSocketSession {
                 } catch (Exception ignored) {
                 }
             }
-        });
+        }, doneCallback);
     }
 
     /**
@@ -204,7 +220,7 @@ public interface MuWebSocketSession {
      */
     @Deprecated
     default void sendPong(ByteBuffer payload, DoneCallback doneCallback) {
-        CompletableFuture.runAsync(() -> {
+        runAsync(() -> {
             try {
                 sendPong(payload);
                 doneCallback.onComplete(null);
@@ -214,7 +230,7 @@ public interface MuWebSocketSession {
                 } catch (Exception ignored) {
                 }
             }
-        });
+        }, doneCallback);
     }
 
     /**

--- a/src/main/java/io/muserver/WebsocketConnection.java
+++ b/src/main/java/io/muserver/WebsocketConnection.java
@@ -12,6 +12,7 @@ import java.net.ProtocolException;
 import java.net.SocketTimeoutException;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -62,6 +63,10 @@ class WebsocketConnection implements MuWebSocketSession {
 
     MuWebSocket webSocket() {
         return webSocket;
+    }
+
+    ExecutorService asyncExecutor() {
+        return httpConnection.serverImpl().asyncExecutor();
     }
 
 

--- a/src/test/java/io/muserver/ExecutionDomainsTest.java
+++ b/src/test/java/io/muserver/ExecutionDomainsTest.java
@@ -1,8 +1,11 @@
 package io.muserver;
 
 import okhttp3.Response;
+import okhttp3.MediaType;
+import okhttp3.RequestBody;
 import okhttp3.WebSocket;
 import okhttp3.WebSocketListener;
+import okio.BufferedSink;
 import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.RepeatedTest;
@@ -19,6 +22,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -33,6 +37,8 @@ import static io.muserver.MuServerBuilder.httpServer;
 import static io.muserver.WebSocketHandlerBuilder.webSocketHandler;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.startsWith;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -224,6 +230,124 @@ class ExecutionDomainsTest {
     }
 
     @Test
+    void oneAsyncWorkerCanReadAndEchoARequestBody() throws Exception {
+        var asyncExecutor = track(Executors.newSingleThreadExecutor(namedThreads("async-")));
+        var callbackThreads = new CopyOnWriteArrayList<String>();
+        byte[] payload = new byte[20_000];
+        for (int i = 0; i < payload.length; i++) {
+            payload[i] = (byte) ('a' + (i % 26));
+        }
+        server = httpServer()
+            .withAsyncExecutor(asyncExecutor)
+            .addHandler(Method.POST, "/", (request, response, pathParams) -> {
+                AsyncHandle handle = request.handleAsync();
+                handle.setReadListener(new RequestBodyListener() {
+                    @Override
+                    public void onDataReceived(ByteBuffer data, DoneCallback doneCallback) {
+                        callbackThreads.add(Thread.currentThread().getName());
+                        handle.write(data, error -> {
+                            callbackThreads.add(Thread.currentThread().getName());
+                            doneCallback.onComplete(error);
+                        });
+                    }
+
+                    @Override
+                    public void onComplete() {
+                        callbackThreads.add(Thread.currentThread().getName());
+                        handle.complete();
+                    }
+
+                    @Override
+                    public void onError(Throwable t) {
+                        handle.complete(t);
+                    }
+                });
+            })
+            .start();
+
+        RequestBody body = new RequestBody() {
+            @Override
+            public MediaType contentType() {
+                return null;
+            }
+
+            @Override
+            public void writeTo(BufferedSink sink) throws IOException {
+                sink.write(payload);
+            }
+        };
+        try (Response response = call(request(server.uri()).post(body))) {
+            assertThat(response.body().bytes(), equalTo(payload));
+        }
+        assertThat(callbackThreads.size(), greaterThanOrEqualTo(3));
+        for (String callbackThread : callbackThreads) {
+            assertThat(callbackThread, startsWith("async-"));
+        }
+    }
+
+    @Test
+    void rejectedAsyncWritesFailTheRequestAndInvokeTheCallback() throws Exception {
+        var asyncExecutor = track(Executors.newSingleThreadExecutor(namedThreads("async-")));
+        asyncExecutor.shutdown();
+        var callbackFailure = new CompletableFuture<Throwable>();
+        server = httpServer()
+            .withAsyncExecutor(asyncExecutor)
+            .addHandler(Method.GET, "/", (request, response, pathParams) -> {
+                AsyncHandle handle = request.handleAsync();
+                handle.write(ByteBuffer.wrap(new byte[]{1}), error -> {
+                    if (error != null) {
+                        callbackFailure.complete(error);
+                    }
+                });
+            })
+            .start();
+
+        try (Response response = call(request(server.uri()))) {
+            assertThat(response.code(), is(500));
+        }
+        assertThat(callbackFailure.get(5, TimeUnit.SECONDS), instanceOf(RejectedExecutionException.class));
+    }
+
+    @SuppressWarnings("deprecation")
+    @Test
+    void deprecatedWebSocketAdaptersUseTheAsyncExecutorWithoutSelfDeadlock() throws Exception {
+        var asyncExecutor = track(Executors.newSingleThreadExecutor(namedThreads("async-")));
+        var callbackThreads = new CopyOnWriteArrayList<String>();
+        var clientMessage = new CompletableFuture<String>();
+        server = httpServer()
+            .withAsyncExecutor(asyncExecutor)
+            .addHandler(webSocketHandler((request, responseHeaders) -> new BaseWebSocket() {
+                @Override
+                public void onText(String message, boolean isLast, DoneCallback onComplete) {
+                    callbackThreads.add(Thread.currentThread().getName());
+                    session().sendText(message, error -> {
+                        callbackThreads.add(Thread.currentThread().getName());
+                        onComplete.onComplete(error);
+                    });
+                }
+            }))
+            .start();
+
+        String websocketUrl = "ws" + server.uri().toString().substring(4);
+        WebSocket webSocket = client.newWebSocket(
+            request().url(websocketUrl).build(),
+            new WebSocketListener() {
+                @Override
+                public void onMessage(WebSocket webSocket, String text) {
+                    clientMessage.complete(text);
+                }
+            }
+        );
+        webSocket.send("hello");
+        assertThat(clientMessage.get(5, TimeUnit.SECONDS), equalTo("hello"));
+        webSocket.close(1000, "Done");
+        assertThat(callbackThreads.size(), is(2));
+        for (String callbackThread : callbackThreads) {
+            assertThat(callbackThread, startsWith("async-"));
+        }
+    }
+
+    @Test
     void oneWriterThreadCanServeMultipleLiveHttp2Connections() throws Exception {
         var connectionExecutor = track(Executors.newFixedThreadPool(2, namedThreads("connection-")));
         var writerExecutor = track(Executors.newSingleThreadExecutor(namedThreads("h2-writer-")));
@@ -278,6 +402,7 @@ class ExecutionDomainsTest {
     @Test
     void configuredExecutorsStayCallerOwnedAndHttp1UsesTheHandlerExecutor() throws Exception {
         var handlerExecutor = track(Executors.newSingleThreadExecutor(namedThreads("handler-")));
+        var asyncExecutor = track(Executors.newSingleThreadExecutor(namedThreads("async-")));
         var connectionExecutor = track(Executors.newCachedThreadPool(namedThreads("connection-")));
         var writerExecutor = track(Executors.newCachedThreadPool(namedThreads("h2-writer-")));
         var maintenanceExecutor = track(Executors.newCachedThreadPool(namedThreads("maintenance-")));
@@ -285,6 +410,7 @@ class ExecutionDomainsTest {
 
         var builder = httpServer()
             .withHandlerExecutor(handlerExecutor)
+            .withAsyncExecutor(asyncExecutor)
             .withConnectionExecutor(connectionExecutor)
             .withHttp2WriterExecutor(writerExecutor)
             .withConnectionMaintenanceExecutor(maintenanceExecutor)
@@ -292,6 +418,7 @@ class ExecutionDomainsTest {
             .addHandler(Method.GET, "/", (request, response, pathParams) ->
                 response.write(Thread.currentThread().getName()));
         assertThat(builder.connectionExecutor(), is(connectionExecutor));
+        assertThat(builder.asyncExecutor(), is(asyncExecutor));
         assertThat(builder.http2WriterExecutor(), is(writerExecutor));
         assertThat(builder.connectionMaintenanceExecutor(), is(maintenanceExecutor));
         assertThat(builder.timerExecutor(), is(timerExecutor));
@@ -308,6 +435,7 @@ class ExecutionDomainsTest {
         assertThat(writerExecutor.isShutdown(), is(false));
         assertThat(maintenanceExecutor.isShutdown(), is(false));
         assertThat(handlerExecutor.isShutdown(), is(false));
+        assertThat(asyncExecutor.isShutdown(), is(false));
         assertThat(timerExecutor.isShutdown(), is(false));
     }
 
@@ -317,6 +445,7 @@ class ExecutionDomainsTest {
         var serverImpl = (Mu3ServerImpl) server;
         List<ExecutorService> serverOwnedExecutors = List.of(
             getField(serverImpl, "handlerExecutor", ExecutorService.class),
+            getField(serverImpl, "asyncExecutor", ExecutorService.class),
             getField(serverImpl, "connectionExecutor", ExecutorService.class),
             getField(serverImpl, "http2WriterExecutor", ExecutorService.class),
             getField(serverImpl, "connectionMaintenanceExecutor", ExecutorService.class),
@@ -334,6 +463,7 @@ class ExecutionDomainsTest {
     @Test
     void rejectedTimerSchedulingRollsBackStartupWithoutTakingCallerExecutors() throws Exception {
         var handlerExecutor = track(Executors.newSingleThreadExecutor(namedThreads("handler-")));
+        var asyncExecutor = track(Executors.newSingleThreadExecutor(namedThreads("async-")));
         var connectionExecutor = track(Executors.newCachedThreadPool(namedThreads("connection-")));
         var writerExecutor = track(Executors.newCachedThreadPool(namedThreads("h2-writer-")));
         var maintenanceExecutor = track(Executors.newCachedThreadPool(namedThreads("maintenance-")));
@@ -344,6 +474,7 @@ class ExecutionDomainsTest {
         assertThrows(RejectedExecutionException.class, () -> httpServer()
             .withHttpPort(port)
             .withHandlerExecutor(handlerExecutor)
+            .withAsyncExecutor(asyncExecutor)
             .withConnectionExecutor(connectionExecutor)
             .withHttp2WriterExecutor(writerExecutor)
             .withConnectionMaintenanceExecutor(maintenanceExecutor)
@@ -351,6 +482,7 @@ class ExecutionDomainsTest {
             .start());
 
         assertThat(handlerExecutor.isShutdown(), is(false));
+        assertThat(asyncExecutor.isShutdown(), is(false));
         assertThat(connectionExecutor.isShutdown(), is(false));
         assertThat(writerExecutor.isShutdown(), is(false));
         assertThat(maintenanceExecutor.isShutdown(), is(false));
@@ -362,6 +494,7 @@ class ExecutionDomainsTest {
     @Test
     void listenerCreationFailureRollsBackEarlierListenersWithoutTakingCallerExecutors() throws Exception {
         var handlerExecutor = track(Executors.newSingleThreadExecutor(namedThreads("handler-")));
+        var asyncExecutor = track(Executors.newSingleThreadExecutor(namedThreads("async-")));
         var connectionExecutor = track(Executors.newCachedThreadPool(namedThreads("connection-")));
         var writerExecutor = track(Executors.newCachedThreadPool(namedThreads("h2-writer-")));
         var maintenanceExecutor = track(Executors.newCachedThreadPool(namedThreads("maintenance-")));
@@ -373,6 +506,7 @@ class ExecutionDomainsTest {
                 .withHttpsPort(firstPort)
                 .withHttpPort(occupiedListener.getLocalPort())
                 .withHandlerExecutor(handlerExecutor)
+                .withAsyncExecutor(asyncExecutor)
                 .withConnectionExecutor(connectionExecutor)
                 .withHttp2WriterExecutor(writerExecutor)
                 .withConnectionMaintenanceExecutor(maintenanceExecutor)
@@ -381,6 +515,7 @@ class ExecutionDomainsTest {
         }
 
         assertThat(handlerExecutor.isShutdown(), is(false));
+        assertThat(asyncExecutor.isShutdown(), is(false));
         assertThat(connectionExecutor.isShutdown(), is(false));
         assertThat(writerExecutor.isShutdown(), is(false));
         assertThat(maintenanceExecutor.isShutdown(), is(false));


### PR DESCRIPTION
## Summary
- add a configurable, server-owned `withAsyncExecutor(...)` domain
- route `AsyncHandle` request-body reads and response writes through it instead of the JVM common pool
- route server WebSocket sessions' deprecated asynchronous methods and `BaseWebSocket` compatibility adapters through the same owned domain
- replace the blocking request-body callback latch with resumable read tasks
- propagate async-executor rejection to callbacks/futures and fail the suspended request

## Why
Callback-based APIs adapt blocking socket operations and cannot safely share bounded executors with long-lived connection readers, request handlers waiting for async completion, HTTP/2 writer actors, or maintenance tasks. They currently escape server ownership to `ForkJoinPool.commonPool()`.

Simply making that pool configurable exposes another deadlock: the old request-body loop retained its worker while waiting for `DoneCallback`; if the callback queued an async response write onto the same single worker, the write could never run. The new reader performs one blocking read, invokes the listener, returns the worker, and schedules the next read only when the callback releases the buffer.

## Compatibility and ownership
- default remains asynchronous, using the same virtual-thread-per-task/cached fallback policy as other blocking domains
- caller-supplied executors remain caller-owned; server defaults are shut down
- response writes remain ordered through the existing per-response future chain
- external implementations of `MuWebSocketSession` retain the previous common-pool fallback; actual server sessions use the configured executor
- no runtime dependencies added

## Tests
- a single async worker reads and echoes a multi-buffer request body without self-deadlock, with every callback on the configured thread
- deprecated WebSocket adapter plus nested async send make progress on one worker
- rejected async write invokes its callback and terminates the suspended request with 500
- configured/default ownership and startup rollback coverage includes the new domain
- clean Java 11 targeted async, request-body, WebSocket, SSE, server, and stop suites
- clean Java 25 targeted async/WebSocket/lifecycle suites
- clean Java 21 full `mvn -q clean -Pnullaway verify`