### PR TITLE
Drain detached application callbacks during shutdown

### DIFF
--- a/src/main/java/io/muserver/Mu3ServerImpl.java
+++ b/src/main/java/io/muserver/Mu3ServerImpl.java
@@ -50,7 +50,7 @@ class Mu3ServerImpl implements MuServer {
     private final boolean ownsConnectionMaintenanceExecutor;
     private final ScheduledExecutorService timerExecutor;
     private final boolean ownsTimerExecutor;
-    private final Phaser responseCompletionTasks = new Phaser() {
+    private final Phaser detachedApplicationTasks = new Phaser() {
         @Override
         protected boolean onAdvance(int phase, int registeredParties) {
             // Keep accepting tasks after an idle phase. Server.stop() can also be called
@@ -123,7 +123,7 @@ class Mu3ServerImpl implements MuServer {
                 stoppedCleanly = false;
             }
         }
-        if (!awaitResponseCompletionTasks(deadline)) {
+        if (!awaitDetachedApplicationTasks(deadline)) {
             stoppedCleanly = false;
         }
         if (ownsTimerExecutor) {
@@ -147,12 +147,12 @@ class Mu3ServerImpl implements MuServer {
         return stoppedCleanly;
     }
 
-    private boolean awaitResponseCompletionTasks(long deadline) {
-        while (responseCompletionTasks.getRegisteredParties() > 0) {
-            int phase = responseCompletionTasks.getPhase();
+    private boolean awaitDetachedApplicationTasks(long deadline) {
+        while (detachedApplicationTasks.getRegisteredParties() > 0) {
+            int phase = detachedApplicationTasks.getPhase();
             long remaining = Math.max(0L, deadline - System.currentTimeMillis());
             try {
-                responseCompletionTasks.awaitAdvanceInterruptibly(
+                detachedApplicationTasks.awaitAdvanceInterruptibly(
                     phase,
                     remaining,
                     TimeUnit.MILLISECONDS
@@ -167,20 +167,29 @@ class Mu3ServerImpl implements MuServer {
         return true;
     }
 
-    @SuppressWarnings("ReferenceEquality") // Execution-domain identity belongs to the exact executor instance.
     void executeResponseCompletionTask(Runnable task) {
-        responseCompletionTasks.register();
+        executeTrackedApplicationTask(task, true, "response completion callback");
+    }
+
+    private void executeTrackedApplicationTask(
+        Runnable task,
+        boolean preferHandlerExecutor,
+        String description
+    ) {
+        detachedApplicationTasks.register();
         Runnable trackedTask = () -> {
             try {
                 task.run();
             } finally {
-                responseCompletionTasks.arriveAndDeregister();
+                detachedApplicationTasks.arriveAndDeregister();
             }
         };
-        RejectedExecutionException rejected = tryExecuteHandlerTask(trackedTask);
+        RejectedExecutionException rejected = preferHandlerExecutor
+            ? tryExecuteHandlerTask(trackedTask)
+            : tryExecuteAsyncTask(trackedTask);
         if (rejected != null) {
-            responseCompletionTasks.arriveAndDeregister();
-            log.warn("Dropping response completion callback because its application executors rejected it", rejected);
+            detachedApplicationTasks.arriveAndDeregister();
+            log.warn("Dropping {} because its application executors rejected it", description, rejected);
         }
     }
 
@@ -189,22 +198,34 @@ class Mu3ServerImpl implements MuServer {
      * The async executor is the secondary application domain when handler dispatch
      * is unavailable; the returned rejection means neither domain can accept work.
      */
-    @SuppressWarnings("ReferenceEquality") // Execution-domain identity belongs to the exact executor instance.
     @Nullable RejectedExecutionException tryExecuteHandlerTask(Runnable task) {
+        return tryExecuteApplicationTask(task, handlerExecutor, asyncExecutor);
+    }
+
+    private @Nullable RejectedExecutionException tryExecuteAsyncTask(Runnable task) {
+        return tryExecuteApplicationTask(task, asyncExecutor, handlerExecutor);
+    }
+
+    @SuppressWarnings("ReferenceEquality") // Execution-domain identity belongs to the exact executor instance.
+    private static @Nullable RejectedExecutionException tryExecuteApplicationTask(
+        Runnable task,
+        ExecutorService primaryExecutor,
+        ExecutorService fallbackExecutor
+    ) {
         try {
-            handlerExecutor.execute(task);
+            primaryExecutor.execute(task);
             return null;
-        } catch (RejectedExecutionException handlerRejected) {
-            if (asyncExecutor != handlerExecutor) {
+        } catch (RejectedExecutionException primaryRejected) {
+            if (fallbackExecutor != primaryExecutor) {
                 try {
-                    asyncExecutor.execute(task);
+                    fallbackExecutor.execute(task);
                     return null;
-                } catch (RejectedExecutionException asyncRejected) {
-                    asyncRejected.addSuppressed(handlerRejected);
-                    return asyncRejected;
+                } catch (RejectedExecutionException fallbackRejected) {
+                    fallbackRejected.addSuppressed(primaryRejected);
+                    return fallbackRejected;
                 }
             }
-            return handlerRejected;
+            return primaryRejected;
         }
     }
 
@@ -388,29 +409,15 @@ class Mu3ServerImpl implements MuServer {
         }
     }
 
-    @SuppressWarnings("ReferenceEquality") // Execution-domain identity belongs to the exact executor instance.
     void onRequestRejected(RejectedRequest info) {
         if (requestRejectListeners.isEmpty()) {
             return;
         }
-        Runnable notification = () -> notifyRequestRejected(info);
-        try {
-            asyncExecutor.execute(notification);
-        } catch (RejectedExecutionException asyncRejected) {
-            // Keep user callbacks off protocol readers even if a caller-supplied async
-            // executor is unavailable. The handler executor is the remaining application
-            // domain; if both reject, there is no safe executor on which to deliver this.
-            if (handlerExecutor == asyncExecutor) {
-                log.error("Request rejection notification was not delivered because the application executor rejected it", asyncRejected);
-                return;
-            }
-            try {
-                handlerExecutor.execute(notification);
-            } catch (RejectedExecutionException handlerRejected) {
-                handlerRejected.addSuppressed(asyncRejected);
-                log.error("Request rejection notification was not delivered because both application executors rejected it", handlerRejected);
-            }
-        }
+        executeTrackedApplicationTask(
+            () -> notifyRequestRejected(info),
+            false,
+            "request rejection notification"
+        );
     }
 
     private void notifyRequestRejected(RejectedRequest info) {

--- a/src/main/java/io/muserver/Mu3ServerImpl.java
+++ b/src/main/java/io/muserver/Mu3ServerImpl.java
@@ -58,6 +58,8 @@ class Mu3ServerImpl implements MuServer {
             return false;
         }
     };
+    private final ThreadLocal<@Nullable DetachedApplicationTask> activeDetachedApplicationTask =
+        new ThreadLocal<>();
     private final Mu3StatsImpl statsImpl = new Mu3StatsImpl();
 
     Mu3ServerImpl(List<ConnectionAcceptor> acceptors, List<MuHandler> handlers, List<ResponseCompleteListener> responseCompleteListeners, List<RequestRejectListener> requestRejectListeners, UnhandledExceptionHandler exceptionHandler, Long maxRequestBodySize, List<ContentEncoder> contentEncoders, Long requestIdleTimeoutMillis, Long idleTimeoutMillis, int maxUrlSize, int maxHeadersSize, List<RateLimiterImpl> rateLimiters, Path tempDir, ExecutorService handlerExecutor, boolean ownsHandlerExecutor, ExecutorService asyncExecutor, boolean ownsAsyncExecutor, ExecutorService connectionExecutor, boolean ownsConnectionExecutor, ExecutorService http2WriterExecutor, boolean ownsHttp2WriterExecutor, ExecutorService connectionMaintenanceExecutor, boolean ownsConnectionMaintenanceExecutor, ScheduledExecutorService timerExecutor, boolean ownsTimerExecutor) {
@@ -148,11 +150,23 @@ class Mu3ServerImpl implements MuServer {
     }
 
     private boolean awaitDetachedApplicationTasks(long deadline) {
-        while (detachedApplicationTasks.getRegisteredParties() > 0) {
-            int phase = detachedApplicationTasks.getPhase();
+        DetachedApplicationTask currentTask = activeDetachedApplicationTask.get();
+        while (currentTask != null) {
+            currentTask.deregister();
+            currentTask = currentTask.previous;
+        }
+        return awaitDetachedApplicationTasks(detachedApplicationTasks, deadline);
+    }
+
+    static boolean awaitDetachedApplicationTasks(Phaser tasks, long deadline) {
+        while (true) {
+            int phase = tasks.getPhase();
+            if (tasks.getRegisteredParties() == 0) {
+                return true;
+            }
             long remaining = Math.max(0L, deadline - System.currentTimeMillis());
             try {
-                detachedApplicationTasks.awaitAdvanceInterruptibly(
+                tasks.awaitAdvanceInterruptibly(
                     phase,
                     remaining,
                     TimeUnit.MILLISECONDS
@@ -164,7 +178,6 @@ class Mu3ServerImpl implements MuServer {
                 return false;
             }
         }
-        return true;
     }
 
     void executeResponseCompletionTask(Runnable task) {
@@ -195,11 +208,20 @@ class Mu3ServerImpl implements MuServer {
         boolean alreadyOnApplicationExecutor
     ) {
         detachedApplicationTasks.register();
+        DetachedApplicationTask registration = new DetachedApplicationTask();
         Runnable trackedTask = () -> {
+            DetachedApplicationTask previous = activeDetachedApplicationTask.get();
+            registration.previous = previous;
+            activeDetachedApplicationTask.set(registration);
             try {
                 task.run();
             } finally {
-                detachedApplicationTasks.arriveAndDeregister();
+                registration.deregister();
+                if (previous == null) {
+                    activeDetachedApplicationTask.remove();
+                } else {
+                    activeDetachedApplicationTask.set(previous);
+                }
             }
         };
         if (alreadyOnApplicationExecutor) {
@@ -210,8 +232,20 @@ class Mu3ServerImpl implements MuServer {
             ? tryExecuteHandlerTask(trackedTask)
             : tryExecuteAsyncTask(trackedTask);
         if (rejected != null) {
-            detachedApplicationTasks.arriveAndDeregister();
+            registration.deregister();
             log.warn("Dropping {} because its application executors rejected it", description, rejected);
+        }
+    }
+
+    private final class DetachedApplicationTask {
+        private @Nullable DetachedApplicationTask previous;
+        private boolean registered = true;
+
+        private void deregister() {
+            if (registered) {
+                registered = false;
+                detachedApplicationTasks.arriveAndDeregister();
+            }
         }
     }
 

--- a/src/main/java/io/muserver/Mu3ServerImpl.java
+++ b/src/main/java/io/muserver/Mu3ServerImpl.java
@@ -150,17 +150,12 @@ class Mu3ServerImpl implements MuServer {
     }
 
     private boolean awaitDetachedApplicationTasks(long deadline) {
-        DetachedApplicationTask currentTask = activeDetachedApplicationTask.get();
-        boolean calledFromDetachedTask = currentTask != null;
-        while (currentTask != null) {
-            currentTask.deregister();
-            currentTask = currentTask.previous;
-        }
         // A callback cannot safely wait for other detached callbacks: with a
         // single-worker application executor, they may be queued behind this
-        // callback and cannot start until stop() returns. External stop callers
-        // still wait for every registered task.
-        if (calledFromDetachedTask) {
+        // callback and cannot start until stop() returns. Leave every registration
+        // intact so a concurrent external stop caller still observes and waits for
+        // the callback until its wrapper finishes.
+        if (activeDetachedApplicationTask.get() != null) {
             return true;
         }
         return awaitDetachedApplicationTasks(detachedApplicationTasks, deadline);

--- a/src/main/java/io/muserver/Mu3ServerImpl.java
+++ b/src/main/java/io/muserver/Mu3ServerImpl.java
@@ -151,9 +151,17 @@ class Mu3ServerImpl implements MuServer {
 
     private boolean awaitDetachedApplicationTasks(long deadline) {
         DetachedApplicationTask currentTask = activeDetachedApplicationTask.get();
+        boolean calledFromDetachedTask = currentTask != null;
         while (currentTask != null) {
             currentTask.deregister();
             currentTask = currentTask.previous;
+        }
+        // A callback cannot safely wait for other detached callbacks: with a
+        // single-worker application executor, they may be queued behind this
+        // callback and cannot start until stop() returns. External stop callers
+        // still wait for every registered task.
+        if (calledFromDetachedTask) {
+            return true;
         }
         return awaitDetachedApplicationTasks(detachedApplicationTasks, deadline);
     }

--- a/src/test/java/io/muserver/ExecutionDomainsTest.java
+++ b/src/test/java/io/muserver/ExecutionDomainsTest.java
@@ -388,6 +388,63 @@ class ExecutionDomainsTest {
     }
 
     @Test
+    void requestRejectionListenerDoesNotWaitForCallbackQueuedBehindIt() throws Exception {
+        var asyncExecutor = track(Executors.newSingleThreadExecutor(namedThreads("async-")));
+        var blockerEntered = new CountDownLatch(1);
+        var releaseBlocker = new CountDownLatch(1);
+        asyncExecutor.execute(() -> {
+            blockerEntered.countDown();
+            try {
+                releaseBlocker.await();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        });
+        assertThat(blockerEntered.await(5, TimeUnit.SECONDS), is(true));
+
+        var runningServer = new CompletableFuture<MuServer>();
+        var stopResult = new CompletableFuture<Boolean>();
+        var callbackNumber = new AtomicInteger();
+        var secondCallbackRan = new CountDownLatch(1);
+        server = httpServer()
+            .withMaxHeadersSize(1024)
+            .withAsyncExecutor(asyncExecutor)
+            .addRequestRejectListener(info -> {
+                if (callbackNumber.incrementAndGet() == 1) {
+                    try {
+                        stopResult.complete(
+                            runningServer.get().stop(2, TimeUnit.SECONDS)
+                        );
+                    } catch (Throwable failure) {
+                        stopResult.completeExceptionally(failure);
+                    }
+                } else {
+                    secondCallbackRan.countDown();
+                }
+            })
+            .start();
+        runningServer.complete(server);
+
+        try {
+            for (int i = 0; i < 2; i++) {
+                try (var client = Http1Client.connect(server)) {
+                    client.writeRequestLine(Method.GET, "/")
+                        .writeHeader("x-big", "a".repeat(2000))
+                        .flushHeaders();
+                    assertThat(client.readLine(), startsWith("HTTP/1.1 431"));
+                }
+            }
+
+            releaseBlocker.countDown();
+            assertThat(stopResult.get(1, TimeUnit.SECONDS), is(true));
+            assertThat(secondCallbackRan.await(1, TimeUnit.SECONDS), is(true));
+            server = null;
+        } finally {
+            releaseBlocker.countDown();
+        }
+    }
+
+    @Test
     void anIdleHttp1ConnectionDoesNotRetainAHandlerWorker() throws Exception {
         var handlerExecutor = track(Executors.newSingleThreadExecutor(namedThreads("handler-")));
         var connectionExecutor = track(Executors.newCachedThreadPool(namedThreads("connection-")));

--- a/src/test/java/io/muserver/ExecutionDomainsTest.java
+++ b/src/test/java/io/muserver/ExecutionDomainsTest.java
@@ -27,6 +27,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import java.util.concurrent.Phaser;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.ThreadPoolExecutor;
@@ -321,6 +322,59 @@ class ExecutionDomainsTest {
             server = null;
         } finally {
             releaseListener.countDown();
+        }
+    }
+
+    @Test
+    void detachedTaskWaitDoesNotWaitOnANewEmptyPhase() {
+        Phaser tasks = new Phaser(1) {
+            private boolean advanceBeforeReturningParties = true;
+
+            @Override
+            public int getRegisteredParties() {
+                int parties = super.getRegisteredParties();
+                if (advanceBeforeReturningParties) {
+                    advanceBeforeReturningParties = false;
+                    arriveAndDeregister();
+                }
+                return parties;
+            }
+        };
+
+        assertThat(
+            Mu3ServerImpl.awaitDetachedApplicationTasks(
+                tasks,
+                System.currentTimeMillis() + 100
+            ),
+            is(true)
+        );
+    }
+
+    @Test
+    void requestRejectionListenerCanStopItsServerWithoutWaitingForItself() throws Exception {
+        var runningServer = new CompletableFuture<MuServer>();
+        var stopResult = new CompletableFuture<Boolean>();
+        server = httpServer()
+            .withMaxHeadersSize(1024)
+            .addRequestRejectListener(info -> {
+                try {
+                    stopResult.complete(
+                        runningServer.get().stop(2, TimeUnit.SECONDS)
+                    );
+                } catch (Throwable failure) {
+                    stopResult.completeExceptionally(failure);
+                }
+            })
+            .start();
+        runningServer.complete(server);
+
+        try (var client = Http1Client.connect(server)) {
+            client.writeRequestLine(Method.GET, "/")
+                .writeHeader("x-big", "a".repeat(2000))
+                .flushHeaders();
+            assertThat(client.readLine(), startsWith("HTTP/1.1 431"));
+            assertThat(stopResult.get(1, TimeUnit.SECONDS), is(true));
+            server = null;
         }
     }
 

--- a/src/test/java/io/muserver/ExecutionDomainsTest.java
+++ b/src/test/java/io/muserver/ExecutionDomainsTest.java
@@ -279,6 +279,52 @@ class ExecutionDomainsTest {
     }
 
     @Test
+    void gracefulStopWaitsForDispatchedRequestRejectionListeners() throws Exception {
+        var asyncExecutor = track(Executors.newSingleThreadExecutor(namedThreads("async-")));
+        var connectionExecutor = track(Executors.newSingleThreadExecutor(namedThreads("connection-")));
+        var clientExecutor = track(Executors.newSingleThreadExecutor(namedThreads("client-")));
+        var listenerEntered = new CountDownLatch(1);
+        var releaseListener = new CountDownLatch(1);
+        server = httpServer()
+            .withMaxHeadersSize(1024)
+            .withAsyncExecutor(asyncExecutor)
+            .withConnectionExecutor(connectionExecutor)
+            .addRequestRejectListener(info -> {
+                listenerEntered.countDown();
+                try {
+                    releaseListener.await();
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+            })
+            .start();
+
+        try {
+            try (var client = Http1Client.connect(server)) {
+                client.writeRequestLine(Method.GET, "/")
+                    .writeHeader("x-big", "a".repeat(2000))
+                    .flushHeaders();
+                assertThat(client.readLine(), startsWith("HTTP/1.1 431"));
+                client.readBody(client.readHeaders());
+                assertThat(listenerEntered.await(5, TimeUnit.SECONDS), is(true));
+            }
+
+            MuServer runningServer = Objects.requireNonNull(server);
+            Future<Boolean> stopped = clientExecutor.submit(() ->
+                runningServer.stop(2, TimeUnit.SECONDS)
+            );
+            assertThrows(TimeoutException.class, () ->
+                stopped.get(100, TimeUnit.MILLISECONDS)
+            );
+            releaseListener.countDown();
+            assertThat(stopped.get(5, TimeUnit.SECONDS), is(true));
+            server = null;
+        } finally {
+            releaseListener.countDown();
+        }
+    }
+
+    @Test
     void anIdleHttp1ConnectionDoesNotRetainAHandlerWorker() throws Exception {
         var handlerExecutor = track(Executors.newSingleThreadExecutor(namedThreads("handler-")));
         var connectionExecutor = track(Executors.newCachedThreadPool(namedThreads("connection-")));

--- a/src/test/java/io/muserver/ExecutionDomainsTest.java
+++ b/src/test/java/io/muserver/ExecutionDomainsTest.java
@@ -21,6 +21,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
@@ -63,7 +64,7 @@ class ExecutionDomainsTest {
             1,
             0,
             TimeUnit.MILLISECONDS,
-            new SynchronousQueue<>(),
+            new ArrayBlockingQueue<>(1),
             namedThreads("handler-")
         ));
         var asyncExecutor = track(Executors.newSingleThreadExecutor(namedThreads("async-")));
@@ -83,6 +84,13 @@ class ExecutionDomainsTest {
             }
         });
         assertThat(blockerStarted.await(5, TimeUnit.SECONDS), is(true));
+        Future<?> queuedBlocker = handlerExecutor.submit(() -> {
+            try {
+                releaseBlocker.await();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        });
 
         server = httpServer()
             .withHttp2Config(Http2ConfigBuilder.http2Enabled())
@@ -148,6 +156,7 @@ class ExecutionDomainsTest {
 
             releaseBlocker.countDown();
             blocker.get(5, TimeUnit.SECONDS);
+            queuedBlocker.get(5, TimeUnit.SECONDS);
 
             con.writeFrame(new Http2HeadersFrame(
                     3,

--- a/src/test/java/io/muserver/ExecutionDomainsTest.java
+++ b/src/test/java/io/muserver/ExecutionDomainsTest.java
@@ -445,6 +445,57 @@ class ExecutionDomainsTest {
     }
 
     @Test
+    void externalStopStillWaitsAfterCallbackLocalStopReturns() throws Exception {
+        var asyncExecutor = track(Executors.newSingleThreadExecutor(namedThreads("async-")));
+        var clientExecutor = track(Executors.newSingleThreadExecutor(namedThreads("client-")));
+        var runningServer = new CompletableFuture<MuServer>();
+        var localStopResult = new CompletableFuture<Boolean>();
+        var localStopReturned = new CountDownLatch(1);
+        var releaseCallback = new CountDownLatch(1);
+        server = httpServer()
+            .withMaxHeadersSize(1024)
+            .withAsyncExecutor(asyncExecutor)
+            .addRequestRejectListener(info -> {
+                try {
+                    localStopResult.complete(
+                        runningServer.get().stop(2, TimeUnit.SECONDS)
+                    );
+                    localStopReturned.countDown();
+                    releaseCallback.await();
+                } catch (Throwable failure) {
+                    localStopResult.completeExceptionally(failure);
+                }
+            })
+            .start();
+        runningServer.complete(server);
+
+        try {
+            try (var client = Http1Client.connect(server)) {
+                client.writeRequestLine(Method.GET, "/")
+                    .writeHeader("x-big", "a".repeat(2000))
+                    .flushHeaders();
+                assertThat(client.readLine(), startsWith("HTTP/1.1 431"));
+            }
+
+            assertThat(localStopResult.get(1, TimeUnit.SECONDS), is(true));
+            assertThat(localStopReturned.await(1, TimeUnit.SECONDS), is(true));
+
+            Future<Boolean> externalStop = clientExecutor.submit(() ->
+                runningServer.get().stop(2, TimeUnit.SECONDS)
+            );
+            assertThrows(
+                TimeoutException.class,
+                () -> externalStop.get(100, TimeUnit.MILLISECONDS)
+            );
+            releaseCallback.countDown();
+            assertThat(externalStop.get(5, TimeUnit.SECONDS), is(true));
+            server = null;
+        } finally {
+            releaseCallback.countDown();
+        }
+    }
+
+    @Test
     void anIdleHttp1ConnectionDoesNotRetainAHandlerWorker() throws Exception {
         var handlerExecutor = track(Executors.newSingleThreadExecutor(namedThreads("handler-")));
         var connectionExecutor = track(Executors.newCachedThreadPool(namedThreads("connection-")));


### PR DESCRIPTION
## Summary

- generalize the bounded shutdown tracker from response-completion callbacks to detached application callbacks
- include request-rejection listener notifications in that drain
- preserve async-first rejection delivery and handler-first completion delivery, including the existing safe executor fallback
- add a deterministic test proving graceful stop waits for an in-flight rejection listener

This does not change the public API or normal wire behaviour. It makes a successful graceful stop mean that already-dispatched detached callbacks have completed, subject to the caller's existing stop deadline.

## Validation

- `mise exec java@temurin-11 -- mvn -Dtest=ExecutionDomainsTest,EventsTest,StopTest test` (44 tests)
- `mise exec java@temurin-21 -- mvn -Pnullaway -DskipTests test`
- `git diff --check`