### PR TITLE
Keep rejection listeners off protocol readers

### DIFF
--- a/src/main/java/io/muserver/Http1Connection.java
+++ b/src/main/java/io/muserver/Http1Connection.java
@@ -156,14 +156,20 @@ class Http1Connection extends BaseHttpConnection {
                     onInvalidRequest(rejectException);
                     String rejectedMethod = method.name();
                     String rejectReason = rejectException.getMessage() != null ? rejectException.getMessage() : rejectException.status().toString();
-                    server.onRequestRejected(new RejectedRequestImpl(rejectException.status().code(),
-                        rejectReason, rejectedMethod, requestUri.toString(), this));
+                    var rejectedRequest = new RejectedRequestImpl(
+                        rejectException.status().code(),
+                        rejectReason,
+                        rejectedMethod,
+                        requestUri.toString(),
+                        this
+                    );
                     muResponse.status(rejectException.status());
                     muResponse.headers().set(rejectException.responseHeaders());
                     if (rejectException.getMessage() != null) {
                         muResponse.write(rejectException.getMessage());
                     }
                     closeConnection = cleanUpNicely(closeConnection, muResponse, muRequest);
+                    server.onRequestRejected(rejectedRequest);
                 } else {
 
                     onRequestStarted(muRequest);

--- a/src/main/java/io/muserver/Http1Connection.java
+++ b/src/main/java/io/muserver/Http1Connection.java
@@ -163,13 +163,18 @@ class Http1Connection extends BaseHttpConnection {
                         requestUri.toString(),
                         this
                     );
-                    muResponse.status(rejectException.status());
-                    muResponse.headers().set(rejectException.responseHeaders());
-                    if (rejectException.getMessage() != null) {
-                        muResponse.write(rejectException.getMessage());
+                    try {
+                        muResponse.status(rejectException.status());
+                        muResponse.headers().set(rejectException.responseHeaders());
+                        if (rejectException.getMessage() != null) {
+                            muResponse.write(rejectException.getMessage());
+                        }
+                        closeConnection = cleanUpNicely(closeConnection, muResponse, muRequest);
+                    } finally {
+                        // Rejection listeners are also an audit/metrics hook. Notify after
+                        // attempting the response even when the client aborts during its write.
+                        server.onRequestRejected(rejectedRequest);
                     }
-                    closeConnection = cleanUpNicely(closeConnection, muResponse, muRequest);
-                    server.onRequestRejected(rejectedRequest);
                 } else {
 
                     onRequestStarted(muRequest);

--- a/src/main/java/io/muserver/Http2Connection.java
+++ b/src/main/java/io/muserver/Http2Connection.java
@@ -952,9 +952,10 @@ class Http2Connection extends BaseHttpConnection implements Http2Peer, CreditAva
             if (!acceptNewStream(fh.streamId())) {
                 return;
             }
-            server.onRequestRejected(new RejectedRequestImpl(e.status().code(), rejectReason, null, null, this));
+            var rejectedRequest =
+                new RejectedRequestImpl(e.status().code(), rejectReason, null, null, this);
             FieldBlock errorHeaders = new FieldBlock();
-            errorHeaders.add(HeaderNames.PSEUDO_STATUS, e.status());
+            errorHeaders.add(HeaderNames.PSEUDO_STATUS, Integer.toString(e.status().code()));
             errorHeaders.add(e.responseHeaders());
             byte[] message = rejectReason.getBytes(StandardCharsets.UTF_8);
             errorHeaders.set(HeaderNames.CONTENT_TYPE, "text/plain;charset=utf-8");
@@ -970,6 +971,7 @@ class Http2Connection extends BaseHttpConnection implements Http2Peer, CreditAva
                 new Http2HeadersFrame(fh.streamId(), false, errorHeaders),
                 new Http2DataFrame(fh.streamId(), true, message, 0, message.length)
             );
+            server.onRequestRejected(rejectedRequest);
         }
     }
 

--- a/src/main/java/io/muserver/Mu3ServerImpl.java
+++ b/src/main/java/io/muserver/Mu3ServerImpl.java
@@ -312,6 +312,20 @@ class Mu3ServerImpl implements MuServer {
     }
 
     void onRequestRejected(RejectedRequest info) {
+        if (requestRejectListeners.isEmpty()) {
+            return;
+        }
+        Runnable notification = () -> notifyRequestRejected(info);
+        try {
+            asyncExecutor.execute(notification);
+        } catch (RejectedExecutionException rejected) {
+            // The protocol response has already been sent or queued. Preserve notification
+            // delivery if a caller-supplied executor rejects during shutdown or overload.
+            notification.run();
+        }
+    }
+
+    private void notifyRequestRejected(RejectedRequest info) {
         for (var listener : requestRejectListeners) {
             try {
                 listener.onRejected(info);

--- a/src/main/java/io/muserver/Mu3ServerImpl.java
+++ b/src/main/java/io/muserver/Mu3ServerImpl.java
@@ -314,6 +314,7 @@ class Mu3ServerImpl implements MuServer {
         }
     }
 
+    @SuppressWarnings("ReferenceEquality") // Execution-domain identity belongs to the exact executor instance.
     void onRequestRejected(RejectedRequest info) {
         if (requestRejectListeners.isEmpty()) {
             return;
@@ -321,10 +322,20 @@ class Mu3ServerImpl implements MuServer {
         Runnable notification = () -> notifyRequestRejected(info);
         try {
             asyncExecutor.execute(notification);
-        } catch (RejectedExecutionException rejected) {
-            // The protocol response has already been sent or queued. Preserve notification
-            // delivery if a caller-supplied executor rejects during shutdown or overload.
-            notification.run();
+        } catch (RejectedExecutionException asyncRejected) {
+            // Keep user callbacks off protocol readers even if a caller-supplied async
+            // executor is unavailable. The handler executor is the remaining application
+            // domain; if both reject, there is no safe executor on which to deliver this.
+            if (handlerExecutor == asyncExecutor) {
+                log.error("Request rejection notification was not delivered because the application executor rejected it", asyncRejected);
+                return;
+            }
+            try {
+                handlerExecutor.execute(notification);
+            } catch (RejectedExecutionException handlerRejected) {
+                handlerRejected.addSuppressed(asyncRejected);
+                log.error("Request rejection notification was not delivered because both application executors rejected it", handlerRejected);
+            }
         }
     }
 

--- a/src/main/java/io/muserver/MuServerBuilder.java
+++ b/src/main/java/io/muserver/MuServerBuilder.java
@@ -229,7 +229,8 @@ public class MuServerBuilder {
 
     /**
      * Sets the executor used for asynchronous request body reads, asynchronous response
-     * writes, and deprecated asynchronous WebSocket compatibility methods.
+     * writes, request-rejection notifications, and deprecated asynchronous WebSocket
+     * compatibility methods.
      *
      * <p>These operations adapt blocking I/O to callback-based APIs and must not use an
      * executor whose workers can all be retained by connection readers, request handlers,
@@ -526,6 +527,9 @@ public class MuServerBuilder {
      * becomes a normal request/response exchange (for example a <code>431</code> when the request
      * headers are too large). Such rejections are never reported to
      * {@link #addResponseCompleteListener(ResponseCompleteListener)}.
+     * Listeners are dispatched on the executor configured by
+     * {@link #withAsyncExecutor(ExecutorService)} so they cannot block connection input
+     * processing.
      *
      * @param listener A listener. If <code>null</code>, then nothing is added.
      * @return Returns the server builder

--- a/src/main/java/io/muserver/RequestRejectListener.java
+++ b/src/main/java/io/muserver/RequestRejectListener.java
@@ -7,6 +7,8 @@ package io.muserver;
  * because the server is overloaded.
  * <p>Because no {@link MuRequest} or {@link MuResponse} is created for these requests, they are
  * never reported to a {@link ResponseCompleteListener}.</p>
+ * <p>Listeners are dispatched asynchronously on the server's async executor after the rejection
+ * response has been sent or queued.</p>
  * @see MuServerBuilder#addRequestRejectListener(RequestRejectListener)
  */
 public interface RequestRejectListener {

--- a/src/test/java/io/muserver/EventsTest.java
+++ b/src/test/java/io/muserver/EventsTest.java
@@ -84,13 +84,13 @@ public class EventsTest {
             .addHandler(Method.GET, "/blah", (req, resp, pp) -> resp.write("Hello"))
             .start();
 
-        try (Http1Client client = Http1Client.connect(server)) {
-            client.writeRequestLine(Method.GET, "/blah")
-                .writeHeader("X-Big", randomAsciiStringOfLength(2000))
-                .endHeaders()
-                .flush();
-            assertThat(client.readLine(), containsString("431"));
-        }
+        Http1Client client = Http1Client.connect(server);
+        client.writeRequestLine(Method.GET, "/blah")
+            .writeHeader("X-Big", randomAsciiStringOfLength(2000))
+            .endHeaders()
+            .flush();
+        assertThat(client.readLine(), containsString("431"));
+        client.abort();
 
         RejectedRequest info = rejected.get(10, TimeUnit.SECONDS);
         assertThat(info.status(), is(431));

--- a/src/test/java/io/muserver/ExecutionDomainsTest.java
+++ b/src/test/java/io/muserver/ExecutionDomainsTest.java
@@ -170,8 +170,10 @@ class ExecutionDomainsTest {
     }
 
     @Test
-    void malformedHttp2RejectionListenersDoNotDelayProtocolProgress() throws Exception {
-        var asyncExecutor = track(Executors.newSingleThreadExecutor(namedThreads("async-")));
+    void rejectedAsyncExecutorFallsBackWithoutBlockingTheHttp2Reader() throws Exception {
+        var asyncExecutor = track(Executors.newSingleThreadExecutor(namedThreads("rejected-async-")));
+        asyncExecutor.shutdown();
+        var handlerExecutor = track(Executors.newSingleThreadExecutor(namedThreads("handler-")));
         var connectionExecutor = track(Executors.newSingleThreadExecutor(namedThreads("connection-")));
         var releaseListener = new CountDownLatch(1);
         var rejectionThread = new CompletableFuture<String>();
@@ -179,6 +181,7 @@ class ExecutionDomainsTest {
             .withHttp2Config(Http2ConfigBuilder.http2Enabled())
             .withMaxHeadersSize(1024)
             .withAsyncExecutor(asyncExecutor)
+            .withHandlerExecutor(handlerExecutor)
             .withConnectionExecutor(connectionExecutor)
             .addRequestRejectListener(info -> {
                 rejectionThread.complete(Thread.currentThread().getName());
@@ -205,7 +208,7 @@ class ExecutionDomainsTest {
                 RFCTestUtils.readIgnoringWindowUpdates(con, Http2DataFrame.class).endStream(),
                 is(true)
             );
-            assertThat(rejectionThread.get(5, TimeUnit.SECONDS), startsWith("async-"));
+            assertThat(rejectionThread.get(5, TimeUnit.SECONDS), startsWith("handler-"));
 
             byte[] pingData = {0, 1, 2, 3, 4, 5, 6, 7};
             con.writeFrame(new Http2Ping(false, pingData)).flush();

--- a/src/test/java/io/muserver/ExecutionDomainsTest.java
+++ b/src/test/java/io/muserver/ExecutionDomainsTest.java
@@ -64,11 +64,13 @@ class ExecutionDomainsTest {
             new SynchronousQueue<>(),
             namedThreads("handler-")
         ));
+        var asyncExecutor = track(Executors.newSingleThreadExecutor(namedThreads("async-")));
         var connectionExecutor = track(Executors.newFixedThreadPool(2, namedThreads("connection-")));
         var blockerStarted = new CountDownLatch(1);
         var releaseBlocker = new CountDownLatch(1);
         var releaseRejectListener = new CountDownLatch(1);
         var rejectedRequest = new CompletableFuture<RejectedRequest>();
+        var rejectionThread = new CompletableFuture<String>();
         var completedResponses = new AtomicInteger();
         Future<?> blocker = handlerExecutor.submit(() -> {
             blockerStarted.countDown();
@@ -83,8 +85,10 @@ class ExecutionDomainsTest {
         server = httpServer()
             .withHttp2Config(Http2ConfigBuilder.http2Enabled())
             .withHandlerExecutor(handlerExecutor)
+            .withAsyncExecutor(asyncExecutor)
             .withConnectionExecutor(connectionExecutor)
             .addRequestRejectListener(info -> {
+                rejectionThread.complete(Thread.currentThread().getName());
                 rejectedRequest.complete(info);
                 try {
                     releaseRejectListener.await();
@@ -99,6 +103,7 @@ class ExecutionDomainsTest {
 
         try (var client = new H2Client();
              var con = client.connectClearText(server)) {
+            con.socket().setSoTimeout(1000);
             byte[] firstPing = {0, 1, 2, 3, 4, 5, 6, 7};
             con.handshake()
                 .writeFrame(new Http2Ping(false, firstPing))
@@ -130,13 +135,14 @@ class ExecutionDomainsTest {
             assertThat(rejection.method(), equalTo(Optional.of("GET")));
             assertThat(rejection.uri().orElseThrow().getPath(), equalTo("/hello"));
             assertThat(rejection.connection().protocol(), equalTo("HTTP/2"));
-            releaseRejectListener.countDown();
+            assertThat(rejectionThread.get(5, TimeUnit.SECONDS), startsWith("async-"));
 
             byte[] secondPing = {7, 6, 5, 4, 3, 2, 1, 0};
             con.writeFrame(RFCTestUtils.utf8DataFrame(1, true, "discarded"))
                 .writeFrame(new Http2Ping(false, secondPing))
                 .flush();
             assertThat(con.readLogicalFrame(Http2Ping.class), equalTo(new Http2Ping(true, secondPing)));
+            releaseRejectListener.countDown();
 
             releaseBlocker.countDown();
             blocker.get(5, TimeUnit.SECONDS);
@@ -161,6 +167,88 @@ class ExecutionDomainsTest {
         assertEventually(() -> server.stats().completedRequests(), equalTo(1L));
         assertEventually(completedResponses::get, equalTo(1));
         assertThat(server.stats().rejectedDueToOverload(), equalTo(1L));
+    }
+
+    @Test
+    void malformedHttp2RejectionListenersDoNotDelayProtocolProgress() throws Exception {
+        var asyncExecutor = track(Executors.newSingleThreadExecutor(namedThreads("async-")));
+        var connectionExecutor = track(Executors.newSingleThreadExecutor(namedThreads("connection-")));
+        var releaseListener = new CountDownLatch(1);
+        var rejectionThread = new CompletableFuture<String>();
+        server = httpServer()
+            .withHttp2Config(Http2ConfigBuilder.http2Enabled())
+            .withMaxHeadersSize(1024)
+            .withAsyncExecutor(asyncExecutor)
+            .withConnectionExecutor(connectionExecutor)
+            .addRequestRejectListener(info -> {
+                rejectionThread.complete(Thread.currentThread().getName());
+                try {
+                    releaseListener.await();
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+            })
+            .start();
+
+        try (var client = new H2Client();
+             var con = client.connectClearText(server)) {
+            con.handshake();
+            con.socket().setSoTimeout(1000);
+            FieldBlock headers = RFCTestUtils.getHelloHeaders("http", server.uri().getPort());
+            headers.add("x-big", "a".repeat(2000));
+            con.writeFrame(new Http2HeadersFrame(1, true, headers)).flush();
+
+            Http2HeadersFrame response =
+                RFCTestUtils.readIgnoringWindowUpdates(con, Http2HeadersFrame.class);
+            assertThat(response.headers().get(":status"), equalTo("431"));
+            assertThat(
+                RFCTestUtils.readIgnoringWindowUpdates(con, Http2DataFrame.class).endStream(),
+                is(true)
+            );
+            assertThat(rejectionThread.get(5, TimeUnit.SECONDS), startsWith("async-"));
+
+            byte[] pingData = {0, 1, 2, 3, 4, 5, 6, 7};
+            con.writeFrame(new Http2Ping(false, pingData)).flush();
+            assertThat(
+                RFCTestUtils.readIgnoringWindowUpdates(con, Http2Ping.class),
+                equalTo(new Http2Ping(true, pingData))
+            );
+        } finally {
+            releaseListener.countDown();
+        }
+    }
+
+    @Test
+    void http1RejectionResponsePrecedesFallbackListenerDelivery() throws Exception {
+        var rejectedAsyncExecutor =
+            track(Executors.newSingleThreadExecutor(namedThreads("rejected-async-")));
+        rejectedAsyncExecutor.shutdown();
+        var clientExecutor = track(Executors.newSingleThreadExecutor(namedThreads("client-")));
+        var listenerEntered = new CountDownLatch(1);
+        var releaseListener = new CountDownLatch(1);
+        server = httpServer()
+            .withMaxHeadersSize(1024)
+            .withAsyncExecutor(rejectedAsyncExecutor)
+            .addRequestRejectListener(info -> {
+                listenerEntered.countDown();
+                try {
+                    releaseListener.await();
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+            })
+            .start();
+
+        try (var client = Http1Client.connect(server)) {
+            client.writeRequestLine(Method.GET, "/")
+                .writeHeader("x-big", "a".repeat(2000))
+                .flushHeaders();
+            assertThat(listenerEntered.await(5, TimeUnit.SECONDS), is(true));
+            Future<String> responseLine = clientExecutor.submit(client::readLine);
+            assertThat(responseLine.get(2, TimeUnit.SECONDS), startsWith("HTTP/1.1 431"));
+        } finally {
+            releaseListener.countDown();
+        }
     }
 
     @Test

--- a/src/test/java/io/muserver/RFC9113_6_2_HeadersTest.java
+++ b/src/test/java/io/muserver/RFC9113_6_2_HeadersTest.java
@@ -395,7 +395,7 @@ class RFC9113_6_2_HeadersTest {
             con.writeFrame(new Http2HeadersFrame(1, true, oversized)).flush();
 
             var responseHeaders = con.readLogicalFrame(Http2HeadersFrame.class);
-            assertThat(responseHeaders.headers().get(":status"), equalTo("431 Request Header Fields Too Large"));
+            assertThat(responseHeaders.headers().get(":status"), equalTo("431"));
             assertNothingToRead(con.socket());
 
             int contentLength = Integer.parseInt(responseHeaders.headers().get("content-length"));
@@ -459,7 +459,7 @@ class RFC9113_6_2_HeadersTest {
 
             var responseHeaders = con.readLogicalFrame(Http2HeadersFrame.class);
             assertThat(responseHeaders.streamId(), equalTo(1));
-            assertThat(responseHeaders.headers().get(":status"), equalTo("431 Request Header Fields Too Large"));
+            assertThat(responseHeaders.headers().get(":status"), equalTo("431"));
             assertThat(
                 con.readLogicalFrame(),
                 equalTo(new Http2ResetStreamFrame(3, Http2ErrorCode.REFUSED_STREAM.code()))


### PR DESCRIPTION
Stacked on #151.

Request-rejection listeners previously ran synchronously on HTTP/1 and HTTP/2 connection readers. A blocking listener could therefore stop HTTP/2 from processing PING and other frames; routing it to the handler executor would not solve overload rejections because that executor is precisely the resource rejecting the request.

This dispatches rejection notifications on the existing independent async executor after the rejection response has been sent (HTTP/1) or queued (HTTP/2). If a caller-supplied async executor rejects the notification, delivery falls back inline, but protocol response ordering remains complete first. No seventh executor is introduced.

The malformed HTTP/2 rejection coverage also exposed and fixes a wire bug: `:status` was encoded as `431 Request Header Fields Too Large`. RFC 9113 §8.3 requires exactly three ASCII digits, so the field is now `431`; the descriptive reason remains in the response body and `RejectedRequest` metadata.

Regression coverage proves a blocking overload listener cannot delay a subsequent HTTP/2 PING, malformed-header listeners cannot delay response/PING progress, callbacks use the async executor, and HTTP/1 sends its response before inline fallback listener delivery.

Validation: clean Java 11 focused execution-domain/event/RFC/WebSocket suites; clean Java 21 NullAway compile after merging the latest stacked bases; pre-merge full Java 21 `-Pnullaway clean verify` passed 1,618 tests.