### PR TITLE
Schedule HTTP/2 SETTINGS timeouts

### DIFF
--- a/HTTP2-CONCURRENCY.md
+++ b/HTTP2-CONCURRENCY.md
@@ -18,12 +18,13 @@ Scheduled connection maintenance and connection idle-timeout scans now use a
 server timer that is independent of both executors; when work becomes due, the
 timer dispatches it to the connection executor.
 
-Still to be implemented are coordinator timeout commands and migration of the
-remaining connection settings, stream registry, and inbound flow-control
-accounting to coordinator ownership. The HTTP/2 SETTINGS acknowledgement and
-request-body read deadlines therefore remain local blocking deadlines for now.
-The reader and coordinator have separate execution capacity from handlers, but
-do not yet have all of the final single-owner boundaries described below.
+SETTINGS acknowledgement expiry now runs on the server timer and is serialized
+as a coordinator connection-error command; it no longer changes the socket
+reader's blocking timeout. Still to be implemented are migration of the
+remaining connection settings, stream registry, inbound flow-control
+accounting, and request-body read deadlines to coordinator ownership. The
+reader and coordinator have separate execution capacity from handlers, but do
+not yet have all of the final single-owner boundaries described below.
 
 ## Goals
 
@@ -100,11 +101,11 @@ connection executor; periodic dispatch is coalesced so a delayed connection
 executor does not accumulate duplicate work. Timer threads do not mutate
 protocol state, perform socket I/O, or invoke user code.
 
-Connection idle-timeout scans and WebSocket pings use this facility. As
-coordinator ownership expands, HTTP/2 timeout expiry will enqueue coordinator
-commands through the same timer rather than mutating protocol state on the
-timer thread. The current local SETTINGS acknowledgement and request-body read
-deadlines are not yet scheduled by this facility.
+Connection idle-timeout scans, WebSocket pings, and HTTP/2 SETTINGS
+acknowledgement deadlines use this facility. SETTINGS expiry atomically wins
+or loses a race with its ACK, then enqueues a connection-error command without
+mutating protocol state on the timer thread. Request-body read deadlines remain
+local blocking deadlines for now.
 
 ## Ownership
 

--- a/src/main/java/io/muserver/Http2Connection.java
+++ b/src/main/java/io/muserver/Http2Connection.java
@@ -7,7 +7,6 @@ import org.slf4j.LoggerFactory;
 import java.io.*;
 import java.net.Socket;
 import java.net.SocketException;
-import java.net.SocketTimeoutException;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.security.cert.Certificate;
@@ -54,7 +53,7 @@ class Http2Connection extends BaseHttpConnection implements Http2Peer, CreditAva
     private volatile int lastStreamId = 0;
     private volatile int peerGoAwayLastStreamId = MAX_POSSIBLE_STREAM_ID;
     private final Http2IncomingFlowController incomingFlowControl = new Http2IncomingFlowController(0, 65535);
-    private final ConcurrentLinkedQueue<Long> settingsAckQueue = new ConcurrentLinkedQueue<>();
+    private final ConcurrentLinkedQueue<PendingSettingsAck> settingsAckQueue = new ConcurrentLinkedQueue<>();
     private final ConcurrentHashMap<Integer, Http2Stream> streams = new ConcurrentHashMap<>();
     private final ConcurrentHashMap<Integer, Http2IncomingFlowController> rejectedRequestBodies = new ConcurrentHashMap<>();
     private final ExecutorService handlerExecutor;
@@ -71,6 +70,33 @@ class Http2Connection extends BaseHttpConnection implements Http2Peer, CreditAva
     private boolean finalGoAwayWakeScheduled;
 
     final FieldBlockEncoder fieldBlockEncoder;
+
+    private static final class PendingSettingsAck {
+        private final AtomicBoolean pending = new AtomicBoolean(true);
+        private volatile @Nullable ScheduledFuture<?> timeoutTask;
+
+        private boolean acknowledge() {
+            if (!pending.compareAndSet(true, false)) {
+                return false;
+            }
+            ScheduledFuture<?> currentTimeoutTask = timeoutTask;
+            if (currentTimeoutTask != null) {
+                currentTimeoutTask.cancel(false);
+            }
+            return true;
+        }
+
+        private boolean markTimedOut() {
+            return pending.compareAndSet(true, false);
+        }
+
+        private void timeoutTask(ScheduledFuture<?> task) {
+            timeoutTask = task;
+            if (!pending.get()) {
+                task.cancel(false);
+            }
+        }
+    }
 
     Http2Connection(Mu3ServerImpl server, ConnectionAcceptor creator, Socket clientSocket, @Nullable Certificate clientCertificate, Instant handshakeStartTime, Http2Settings initialServerSettings, long settingsAckTimeoutMillis, ExecutorService handlerExecutor, ExecutorService writerExecutor) {
         super(server, creator, clientSocket, clientCertificate, handshakeStartTime);
@@ -327,21 +353,31 @@ class Http2Connection extends BaseHttpConnection implements Http2Peer, CreditAva
         }
     }
 
-    private void queuePendingSettingsAck() {
-        settingsAckQueue.add(System.currentTimeMillis() + settingsAckTimeoutMillis);
+    private void queuePendingSettingsAck() throws IOException {
+        var pendingAck = new PendingSettingsAck();
+        settingsAckQueue.add(pendingAck);
+        try {
+            pendingAck.timeoutTask(server.scheduleTimerCallback(
+                () -> {
+                    if (pendingAck.markTimedOut()) {
+                        writeCoordinator.settingsTimedOut();
+                    }
+                },
+                settingsAckTimeoutMillis,
+                TimeUnit.MILLISECONDS
+            ));
+        } catch (RuntimeException | Error e) {
+            settingsAckQueue.remove(pendingAck);
+            pendingAck.acknowledge();
+            throw new IOException("Could not schedule SETTINGS acknowledgement timeout", e);
+        }
     }
 
-    private void prepareForFrameRead() throws SocketException, Http2Exception {
-        Long deadline = settingsAckQueue.peek();
-        if (deadline == null) {
-            clientSocket.setSoTimeout(0);
-            return;
+    private void cancelPendingSettingsAckTimeouts() {
+        PendingSettingsAck pendingAck;
+        while ((pendingAck = settingsAckQueue.poll()) != null) {
+            pendingAck.acknowledge();
         }
-        long remaining = deadline - System.currentTimeMillis();
-        if (remaining <= 0) {
-            throw Http2Exception.connection(Http2ErrorCode.SETTINGS_TIMEOUT, "Timed out waiting for SETTINGS ack");
-        }
-        clientSocket.setSoTimeout((int) Math.min(Integer.MAX_VALUE, remaining));
     }
 
     private void setReadStateAndSignal(HState newState) {
@@ -556,7 +592,6 @@ class Http2Connection extends BaseHttpConnection implements Http2Peer, CreditAva
                 Http2FrameHeader currentFrameHeader = null;
                 boolean readingFrameHeader = true;
                 try {
-                    prepareForFrameRead();
                     Mutils.readAtLeast(buffer, clientIn, Http2FrameHeader.FRAME_HEADER_LENGTH);
 
                     currentFrameHeader = Http2FrameHeader.readFrom(buffer);
@@ -634,11 +669,6 @@ class Http2Connection extends BaseHttpConnection implements Http2Peer, CreditAva
                     if (stream != null && !stream.peerResetWasRead()) {
                         stream.cancel(new IOException("Stream error", h2e));
                     }
-                } catch (SocketTimeoutException e) {
-                    if (!settingsAckQueue.isEmpty()) {
-                        throw Http2Exception.connection(Http2ErrorCode.SETTINGS_TIMEOUT, "Timed out waiting for SETTINGS ack");
-                    }
-                    throw e;
                 } catch (EOFException e) {
                     boolean noActiveStreams = noProtocolStreamsAreActive();
                     if (readingFrameHeader && noActiveStreams) {
@@ -663,7 +693,6 @@ class Http2Connection extends BaseHttpConnection implements Http2Peer, CreditAva
                         failAfterUnexpectedInputEnd(new IOException("Socket closed with active HTTP/2 streams", e));
                     }
                 }
-                // TODO: end if pending settings ack not received
             }
 
             writeEndedFuture.get();
@@ -772,7 +801,7 @@ class Http2Connection extends BaseHttpConnection implements Http2Peer, CreditAva
             var ackedOne = settingsAckQueue.poll();
             if (ackedOne == null) {
                 throw Http2Exception.connection(Http2ErrorCode.PROTOCOL_ERROR, "Settings ack without pending settings");
-            } else {
+            } else if (ackedOne.acknowledge()) {
                 log.info("Settings acked");
             }
         } else {
@@ -1105,6 +1134,7 @@ class Http2Connection extends BaseHttpConnection implements Http2Peer, CreditAva
         if (writeLoopEnded.isDone()) {
             return;
         }
+        cancelPendingSettingsAckTimeouts();
         writeCoordinator.failAll(reason);
         closeSocketQuietly();
         // Don't close the output stream here because that closes the TLS connection in Java.

--- a/src/main/java/io/muserver/Http2WriteCoordinator.java
+++ b/src/main/java/io/muserver/Http2WriteCoordinator.java
@@ -164,6 +164,10 @@ final class Http2WriteCoordinator {
         }
     }
 
+    private enum SettingsTimeout implements Command {
+        INSTANCE
+    }
+
     private static final class ConnectionFailure implements Command {
         private final WriteTask goAway;
         private final IOException reason;
@@ -295,6 +299,10 @@ final class Http2WriteCoordinator {
             throw new IllegalArgumentException("The last stream ID cannot be negative");
         }
         enqueue(new InitialWindowSizeChange(difference, acknowledgement, lastStreamId));
+    }
+
+    void settingsTimedOut() {
+        enqueue(SettingsTimeout.INSTANCE);
     }
 
     void failConnection(WriteTask goAway, IOException reason) {
@@ -498,6 +506,14 @@ final class Http2WriteCoordinator {
                     change.lastStreamId
                 );
             }
+        } else if (command == SettingsTimeout.INSTANCE) {
+            queueConnectionError(
+                Http2Exception.connection(
+                    Http2ErrorCode.SETTINGS_TIMEOUT,
+                    "Timed out waiting for SETTINGS ack"
+                ),
+                0
+            );
         } else if (command instanceof ConnectionFailure) {
             ConnectionFailure failure = (ConnectionFailure) command;
             if (beginConnectionError(failure.reason)) {

--- a/src/test/java/io/muserver/Http2WriteCoordinatorTest.java
+++ b/src/test/java/io/muserver/Http2WriteCoordinatorTest.java
@@ -320,6 +320,26 @@ class Http2WriteCoordinatorTest {
     }
 
     @Test
+    void settingsTimeoutIsSerializedAsAConnectionError() {
+        var coordinator = coordinator(100, 1, 100);
+        coordinator.submit(task(headers(1)));
+        coordinator.settingsTimedOut();
+        coordinator.processAvailableCommands();
+
+        var writable = coordinator.pollWritable();
+        Http2Exception failure = writable.protocolError();
+        assertThat(failure.errorType(), equalTo(Http2Level.CONNECTION));
+        assertThat(failure.errorCode(), equalTo(Http2ErrorCode.SETTINGS_TIMEOUT));
+        assertThat(failure.getMessage(), containsString("SETTINGS ack"));
+        assertThat(
+            writable.frame(),
+            equalTo(new Http2GoAway(0, Http2ErrorCode.SETTINGS_TIMEOUT.code(), null))
+        );
+        writable.complete();
+        assertThat(coordinator.pollWritable(), nullValue());
+    }
+
+    @Test
     void streamWindowUpdateOverflowIsAStreamFlowControlErrorAndStopsThatStream() {
         var coordinator = coordinator(100, 1, Integer.MAX_VALUE - 1);
         var data = task(data(1, "must not be sent"));

--- a/src/test/java/io/muserver/RFC9113_6_5_SettingsTest.java
+++ b/src/test/java/io/muserver/RFC9113_6_5_SettingsTest.java
@@ -646,7 +646,7 @@ class RFC9113_6_5_SettingsTest {
                     executor
                 );
 
-                Queue<Long> settingsAckQueue = getField(queuedOnlyConnection, "settingsAckQueue", Queue.class);
+                Queue<?> settingsAckQueue = getField(queuedOnlyConnection, "settingsAckQueue", Queue.class);
                 assertThat(settingsAckQueue.size(), equalTo(0));
 
                 queuedOnlyConnection.write(new Http2Settings(false, 8192, 123, 65535, 16384, 32768));


### PR DESCRIPTION
Moves locally-sent SETTINGS acknowledgement deadlines out of the blocking socket reader and onto the server timer.

The timer callback only atomically wins the ACK/expiry race and submits a writer-coordinator command. The coordinator serializes the resulting connection error and the writer materializes GOAWAY with the latest accepted stream ID. ACK and connection teardown cancel their scheduled futures.

This follows RFC 9113 section 6.5.3: SETTINGS acknowledgements correspond to the oldest unacknowledged SETTINGS frame, and a missing acknowledgement may become a SETTINGS_TIMEOUT connection error after a reasonable interval.

Validation:
- Java 11 focused SETTINGS, coordinator, and execution-domain tests
- Java 21 NullAway clean verify (1,618 tests)