### PR TITLE
Allow response frames before HTTP/2 stream errors

### DIFF
--- a/src/test/java/io/muserver/RFC9113_6_9_WindowUpdateTest.java
+++ b/src/test/java/io/muserver/RFC9113_6_9_WindowUpdateTest.java
@@ -40,7 +40,7 @@ class RFC9113_6_9_WindowUpdateTest {
     }
 
     @Test
-    void streamWindowUpdateOf0IsNotAllowed() throws Exception {
+    void streamWindowUpdateOf0ResetsTheStreamWhenResponseWorkRaces() throws Exception {
         var completedStreams = new LinkedBlockingQueue<ResponseInfo>(1);
         server = httpsServer()
             .addHandler(Method.GET, "/hello", (request, response, pathParams) -> {
@@ -55,7 +55,7 @@ class RFC9113_6_9_WindowUpdateTest {
                 .writeFrame(new Http2HeadersFrame(1, false, postHelloHeaders(getPort())))
                 .writeFrame(windowUpdate(1, 0))
                 .flush();
-            var reset = con.readLogicalFrame(Http2ResetStreamFrame.class);
+            var reset = readResetAfterAlreadyWrittenStreamFrames(con, 1);
             assertThat(reset.errorCodeEnum(), equalTo(Http2ErrorCode.PROTOCOL_ERROR));
 
             // The http exchange is considered failed
@@ -74,6 +74,30 @@ class RFC9113_6_9_WindowUpdateTest {
             assertThat(info, notNullValue());
             assertThat(info.completedSuccessfully(), equalTo(true));
             System.out.println("And now I'm about to close with EOF");
+        }
+    }
+
+    @Test
+    void streamErrorCanFollowAResponseThatWasAlreadyStarted() throws Exception {
+        server = httpsServer()
+            .withHttp2Config(Http2ConfigBuilder.http2Enabled())
+            .start();
+        try (var client = new H2Client();
+             var con = client.connect(server)) {
+            con.handshake()
+                .writeFrame(new Http2HeadersFrame(1, false, postHelloHeaders(getPort())))
+                .flush();
+
+            // The unmatched request can start its 404 response before the peer sends
+            // a later frame that makes the stream erroneous.
+            var responseHeaders = con.readLogicalFrame();
+            assertThat(responseHeaders.streamId(), equalTo(1));
+
+            con.writeFrame(windowUpdate(1, 0))
+                .flush();
+
+            var reset = readResetAfterAlreadyWrittenStreamFrames(con, 1);
+            assertThat(reset.errorCodeEnum(), equalTo(Http2ErrorCode.PROTOCOL_ERROR));
         }
     }
 
@@ -346,6 +370,21 @@ class RFC9113_6_9_WindowUpdateTest {
 
     private int getPort() {
         return server.uri().getPort();
+    }
+
+    private static Http2ResetStreamFrame readResetAfterAlreadyWrittenStreamFrames(
+        H2ClientConnection connection,
+        int streamId
+    ) throws Exception {
+        // RFC 9113 §5.4.2 makes RST_STREAM the last frame sent on the stream. Frames
+        // that the writer committed before the reader detected the error remain valid.
+        while (true) {
+            LogicalHttp2Frame frame = connection.readLogicalFrame();
+            assertThat(frame.streamId(), equalTo(streamId));
+            if (frame instanceof Http2ResetStreamFrame) {
+                return (Http2ResetStreamFrame) frame;
+            }
+        }
     }
 
     @AfterEach


### PR DESCRIPTION
## What changed

- Updated the zero-increment stream `WINDOW_UPDATE` test to read through response frames that were already committed before the stream error was detected.
- Added a deterministic regression that starts a response before sending the invalid `WINDOW_UPDATE`, then requires the `PROTOCOL_ERROR` reset to follow.

## Why

The flaky test assumed `RST_STREAM` had to be the first frame observed after the invalid input. HTTP/2 reader and writer work are independent: the writer may already have committed response frames for that stream before the reader detects the later invalid frame. RFC 9113 §5.4.2 requires `RST_STREAM` to be the last frame sent on an errored stream; it does not invalidate frames sent before error detection.

This is a test-contract correction only; production wire behavior is unchanged.

## Validation

- Java 11: `RFC9113_6_9_WindowUpdateTest` (11 tests)
- Java 21 with NullAway: production and test compilation
- The formerly flaky test was also stress-run 100 times while investigating the race
