### PR TITLE
Serialize WebSocket events on the handler executor

### DIFF
--- a/src/main/java/io/muserver/Http1Connection.java
+++ b/src/main/java/io/muserver/Http1Connection.java
@@ -464,6 +464,14 @@ class Http1Connection extends BaseHttpConnection {
         return handlerExecutor;
     }
 
+    void wakeWebSocketReader() {
+        try {
+            clientSocket.shutdownInput();
+        } catch (IOException e) {
+            log.debug("Could not wake WebSocket reader", e);
+        }
+    }
+
     boolean webSocketEventsRunOnConnectionTask() {
         return handlersRunOnConnectionTask;
     }

--- a/src/main/java/io/muserver/Http1Connection.java
+++ b/src/main/java/io/muserver/Http1Connection.java
@@ -421,10 +421,11 @@ class Http1Connection extends BaseHttpConnection {
         if (isIdle()) {
             log.info("Connection is idle; shutting down");
             forceShutdown();
-        } else if (!activeWebsockets().isEmpty()) {
-            for (MuWebSocket activeWebsocket : activeWebsockets()) {
+        } else {
+            var cur = activeExchange.get();
+            if (cur != null && cur.websocket != null) {
                 try {
-                    activeWebsocket.onServerShuttingDown();
+                    cur.websocket.onServerShuttingDown();
                 } catch (Exception e) {
                     log.info("Error while aborting websocket: {}", e.getMessage());
                     forceShutdown();
@@ -480,5 +481,13 @@ class Http1Connection extends BaseHttpConnection {
         if (cur != null && cur.websocket != null) {
             cur.websocket.onTimeout();
         }
+    }
+
+    ExecutorService webSocketHandlerExecutor() {
+        return handlerExecutor;
+    }
+
+    boolean webSocketEventsRunOnConnectionTask() {
+        return handlersRunOnConnectionTask;
     }
 }

--- a/src/main/java/io/muserver/MuServerBuilder.java
+++ b/src/main/java/io/muserver/MuServerBuilder.java
@@ -215,6 +215,10 @@ public class MuServerBuilder {
      * both, HTTP/1 handlers run on their connection task to avoid submitting work back
      * to an executor that may already be at capacity.</p>
      *
+     * <p>This executor also dispatches response-completion listeners and serialized
+     * WebSocket lifecycle and message callbacks. A WebSocket connection does not retain
+     * a worker while waiting for frames; each callback is short-lived executor work.</p>
+     *
      * @param executor The executor service to use to handle requests
      * @return The current Mu Server builder
      */

--- a/src/main/java/io/muserver/WebsocketConnection.java
+++ b/src/main/java/io/muserver/WebsocketConnection.java
@@ -33,19 +33,21 @@ class WebsocketConnection implements MuWebSocketSession {
     final WebSocketHandlerBuilder.Settings settings;
 
     private volatile WebsocketSessionState state = WebsocketSessionState.NOT_STARTED;
-    private final BaseHttpConnection httpConnection;
+    private final Http1Connection httpConnection;
     private final MuWebSocket webSocket;
     private final ExecutorService handlerExecutor;
     private final boolean eventsRunOnConnectionTask;
     private final Queue<ApplicationEventTask> applicationEvents = new ConcurrentLinkedQueue<>();
     private final AtomicBoolean applicationEventRunnerScheduled = new AtomicBoolean();
     private final AtomicBoolean errorEventQueued = new AtomicBoolean();
+    private final AtomicBoolean serverShutdownRequested = new AtomicBoolean();
     private boolean closeReceived = false;
     private boolean closeSent = false;
     private final Lock writeLock = new ReentrantLock();
     private final @Nullable ByteBuffer pingBuffer;
     private ReadState readState = ReadState.NONE;
     private volatile @Nullable ScheduledFuture<?> pingFuture;
+    private volatile @Nullable Thread connectionTaskThread;
 
     private enum ReadState {
         NONE, TEXT, BINARY,
@@ -128,6 +130,7 @@ class WebsocketConnection implements MuWebSocketSession {
         this.inputStream = inputStream;
         this.outputStream = outputStream;
         this.buffer = ByteBuffer.wrap(readBuffer).flip();
+        connectionTaskThread = Thread.currentThread();
 
         try {
             state = WebsocketSessionState.OPEN;
@@ -279,7 +282,9 @@ class WebsocketConnection implements MuWebSocketSession {
 
             // it's finished - the TCP connection will be closed
         } catch (Throwable e) {
-            if (!errorEventQueued.get() && state != WebsocketSessionState.TIMED_OUT) {
+            if (!serverShutdownRequested.get()
+                && !errorEventQueued.get()
+                && state != WebsocketSessionState.TIMED_OUT) {
                 WebsocketSessionState errorState =
                     e instanceof TimeoutException || e instanceof SocketTimeoutException
                         ? WebsocketSessionState.TIMED_OUT
@@ -295,6 +300,7 @@ class WebsocketConnection implements MuWebSocketSession {
                 currentPing.cancel(false);
                 pingFuture = null;
             }
+            connectionTaskThread = null;
         }
     }
 
@@ -384,12 +390,27 @@ class WebsocketConnection implements MuWebSocketSession {
     }
 
     void onServerShuttingDown() throws Exception {
-        invokeApplicationEvent(webSocket::onServerShuttingDown);
+        if (!serverShutdownRequested.compareAndSet(false, true)) {
+            return;
+        }
+        enqueueApplicationEvent(webSocket::onServerShuttingDown)
+            .whenComplete((ignored, failure) -> {
+                if (failure != null) {
+                    log.info("Error while shutting down WebSocket", failure);
+                    httpConnection.forceShutdown();
+                }
+            });
     }
 
     private void invokeApplicationEvent(ApplicationEvent event) throws Exception {
         if (eventsRunOnConnectionTask) {
-            event.run();
+            try {
+                event.run();
+            } finally {
+                // A terminal event can be queued by a write attempted inside a callback.
+                // Drain it before returning to the blocking socket read.
+                drainApplicationEvents();
+            }
             return;
         }
         CompletableFuture<@Nullable Void> completion = enqueueApplicationEvent(event);
@@ -432,25 +453,51 @@ class WebsocketConnection implements MuWebSocketSession {
         };
     }
 
+    @SuppressWarnings("ReferenceEquality") // Connection-task ownership belongs to the exact thread instance.
     private CompletableFuture<@Nullable Void> enqueueApplicationEvent(ApplicationEvent event) {
         var task = new ApplicationEventTask(event);
         applicationEvents.add(task);
-        if (!eventsRunOnConnectionTask) {
+        if (eventsRunOnConnectionTask) {
+            if (Thread.currentThread() != connectionTaskThread) {
+                // A shared single-thread executor cannot run another task while its
+                // connection reader is blocked. Terminal external events wake that reader,
+                // which drains this mailbox from its finally block.
+                httpConnection.wakeWebSocketReader();
+            }
+        } else {
             scheduleApplicationEventRunner();
         }
         return task.completion;
     }
 
+    @SuppressWarnings("ReferenceEquality") // Execution-domain identity belongs to the exact executor instance.
     private void scheduleApplicationEventRunner() {
         if (!applicationEventRunnerScheduled.compareAndSet(false, true)) {
             return;
         }
         try {
             handlerExecutor.execute(this::runApplicationEvents);
-        } catch (RejectedExecutionException rejected) {
-            // These events belong to an already-accepted WebSocket. Preserve delivery and
-            // serialization during shutdown or a transient capacity rejection.
-            runApplicationEvents();
+        } catch (RejectedExecutionException handlerRejected) {
+            ExecutorService fallbackExecutor = asyncExecutor();
+            if (fallbackExecutor != handlerExecutor) {
+                try {
+                    fallbackExecutor.execute(this::runApplicationEvents);
+                    return;
+                } catch (RejectedExecutionException asyncRejected) {
+                    asyncRejected.addSuppressed(handlerRejected);
+                    failApplicationEvents(asyncRejected);
+                    return;
+                }
+            }
+            failApplicationEvents(handlerRejected);
+        }
+    }
+
+    private void failApplicationEvents(RejectedExecutionException failure) {
+        applicationEventRunnerScheduled.set(false);
+        ApplicationEventTask task;
+        while ((task = applicationEvents.poll()) != null) {
+            task.completion.completeExceptionally(failure);
         }
     }
 

--- a/src/main/java/io/muserver/WebsocketConnection.java
+++ b/src/main/java/io/muserver/WebsocketConnection.java
@@ -12,10 +12,16 @@ import java.net.ProtocolException;
 import java.net.SocketTimeoutException;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
+import java.util.Queue;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
@@ -29,6 +35,11 @@ class WebsocketConnection implements MuWebSocketSession {
     private volatile WebsocketSessionState state = WebsocketSessionState.NOT_STARTED;
     private final BaseHttpConnection httpConnection;
     private final MuWebSocket webSocket;
+    private final ExecutorService handlerExecutor;
+    private final boolean eventsRunOnConnectionTask;
+    private final Queue<ApplicationEventTask> applicationEvents = new ConcurrentLinkedQueue<>();
+    private final AtomicBoolean applicationEventRunnerScheduled = new AtomicBoolean();
+    private final AtomicBoolean errorEventQueued = new AtomicBoolean();
     private boolean closeReceived = false;
     private boolean closeSent = false;
     private final Lock writeLock = new ReentrantLock();
@@ -44,10 +55,26 @@ class WebsocketConnection implements MuWebSocketSession {
         UNKNOWN
     }
 
+    @FunctionalInterface
+    private interface ApplicationEvent {
+        void run() throws Exception;
+    }
+
+    private static final class ApplicationEventTask {
+        private final ApplicationEvent event;
+        private final CompletableFuture<@Nullable Void> completion = new CompletableFuture<>();
+
+        private ApplicationEventTask(ApplicationEvent event) {
+            this.event = event;
+        }
+    }
+
     WebsocketConnection(Http1Connection httpConnection, MuWebSocket webSocket, WebSocketHandlerBuilder.Settings settings) {
         this.httpConnection = httpConnection;
         this.webSocket = webSocket;
         this.settings = settings;
+        this.handlerExecutor = httpConnection.webSocketHandlerExecutor();
+        this.eventsRunOnConnectionTask = httpConnection.webSocketEventsRunOnConnectionTask();
         if (settings.pingIntervalMillis == 0) {
             pingBuffer = null;
         } else {
@@ -104,7 +131,7 @@ class WebsocketConnection implements MuWebSocketSession {
 
         try {
             state = WebsocketSessionState.OPEN;
-            webSocket.onConnect(this);
+            invokeApplicationEvent(() -> webSocket.onConnect(this));
 
             if (settings.pingIntervalMillis > 0) {
                 startPinging();
@@ -175,9 +202,9 @@ class WebsocketConnection implements MuWebSocketSession {
                     // continuation frame
                     messageLength += payloadLength;
                     if (readState == ReadState.TEXT) {
-                        webSocket.onTextFragment(slice, fin);
+                        invokeApplicationEvent(() -> webSocket.onTextFragment(slice, fin));
                     } else if (readState == ReadState.BINARY) {
-                        webSocket.onBinaryFragment(slice, fin);
+                        invokeApplicationEvent(() -> webSocket.onBinaryFragment(slice, fin));
                     } else if (readState != ReadState.UNKNOWN) {
                         throw frameError(1002, "Continuation frame received unexpectedly");
                     }
@@ -193,10 +220,10 @@ class WebsocketConnection implements MuWebSocketSession {
                     messageLength = payloadLength;
                     if (fin) {
                         var text = StandardCharsets.UTF_8.newDecoder().decode(slice).toString();
-                        webSocket.onText(text);
+                        invokeApplicationEvent(() -> webSocket.onText(text));
                     } else {
                         readState = ReadState.TEXT;
-                        webSocket.onTextFragment(slice, false);
+                        invokeApplicationEvent(() -> webSocket.onTextFragment(slice, false));
                     }
                 } else if (opcode == 0x2) {
                     // binary frame
@@ -205,10 +232,10 @@ class WebsocketConnection implements MuWebSocketSession {
                     }
                     messageLength = payloadLength;
                     if (fin) {
-                        webSocket.onBinary(slice);
+                        invokeApplicationEvent(() -> webSocket.onBinary(slice));
                     } else {
                         readState = ReadState.BINARY;
-                        webSocket.onBinaryFragment(slice, false);
+                        invokeApplicationEvent(() -> webSocket.onBinaryFragment(slice, false));
                     }
                 } else if (opcode == 0x8) {
                     if (payloadLen == 1) {
@@ -230,7 +257,8 @@ class WebsocketConnection implements MuWebSocketSession {
                         closeCode = 1005;
                     }
                     log.info("Client close: " + closeCode + " " + reason);
-                    webSocket.onClientClosed(closeCode, reason);
+                    String closeReason = reason;
+                    invokeApplicationEvent(() -> webSocket.onClientClosed(closeCode, closeReason));
                     if (closeSent) {
                         if (state == WebsocketSessionState.CLIENT_CLOSING) {
                             state = WebsocketSessionState.CLIENT_CLOSED;
@@ -239,9 +267,9 @@ class WebsocketConnection implements MuWebSocketSession {
                         }
                     }
                 } else if (opcode == 0x9) {
-                    webSocket.onPing(slice);
+                    invokeApplicationEvent(() -> webSocket.onPing(slice));
                 } else if (opcode == 0xA) {
-                    webSocket.onPong(slice);
+                    invokeApplicationEvent(() -> webSocket.onPong(slice));
                 } else if (!fin) {
                     // ignore unknown types, but do allow continuation frames for them
                     readState = ReadState.UNKNOWN;
@@ -251,12 +279,17 @@ class WebsocketConnection implements MuWebSocketSession {
 
             // it's finished - the TCP connection will be closed
         } catch (Throwable e) {
-            if (state != WebsocketSessionState.TIMED_OUT) {
-                webSocket.onError(e);
-                state = (e instanceof TimeoutException || e instanceof SocketTimeoutException) ?
-                    WebsocketSessionState.TIMED_OUT : WebsocketSessionState.ERRORED;
+            if (!errorEventQueued.get() && state != WebsocketSessionState.TIMED_OUT) {
+                WebsocketSessionState errorState =
+                    e instanceof TimeoutException || e instanceof SocketTimeoutException
+                        ? WebsocketSessionState.TIMED_OUT
+                        : WebsocketSessionState.ERRORED;
+                invokeApplicationError(e, errorState);
             }
         } finally {
+            if (eventsRunOnConnectionTask) {
+                drainApplicationEvents();
+            }
             ScheduledFuture<?> currentPing = pingFuture;
             if (currentPing != null) {
                 currentPing.cancel(false);
@@ -339,11 +372,108 @@ class WebsocketConnection implements MuWebSocketSession {
     private @Nullable IOException writeFailure;
 
     void onTimeout() {
-        try {
-            this.webSocket.onError(new TimeoutException("Connection idle timeout"));
-        } catch (Exception ignored) {
-        } finally {
+        if (errorEventQueued.compareAndSet(false, true)) {
+            // The connection-level timeout closes the transport immediately after this
+            // method returns. Publish the terminal state before the callback so default
+            // implementations do not try to write a close frame to that closed transport.
             state = WebsocketSessionState.TIMED_OUT;
+            enqueueApplicationEvent(() ->
+                webSocket.onError(new TimeoutException("Connection idle timeout"))
+            );
+        }
+    }
+
+    void onServerShuttingDown() throws Exception {
+        invokeApplicationEvent(webSocket::onServerShuttingDown);
+    }
+
+    private void invokeApplicationEvent(ApplicationEvent event) throws Exception {
+        if (eventsRunOnConnectionTask) {
+            event.run();
+            return;
+        }
+        CompletableFuture<@Nullable Void> completion = enqueueApplicationEvent(event);
+        try {
+            completion.get();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw e;
+        } catch (ExecutionException e) {
+            Throwable cause = e.getCause();
+            if (cause instanceof Exception) {
+                throw (Exception) cause;
+            }
+            if (cause instanceof Error) {
+                throw (Error) cause;
+            }
+            throw new MuException("Unexpected WebSocket callback failure", cause);
+        }
+    }
+
+    private void invokeApplicationError(Throwable cause, WebsocketSessionState errorState) throws Exception {
+        if (errorEventQueued.compareAndSet(false, true)) {
+            invokeApplicationEvent(errorEvent(cause, errorState));
+        }
+    }
+
+    private void enqueueApplicationError(Throwable cause, WebsocketSessionState errorState) {
+        if (errorEventQueued.compareAndSet(false, true)) {
+            enqueueApplicationEvent(errorEvent(cause, errorState));
+        }
+    }
+
+    private ApplicationEvent errorEvent(Throwable cause, WebsocketSessionState errorState) {
+        return () -> {
+            try {
+                webSocket.onError(cause);
+            } finally {
+                state = errorState;
+            }
+        };
+    }
+
+    private CompletableFuture<@Nullable Void> enqueueApplicationEvent(ApplicationEvent event) {
+        var task = new ApplicationEventTask(event);
+        applicationEvents.add(task);
+        if (!eventsRunOnConnectionTask) {
+            scheduleApplicationEventRunner();
+        }
+        return task.completion;
+    }
+
+    private void scheduleApplicationEventRunner() {
+        if (!applicationEventRunnerScheduled.compareAndSet(false, true)) {
+            return;
+        }
+        try {
+            handlerExecutor.execute(this::runApplicationEvents);
+        } catch (RejectedExecutionException rejected) {
+            // These events belong to an already-accepted WebSocket. Preserve delivery and
+            // serialization during shutdown or a transient capacity rejection.
+            runApplicationEvents();
+        }
+    }
+
+    private void runApplicationEvents() {
+        while (true) {
+            drainApplicationEvents();
+            applicationEventRunnerScheduled.set(false);
+            if (applicationEvents.isEmpty()
+                || !applicationEventRunnerScheduled.compareAndSet(false, true)) {
+                return;
+            }
+        }
+    }
+
+    private void drainApplicationEvents() {
+        ApplicationEventTask task;
+        while ((task = applicationEvents.poll()) != null) {
+            try {
+                task.event.run();
+                task.completion.complete(null);
+            } catch (Throwable t) {
+                task.completion.completeExceptionally(t);
+            }
         }
     }
 
@@ -490,6 +620,7 @@ class WebsocketConnection implements MuWebSocketSession {
     private void writeFragment(byte firstByte, byte@Nullable[] payload, int payloadOffset, int payloadLen, @Nullable MessageWritingState expectedState, @Nullable MessageWritingState endState) throws IOException {
         var header = header(firstByte, payloadLen);
         OutputStream output = java.util.Objects.requireNonNull(outputStream);
+        IOException failure = null;
         writeLock.lock();
         try {
             throwStoredWriteFailure();
@@ -511,16 +642,14 @@ class WebsocketConnection implements MuWebSocketSession {
             } catch (IOException e) {
                 writeFailure = e;
                 messageWritingState = MessageWritingState.ERROR;
-                state = WebsocketSessionState.ERRORED;
-                try {
-                    webSocket.onError(e);
-                } catch (Exception userException) {
-                    e.addSuppressed(userException);
-                }
-                throw e;
+                failure = e;
             }
         } finally {
             writeLock.unlock();
+        }
+        if (failure != null) {
+            enqueueApplicationError(failure, WebsocketSessionState.ERRORED);
+            throw failure;
         }
     }
 

--- a/src/test/java/io/muserver/ExecutionDomainsTest.java
+++ b/src/test/java/io/muserver/ExecutionDomainsTest.java
@@ -32,6 +32,7 @@ import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static io.muserver.MuServerBuilder.httpServer;
@@ -677,6 +678,124 @@ class ExecutionDomainsTest {
             assertThat(shutdownThread.get(5, TimeUnit.SECONDS), startsWith("handler-"));
             server = null;
         } finally {
+            webSocket.cancel();
+        }
+    }
+
+    @Test
+    void blockedWebSocketShutdownCallbackDoesNotBlockTheShutdownDeadline() throws Exception {
+        var handlerExecutor = track(Executors.newSingleThreadExecutor(namedThreads("handler-")));
+        var connectionExecutor = track(Executors.newCachedThreadPool(namedThreads("connection-")));
+        var clientExecutor = track(Executors.newSingleThreadExecutor(namedThreads("client-")));
+        var connected = new CountDownLatch(1);
+        var shutdownEntered = new CountDownLatch(1);
+        var releaseShutdown = new CountDownLatch(1);
+        server = httpServer()
+            .withHandlerExecutor(handlerExecutor)
+            .withConnectionExecutor(connectionExecutor)
+            .addHandler(webSocketHandler((request, responseHeaders) -> new SimpleWebSocket() {
+                @Override
+                public void onConnect(MuWebSocketSession session) throws Exception {
+                    super.onConnect(session);
+                    connected.countDown();
+                }
+
+                @Override
+                public void onText(String message) {
+                }
+
+                @Override
+                public void onBinary(ByteBuffer payload) {
+                }
+
+                @Override
+                public void onServerShuttingDown() throws Exception {
+                    shutdownEntered.countDown();
+                    releaseShutdown.await();
+                }
+            }))
+            .start();
+
+        String websocketUrl = "ws" + server.uri().toString().substring(4);
+        WebSocket webSocket = client.newWebSocket(
+            request().url(websocketUrl).build(),
+            new WebSocketListener() {
+            }
+        );
+        try {
+            assertThat(connected.await(5, TimeUnit.SECONDS), is(true));
+            MuServer runningServer = Objects.requireNonNull(server);
+            Future<Boolean> stopped = clientExecutor.submit(() ->
+                runningServer.stop(100, TimeUnit.MILLISECONDS)
+            );
+            assertThat(shutdownEntered.await(5, TimeUnit.SECONDS), is(true));
+            assertThat(stopped.get(2, TimeUnit.SECONDS), is(false));
+            server = null;
+        } finally {
+            releaseShutdown.countDown();
+            webSocket.cancel();
+        }
+    }
+
+    @Test
+    void sharedExecutorSerializesShutdownBehindAnInFlightWebSocketCallback() throws Exception {
+        var sharedExecutor = track(Executors.newSingleThreadExecutor(namedThreads("shared-")));
+        var clientExecutor = track(Executors.newSingleThreadExecutor(namedThreads("client-")));
+        var textEntered = new CountDownLatch(1);
+        var releaseText = new CountDownLatch(1);
+        var shutdownCalled = new CompletableFuture<@Nullable Void>();
+        var callbackActive = new AtomicBoolean();
+        var callbacksOverlapped = new AtomicBoolean();
+        server = httpServer()
+            .withHandlerExecutor(sharedExecutor)
+            .withConnectionExecutor(sharedExecutor)
+            .addHandler(webSocketHandler((request, responseHeaders) -> new SimpleWebSocket() {
+                @Override
+                public void onText(String message) throws Exception {
+                    callbackActive.set(true);
+                    textEntered.countDown();
+                    try {
+                        releaseText.await();
+                    } finally {
+                        callbackActive.set(false);
+                    }
+                }
+
+                @Override
+                public void onBinary(ByteBuffer payload) {
+                }
+
+                @Override
+                public void onServerShuttingDown() {
+                    callbacksOverlapped.set(callbackActive.get());
+                    shutdownCalled.complete(null);
+                }
+            }))
+            .start();
+
+        String websocketUrl = "ws" + server.uri().toString().substring(4);
+        WebSocket webSocket = client.newWebSocket(
+            request().url(websocketUrl).build(),
+            new WebSocketListener() {
+            }
+        );
+        try {
+            assertThat(webSocket.send("hold"), is(true));
+            assertThat(textEntered.await(5, TimeUnit.SECONDS), is(true));
+            MuServer runningServer = Objects.requireNonNull(server);
+            Future<Boolean> stopped = clientExecutor.submit(() ->
+                runningServer.stop(2, TimeUnit.SECONDS)
+            );
+            assertThrows(TimeoutException.class, () ->
+                shutdownCalled.get(100, TimeUnit.MILLISECONDS)
+            );
+            releaseText.countDown();
+            shutdownCalled.get(5, TimeUnit.SECONDS);
+            assertThat(callbacksOverlapped.get(), is(false));
+            assertThat(stopped.get(5, TimeUnit.SECONDS), is(true));
+            server = null;
+        } finally {
+            releaseText.countDown();
             webSocket.cancel();
         }
     }

--- a/src/test/java/io/muserver/ExecutionDomainsTest.java
+++ b/src/test/java/io/muserver/ExecutionDomainsTest.java
@@ -845,6 +845,65 @@ class ExecutionDomainsTest {
     }
 
     @Test
+    void sharedExecutorDrainsAWriteFailureCaughtInsideAWebSocketCallback() throws Exception {
+        var sharedExecutor = track(Executors.newSingleThreadExecutor(namedThreads("shared-")));
+        var textEntered = new CountDownLatch(1);
+        var attemptWrite = new CountDownLatch(1);
+        var writeFailure = new CompletableFuture<IOException>();
+        var errorCallback = new CompletableFuture<Throwable>();
+        server = httpServer()
+            .withHandlerExecutor(sharedExecutor)
+            .withConnectionExecutor(sharedExecutor)
+            .addHandler(webSocketHandler((request, responseHeaders) -> new SimpleWebSocket() {
+                @Override
+                public void onText(String message) throws Exception {
+                    textEntered.countDown();
+                    attemptWrite.await();
+                    try {
+                        session().sendBinary(ByteBuffer.allocate(1024 * 1024));
+                    } catch (IOException e) {
+                        writeFailure.complete(e);
+                    }
+                }
+
+                @Override
+                public void onBinary(ByteBuffer payload) {
+                }
+
+                @Override
+                public void onError(Throwable cause) {
+                    errorCallback.complete(cause);
+                }
+            }))
+            .start();
+
+        try (var client = Http1Client.connect(server)) {
+            client.writeRequestLine(Method.GET, "/")
+                .writeHeader("Upgrade", "websocket")
+                .writeHeader("Connection", "Upgrade")
+                .writeHeader("Sec-WebSocket-Key", "dGhlIHNhbXBsZSBub25jZQ==")
+                .writeHeader("Sec-WebSocket-Version", "13")
+                .flushHeaders();
+            assertThat(client.readLine(), equalTo("HTTP/1.1 101 Switching Protocols"));
+            client.readHeaders();
+
+            // A masked "hold" frame. A zero mask is valid and leaves the payload unchanged.
+            client.out().write(new byte[]{
+                (byte) 0x81, (byte) 0x84, 0, 0, 0, 0, 'h', 'o', 'l', 'd'
+            });
+            client.out().flush();
+            assertThat(textEntered.await(5, TimeUnit.SECONDS), is(true));
+            client.abort();
+            attemptWrite.countDown();
+
+            IOException expected = writeFailure.get(5, TimeUnit.SECONDS);
+            assertThat(errorCallback.get(5, TimeUnit.SECONDS), is(expected));
+        } finally {
+            attemptWrite.countDown();
+        }
+    }
+
+    @Test
     void sharedConnectionAndHandlerExecutorDoesNotDeadlockWebSocketEvents() throws Exception {
         var sharedExecutor = track(Executors.newSingleThreadExecutor(namedThreads("shared-")));
         var callbackThread = new CompletableFuture<String>();

--- a/src/test/java/io/muserver/ExecutionDomainsTest.java
+++ b/src/test/java/io/muserver/ExecutionDomainsTest.java
@@ -31,6 +31,7 @@ import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static io.muserver.MuServerBuilder.httpServer;
@@ -473,6 +474,206 @@ class ExecutionDomainsTest {
         assertThat(callbackThreads.size(), is(2));
         for (String callbackThread : callbackThreads) {
             assertThat(callbackThread, startsWith("async-"));
+        }
+    }
+
+    @Test
+    void webSocketEventsUseTheHandlerExecutor() throws Exception {
+        var handlerExecutor = track(Executors.newSingleThreadExecutor(namedThreads("handler-")));
+        var connectionExecutor = track(Executors.newCachedThreadPool(namedThreads("connection-")));
+        var connectedThread = new CompletableFuture<String>();
+        var messageThread = new CompletableFuture<String>();
+        var errorThread = new CompletableFuture<String>();
+        server = httpServer()
+            .withHandlerExecutor(handlerExecutor)
+            .withConnectionExecutor(connectionExecutor)
+            .addHandler(webSocketHandler((request, responseHeaders) -> new SimpleWebSocket() {
+                @Override
+                public void onConnect(MuWebSocketSession session) throws Exception {
+                    super.onConnect(session);
+                    connectedThread.complete(Thread.currentThread().getName());
+                }
+
+                @Override
+                public void onText(String message) {
+                    messageThread.complete(Thread.currentThread().getName());
+                    throw new MuException("message failure");
+                }
+
+                @Override
+                public void onBinary(ByteBuffer payload) {
+                }
+
+                @Override
+                public void onError(Throwable cause) {
+                    errorThread.complete(Thread.currentThread().getName());
+                }
+            }))
+            .start();
+
+        String websocketUrl = "ws" + server.uri().toString().substring(4);
+        WebSocket webSocket = client.newWebSocket(
+            request().url(websocketUrl).build(),
+            new WebSocketListener() {
+            }
+        );
+        try {
+            assertThat(connectedThread.get(5, TimeUnit.SECONDS), startsWith("handler-"));
+            assertThat(webSocket.send("hello"), is(true));
+            assertThat(messageThread.get(5, TimeUnit.SECONDS), startsWith("handler-"));
+            assertThat(errorThread.get(5, TimeUnit.SECONDS), startsWith("handler-"));
+        } finally {
+            webSocket.cancel();
+        }
+    }
+
+    @Test
+    void webSocketTimeoutWaitsForAnInFlightCallbackAndUsesTheHandlerExecutor() throws Exception {
+        var handlerExecutor = track(Executors.newFixedThreadPool(2, namedThreads("handler-")));
+        var connectionExecutor = track(Executors.newCachedThreadPool(namedThreads("connection-")));
+        var maintenanceExecutor = track(Executors.newSingleThreadExecutor(namedThreads("maintenance-")));
+        var textEntered = new CountDownLatch(1);
+        var releaseText = new CountDownLatch(1);
+        var timeoutThread = new CompletableFuture<String>();
+        var clientDisconnected = new CompletableFuture<Void>();
+        server = httpServer()
+            .withHandlerExecutor(handlerExecutor)
+            .withConnectionExecutor(connectionExecutor)
+            .withConnectionMaintenanceExecutor(maintenanceExecutor)
+            .withIdleTimeout(100, TimeUnit.MILLISECONDS)
+            .addHandler(webSocketHandler((request, responseHeaders) -> new SimpleWebSocket() {
+                @Override
+                public void onText(String message) {
+                    textEntered.countDown();
+                    try {
+                        releaseText.await();
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                    }
+                }
+
+                @Override
+                public void onBinary(ByteBuffer payload) {
+                }
+
+                @Override
+                public void onError(Throwable cause) {
+                    if (cause instanceof TimeoutException) {
+                        timeoutThread.complete(Thread.currentThread().getName());
+                    }
+                }
+            })
+                .withPingInterval(0, TimeUnit.MILLISECONDS)
+                .withIdleReadTimeout(0, TimeUnit.MILLISECONDS))
+            .start();
+
+        String websocketUrl = "ws" + server.uri().toString().substring(4);
+        WebSocket webSocket = client.newWebSocket(
+            request().url(websocketUrl).build(),
+            new WebSocketListener() {
+                @Override
+                public void onFailure(WebSocket webSocket, Throwable t, @Nullable Response response) {
+                    clientDisconnected.complete(null);
+                }
+            }
+        );
+        try {
+            assertThat(webSocket.send("hold"), is(true));
+            assertThat(textEntered.await(5, TimeUnit.SECONDS), is(true));
+            clientDisconnected.get(5, TimeUnit.SECONDS);
+            assertThat(timeoutThread.isDone(), is(false));
+        } finally {
+            releaseText.countDown();
+            webSocket.cancel();
+        }
+        assertThat(timeoutThread.get(5, TimeUnit.SECONDS), startsWith("handler-"));
+    }
+
+    @Test
+    void webSocketShutdownCallbacksUseTheHandlerExecutor() throws Exception {
+        var handlerExecutor = track(Executors.newSingleThreadExecutor(namedThreads("handler-")));
+        var connectionExecutor = track(Executors.newCachedThreadPool(namedThreads("connection-")));
+        var connected = new CountDownLatch(1);
+        var shutdownThread = new CompletableFuture<String>();
+        server = httpServer()
+            .withHandlerExecutor(handlerExecutor)
+            .withConnectionExecutor(connectionExecutor)
+            .addHandler(webSocketHandler((request, responseHeaders) -> new SimpleWebSocket() {
+                @Override
+                public void onConnect(MuWebSocketSession session) throws Exception {
+                    super.onConnect(session);
+                    connected.countDown();
+                }
+
+                @Override
+                public void onText(String message) {
+                }
+
+                @Override
+                public void onBinary(ByteBuffer payload) {
+                }
+
+                @Override
+                public void onServerShuttingDown() throws Exception {
+                    shutdownThread.complete(Thread.currentThread().getName());
+                    session().close(1001, "Going away");
+                }
+            }))
+            .start();
+
+        String websocketUrl = "ws" + server.uri().toString().substring(4);
+        WebSocket webSocket = client.newWebSocket(
+            request().url(websocketUrl).build(),
+            new WebSocketListener() {
+            }
+        );
+        try {
+            assertThat(connected.await(5, TimeUnit.SECONDS), is(true));
+            server.stop(2, TimeUnit.SECONDS);
+            assertThat(shutdownThread.get(5, TimeUnit.SECONDS), startsWith("handler-"));
+            server = null;
+        } finally {
+            webSocket.cancel();
+        }
+    }
+
+    @Test
+    void sharedConnectionAndHandlerExecutorDoesNotDeadlockWebSocketEvents() throws Exception {
+        var sharedExecutor = track(Executors.newSingleThreadExecutor(namedThreads("shared-")));
+        var callbackThread = new CompletableFuture<String>();
+        var clientMessage = new CompletableFuture<String>();
+        server = httpServer()
+            .withHandlerExecutor(sharedExecutor)
+            .withConnectionExecutor(sharedExecutor)
+            .addHandler(webSocketHandler((request, responseHeaders) -> new SimpleWebSocket() {
+                @Override
+                public void onText(String message) throws IOException {
+                    callbackThread.complete(Thread.currentThread().getName());
+                    session().sendText(message);
+                }
+
+                @Override
+                public void onBinary(ByteBuffer payload) {
+                }
+            }))
+            .start();
+
+        String websocketUrl = "ws" + server.uri().toString().substring(4);
+        WebSocket webSocket = client.newWebSocket(
+            request().url(websocketUrl).build(),
+            new WebSocketListener() {
+                @Override
+                public void onMessage(WebSocket webSocket, String text) {
+                    clientMessage.complete(text);
+                }
+            }
+        );
+        try {
+            assertThat(webSocket.send("hello"), is(true));
+            assertThat(clientMessage.get(5, TimeUnit.SECONDS), equalTo("hello"));
+            assertThat(callbackThread.get(5, TimeUnit.SECONDS), startsWith("shared-"));
+        } finally {
+            webSocket.cancel();
         }
     }
 


### PR DESCRIPTION
Stacked on #150.

WebSocket lifecycle, message, control-frame, error, timeout, and shutdown callbacks previously ran directly on connection readers, maintenance workers, or socket-writing caller threads. In particular, a server idle timeout could invoke `onError` concurrently with an in-flight `onText` callback, and write failures invoked application code while holding the WebSocket write lock.

This adds a per-session MPSC application-event mailbox with a transient handler-executor runner. The connection reader waits for each normal event to preserve frame order and ByteBuffer lifetime, but retains no handler worker while waiting for the next frame. Maintenance timeout work only enqueues its terminal error event and closes the transport, so it neither runs nor waits for application code. Write failures enqueue error delivery after releasing the write lock. Error delivery is exactly once per terminal session failure.

When the exact same executor instance is configured for handler and connection work, connection-originated events continue inline to avoid self-deadlock; queued timeout events are drained as the closed connection reader unwinds.

Regression coverage proves handler-executor affinity for connect/message/error/shutdown callbacks, timeout serialization behind an in-flight message callback, shared single-thread executor compatibility, and deprecated WebSocket adapter compatibility.

Validation: focused modern/deprecated WebSocket, stop, and execution-domain suites on Java 11; `mise exec java@temurin-21 -- mvn --batch-mode -Pnullaway clean verify` (1,616 tests, 0 failures).