### PR TITLE
Release handlers while async exchanges wait

### DIFF
--- a/src/main/java/io/muserver/BaseHttpConnection.java
+++ b/src/main/java/io/muserver/BaseHttpConnection.java
@@ -16,6 +16,7 @@ import java.net.Socket;
 import java.security.cert.Certificate;
 import java.time.Instant;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -64,7 +65,7 @@ abstract class BaseHttpConnection implements HttpConnection {
         server.onRequestStarted(req);
     }
 
-    protected void handleExchange(Mu3Request muRequest, BaseResponse muResponse) throws Throwable {
+    protected @Nullable CompletableFuture<Void> handleExchange(Mu3Request muRequest, BaseResponse muResponse) throws Throwable {
         try {
             var handled = false;
             for (var handler : server.handlers()) {
@@ -77,17 +78,20 @@ abstract class BaseHttpConnection implements HttpConnection {
 
             if (muRequest.isAsync()) {
                 var asyncHandle = java.util.Objects.requireNonNull(muRequest.getAsyncHandle());
-                    // TODO set proper timeout
-                asyncHandle.waitForCompletion(Long.MAX_VALUE);
+                return asyncHandle.exchangeCompletion();
             }
-
         } catch (Exception e) {
-            if (muResponse.hasStartedSendingData()) {
-                // can't write a custom error at this point
-                throw e;
-            } else {
-                server.exceptionHandler().handle(muRequest, muResponse, e);
-            }
+            handleExchangeException(muRequest, muResponse, e);
+        }
+        return null;
+    }
+
+    protected void handleExchangeException(Mu3Request muRequest, BaseResponse muResponse, Exception failure) throws Throwable {
+        if (muResponse.hasStartedSendingData()) {
+            // can't write a custom error at this point
+            throw failure;
+        } else {
+            server.exceptionHandler().handle(muRequest, muResponse, failure);
         }
     }
 

--- a/src/main/java/io/muserver/BaseHttpConnection.java
+++ b/src/main/java/io/muserver/BaseHttpConnection.java
@@ -65,7 +65,7 @@ abstract class BaseHttpConnection implements HttpConnection {
         server.onRequestStarted(req);
     }
 
-    protected @Nullable CompletableFuture<Void> handleExchange(Mu3Request muRequest, BaseResponse muResponse) throws Throwable {
+    protected @Nullable CompletableFuture<@Nullable Void> handleExchange(Mu3Request muRequest, BaseResponse muResponse) throws Throwable {
         try {
             var handled = false;
             for (var handler : server.handlers()) {

--- a/src/main/java/io/muserver/Http1Connection.java
+++ b/src/main/java/io/muserver/Http1Connection.java
@@ -57,14 +57,14 @@ class Http1Connection extends BaseHttpConnection {
 
     private static final class HandlerExecution {
         private final boolean accepted;
-        private final @Nullable CompletableFuture<Void> asyncCompletion;
+        private final @Nullable CompletableFuture<@Nullable Void> asyncCompletion;
 
-        private HandlerExecution(boolean accepted, @Nullable CompletableFuture<Void> asyncCompletion) {
+        private HandlerExecution(boolean accepted, @Nullable CompletableFuture<@Nullable Void> asyncCompletion) {
             this.accepted = accepted;
             this.asyncCompletion = asyncCompletion;
         }
 
-        private static HandlerExecution accepted(@Nullable CompletableFuture<Void> asyncCompletion) {
+        private static HandlerExecution accepted(@Nullable CompletableFuture<@Nullable Void> asyncCompletion) {
             return new HandlerExecution(true, asyncCompletion);
         }
 
@@ -172,7 +172,7 @@ class Http1Connection extends BaseHttpConnection {
                     try {
                         HandlerExecution execution = handleExchangeOnHandlerExecutor(muRequest, muResponse);
                         if (execution.accepted) {
-                            CompletableFuture<Void> asyncCompletion = execution.asyncCompletion;
+                            CompletableFuture<@Nullable Void> asyncCompletion = execution.asyncCompletion;
                             if (asyncCompletion != null) {
                                 awaitAsyncCompletion(asyncCompletion, muRequest, muResponse);
                             }
@@ -214,7 +214,7 @@ class Http1Connection extends BaseHttpConnection {
         if (handlersRunOnConnectionTask) {
             return HandlerExecution.accepted(handleExchange(request, response));
         }
-        CompletableFuture<@Nullable CompletableFuture<Void>> completion = new CompletableFuture<>();
+        CompletableFuture<@Nullable CompletableFuture<@Nullable Void>> completion = new CompletableFuture<>();
         try {
             handlerExecutor.execute(() -> {
                 try {
@@ -233,7 +233,7 @@ class Http1Connection extends BaseHttpConnection {
         }
     }
 
-    private void awaitAsyncCompletion(CompletableFuture<Void> completion, Mu3Request request,
+    private void awaitAsyncCompletion(CompletableFuture<@Nullable Void> completion, Mu3Request request,
                                       Http1Response response) throws Throwable {
         try {
             completion.get();

--- a/src/main/java/io/muserver/Http1Connection.java
+++ b/src/main/java/io/muserver/Http1Connection.java
@@ -55,6 +55,24 @@ class Http1Connection extends BaseHttpConnection {
         }
     }
 
+    private static final class HandlerExecution {
+        private final boolean accepted;
+        private final @Nullable CompletableFuture<Void> asyncCompletion;
+
+        private HandlerExecution(boolean accepted, @Nullable CompletableFuture<Void> asyncCompletion) {
+            this.accepted = accepted;
+            this.asyncCompletion = asyncCompletion;
+        }
+
+        private static HandlerExecution accepted(@Nullable CompletableFuture<Void> asyncCompletion) {
+            return new HandlerExecution(true, asyncCompletion);
+        }
+
+        private static HandlerExecution rejected() {
+            return new HandlerExecution(false, null);
+        }
+    }
+
     Http1Connection(Mu3ServerImpl server, ConnectionAcceptor creator, Socket clientSocket,
                     @Nullable Certificate clientCertificate, Instant handshakeStartTime,
                     ExecutorService handlerExecutor, boolean handlersRunOnConnectionTask) {
@@ -152,7 +170,12 @@ class Http1Connection extends BaseHttpConnection {
 
                     boolean rejectedByHandlerExecutor = false;
                     try {
-                        if (handleExchangeOnHandlerExecutor(muRequest, muResponse)) {
+                        HandlerExecution execution = handleExchangeOnHandlerExecutor(muRequest, muResponse);
+                        if (execution.accepted) {
+                            CompletableFuture<Void> asyncCompletion = execution.asyncCompletion;
+                            if (asyncCompletion != null) {
+                                awaitAsyncCompletion(asyncCompletion, muRequest, muResponse);
+                            }
                             closeConnection = cleanUpNicely(closeConnection, muResponse, muRequest);
                         } else {
                             rejectedByHandlerExecutor = true;
@@ -187,27 +210,64 @@ class Http1Connection extends BaseHttpConnection {
         }
     }
 
-    private boolean handleExchangeOnHandlerExecutor(Mu3Request request, Http1Response response) throws Throwable {
+    private HandlerExecution handleExchangeOnHandlerExecutor(Mu3Request request, Http1Response response) throws Throwable {
         if (handlersRunOnConnectionTask) {
-            handleExchange(request, response);
-            return true;
+            return HandlerExecution.accepted(handleExchange(request, response));
         }
-        CompletableFuture<@Nullable Void> completion = new CompletableFuture<>();
+        CompletableFuture<@Nullable CompletableFuture<Void>> completion = new CompletableFuture<>();
         try {
             handlerExecutor.execute(() -> {
                 try {
-                    handleExchange(request, response);
-                    completion.complete(null);
+                    completion.complete(handleExchange(request, response));
                 } catch (Throwable t) {
                     completion.completeExceptionally(t);
                 }
             });
         } catch (RejectedExecutionException rejected) {
-            return false;
+            return HandlerExecution.rejected();
         }
         try {
+            return HandlerExecution.accepted(completion.get());
+        } catch (ExecutionException e) {
+            throw e.getCause();
+        }
+    }
+
+    private void awaitAsyncCompletion(CompletableFuture<Void> completion, Mu3Request request,
+                                      Http1Response response) throws Throwable {
+        try {
             completion.get();
-            return true;
+        } catch (ExecutionException e) {
+            Throwable failure = e.getCause();
+            if (!(failure instanceof Exception)) {
+                throw failure;
+            }
+            handleAsyncExceptionOnHandler(request, response, (Exception) failure);
+        }
+    }
+
+    private void handleAsyncExceptionOnHandler(Mu3Request request, Http1Response response,
+                                               Exception failure) throws Throwable {
+        if (handlersRunOnConnectionTask) {
+            handleExchangeException(request, response, failure);
+            return;
+        }
+        CompletableFuture<@Nullable Void> handled = new CompletableFuture<>();
+        Runnable task = () -> {
+            try {
+                handleExchangeException(request, response, failure);
+                handled.complete(null);
+            } catch (Throwable t) {
+                handled.completeExceptionally(t);
+            }
+        };
+        try {
+            handlerExecutor.execute(task);
+        } catch (RejectedExecutionException rejected) {
+            task.run();
+        }
+        try {
+            handled.get();
         } catch (ExecutionException e) {
             throw e.getCause();
         }

--- a/src/main/java/io/muserver/Http2Connection.java
+++ b/src/main/java/io/muserver/Http2Connection.java
@@ -1147,7 +1147,7 @@ class Http2Connection extends BaseHttpConnection implements Http2Peer, CreditAva
 
     private void startHandledStream(Http2Stream stream) {
         try {
-            CompletableFuture<Void> asyncCompletion = handleExchange(stream.request, stream.response());
+            CompletableFuture<@Nullable Void> asyncCompletion = handleExchange(stream.request, stream.response());
             if (asyncCompletion == null) {
                 finishHandledStream(stream, null, false);
             } else {

--- a/src/main/java/io/muserver/Http2Connection.java
+++ b/src/main/java/io/muserver/Http2Connection.java
@@ -1138,30 +1138,78 @@ class Http2Connection extends BaseHttpConnection implements Http2Peer, CreditAva
 
         onRequestStarted(stream.request);
         try {
-            handlerExecutor.submit(() -> {
-                try {
-                    handleExchange(stream.request, stream.response());
-                    stream.cleanup();
-                } catch (Throwable e) {
-                    if (e instanceof InterruptedException) {
-                        Thread.currentThread().interrupt();
-                    }
-                    log.info("Unhandled stream exception", e);
-                    if (stream.response().hasStartedSendingData()
-                        && !stream.resetWasInitiated()
-                        && !stream.response().responseState().endState()) {
-                        stream.response().setState(ResponseState.ERRORED);
-                        write(new Http2ResetStreamFrame(stream.id, Http2ErrorCode.INTERNAL_ERROR.code()));
-                        stream.cancel(new IOException("Unhandled stream exception", e), false);
-                    }
-                } finally {
-                    onExchangeEnded(stream);
-                }
-            });
+            handlerExecutor.submit(() -> startHandledStream(stream));
         } catch (RejectedExecutionException e) {
             server.onRequestSubmissionRejected(stream.request);
             rejectRequestDueToHandlerOverload(frame, stream);
         }
+    }
+
+    private void startHandledStream(Http2Stream stream) {
+        try {
+            CompletableFuture<Void> asyncCompletion = handleExchange(stream.request, stream.response());
+            if (asyncCompletion == null) {
+                finishHandledStream(stream, null, false);
+            } else {
+                asyncCompletion.whenComplete((ignored, failure) ->
+                    scheduleAsyncStreamCompletion(stream, failure)
+                );
+            }
+        } catch (Throwable failure) {
+            finishHandledStream(stream, failure, false);
+        }
+    }
+
+    private void scheduleAsyncStreamCompletion(Http2Stream stream, @Nullable Throwable failure) {
+        Runnable completionTask = () -> finishHandledStream(
+            stream,
+            failure == null ? null : completionCause(failure),
+            true
+        );
+        try {
+            handlerExecutor.execute(completionTask);
+        } catch (RejectedExecutionException rejected) {
+            // The exchange was already accepted. Finishing on the completing thread is
+            // preferable to leaking the stream merely because handler capacity is transiently full.
+            completionTask.run();
+        }
+    }
+
+    private void finishHandledStream(Http2Stream stream, @Nullable Throwable failure,
+                                     boolean handleAsyncFailure) {
+        try {
+            if (failure != null) {
+                if (handleAsyncFailure && failure instanceof Exception) {
+                    handleExchangeException(stream.request, stream.response(), (Exception) failure);
+                } else {
+                    throw failure;
+                }
+            }
+            stream.cleanup();
+        } catch (Throwable e) {
+            if (e instanceof InterruptedException) {
+                Thread.currentThread().interrupt();
+            }
+            log.info("Unhandled stream exception", e);
+            if (stream.response().hasStartedSendingData()
+                && !stream.resetWasInitiated()
+                && !stream.response().responseState().endState()) {
+                stream.response().setState(ResponseState.ERRORED);
+                write(new Http2ResetStreamFrame(stream.id, Http2ErrorCode.INTERNAL_ERROR.code()));
+                stream.cancel(new IOException("Unhandled stream exception", e), false);
+            }
+        } finally {
+            onExchangeEnded(stream);
+        }
+    }
+
+    private static Throwable completionCause(Throwable failure) {
+        Throwable cause = failure;
+        while ((cause instanceof CompletionException || cause instanceof ExecutionException)
+            && cause.getCause() != null) {
+            cause = cause.getCause();
+        }
+        return cause;
     }
 
     private void rejectRequestDueToHandlerOverload(Http2HeadersFrame frame, Http2Stream stream) {

--- a/src/main/java/io/muserver/Mu3AsyncHandleImpl.java
+++ b/src/main/java/io/muserver/Mu3AsyncHandleImpl.java
@@ -25,22 +25,29 @@ class Mu3AsyncHandleImpl implements AsyncHandle {
         this.asyncExecutor = asyncExecutor;
     }
 
-    public void waitForCompletion(long timeoutMillis) throws Throwable {
-        try {
-            var before = System.currentTimeMillis();
-            completionFuture.get(timeoutMillis, TimeUnit.MILLISECONDS);
-            var duration = System.currentTimeMillis() - before;
-            var newTimeout = timeoutMillis - duration;
-            if (newTimeout <= 0) throw new TimeoutException("Timeout on completion future");
+    CompletableFuture<@Nullable Void> exchangeCompletion() {
+        CompletableFuture<@Nullable Void> exchangeCompletion = new CompletableFuture<>();
+        completionFuture.whenComplete((ignored, completionFailure) -> {
+            if (completionFailure != null) {
+                exchangeCompletion.completeExceptionally(completionCause(completionFailure));
+                return;
+            }
+            CompletableFuture<@Nullable Void> writes;
             lock.lock();
             try {
-                responseFuture.get(newTimeout, TimeUnit.MILLISECONDS);
+                writes = responseFuture;
             } finally {
                 lock.unlock();
             }
-        } catch (ExecutionException e) {
-            throw e.getCause();
-        }
+            writes.whenComplete((writeIgnored, writeFailure) -> {
+                if (writeFailure == null) {
+                    exchangeCompletion.complete(null);
+                } else {
+                    exchangeCompletion.completeExceptionally(completionCause(writeFailure));
+                }
+            });
+        });
+        return exchangeCompletion;
     }
 
     @Override

--- a/src/test/java/io/muserver/ExecutionDomainsTest.java
+++ b/src/test/java/io/muserver/ExecutionDomainsTest.java
@@ -308,6 +308,94 @@ class ExecutionDomainsTest {
         assertThat(callbackFailure.get(5, TimeUnit.SECONDS), instanceOf(RejectedExecutionException.class));
     }
 
+    @Test
+    void aSuspendedHttp1ExchangeDoesNotRetainAHandlerWorker() throws Exception {
+        var handlerExecutor = track(Executors.newSingleThreadExecutor(namedThreads("handler-")));
+        var clientExecutor = track(Executors.newSingleThreadExecutor(namedThreads("client-")));
+        var suspendedHandle = new CompletableFuture<AsyncHandle>();
+        server = httpServer()
+            .withHandlerExecutor(handlerExecutor)
+            .addHandler((request, response) -> {
+                if (request.relativePath().equals("/suspend")) {
+                    suspendedHandle.complete(request.handleAsync());
+                } else {
+                    response.write(Thread.currentThread().getName());
+                }
+                return true;
+            })
+            .start();
+
+        try (var first = Http1Client.connect(server);
+             var second = Http1Client.connect(server)) {
+            first.writeRequestLine(Method.GET, "/suspend").flushHeaders();
+            AsyncHandle handle = suspendedHandle.get(5, TimeUnit.SECONDS);
+            try {
+                Future<String> secondResponse = clientExecutor.submit(() -> {
+                    second.writeRequestLine(Method.GET, "/second").flushHeaders();
+                    assertThat(second.readLine(), equalTo("HTTP/1.1 200 OK"));
+                    return second.readBody(second.readHeaders());
+                });
+                assertThat(secondResponse.get(2, TimeUnit.SECONDS), startsWith("handler-"));
+            } finally {
+                handle.complete();
+            }
+
+            assertThat(first.readLine(), equalTo("HTTP/1.1 200 OK"));
+            assertThat(first.readBody(first.readHeaders()), equalTo(""));
+        }
+    }
+
+    @Test
+    void aSuspendedHttp2ExchangeDoesNotRetainAHandlerWorker() throws Exception {
+        var handlerExecutor = track(Executors.newSingleThreadExecutor(namedThreads("handler-")));
+        var suspendedHandle = new CompletableFuture<AsyncHandle>();
+        var completionThread = new CompletableFuture<String>();
+        server = httpServer()
+            .withHttp2Config(Http2ConfigBuilder.http2Enabled())
+            .withHandlerExecutor(handlerExecutor)
+            .addHandler((request, response) -> {
+                if (request.relativePath().equals("/suspend")) {
+                    AsyncHandle handle = request.handleAsync();
+                    handle.addResponseCompleteHandler(info ->
+                        completionThread.complete(Thread.currentThread().getName())
+                    );
+                    suspendedHandle.complete(handle);
+                } else {
+                    response.write(Thread.currentThread().getName());
+                }
+                return true;
+            })
+            .start();
+
+        try (var h2Client = new H2Client();
+             var connection = h2Client.connectClearText(server)) {
+            connection.handshake();
+            connection.socket().setSoTimeout(2000);
+            int port = server.uri().getPort();
+            FieldBlock firstHeaders = RFCTestUtils.getHelloHeaders("http", port);
+            firstHeaders.set(":path", "/suspend");
+            connection.writeFrame(new Http2HeadersFrame(1, true, firstHeaders)).flush();
+            AsyncHandle handle = suspendedHandle.get(5, TimeUnit.SECONDS);
+            try {
+                FieldBlock secondHeaders = RFCTestUtils.getHelloHeaders("http", port);
+                secondHeaders.set(":path", "/second");
+                connection.writeFrame(new Http2HeadersFrame(3, true, secondHeaders)).flush();
+
+                Http2HeadersFrame responseHeaders =
+                    RFCTestUtils.readIgnoringWindowUpdates(connection, Http2HeadersFrame.class);
+                assertThat(responseHeaders.streamId(), is(3));
+                assertThat(responseHeaders.headers().get(":status"), equalTo("200"));
+                Http2DataFrame responseData =
+                    RFCTestUtils.readIgnoringWindowUpdates(connection, Http2DataFrame.class);
+                assertThat(responseData.streamId(), is(3));
+                assertThat(responseData.toUTF8(), startsWith("handler-"));
+            } finally {
+                handle.complete();
+            }
+            assertThat(completionThread.get(5, TimeUnit.SECONDS), startsWith("handler-"));
+        }
+    }
+
     @SuppressWarnings("deprecation")
     @Test
     void deprecatedWebSocketAdaptersUseTheAsyncExecutorWithoutSelfDeadlock() throws Exception {

--- a/src/test/java/io/muserver/RFC9113_6_4_RstStreamTest.java
+++ b/src/test/java/io/muserver/RFC9113_6_4_RstStreamTest.java
@@ -34,18 +34,12 @@ class RFC9113_6_4_RstStreamTest {
         var requestStarted = new CountDownLatch(1);
         var completedStreams = new LinkedBlockingQueue<ResponseInfo>(1);
         var handleRef = new AtomicReference<AsyncHandle>();
-        var handlerThread = new AtomicReference<Thread>();
-        var completionThread = new AtomicReference<Thread>();
         server = httpsServer()
             .withHttp2Config(Http2ConfigBuilder.http2Enabled())
             .addHandler(Method.GET, "/hello", (request, response, pathParams) -> {
-                handlerThread.set(Thread.currentThread());
                 AsyncHandle handle = request.handleAsync();
                 handleRef.set(handle);
-                handle.addResponseCompleteHandler(info -> {
-                    completionThread.set(Thread.currentThread());
-                    completedStreams.add(info);
-                });
+                handle.addResponseCompleteHandler(completedStreams::add);
                 requestStarted.countDown();
             })
             .start();
@@ -73,7 +67,6 @@ class RFC9113_6_4_RstStreamTest {
         assertThat("Resetting the HTTP/2 stream did not complete the suspended request", completedStream, is(notNullValue()));
         assertThat(completedStream.completedSuccessfully(), is(false));
         assertThat(completedStream.response().responseState(), is(ResponseState.CLIENT_CANCELLED));
-        assertThat(completionThread.get(), sameInstance(handlerThread.get()));
     }
 
     @Test


### PR DESCRIPTION
## Summary
- represent `AsyncHandle` completion plus its ordered response writes as an exchange-completion future
- release HTTP/1 handler workers after the application handler returns, while the connection task waits for async completion
- release HTTP/2 handler workers and schedule final exception handling/stream cleanup as a later handler-domain task
- preserve exactly-once exchange completion and protocol cleanup
- replace the old same-`Thread` assertion with the actual contract: completion callbacks run in the handler domain

## Why
`handleExchange` previously blocked the handler worker until `AsyncHandle.complete()`. A handler that suspended a request had returned, but still retained scarce handler capacity for the full asynchronous lifetime. With one handler worker, a suspended request caused an unrelated request/stream to time out.

The new completion future waits for the completion signal and the response writes already serialized by `AsyncHandle`. Protocol cleanup starts only after that future resolves. HTTP/1 can wait on its per-connection task; HTTP/2 schedules cleanup back to the handler executor so response-complete callbacks stay in the handler domain without pinning the original worker.

## Observable concurrency change
A response-complete callback for an async HTTP/2 exchange is still dispatched through the handler executor, but it may run in a later task and therefore on a different platform or virtual `Thread`. No public API documents same-thread affinity, and retaining exact thread identity is incompatible with releasing the worker.

## Tests
- deterministic HTTP/1 regression: a suspended first connection no longer starves a second request with one handler worker
- deterministic HTTP/2 regression: a suspended stream no longer starves a second stream with one handler worker
- named-executor assertion proves HTTP/2 completion callbacks remain in the handler domain
- reset-stream cancellation/state coverage retained without physical-thread affinity
- clean Java 11 async, request-body, SSE, server, stop, RST_STREAM, GOAWAY, WINDOW_UPDATE, and WebSocket suites
- clean Java 25 execution-domain, RST_STREAM, and async suites
- clean Java 21 full `mvn -q clean -Pnullaway verify`