### PR TITLE
Run HTTP/1 completion callbacks on the handler executor

### DIFF
--- a/src/main/java/io/muserver/BaseHttpConnection.java
+++ b/src/main/java/io/muserver/BaseHttpConnection.java
@@ -96,12 +96,21 @@ abstract class BaseHttpConnection implements HttpConnection {
     }
 
     protected void onExchangeEnded(ResponseInfo exchange) {
+        recordExchangeEnded(exchange);
+        notifyExchangeEnded(exchange);
+    }
+
+    protected void recordExchangeEnded(ResponseInfo exchange) {
         completedRequests.incrementAndGet();
+        server.recordExchangeEnded(exchange);
+    }
+
+    protected void notifyExchangeEnded(ResponseInfo exchange) {
         BaseResponse resp = (BaseResponse) exchange.response();
         for (var listener : resp.completionListeners()) {
             listener.onComplete(exchange);
         }
-        server.onExchangeEnded(exchange);
+        server.notifyExchangeEnded(exchange);
     }
 
 

--- a/src/main/java/io/muserver/Http1Connection.java
+++ b/src/main/java/io/muserver/Http1Connection.java
@@ -279,14 +279,7 @@ class Http1Connection extends BaseHttpConnection {
             notifyExchangeEnded(response);
             return;
         }
-        Runnable task = () -> notifyExchangeEnded(response);
-        try {
-            handlerExecutor.execute(task);
-        } catch (RejectedExecutionException rejected) {
-            // Internal exchange accounting is already complete. Preserve application
-            // notifications during shutdown or a transient capacity rejection.
-            task.run();
-        }
+        server.executeResponseCompletionTask(() -> notifyExchangeEnded(response));
     }
 
     private boolean rejectRequestDueToHandlerOverload(Mu3Request request, OutputStream outputStream) throws IOException {

--- a/src/main/java/io/muserver/Http1Connection.java
+++ b/src/main/java/io/muserver/Http1Connection.java
@@ -187,7 +187,7 @@ class Http1Connection extends BaseHttpConnection {
                         muResponse.setState(ResponseState.ERRORED);
                     } finally {
                         if (!rejectedByHandlerExecutor) {
-                            onExchangeEnded(muResponse);
+                            onExchangeEndedOnHandler(muResponse);
                         }
                         clientSocket.setSoTimeout(0);
                     }
@@ -270,6 +270,45 @@ class Http1Connection extends BaseHttpConnection {
             handled.get();
         } catch (ExecutionException e) {
             throw e.getCause();
+        }
+    }
+
+    private void onExchangeEndedOnHandler(Http1Response response) {
+        if (handlersRunOnConnectionTask) {
+            onExchangeEnded(response);
+            return;
+        }
+        CompletableFuture<Void> ended = new CompletableFuture<>();
+        Runnable task = () -> {
+            try {
+                onExchangeEnded(response);
+                ended.complete(null);
+            } catch (Throwable t) {
+                ended.completeExceptionally(t);
+            }
+        };
+        try {
+            handlerExecutor.execute(task);
+        } catch (RejectedExecutionException rejected) {
+            // The exchange was already accepted and its response has been cleaned up.
+            // Finish inline rather than losing its completion notifications during shutdown
+            // or a transient executor-capacity rejection.
+            task.run();
+        }
+        try {
+            ended.get();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new MuException("Interrupted waiting for response completion callbacks", e);
+        } catch (ExecutionException e) {
+            Throwable cause = e.getCause();
+            if (cause instanceof RuntimeException) {
+                throw (RuntimeException) cause;
+            }
+            if (cause instanceof Error) {
+                throw (Error) cause;
+            }
+            throw new MuException("Unexpected response completion callback failure", cause);
         }
     }
 

--- a/src/main/java/io/muserver/Http1Connection.java
+++ b/src/main/java/io/muserver/Http1Connection.java
@@ -274,41 +274,18 @@ class Http1Connection extends BaseHttpConnection {
     }
 
     private void onExchangeEndedOnHandler(Http1Response response) {
+        recordExchangeEnded(response);
         if (handlersRunOnConnectionTask) {
-            onExchangeEnded(response);
+            notifyExchangeEnded(response);
             return;
         }
-        CompletableFuture<Void> ended = new CompletableFuture<>();
-        Runnable task = () -> {
-            try {
-                onExchangeEnded(response);
-                ended.complete(null);
-            } catch (Throwable t) {
-                ended.completeExceptionally(t);
-            }
-        };
+        Runnable task = () -> notifyExchangeEnded(response);
         try {
             handlerExecutor.execute(task);
         } catch (RejectedExecutionException rejected) {
-            // The exchange was already accepted and its response has been cleaned up.
-            // Finish inline rather than losing its completion notifications during shutdown
-            // or a transient executor-capacity rejection.
+            // Internal exchange accounting is already complete. Preserve application
+            // notifications during shutdown or a transient capacity rejection.
             task.run();
-        }
-        try {
-            ended.get();
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new MuException("Interrupted waiting for response completion callbacks", e);
-        } catch (ExecutionException e) {
-            Throwable cause = e.getCause();
-            if (cause instanceof RuntimeException) {
-                throw (RuntimeException) cause;
-            }
-            if (cause instanceof Error) {
-                throw (Error) cause;
-            }
-            throw new MuException("Unexpected response completion callback failure", cause);
         }
     }
 
@@ -363,9 +340,9 @@ class Http1Connection extends BaseHttpConnection {
     }
 
     @Override
-    public void onExchangeEnded(ResponseInfo exchange) {
+    protected void recordExchangeEnded(ResponseInfo exchange) {
         activeExchange.updateAndGet(cur -> cur != null && isSameRequest(cur.request, exchange.request()) ? null : cur);
-        super.onExchangeEnded(exchange);
+        super.recordExchangeEnded(exchange);
     }
 
     @SuppressWarnings("ReferenceEquality") // Connection ownership belongs to the exact request instance.

--- a/src/main/java/io/muserver/Mu3ServerImpl.java
+++ b/src/main/java/io/muserver/Mu3ServerImpl.java
@@ -167,6 +167,7 @@ class Mu3ServerImpl implements MuServer {
         return true;
     }
 
+    @SuppressWarnings("ReferenceEquality") // Execution-domain identity belongs to the exact executor instance.
     void executeResponseCompletionTask(Runnable task) {
         responseCompletionTasks.register();
         Runnable trackedTask = () -> {
@@ -178,10 +179,20 @@ class Mu3ServerImpl implements MuServer {
         };
         try {
             handlerExecutor.execute(trackedTask);
-        } catch (RejectedExecutionException rejected) {
-            // Internal exchange accounting is already complete. Preserve application
-            // notifications during shutdown or a transient capacity rejection.
-            trackedTask.run();
+        } catch (RejectedExecutionException handlerRejected) {
+            if (asyncExecutor != handlerExecutor) {
+                try {
+                    asyncExecutor.execute(trackedTask);
+                    return;
+                } catch (RejectedExecutionException asyncRejected) {
+                    asyncRejected.addSuppressed(handlerRejected);
+                    responseCompletionTasks.arriveAndDeregister();
+                    log.warn("Dropping response completion callback because its executors rejected it", asyncRejected);
+                    return;
+                }
+            }
+            responseCompletionTasks.arriveAndDeregister();
+            log.warn("Dropping response completion callback because its executor rejected it", handlerRejected);
         }
     }
 

--- a/src/main/java/io/muserver/Mu3ServerImpl.java
+++ b/src/main/java/io/muserver/Mu3ServerImpl.java
@@ -304,8 +304,11 @@ class Mu3ServerImpl implements MuServer {
         statsImpl.onRequestSubmissionRejected(req);
     }
 
-    void onExchangeEnded(ResponseInfo exchange) {
+    void recordExchangeEnded(ResponseInfo exchange) {
         statsImpl.onRequestEnded(exchange);
+    }
+
+    void notifyExchangeEnded(ResponseInfo exchange) {
         for (var listener : responseCompleteListeners) {
             listener.onComplete(exchange);
         }

--- a/src/main/java/io/muserver/Mu3ServerImpl.java
+++ b/src/main/java/io/muserver/Mu3ServerImpl.java
@@ -10,10 +10,12 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.*;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Phaser;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static io.muserver.GZIPEncoderBuilder.gzipEncoder;
@@ -48,6 +50,14 @@ class Mu3ServerImpl implements MuServer {
     private final boolean ownsConnectionMaintenanceExecutor;
     private final ScheduledExecutorService timerExecutor;
     private final boolean ownsTimerExecutor;
+    private final Phaser responseCompletionTasks = new Phaser() {
+        @Override
+        protected boolean onAdvance(int phase, int registeredParties) {
+            // Keep accepting tasks after an idle phase. Server.stop() can also be called
+            // again after an earlier bounded stop timed out.
+            return false;
+        }
+    };
     private final Mu3StatsImpl statsImpl = new Mu3StatsImpl();
 
     Mu3ServerImpl(List<ConnectionAcceptor> acceptors, List<MuHandler> handlers, List<ResponseCompleteListener> responseCompleteListeners, List<RequestRejectListener> requestRejectListeners, UnhandledExceptionHandler exceptionHandler, Long maxRequestBodySize, List<ContentEncoder> contentEncoders, Long requestIdleTimeoutMillis, Long idleTimeoutMillis, int maxUrlSize, int maxHeadersSize, List<RateLimiterImpl> rateLimiters, Path tempDir, ExecutorService handlerExecutor, boolean ownsHandlerExecutor, ExecutorService asyncExecutor, boolean ownsAsyncExecutor, ExecutorService connectionExecutor, boolean ownsConnectionExecutor, ExecutorService http2WriterExecutor, boolean ownsHttp2WriterExecutor, ExecutorService connectionMaintenanceExecutor, boolean ownsConnectionMaintenanceExecutor, ScheduledExecutorService timerExecutor, boolean ownsTimerExecutor) {
@@ -113,6 +123,9 @@ class Mu3ServerImpl implements MuServer {
                 stoppedCleanly = false;
             }
         }
+        if (!awaitResponseCompletionTasks(deadline)) {
+            stoppedCleanly = false;
+        }
         if (ownsTimerExecutor) {
             timerExecutor.shutdown();
         }
@@ -132,6 +145,44 @@ class Mu3ServerImpl implements MuServer {
             asyncExecutor.shutdown();
         }
         return stoppedCleanly;
+    }
+
+    private boolean awaitResponseCompletionTasks(long deadline) {
+        while (responseCompletionTasks.getRegisteredParties() > 0) {
+            int phase = responseCompletionTasks.getPhase();
+            long remaining = Math.max(0L, deadline - System.currentTimeMillis());
+            try {
+                responseCompletionTasks.awaitAdvanceInterruptibly(
+                    phase,
+                    remaining,
+                    TimeUnit.MILLISECONDS
+                );
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                return false;
+            } catch (TimeoutException e) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    void executeResponseCompletionTask(Runnable task) {
+        responseCompletionTasks.register();
+        Runnable trackedTask = () -> {
+            try {
+                task.run();
+            } finally {
+                responseCompletionTasks.arriveAndDeregister();
+            }
+        };
+        try {
+            handlerExecutor.execute(trackedTask);
+        } catch (RejectedExecutionException rejected) {
+            // Internal exchange accounting is already complete. Preserve application
+            // notifications during shutdown or a transient capacity rejection.
+            trackedTask.run();
+        }
     }
 
     ExecutorService asyncExecutor() {

--- a/src/test/java/io/muserver/ExecutionDomainsTest.java
+++ b/src/test/java/io/muserver/ExecutionDomainsTest.java
@@ -215,9 +215,13 @@ class ExecutionDomainsTest {
     @Test
     void aSharedConnectionAndHandlerExecutorDoesNotSubmitBackToItself() throws Exception {
         var sharedExecutor = track(Executors.newSingleThreadExecutor(namedThreads("shared-")));
+        var completionThread = new CompletableFuture<String>();
         server = httpServer()
             .withHandlerExecutor(sharedExecutor)
             .withConnectionExecutor(sharedExecutor)
+            .addResponseCompleteListener(info ->
+                completionThread.complete(Thread.currentThread().getName())
+            )
             .addHandler(Method.GET, "/", (request, response, pathParams) ->
                 response.write(Thread.currentThread().getName()))
             .start();
@@ -227,6 +231,37 @@ class ExecutionDomainsTest {
             assertThat(client.readLine(), equalTo("HTTP/1.1 200 OK"));
             assertThat(client.readBody(client.readHeaders()), startsWith("shared-"));
         }
+        assertThat(completionThread.get(5, TimeUnit.SECONDS), startsWith("shared-"));
+    }
+
+    @Test
+    void http1ResponseCompletionCallbacksUseTheHandlerExecutor() throws Exception {
+        var handlerExecutor = track(Executors.newSingleThreadExecutor(namedThreads("handler-")));
+        var connectionExecutor = track(Executors.newCachedThreadPool(namedThreads("connection-")));
+        var responseCompletionThread = new CompletableFuture<String>();
+        var serverCompletionThread = new CompletableFuture<String>();
+        server = httpServer()
+            .withHandlerExecutor(handlerExecutor)
+            .withConnectionExecutor(connectionExecutor)
+            .addResponseCompleteListener(info ->
+                serverCompletionThread.complete(Thread.currentThread().getName())
+            )
+            .addHandler(Method.GET, "/", (request, response, pathParams) -> {
+                response.addCompletionListener(info ->
+                    responseCompletionThread.complete(Thread.currentThread().getName())
+                );
+                response.write("done");
+            })
+            .start();
+
+        try (var client = Http1Client.connect(server)) {
+            client.writeRequestLine(Method.GET, "/").flushHeaders();
+            assertThat(client.readLine(), equalTo("HTTP/1.1 200 OK"));
+            assertThat(client.readBody(client.readHeaders()), equalTo("done"));
+        }
+
+        assertThat(responseCompletionThread.get(5, TimeUnit.SECONDS), startsWith("handler-"));
+        assertThat(serverCompletionThread.get(5, TimeUnit.SECONDS), startsWith("handler-"));
     }
 
     @Test
@@ -313,11 +348,16 @@ class ExecutionDomainsTest {
         var handlerExecutor = track(Executors.newSingleThreadExecutor(namedThreads("handler-")));
         var clientExecutor = track(Executors.newSingleThreadExecutor(namedThreads("client-")));
         var suspendedHandle = new CompletableFuture<AsyncHandle>();
+        var completionThread = new CompletableFuture<String>();
         server = httpServer()
             .withHandlerExecutor(handlerExecutor)
             .addHandler((request, response) -> {
                 if (request.relativePath().equals("/suspend")) {
-                    suspendedHandle.complete(request.handleAsync());
+                    AsyncHandle handle = request.handleAsync();
+                    handle.addResponseCompleteHandler(info ->
+                        completionThread.complete(Thread.currentThread().getName())
+                    );
+                    suspendedHandle.complete(handle);
                 } else {
                     response.write(Thread.currentThread().getName());
                 }
@@ -342,6 +382,7 @@ class ExecutionDomainsTest {
 
             assertThat(first.readLine(), equalTo("HTTP/1.1 200 OK"));
             assertThat(first.readBody(first.readHeaders()), equalTo(""));
+            assertThat(completionThread.get(5, TimeUnit.SECONDS), startsWith("handler-"));
         }
     }
 

--- a/src/test/java/io/muserver/ExecutionDomainsTest.java
+++ b/src/test/java/io/muserver/ExecutionDomainsTest.java
@@ -31,6 +31,7 @@ import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static io.muserver.MuServerBuilder.httpServer;
@@ -305,6 +306,50 @@ class ExecutionDomainsTest {
             assertThat(secondResponse.get(2, TimeUnit.SECONDS), equalTo("/second"));
         } finally {
             releaseFirstCompletion.countDown();
+        }
+    }
+
+    @Test
+    void gracefulStopWaitsForDispatchedHttp1CompletionListeners() throws Exception {
+        var handlerExecutor = track(Executors.newFixedThreadPool(2, namedThreads("handler-")));
+        var connectionExecutor = track(Executors.newSingleThreadExecutor(namedThreads("connection-")));
+        var clientExecutor = track(Executors.newSingleThreadExecutor(namedThreads("client-")));
+        var completionStarted = new CountDownLatch(1);
+        var releaseCompletion = new CountDownLatch(1);
+        server = httpServer()
+            .withHandlerExecutor(handlerExecutor)
+            .withConnectionExecutor(connectionExecutor)
+            .addResponseCompleteListener(info -> {
+                completionStarted.countDown();
+                try {
+                    releaseCompletion.await();
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+            })
+            .addHandler(Method.GET, "/", (request, response, pathParams) ->
+                response.write("done")
+            )
+            .start();
+
+        try (var client = Http1Client.connect(server)) {
+            client.writeRequestLine(Method.GET, "/").flushHeaders();
+            assertThat(client.readLine(), equalTo("HTTP/1.1 200 OK"));
+            assertThat(client.readBody(client.readHeaders()), equalTo("done"));
+            assertThat(completionStarted.await(5, TimeUnit.SECONDS), is(true));
+
+            MuServer runningServer = Objects.requireNonNull(server);
+            Future<Boolean> stopped = clientExecutor.submit(() ->
+                runningServer.stop(2, TimeUnit.SECONDS)
+            );
+            assertThrows(TimeoutException.class, () ->
+                stopped.get(100, TimeUnit.MILLISECONDS)
+            );
+            releaseCompletion.countDown();
+            assertThat(stopped.get(5, TimeUnit.SECONDS), is(true));
+            server = null;
+        } finally {
+            releaseCompletion.countDown();
         }
     }
 

--- a/src/test/java/io/muserver/ExecutionDomainsTest.java
+++ b/src/test/java/io/muserver/ExecutionDomainsTest.java
@@ -354,6 +354,33 @@ class ExecutionDomainsTest {
     }
 
     @Test
+    void rejectedHandlerDispatchFallsBackWithoutRunningCompletionListenersOnTheHttp1Reader() throws Exception {
+        var handlerExecutor = track(Executors.newSingleThreadExecutor(namedThreads("handler-")));
+        var asyncExecutor = track(Executors.newSingleThreadExecutor(namedThreads("async-")));
+        var connectionExecutor = track(Executors.newSingleThreadExecutor(namedThreads("connection-")));
+        var completionThread = new CompletableFuture<String>();
+        server = httpServer()
+            .withHandlerExecutor(handlerExecutor)
+            .withAsyncExecutor(asyncExecutor)
+            .withConnectionExecutor(connectionExecutor)
+            .addResponseCompleteListener(info ->
+                completionThread.complete(Thread.currentThread().getName())
+            )
+            .addHandler(Method.GET, "/", (request, response, pathParams) -> {
+                response.write("done");
+                handlerExecutor.shutdown();
+            })
+            .start();
+
+        try (var client = Http1Client.connect(server)) {
+            client.writeRequestLine(Method.GET, "/").flushHeaders();
+            assertThat(client.readLine(), equalTo("HTTP/1.1 200 OK"));
+            assertThat(client.readBody(client.readHeaders()), equalTo("done"));
+        }
+        assertThat(completionThread.get(5, TimeUnit.SECONDS), startsWith("async-"));
+    }
+
+    @Test
     void oneAsyncWorkerCanReadAndEchoARequestBody() throws Exception {
         var asyncExecutor = track(Executors.newSingleThreadExecutor(namedThreads("async-")));
         var callbackThreads = new CopyOnWriteArrayList<String>();

--- a/src/test/java/io/muserver/ExecutionDomainsTest.java
+++ b/src/test/java/io/muserver/ExecutionDomainsTest.java
@@ -265,6 +265,50 @@ class ExecutionDomainsTest {
     }
 
     @Test
+    void aSlowHttp1CompletionListenerDoesNotDelayTheNextRequest() throws Exception {
+        var handlerExecutor = track(Executors.newFixedThreadPool(2, namedThreads("handler-")));
+        var connectionExecutor = track(Executors.newSingleThreadExecutor(namedThreads("connection-")));
+        var clientExecutor = track(Executors.newSingleThreadExecutor(namedThreads("client-")));
+        var firstCompletionStarted = new CountDownLatch(1);
+        var releaseFirstCompletion = new CountDownLatch(1);
+        server = httpServer()
+            .withHandlerExecutor(handlerExecutor)
+            .withConnectionExecutor(connectionExecutor)
+            .addResponseCompleteListener(info -> {
+                if (info.request().relativePath().equals("/first")) {
+                    firstCompletionStarted.countDown();
+                    try {
+                        releaseFirstCompletion.await();
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                    }
+                }
+            })
+            .addHandler((request, response) -> {
+                response.write(request.relativePath());
+                return true;
+            })
+            .start();
+
+        try (var client = Http1Client.connect(server)) {
+            client.writeRequestLine(Method.GET, "/first").flushHeaders();
+            assertThat(client.readLine(), equalTo("HTTP/1.1 200 OK"));
+            assertThat(client.readBody(client.readHeaders()), equalTo("/first"));
+            assertThat(firstCompletionStarted.await(5, TimeUnit.SECONDS), is(true));
+            assertThat(server.stats().completedRequests(), equalTo(1L));
+
+            Future<String> secondResponse = clientExecutor.submit(() -> {
+                client.writeRequestLine(Method.GET, "/second").flushHeaders();
+                assertThat(client.readLine(), equalTo("HTTP/1.1 200 OK"));
+                return client.readBody(client.readHeaders());
+            });
+            assertThat(secondResponse.get(2, TimeUnit.SECONDS), equalTo("/second"));
+        } finally {
+            releaseFirstCompletion.countDown();
+        }
+    }
+
+    @Test
     void oneAsyncWorkerCanReadAndEchoARequestBody() throws Exception {
         var asyncExecutor = track(Executors.newSingleThreadExecutor(namedThreads("async-")));
         var callbackThreads = new CopyOnWriteArrayList<String>();


### PR DESCRIPTION
Stacked on #149.

This aligns HTTP/1 response-completion callback execution with HTTP/2 and the handler/application execution domain. The HTTP/1 connection task still owns response cleanup and keep-alive sequencing, but dispatches the short completion phase to the handler executor. If the handler executor is shared with connection work, the callbacks run inline to avoid self-deadlock; if an already-accepted exchange cannot be resubmitted during shutdown or transient rejection, completion falls back inline rather than being lost.

Regression coverage proves both per-response and server-wide completion listeners use the handler executor, suspended exchanges retain no handler worker while waiting, and shared single-thread handler/connection executors remain safe.

Validation: `mise exec java@temurin-21 -- mvn --batch-mode -Pnullaway clean verify` (1,612 tests, 0 failures).