### PR TITLE
Keep async exchange completion on application executors

### DIFF
--- a/src/main/java/io/muserver/Http1Connection.java
+++ b/src/main/java/io/muserver/Http1Connection.java
@@ -272,10 +272,9 @@ class Http1Connection extends BaseHttpConnection {
                 handled.completeExceptionally(t);
             }
         };
-        try {
-            handlerExecutor.execute(task);
-        } catch (RejectedExecutionException rejected) {
-            task.run();
+        RejectedExecutionException rejected = server.tryExecuteHandlerTask(task);
+        if (rejected != null) {
+            handled.completeExceptionally(rejected);
         }
         try {
             handled.get();

--- a/src/main/java/io/muserver/Http2Connection.java
+++ b/src/main/java/io/muserver/Http2Connection.java
@@ -1221,7 +1221,7 @@ class Http2Connection extends BaseHttpConnection implements Http2Peer, CreditAva
             }
             stream.abandonApplicationExchange();
         } finally {
-            onExchangeEnded(stream);
+            onExchangeEnded(stream, false);
         }
     }
 
@@ -1249,7 +1249,7 @@ class Http2Connection extends BaseHttpConnection implements Http2Peer, CreditAva
                 stream.cancel(new IOException("Unhandled stream exception", e), false);
             }
         } finally {
-            onExchangeEnded(stream);
+            onExchangeEnded(stream, true);
         }
     }
 
@@ -1385,12 +1385,21 @@ class Http2Connection extends BaseHttpConnection implements Http2Peer, CreditAva
 
     @Override
     protected void onExchangeEnded(ResponseInfo exchange) {
-        var stream = (Http2Stream) exchange;
+        onExchangeEnded((Http2Stream) exchange, false);
+    }
+
+    private void onExchangeEnded(
+        Http2Stream stream,
+        boolean alreadyOnApplicationExecutor
+    ) {
         stream.onApplicationExchangeEnded();
         applicationExchangeEndedForWrites(stream.id);
         signalWriteLoop();
-        recordExchangeEnded(exchange);
-        server.executeResponseCompletionTask(() -> notifyExchangeEnded(exchange));
+        recordExchangeEnded(stream);
+        server.executeResponseCompletionTask(
+            () -> notifyExchangeEnded(stream),
+            alreadyOnApplicationExecutor
+        );
     }
 
     void removeProtocolStream(Http2Stream stream) {

--- a/src/main/java/io/muserver/Http2Connection.java
+++ b/src/main/java/io/muserver/Http2Connection.java
@@ -1198,12 +1198,30 @@ class Http2Connection extends BaseHttpConnection implements Http2Peer, CreditAva
             failure == null ? null : completionCause(failure),
             true
         );
+        RejectedExecutionException rejected = server.tryExecuteHandlerTask(completionTask);
+        if (rejected != null) {
+            abortAsyncStreamAfterDispatchFailure(stream, rejected);
+        }
+    }
+
+    private void abortAsyncStreamAfterDispatchFailure(
+        Http2Stream stream,
+        RejectedExecutionException dispatchFailure
+    ) {
+        log.warn("Aborting accepted HTTP/2 stream because its application executors rejected completion", dispatchFailure);
         try {
-            handlerExecutor.execute(completionTask);
-        } catch (RejectedExecutionException rejected) {
-            // The exchange was already accepted. Finishing on the completing thread is
-            // preferable to leaking the stream merely because handler capacity is transiently full.
-            completionTask.run();
+            BaseResponse response = stream.response();
+            if (!stream.resetWasInitiated() && !response.responseState().endState()) {
+                response.setState(ResponseState.ERRORED);
+                write(new Http2ResetStreamFrame(stream.id, Http2ErrorCode.INTERNAL_ERROR.code()));
+                stream.cancel(
+                    new IOException("Application executors rejected HTTP/2 stream completion", dispatchFailure),
+                    false
+                );
+            }
+            stream.abandonApplicationExchange();
+        } finally {
+            onExchangeEnded(stream);
         }
     }
 
@@ -1371,7 +1389,8 @@ class Http2Connection extends BaseHttpConnection implements Http2Peer, CreditAva
         stream.onApplicationExchangeEnded();
         applicationExchangeEndedForWrites(stream.id);
         signalWriteLoop();
-        super.onExchangeEnded(exchange);
+        recordExchangeEnded(exchange);
+        server.executeResponseCompletionTask(() -> notifyExchangeEnded(exchange));
     }
 
     void removeProtocolStream(Http2Stream stream) {

--- a/src/main/java/io/muserver/Http2Stream.java
+++ b/src/main/java/io/muserver/Http2Stream.java
@@ -398,6 +398,14 @@ class Http2Stream implements ResponseInfo {
         }
     }
 
+    void abandonApplicationExchange() {
+        try {
+            request.cleanup();
+        } finally {
+            endTime = System.currentTimeMillis();
+        }
+    }
+
     private Http2Response requiredResponse() {
         return java.util.Objects.requireNonNull(response, "The HTTP/2 response has not been initialized");
     }

--- a/src/main/java/io/muserver/Mu3ServerImpl.java
+++ b/src/main/java/io/muserver/Mu3ServerImpl.java
@@ -177,22 +177,34 @@ class Mu3ServerImpl implements MuServer {
                 responseCompletionTasks.arriveAndDeregister();
             }
         };
+        RejectedExecutionException rejected = tryExecuteHandlerTask(trackedTask);
+        if (rejected != null) {
+            responseCompletionTasks.arriveAndDeregister();
+            log.warn("Dropping response completion callback because its application executors rejected it", rejected);
+        }
+    }
+
+    /**
+     * Dispatches accepted application work without ever falling back to the caller.
+     * The async executor is the secondary application domain when handler dispatch
+     * is unavailable; the returned rejection means neither domain can accept work.
+     */
+    @SuppressWarnings("ReferenceEquality") // Execution-domain identity belongs to the exact executor instance.
+    @Nullable RejectedExecutionException tryExecuteHandlerTask(Runnable task) {
         try {
-            handlerExecutor.execute(trackedTask);
+            handlerExecutor.execute(task);
+            return null;
         } catch (RejectedExecutionException handlerRejected) {
             if (asyncExecutor != handlerExecutor) {
                 try {
-                    asyncExecutor.execute(trackedTask);
-                    return;
+                    asyncExecutor.execute(task);
+                    return null;
                 } catch (RejectedExecutionException asyncRejected) {
                     asyncRejected.addSuppressed(handlerRejected);
-                    responseCompletionTasks.arriveAndDeregister();
-                    log.warn("Dropping response completion callback because its executors rejected it", asyncRejected);
-                    return;
+                    return asyncRejected;
                 }
             }
-            responseCompletionTasks.arriveAndDeregister();
-            log.warn("Dropping response completion callback because its executor rejected it", handlerRejected);
+            return handlerRejected;
         }
     }
 

--- a/src/main/java/io/muserver/Mu3ServerImpl.java
+++ b/src/main/java/io/muserver/Mu3ServerImpl.java
@@ -167,8 +167,11 @@ class Mu3ServerImpl implements MuServer {
         return true;
     }
 
-    @SuppressWarnings("ReferenceEquality") // Execution-domain identity belongs to the exact executor instance.
     void executeResponseCompletionTask(Runnable task) {
+        executeResponseCompletionTask(task, false);
+    }
+
+    void executeResponseCompletionTask(Runnable task, boolean alreadyOnApplicationExecutor) {
         responseCompletionTasks.register();
         Runnable trackedTask = () -> {
             try {
@@ -177,6 +180,10 @@ class Mu3ServerImpl implements MuServer {
                 responseCompletionTasks.arriveAndDeregister();
             }
         };
+        if (alreadyOnApplicationExecutor) {
+            trackedTask.run();
+            return;
+        }
         RejectedExecutionException rejected = tryExecuteHandlerTask(trackedTask);
         if (rejected != null) {
             responseCompletionTasks.arriveAndDeregister();

--- a/src/test/java/io/muserver/ExecutionDomainsTest.java
+++ b/src/test/java/io/muserver/ExecutionDomainsTest.java
@@ -779,6 +779,7 @@ class ExecutionDomainsTest {
     void rejectedApplicationExecutorsAbortAnAcceptedHttp2AsyncStream() throws Exception {
         var sharedExecutor = track(Executors.newSingleThreadExecutor(namedThreads("application-")));
         var suspendedHandle = new CompletableFuture<AsyncHandle>();
+        var executorStopped = new CompletableFuture<@Nullable Void>();
         server = httpServer()
             .withHttp2Config(Http2ConfigBuilder.http2Enabled())
             .withHandlerExecutor(sharedExecutor)
@@ -786,6 +787,7 @@ class ExecutionDomainsTest {
             .addHandler((request, response) -> {
                 suspendedHandle.complete(request.handleAsync());
                 sharedExecutor.shutdown();
+                executorStopped.complete(null);
                 return true;
             })
             .start();
@@ -799,7 +801,9 @@ class ExecutionDomainsTest {
                 true,
                 RFCTestUtils.getHelloHeaders("http", server.uri().getPort())
             )).flush();
-            suspendedHandle.get(5, TimeUnit.SECONDS).complete();
+            AsyncHandle handle = suspendedHandle.get(5, TimeUnit.SECONDS);
+            executorStopped.get(5, TimeUnit.SECONDS);
+            handle.complete();
 
             Http2ResetStreamFrame reset =
                 RFCTestUtils.readIgnoringWindowUpdates(connection, Http2ResetStreamFrame.class);

--- a/src/test/java/io/muserver/ExecutionDomainsTest.java
+++ b/src/test/java/io/muserver/ExecutionDomainsTest.java
@@ -595,6 +595,38 @@ class ExecutionDomainsTest {
     }
 
     @Test
+    void rejectedHandlerDispatchesHttp1AsyncFailureHandlingToTheAsyncExecutor() throws Exception {
+        var handlerExecutor = track(Executors.newSingleThreadExecutor(namedThreads("handler-")));
+        var asyncExecutor = track(Executors.newSingleThreadExecutor(namedThreads("async-")));
+        var suspendedHandle = new CompletableFuture<AsyncHandle>();
+        var exceptionThread = new CompletableFuture<String>();
+        server = httpServer()
+            .withHandlerExecutor(handlerExecutor)
+            .withAsyncExecutor(asyncExecutor)
+            .withExceptionHandler((request, response, exception) -> {
+                exceptionThread.complete(Thread.currentThread().getName());
+                response.status(500);
+                response.write("handled");
+                return true;
+            })
+            .addHandler((request, response) -> {
+                suspendedHandle.complete(request.handleAsync());
+                handlerExecutor.shutdown();
+                return true;
+            })
+            .start();
+
+        try (var client = Http1Client.connect(server)) {
+            client.writeRequestLine(Method.GET, "/").flushHeaders();
+            suspendedHandle.get(5, TimeUnit.SECONDS).complete(new IOException("async failure"));
+
+            assertThat(client.readLine(), equalTo("HTTP/1.1 500 Internal Server Error"));
+            assertThat(client.readBody(client.readHeaders()), equalTo("handled"));
+            assertThat(exceptionThread.get(5, TimeUnit.SECONDS), startsWith("async-"));
+        }
+    }
+
+    @Test
     void aSuspendedHttp2ExchangeDoesNotRetainAHandlerWorker() throws Exception {
         var handlerExecutor = track(Executors.newSingleThreadExecutor(namedThreads("handler-")));
         var suspendedHandle = new CompletableFuture<AsyncHandle>();
@@ -642,6 +674,90 @@ class ExecutionDomainsTest {
                 handle.complete();
             }
             assertThat(completionThread.get(5, TimeUnit.SECONDS), startsWith("handler-"));
+        }
+    }
+
+    @Test
+    void rejectedHandlerDispatchesHttp2AsyncCompletionToTheAsyncExecutor() throws Exception {
+        var handlerExecutor = track(Executors.newSingleThreadExecutor(namedThreads("handler-")));
+        var asyncExecutor = track(Executors.newSingleThreadExecutor(namedThreads("async-")));
+        var suspendedHandle = new CompletableFuture<AsyncHandle>();
+        var exceptionThread = new CompletableFuture<String>();
+        var completionThread = new CompletableFuture<String>();
+        server = httpServer()
+            .withHttp2Config(Http2ConfigBuilder.http2Enabled())
+            .withHandlerExecutor(handlerExecutor)
+            .withAsyncExecutor(asyncExecutor)
+            .withExceptionHandler((request, response, exception) -> {
+                exceptionThread.complete(Thread.currentThread().getName());
+                response.status(500);
+                response.write("handled");
+                return true;
+            })
+            .addHandler((request, response) -> {
+                AsyncHandle handle = request.handleAsync();
+                handle.addResponseCompleteHandler(info ->
+                    completionThread.complete(Thread.currentThread().getName())
+                );
+                suspendedHandle.complete(handle);
+                handlerExecutor.shutdown();
+                return true;
+            })
+            .start();
+
+        try (var h2Client = new H2Client();
+             var connection = h2Client.connectClearText(server)) {
+            connection.handshake();
+            connection.socket().setSoTimeout(2000);
+            connection.writeFrame(new Http2HeadersFrame(
+                1,
+                true,
+                RFCTestUtils.getHelloHeaders("http", server.uri().getPort())
+            )).flush();
+            suspendedHandle.get(5, TimeUnit.SECONDS).complete(new IOException("async failure"));
+
+            Http2HeadersFrame responseHeaders =
+                RFCTestUtils.readIgnoringWindowUpdates(connection, Http2HeadersFrame.class);
+            assertThat(responseHeaders.headers().get(":status"), equalTo("500"));
+            Http2DataFrame responseData =
+                RFCTestUtils.readIgnoringWindowUpdates(connection, Http2DataFrame.class);
+            assertThat(responseData.toUTF8(), equalTo("handled"));
+            assertThat(exceptionThread.get(5, TimeUnit.SECONDS), startsWith("async-"));
+            assertThat(completionThread.get(5, TimeUnit.SECONDS), startsWith("async-"));
+        }
+    }
+
+    @Test
+    void rejectedApplicationExecutorsAbortAnAcceptedHttp2AsyncStream() throws Exception {
+        var sharedExecutor = track(Executors.newSingleThreadExecutor(namedThreads("application-")));
+        var suspendedHandle = new CompletableFuture<AsyncHandle>();
+        server = httpServer()
+            .withHttp2Config(Http2ConfigBuilder.http2Enabled())
+            .withHandlerExecutor(sharedExecutor)
+            .withAsyncExecutor(sharedExecutor)
+            .addHandler((request, response) -> {
+                suspendedHandle.complete(request.handleAsync());
+                sharedExecutor.shutdown();
+                return true;
+            })
+            .start();
+
+        try (var h2Client = new H2Client();
+             var connection = h2Client.connectClearText(server)) {
+            connection.handshake();
+            connection.socket().setSoTimeout(2000);
+            connection.writeFrame(new Http2HeadersFrame(
+                1,
+                true,
+                RFCTestUtils.getHelloHeaders("http", server.uri().getPort())
+            )).flush();
+            suspendedHandle.get(5, TimeUnit.SECONDS).complete();
+
+            Http2ResetStreamFrame reset =
+                RFCTestUtils.readIgnoringWindowUpdates(connection, Http2ResetStreamFrame.class);
+            assertThat(reset.streamId(), is(1));
+            assertThat(reset.errorCodeEnum(), is(Http2ErrorCode.INTERNAL_ERROR));
+            assertEventually(() -> server.stats().completedRequests(), equalTo(1L));
         }
     }
 

--- a/src/test/java/io/muserver/ExecutionDomainsTest.java
+++ b/src/test/java/io/muserver/ExecutionDomainsTest.java
@@ -779,7 +779,6 @@ class ExecutionDomainsTest {
     void rejectedApplicationExecutorsAbortAnAcceptedHttp2AsyncStream() throws Exception {
         var sharedExecutor = track(Executors.newSingleThreadExecutor(namedThreads("application-")));
         var suspendedHandle = new CompletableFuture<AsyncHandle>();
-        var executorStopped = new CompletableFuture<@Nullable Void>();
         server = httpServer()
             .withHttp2Config(Http2ConfigBuilder.http2Enabled())
             .withHandlerExecutor(sharedExecutor)
@@ -787,7 +786,6 @@ class ExecutionDomainsTest {
             .addHandler((request, response) -> {
                 suspendedHandle.complete(request.handleAsync());
                 sharedExecutor.shutdown();
-                executorStopped.complete(null);
                 return true;
             })
             .start();
@@ -802,7 +800,7 @@ class ExecutionDomainsTest {
                 RFCTestUtils.getHelloHeaders("http", server.uri().getPort())
             )).flush();
             AsyncHandle handle = suspendedHandle.get(5, TimeUnit.SECONDS);
-            executorStopped.get(5, TimeUnit.SECONDS);
+            assertThat(sharedExecutor.awaitTermination(5, TimeUnit.SECONDS), is(true));
             handle.complete();
 
             Http2ResetStreamFrame reset =

--- a/src/test/java/io/muserver/ExecutionDomainsTest.java
+++ b/src/test/java/io/muserver/ExecutionDomainsTest.java
@@ -678,6 +678,54 @@ class ExecutionDomainsTest {
     }
 
     @Test
+    void synchronousHttp2CompletionDoesNotResubmitFromItsApplicationWorker() throws Exception {
+        var applicationExecutor = track(new ThreadPoolExecutor(
+            1,
+            1,
+            0,
+            TimeUnit.MILLISECONDS,
+            new SynchronousQueue<>(),
+            namedThreads("application-")
+        ));
+        var responseCompletionThread = new CompletableFuture<String>();
+        var completionThread = new CompletableFuture<String>();
+        server = httpServer()
+            .withHttp2Config(Http2ConfigBuilder.http2Enabled())
+            .withHandlerExecutor(applicationExecutor)
+            .withAsyncExecutor(applicationExecutor)
+            .addResponseCompleteListener(info ->
+                completionThread.complete(Thread.currentThread().getName())
+            )
+            .addHandler(Method.GET, "/hello", (request, response, pathParams) -> {
+                response.addCompletionListener(info ->
+                    responseCompletionThread.complete(Thread.currentThread().getName())
+                );
+                response.write("done");
+            })
+            .start();
+
+        try (var h2Client = new H2Client();
+             var connection = h2Client.connectClearText(server)) {
+            connection.handshake();
+            connection.socket().setSoTimeout(2000);
+            connection.writeFrame(new Http2HeadersFrame(
+                1,
+                true,
+                RFCTestUtils.getHelloHeaders("http", server.uri().getPort())
+            )).flush();
+
+            Http2HeadersFrame responseHeaders =
+                RFCTestUtils.readIgnoringWindowUpdates(connection, Http2HeadersFrame.class);
+            assertThat(responseHeaders.headers().get(":status"), equalTo("200"));
+            Http2DataFrame responseData =
+                RFCTestUtils.readIgnoringWindowUpdates(connection, Http2DataFrame.class);
+            assertThat(responseData.toUTF8(), equalTo("done"));
+            assertThat(responseCompletionThread.get(5, TimeUnit.SECONDS), startsWith("application-"));
+            assertThat(completionThread.get(5, TimeUnit.SECONDS), startsWith("application-"));
+        }
+    }
+
+    @Test
     void rejectedHandlerDispatchesHttp2AsyncCompletionToTheAsyncExecutor() throws Exception {
         var handlerExecutor = track(Executors.newSingleThreadExecutor(namedThreads("handler-")));
         var asyncExecutor = track(Executors.newSingleThreadExecutor(namedThreads("async-")));


### PR DESCRIPTION
## What changed

- Replaced HTTP/1 and HTTP/2 caller-runs fallbacks for accepted async exchanges with one handler-to-async application dispatch path.
- Moved HTTP/2 response-completion listeners onto the tracked application callback path already used by HTTP/1.
- When both application executors reject an accepted HTTP/2 continuation, abort and retire that stream with `INTERNAL_ERROR` instead of leaking it or running application code on the completing thread.
- Added deterministic HTTP/1 and HTTP/2 rejection-path tests, including the both-executors-rejected stream lifecycle.

## Why

An async exchange can complete on an arbitrary user, future-completion, or I/O thread. The previous rejection fallbacks invoked exception handlers, response cleanup, and completion listeners inline on that thread. HTTP/1 could specifically fall back onto its connection reader. That contradicted the execution-domain split and made callback concurrency depend on executor capacity.

Application work now stays on the handler executor, with the async executor as the bounded fallback. Protocol cleanup remains explicit when neither application domain is available.

## Impact

Normal behavior and public API are unchanged. A caller that shuts down both configured application executors while an HTTP/2 async exchange is active now receives a stream-level `INTERNAL_ERROR` reset rather than an exchange completed on an arbitrary caller thread.

## Validation

- Java 11: 86 focused execution-domain, async, HTTP/2 lifecycle, and writer-coordinator tests
- Java 21 with NullAway: full suite, 1,629 tests, 0 failures
