### PR TITLE
Dispatch JAX-RS async continuations on application executors

### DIFF
--- a/src/main/java/io/muserver/AsyncHandle.java
+++ b/src/main/java/io/muserver/AsyncHandle.java
@@ -3,7 +3,10 @@ package io.muserver;
 import org.jspecify.annotations.Nullable;
 
 import java.nio.ByteBuffer;
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 
 /**
  * <p>A class to handle the request and response handling when using asynchronous request handling.</p>
@@ -50,6 +53,50 @@ public interface AsyncHandle {
      * @return A future that is resolved when the write succeeds or fails.
      */
     Future<@Nullable Void> write(ByteBuffer data);
+
+    /**
+     * Executes an application continuation for this exchange.
+     *
+     * <p>Handles supplied by Mu Server dispatch the task to the request-handler
+     * execution domain and never run it on the calling thread. This is useful when an
+     * asynchronous result becomes available on an executor that should not perform
+     * response serialization or invoke application callbacks.</p>
+     *
+     * <p>The default implementation runs the task immediately to retain compatibility
+     * with custom implementations of this interface.</p>
+     *
+     * @param task The application continuation to execute
+     */
+    default void executeApplicationTask(Runnable task) {
+        Objects.requireNonNull(task, "task").run();
+    }
+
+    /**
+     * Executes an application continuation after a delay.
+     *
+     * <p>Handles supplied by Mu Server use the server timer only to determine when the
+     * task is due, then dispatch the task to the request-handler execution domain. The
+     * returned future can be cancelled before the delay expires to prevent dispatch.
+     * Completion of the future does not guarantee that the application task has
+     * finished.</p>
+     *
+     * <p>The default implementation uses the JDK delayed executor and delegates to
+     * {@link #executeApplicationTask(Runnable)} to retain compatibility with custom implementations of
+     * this interface.</p>
+     *
+     * @param task The application continuation to execute
+     * @param delay The delay before execution
+     * @param unit The unit of {@code delay}
+     * @return A future representing the delayed execution
+     */
+    default Future<?> scheduleApplicationTask(Runnable task, long delay, TimeUnit unit) {
+        Objects.requireNonNull(task, "task");
+        Objects.requireNonNull(unit, "unit");
+        return CompletableFuture.runAsync(
+            () -> executeApplicationTask(task),
+            CompletableFuture.delayedExecutor(delay, unit)
+        );
+    }
 
     /**
      * Add a listener for when request processing is complete. One use of this is to detect early client disconnects

--- a/src/main/java/io/muserver/Mu3AsyncHandleImpl.java
+++ b/src/main/java/io/muserver/Mu3AsyncHandleImpl.java
@@ -6,6 +6,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.ByteBuffer;
+import java.util.Objects;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.Lock;
@@ -17,12 +18,14 @@ class Mu3AsyncHandleImpl implements AsyncHandle {
     private CompletableFuture<@Nullable Void> responseFuture = CompletableFuture.completedFuture(null);
     private final CompletableFuture<@Nullable Void> completionFuture = new CompletableFuture<>();
     private final Lock lock = new ReentrantLock();
+    private final Mu3ServerImpl server;
     private final ExecutorService asyncExecutor;
 
-    Mu3AsyncHandleImpl(Mu3Request request, BaseResponse response, ExecutorService asyncExecutor) {
+    Mu3AsyncHandleImpl(Mu3Request request, BaseResponse response, Mu3ServerImpl server) {
         this.request = request;
         this.response = response;
-        this.asyncExecutor = asyncExecutor;
+        this.server = server;
+        this.asyncExecutor = server.asyncExecutor();
     }
 
     CompletableFuture<@Nullable Void> exchangeCompletion() {
@@ -240,6 +243,28 @@ class Mu3AsyncHandleImpl implements AsyncHandle {
             }
         });
         return writeFuture;
+    }
+
+    @Override
+    public void executeApplicationTask(Runnable task) {
+        Objects.requireNonNull(task, "task");
+        RejectedExecutionException rejected = server.tryExecuteHandlerTask(task);
+        if (rejected != null) {
+            throw rejected;
+        }
+    }
+
+    @Override
+    public Future<?> scheduleApplicationTask(Runnable task, long delay, TimeUnit unit) {
+        Objects.requireNonNull(task, "task");
+        Objects.requireNonNull(unit, "unit");
+        return server.scheduleTimerCallback(() -> {
+            try {
+                executeApplicationTask(task);
+            } catch (RejectedExecutionException rejected) {
+                complete(rejected);
+            }
+        }, delay, unit);
     }
 
     private static Throwable completionCause(Throwable failure) {

--- a/src/main/java/io/muserver/Mu3Request.java
+++ b/src/main/java/io/muserver/Mu3Request.java
@@ -253,9 +253,10 @@ class Mu3Request implements MuRequest {
     @Override
     public synchronized AsyncHandle handleAsync() {
         if (asyncHandle == null) {
+            Mu3ServerImpl server = (Mu3ServerImpl) connection.server();
             asyncHandle = new Mu3AsyncHandleImpl(this,
                 Objects.requireNonNull(response, "The response has not been initialized"),
-                ((Mu3ServerImpl) connection.server()).asyncExecutor());
+                server);
         }
         if (clientCancelled) {
             asyncHandle.complete();

--- a/src/main/java/io/muserver/rest/AsyncResponseAdapter.java
+++ b/src/main/java/io/muserver/rest/AsyncResponseAdapter.java
@@ -1,75 +1,50 @@
 package io.muserver.rest;
 
 import io.muserver.*;
-import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.ServiceUnavailableException;
 import jakarta.ws.rs.container.AsyncResponse;
 import jakarta.ws.rs.container.CompletionCallback;
 import jakarta.ws.rs.container.ConnectionCallback;
 import jakarta.ws.rs.container.TimeoutHandler;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.jspecify.annotations.Nullable;
 
 import java.util.*;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
 class AsyncResponseAdapter implements AsyncResponse, ResponseCompleteListener {
     private static final Logger log = LoggerFactory.getLogger(AsyncResponseAdapter.class);
 
-    private static final ScheduledExecutorService ses = Executors.newSingleThreadScheduledExecutor();
-
     private final AsyncHandle asyncHandle;
     private final Consumer resultConsumer;
-    private volatile boolean isSuspended;
-    private volatile boolean isCancelled;
-    private volatile boolean isDone;
-    private volatile @Nullable ScheduledFuture<?> cancelEvent;
-    private volatile @Nullable TimeoutHandler timeoutHandler;
+    private final Object stateLock = new Object();
+    private State state = State.SUSPENDED;
+    private boolean cancelled;
+    private long timeoutGeneration;
+    private @Nullable Future<?> timeoutTask;
+    private @Nullable TimeoutHandler timeoutHandler;
     private final List<ConnectionCallback> connectionCallbacks = new ArrayList<>();
     private final List<CompletionCallback> completionCallbacks = new ArrayList<>();
-    private @Nullable Throwable exceptionWhileWriting;
+    private volatile @Nullable Throwable exceptionWhileWriting;
 
     AsyncResponseAdapter(AsyncHandle asyncHandle, Consumer resultConsumer) {
         this.asyncHandle = asyncHandle;
-        isSuspended = true;
-        isCancelled = false;
-        isDone = false;
         this.resultConsumer = resultConsumer;
         asyncHandle.addResponseCompleteHandler(this);
     }
 
     @Override
     public boolean resume(@Nullable Object response) {
-        ScheduledFuture<?> event = cancelEvent;
-        if (event != null) {
-            isCancelled = isCancelled || event.cancel(false);
-            cancelEvent = null;
-        }
-        if (isSuspended) {
-            isSuspended = false;
-            try {
-                resultConsumer.accept(response);
-                asyncHandle.complete();
-            } catch (Exception e) {
-                exceptionWhileWriting = e;
-                asyncHandle.complete(e);
-            } finally {
-                isDone = true;
-            }
-            return true;
-        } else {
-            return false;
-        }
+        return beginResuming(response, false);
     }
 
     @Override
     public boolean resume(Throwable response) {
-        return resume((Object) Objects.requireNonNull(response, "response"));
+        return beginResuming(Objects.requireNonNull(response, "response"), false);
     }
 
     @Override
@@ -88,53 +63,155 @@ class AsyncResponseAdapter implements AsyncResponse, ResponseCompleteListener {
     }
 
     private boolean doCancel(@Nullable Object retryAfterValue) {
-        Response.ResponseBuilder resp = Response.status(503);
+        Response.ResponseBuilder response = Response.status(503);
         if (retryAfterValue != null) {
-            resp.header(HeaderNames.RETRY_AFTER.toString(), retryAfterValue);
+            response.header(HeaderNames.RETRY_AFTER.toString(), retryAfterValue);
         }
-        return resume(resp.build());
+        return beginResuming(response.build(), true);
+    }
+
+    private boolean beginResuming(@Nullable Object response, boolean cancellation) {
+        @Nullable Future<?> timeoutToCancel;
+        synchronized (stateLock) {
+            if (cancellation && cancelled) {
+                return true;
+            }
+            if (state != State.SUSPENDED) {
+                return false;
+            }
+            state = State.RESUMING;
+            cancelled = cancellation;
+            timeoutToCancel = clearTimeoutLocked();
+        }
+        cancel(timeoutToCancel);
+        try {
+            asyncHandle.executeApplicationTask(() -> processResponse(response));
+        } catch (Throwable dispatchFailure) {
+            exceptionWhileWriting = dispatchFailure;
+            markDone();
+            asyncHandle.complete(dispatchFailure);
+        }
+        return true;
+    }
+
+    private void processResponse(@Nullable Object response) {
+        try {
+            if (response instanceof Throwable && !(response instanceof Exception)) {
+                Throwable failure = (Throwable) response;
+                exceptionWhileWriting = failure;
+                asyncHandle.complete(failure);
+            } else {
+                resultConsumer.accept(response);
+                asyncHandle.complete();
+            }
+        } catch (Throwable responseFailure) {
+            exceptionWhileWriting = responseFailure;
+            try {
+                asyncHandle.complete(responseFailure);
+            } catch (Throwable completionFailure) {
+                addSuppressedIfDifferent(responseFailure, completionFailure);
+            }
+        } finally {
+            markDone();
+        }
     }
 
     @Override
     public boolean isSuspended() {
-        return isSuspended;
+        synchronized (stateLock) {
+            return state == State.SUSPENDED;
+        }
     }
 
     @Override
     public boolean isCancelled() {
-        return isCancelled;
+        synchronized (stateLock) {
+            return cancelled;
+        }
     }
 
     @Override
     public boolean isDone() {
-        return isDone;
+        synchronized (stateLock) {
+            return state == State.DONE;
+        }
     }
 
     @Override
     public boolean setTimeout(long time, TimeUnit unit) {
         Objects.requireNonNull(unit, "unit");
-        if (!isSuspended) {
-            return false;
-        }
-        if (cancelEvent != null) {
-            cancelEvent.cancel(false);
-        }
-        cancelEvent = ses.schedule(() -> {
-            TimeoutHandler th = this.timeoutHandler;
-            if (th == null) {
-                resume(new WebApplicationException(Response.status(503)
-                    .type(MediaType.TEXT_HTML_TYPE)
-                    .entity("<h1>503 Service Unavailable</h1><p>Timed out</p>").build()));
-            } else {
-                th.handleTimeout(this);
+        @Nullable Future<?> previousTimeout;
+        long generation;
+        synchronized (stateLock) {
+            if (state != State.SUSPENDED) {
+                return false;
             }
-        }, time, unit);
+            generation = ++timeoutGeneration;
+            previousTimeout = timeoutTask;
+            timeoutTask = null;
+        }
+        cancel(previousTimeout);
+
+        if (time <= 0) {
+            return true;
+        }
+
+        Future<?> scheduled = asyncHandle.scheduleApplicationTask(
+            () -> timeoutExpired(generation),
+            time,
+            unit
+        );
+        boolean keepScheduled;
+        synchronized (stateLock) {
+            keepScheduled = state == State.SUSPENDED && timeoutGeneration == generation;
+            if (keepScheduled) {
+                timeoutTask = scheduled;
+            }
+        }
+        if (!keepScheduled) {
+            scheduled.cancel(false);
+        }
         return true;
+    }
+
+    private void timeoutExpired(long generation) {
+        @Nullable TimeoutHandler handler;
+        synchronized (stateLock) {
+            if (state != State.SUSPENDED || timeoutGeneration != generation) {
+                return;
+            }
+            timeoutTask = null;
+            handler = timeoutHandler;
+        }
+
+        if (handler != null) {
+            try {
+                handler.handleTimeout(this);
+            } catch (Throwable timeoutFailure) {
+                resume(timeoutFailure);
+                return;
+            }
+            synchronized (stateLock) {
+                if (state != State.SUSPENDED || timeoutGeneration != generation) {
+                    return;
+                }
+            }
+        }
+        resume(defaultTimeoutException());
+    }
+
+    private static ServiceUnavailableException defaultTimeoutException() {
+        return new ServiceUnavailableException(Response.status(503)
+            .type(MediaType.TEXT_HTML_TYPE)
+            .entity("<h1>503 Service Unavailable</h1><p>Timed out</p>")
+            .build());
     }
 
     @Override
     public void setTimeoutHandler(TimeoutHandler handler) {
-        this.timeoutHandler = Objects.requireNonNull(handler, "handler");
+        synchronized (stateLock) {
+            timeoutHandler = Objects.requireNonNull(handler, "handler");
+        }
     }
 
     @Override
@@ -157,13 +234,15 @@ class AsyncResponseAdapter implements AsyncResponse, ResponseCompleteListener {
     public Collection<Class<?>> register(Object callback) {
         Objects.requireNonNull(callback, "callback");
         Collection<Class<?>> added = new HashSet<>();
-        if (callback instanceof ConnectionCallback) {
-            added.add(ConnectionCallback.class);
-            connectionCallbacks.add((ConnectionCallback) callback);
-        }
-        if (callback instanceof CompletionCallback) {
-            added.add(CompletionCallback.class);
-            completionCallbacks.add((CompletionCallback) callback);
+        synchronized (stateLock) {
+            if (callback instanceof ConnectionCallback) {
+                added.add(ConnectionCallback.class);
+                connectionCallbacks.add((ConnectionCallback) callback);
+            }
+            if (callback instanceof CompletionCallback) {
+                added.add(CompletionCallback.class);
+                completionCallbacks.add((CompletionCallback) callback);
+            }
         }
         return added;
     }
@@ -173,10 +252,9 @@ class AsyncResponseAdapter implements AsyncResponse, ResponseCompleteListener {
         Objects.requireNonNull(callback, "callback");
         Objects.requireNonNull(callbacks, "callbacks");
         Map<Class<?>, Collection<Class<?>>> added = new HashMap<>();
-        if (callback == null) throw new NullPointerException("callback");
         register(callback, added);
-        for (Object cb : callbacks) {
-            register(Objects.requireNonNull(cb, "callbacks element"), added);
+        for (Object additionalCallback : callbacks) {
+            register(Objects.requireNonNull(additionalCallback, "callbacks element"), added);
         }
         return added;
     }
@@ -184,33 +262,76 @@ class AsyncResponseAdapter implements AsyncResponse, ResponseCompleteListener {
     private void register(Object callback, Map<Class<?>, Collection<Class<?>>> added) {
         Collection<Class<?>> registered = register(callback);
         Class<?> callbackClass = callback.getClass();
-        if (!added.containsKey(callbackClass)) {
-            added.put(callbackClass, new HashSet<>());
-        }
-        added.get(callbackClass).addAll(registered);
+        added.computeIfAbsent(callbackClass, ignored -> new HashSet<>()).addAll(registered);
     }
 
     @Override
     public void onComplete(ResponseInfo info) {
+        List<ConnectionCallback> connectionCallbackSnapshot;
+        List<CompletionCallback> completionCallbackSnapshot;
+        @Nullable Future<?> timeoutToCancel;
+        synchronized (stateLock) {
+            state = State.DONE;
+            timeoutToCancel = clearTimeoutLocked();
+            connectionCallbackSnapshot = new ArrayList<>(connectionCallbacks);
+            completionCallbackSnapshot = new ArrayList<>(completionCallbacks);
+        }
+        cancel(timeoutToCancel);
+
         if (!info.completedSuccessfully() && info.response().responseState() == ResponseState.CLIENT_DISCONNECTED) {
-            for (ConnectionCallback connectionCallback : connectionCallbacks) {
+            for (ConnectionCallback connectionCallback : connectionCallbackSnapshot) {
                 try {
                     connectionCallback.onDisconnect(this);
                 } catch (Exception e) {
-                    log.warn("Exception from calling onDisconnect on " + connectionCallback);
+                    log.warn("Exception from calling onDisconnect on " + connectionCallback, e);
                 }
             }
         }
-        for (CompletionCallback completionCallback : completionCallbacks) {
+        for (CompletionCallback completionCallback : completionCallbackSnapshot) {
             try {
                 completionCallback.onComplete(exceptionWhileWriting);
             } catch (Exception e) {
-                log.warn("Exception from calling onComplete on " + completionCallback);
+                log.warn("Exception from calling onComplete on " + completionCallback, e);
             }
+        }
+    }
+
+    private void markDone() {
+        @Nullable Future<?> timeoutToCancel;
+        synchronized (stateLock) {
+            state = State.DONE;
+            timeoutToCancel = clearTimeoutLocked();
+        }
+        cancel(timeoutToCancel);
+    }
+
+    private @Nullable Future<?> clearTimeoutLocked() {
+        timeoutGeneration++;
+        Future<?> task = timeoutTask;
+        timeoutTask = null;
+        return task;
+    }
+
+    private static void cancel(@Nullable Future<?> future) {
+        if (future != null) {
+            future.cancel(false);
+        }
+    }
+
+    @SuppressWarnings("ReferenceEquality") // Throwable forbids suppressing itself; identity is required.
+    private static void addSuppressedIfDifferent(Throwable failure, Throwable suppressed) {
+        if (failure != suppressed) {
+            failure.addSuppressed(suppressed);
         }
     }
 
     interface Consumer {
         void accept(@Nullable Object response) throws Exception;
+    }
+
+    private enum State {
+        SUSPENDED,
+        RESUMING,
+        DONE
     }
 }

--- a/src/main/java/io/muserver/rest/RestHandler.java
+++ b/src/main/java/io/muserver/rest/RestHandler.java
@@ -22,7 +22,9 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 import java.net.URI;
 import java.util.*;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ExecutionException;
 import java.util.function.Function;
 
 import static io.muserver.rest.CORSConfig.getAllowedMethods;
@@ -150,15 +152,30 @@ public class RestHandler implements MuHandler {
 
             if (!muRequest.isAsync()) {
                 if (result instanceof CompletionStage) {
-                    AsyncHandle asyncHandle1 = muRequest.handleAsync();
+                    AsyncHandle asyncHandle = muRequest.handleAsync();
                     CompletionStage cs = (CompletionStage) result;
-                    cs.thenAccept(o -> {
+                    cs.whenComplete((value, stageFailure) -> {
+                        Runnable continuation = () -> {
+                            @Nullable Throwable failure = stageFailure == null
+                                ? null
+                                : completionCause((Throwable) stageFailure);
+                            if (failure != null && !(failure instanceof Exception)) {
+                                asyncHandle.complete(failure);
+                                return;
+                            }
+                            @Nullable Object response = failure == null ? value : failure;
+                            try {
+                                sendResponse(0, requestContext, muResponse, acceptHeaders, produces, directlyProduces, methodAnnotations, response,
+                                    completionStageResultType(methodReturnType));
+                                asyncHandle.complete();
+                            } catch (Throwable responseFailure) {
+                                asyncHandle.complete(responseFailure);
+                            }
+                        };
                         try {
-                            sendResponse(0, requestContext, muResponse, acceptHeaders, produces, directlyProduces, methodAnnotations, o,
-                                completionStageResultType(methodReturnType));
-                            asyncHandle1.complete();
-                        } catch (Exception e) {
-                            asyncHandle1.complete(e);
+                            asyncHandle.executeApplicationTask(continuation);
+                        } catch (Throwable dispatchFailure) {
+                            asyncHandle.complete(dispatchFailure);
                         }
                     });
                 } else {
@@ -181,6 +198,15 @@ public class RestHandler implements MuHandler {
 
     private static @Nullable Type completionStageResultType(@Nullable Type returnType) {
         return GenericTypeResolver.resolveTypeArgument(returnType, CompletionStage.class, 0);
+    }
+
+    private static Throwable completionCause(Throwable failure) {
+        Throwable cause = failure;
+        while ((cause instanceof CompletionException || cause instanceof ExecutionException)
+            && cause.getCause() != null) {
+            cause = cause.getCause();
+        }
+        return cause;
     }
 
     static @Nullable Object invokeResourceMethod(JaxRSRequest requestContext, MuResponse muResponse, RequestMatcher.MatchedMethod mm, Function<ResourceMethod, @Nullable Object> suspendedParamCallback, EntityProviders entityProviders, CollectionParameterStrategy collectionParameterStrategy) throws Exception {

--- a/src/test/java/io/muserver/rest/AsynchronousProcessingTest.java
+++ b/src/test/java/io/muserver/rest/AsynchronousProcessingTest.java
@@ -26,12 +26,19 @@ import java.io.OutputStream;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Date;
+import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.Queue;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BiConsumer;
 
 import static io.muserver.rest.RestHandlerBuilder.restHandler;
 import static java.util.stream.Collectors.toSet;
@@ -43,7 +50,10 @@ import static scaffolding.MuAssert.assertNotTimedOut;
 
 public class AsynchronousProcessingTest {
 
-    private final ExecutorService executor = Executors.newSingleThreadExecutor();
+    private final List<ExecutorService> executors = new ArrayList<>();
+    private final ExecutorService executor = track(
+        Executors.newSingleThreadExecutor(namedThreads("jaxrs-result-"))
+    );
     private MuServer server;
 
     @Test
@@ -116,6 +126,122 @@ public class AsynchronousProcessingTest {
         ))) {
             assertThat(resp.code(), is(200));
             assertThat(resp.body().string(), equalTo(body));
+        }
+    }
+
+    @Test
+    public void completionStageResultsAreProcessedOnTheHandlerExecutor() throws Exception {
+        var handlerExecutor = track(Executors.newSingleThreadExecutor(namedThreads("handler-")));
+        var asyncExecutor = track(Executors.newSingleThreadExecutor(namedThreads("async-")));
+        var completionExecutor = track(Executors.newSingleThreadExecutor(namedThreads("completion-")));
+        var stage = new CallbackSignallingFuture<ThreadReportingEntity>();
+
+        @Path("samples")
+        class Sample {
+            @GET
+            public CompletionStage<ThreadReportingEntity> go() {
+                completionExecutor.execute(() -> {
+                    assertNotTimedOut("Waiting for the REST continuation", stage.callbackRegistered);
+                    stage.complete(new ThreadReportingEntity());
+                });
+                return stage;
+            }
+        }
+
+        server = ServerUtils.httpsServerForTest("http")
+            .withHandlerExecutor(handlerExecutor)
+            .withAsyncExecutor(asyncExecutor)
+            .addHandler(restHandler(new Sample()).addCustomWriter(threadReportingWriter()))
+            .start();
+
+        try (Response response = call(request().url(server.uri().resolve("/samples").toString()))) {
+            assertThat(response.code(), is(200));
+            assertThat(response.body().string(), startsWith("handler-"));
+        }
+    }
+
+    @Test
+    public void suspendedResponsesAreProcessedOnTheHandlerExecutor() throws Exception {
+        var handlerExecutor = track(Executors.newSingleThreadExecutor(namedThreads("handler-")));
+        var asyncExecutor = track(Executors.newSingleThreadExecutor(namedThreads("async-")));
+        var completionExecutor = track(Executors.newSingleThreadExecutor(namedThreads("completion-")));
+
+        @Path("samples")
+        class Sample {
+            @GET
+            public void go(@Suspended AsyncResponse response) {
+                completionExecutor.execute(() -> response.resume(new ThreadReportingEntity()));
+            }
+        }
+
+        server = ServerUtils.httpsServerForTest("http")
+            .withHandlerExecutor(handlerExecutor)
+            .withAsyncExecutor(asyncExecutor)
+            .addHandler(restHandler(new Sample()).addCustomWriter(threadReportingWriter()))
+            .start();
+
+        try (Response response = call(request().url(server.uri().resolve("/samples").toString()))) {
+            assertThat(response.code(), is(200));
+            assertThat(response.body().string(), startsWith("handler-"));
+        }
+    }
+
+    @Test
+    public void asyncResponseTimeoutsUseTheServerTimerAndRunOnTheHandlerExecutor() throws Exception {
+        var handlerExecutor = track(Executors.newSingleThreadExecutor(namedThreads("handler-")));
+        var asyncExecutor = track(Executors.newSingleThreadExecutor(namedThreads("async-")));
+        var timerExecutor = track(Executors.newSingleThreadScheduledExecutor(namedThreads("timer-")));
+        var timeoutThread = new CompletableFuture<String>();
+
+        @Path("samples")
+        class Sample {
+            @GET
+            public void go(@Suspended AsyncResponse response) {
+                response.setTimeoutHandler(timedOut -> {
+                    timeoutThread.complete(Thread.currentThread().getName());
+                    timedOut.resume(new ThreadReportingEntity());
+                });
+                response.setTimeout(1, TimeUnit.MILLISECONDS);
+            }
+        }
+
+        server = ServerUtils.httpsServerForTest("http")
+            .withHandlerExecutor(handlerExecutor)
+            .withAsyncExecutor(asyncExecutor)
+            .withTimerExecutor(timerExecutor)
+            .addHandler(restHandler(new Sample()).addCustomWriter(threadReportingWriter()))
+            .start();
+
+        try (Response response = call(request().url(server.uri().resolve("/samples").toString()))) {
+            assertThat(response.code(), is(200));
+            assertThat(response.body().string(), startsWith("handler-"));
+        }
+        assertThat(timeoutThread.get(5, TimeUnit.SECONDS), startsWith("handler-"));
+    }
+
+    @Test
+    public void exceptionalCompletionStagesResumeRequestProcessing() throws Exception {
+        var stage = new CallbackSignallingFuture<String>();
+
+        @Path("samples")
+        class Sample {
+            @GET
+            public CompletionStage<String> go() {
+                executor.execute(() -> {
+                    assertNotTimedOut("Waiting for the REST continuation", stage.callbackRegistered);
+                    stage.completeExceptionally(new BadRequestException("Bad async result"));
+                });
+                return stage;
+            }
+        }
+
+        server = ServerUtils.httpsServerForTest("http")
+            .addHandler(restHandler(new Sample()))
+            .start();
+
+        try (Response response = call(request().url(server.uri().resolve("/samples").toString()))) {
+            assertThat(response.code(), is(400));
+            assertThat(response.body().string(), containsString("Bad async result"));
         }
     }
 
@@ -234,6 +360,88 @@ public class AsynchronousProcessingTest {
         }
     }
 
+    @Test
+    public void onlyOneConcurrentResumeClaimsAnAsyncResponse() throws Exception {
+        var asyncHandle = new QueuedAsyncHandle();
+        var consumed = new AtomicInteger();
+        var asyncResponse = new AsyncResponseAdapter(asyncHandle, ignored -> consumed.incrementAndGet());
+        var callers = track(Executors.newFixedThreadPool(8));
+        var start = new CountDownLatch(1);
+        List<Future<Boolean>> attempts = new ArrayList<>();
+        for (int i = 0; i < 100; i++) {
+            attempts.add(callers.submit(() -> {
+                assertNotTimedOut("Waiting to race resume calls", start);
+                return asyncResponse.resume("response");
+            }));
+        }
+
+        start.countDown();
+        int successfulResumes = 0;
+        for (Future<Boolean> attempt : attempts) {
+            if (attempt.get(5, TimeUnit.SECONDS)) {
+                successfulResumes++;
+            }
+        }
+
+        assertThat(successfulResumes, is(1));
+        assertThat(asyncHandle.applicationTasks.size(), is(1));
+        assertThat(asyncResponse.isSuspended(), is(false));
+        assertThat(asyncResponse.isDone(), is(false));
+
+        asyncHandle.runNextApplicationTask();
+        assertThat(consumed.get(), is(1));
+        assertThat(asyncResponse.isDone(), is(true));
+    }
+
+    @Test
+    public void cancellationIsAtomicAndIdempotent() {
+        var asyncHandle = new QueuedAsyncHandle();
+        var sentResponse = new AtomicReference<Object>();
+        var asyncResponse = new AsyncResponseAdapter(asyncHandle, sentResponse::set);
+
+        assertThat(asyncResponse.cancel(), is(true));
+        assertThat(asyncResponse.cancel(), is(true));
+        assertThat(asyncResponse.resume("too late"), is(false));
+        assertThat(asyncResponse.isCancelled(), is(true));
+        assertThat(asyncResponse.isSuspended(), is(false));
+        assertThat(asyncHandle.applicationTasks.size(), is(1));
+
+        asyncHandle.runNextApplicationTask();
+        assertThat(sentResponse.get(), instanceOf(jakarta.ws.rs.core.Response.class));
+        assertThat(((jakarta.ws.rs.core.Response) sentResponse.get()).getStatus(), is(503));
+        assertThat(asyncResponse.isDone(), is(true));
+    }
+
+    @Test
+    public void nonPositiveTimeoutMeansSuspendIndefinitely() {
+        var asyncHandle = new QueuedAsyncHandle();
+        var asyncResponse = new AsyncResponseAdapter(asyncHandle, ignored -> {});
+
+        assertThat(asyncResponse.setTimeout(0, TimeUnit.MILLISECONDS), is(true));
+        assertThat(asyncResponse.setTimeout(-1, TimeUnit.SECONDS), is(true));
+
+        assertThat(asyncHandle.delayedTasks.size(), is(0));
+        assertThat(asyncResponse.isSuspended(), is(true));
+    }
+
+    @Test
+    public void unresolvedCustomTimeoutFallsBackToA503() {
+        var asyncHandle = new QueuedAsyncHandle();
+        var sentResponse = new AtomicReference<Object>();
+        var handlerInvocations = new AtomicInteger();
+        var asyncResponse = new AsyncResponseAdapter(asyncHandle, sentResponse::set);
+        asyncResponse.setTimeoutHandler(ignored -> handlerInvocations.incrementAndGet());
+
+        assertThat(asyncResponse.setTimeout(1, TimeUnit.MILLISECONDS), is(true));
+        asyncHandle.runNextDelayedTask();
+
+        assertThat(handlerInvocations.get(), is(1));
+        assertThat(asyncHandle.applicationTasks.size(), is(1));
+        asyncHandle.runNextApplicationTask();
+        assertThat(sentResponse.get(), instanceOf(ServiceUnavailableException.class));
+        assertThat(asyncResponse.isDone(), is(true));
+    }
+
 
     @Test
     public void completionCallbacksCanBeRegistered() {
@@ -308,7 +516,111 @@ public class AsynchronousProcessingTest {
 
     @AfterEach
     public void stop() {
-        MuAssert.stopAndCheck(server);
+        try {
+            MuAssert.stopAndCheck(server);
+        } finally {
+            for (ExecutorService executorService : executors) {
+                executorService.shutdownNow();
+            }
+        }
+    }
+
+    private <T extends ExecutorService> T track(T executorService) {
+        executors.add(executorService);
+        return executorService;
+    }
+
+    private static ThreadFactory namedThreads(String prefix) {
+        var count = new AtomicInteger();
+        return runnable -> new Thread(runnable, prefix + count.incrementAndGet());
+    }
+
+    private static MessageBodyWriter<ThreadReportingEntity> threadReportingWriter() {
+        return new MessageBodyWriter<ThreadReportingEntity>() {
+            @Override
+            public boolean isWriteable(Class<?> type, Type genericType, Annotation[] annotations,
+                                       jakarta.ws.rs.core.MediaType mediaType) {
+                return type == ThreadReportingEntity.class;
+            }
+
+            @Override
+            public void writeTo(ThreadReportingEntity entity, Class<?> type, Type genericType,
+                                Annotation[] annotations, jakarta.ws.rs.core.MediaType mediaType,
+                                MultivaluedMap<String, Object> httpHeaders, OutputStream entityStream)
+                throws IOException {
+                entityStream.write(Thread.currentThread().getName().getBytes(StandardCharsets.UTF_8));
+            }
+        };
+    }
+
+    private static final class ThreadReportingEntity {
+    }
+
+    private static final class CallbackSignallingFuture<T> extends CompletableFuture<T> {
+        private final CountDownLatch callbackRegistered = new CountDownLatch(1);
+
+        @Override
+        public CompletableFuture<T> whenComplete(
+            BiConsumer<? super T, ? super Throwable> action
+        ) {
+            CompletableFuture<T> continuation = super.whenComplete(action);
+            callbackRegistered.countDown();
+            return continuation;
+        }
+    }
+
+    private static final class QueuedAsyncHandle implements AsyncHandle {
+        private final Queue<Runnable> applicationTasks = new ConcurrentLinkedQueue<>();
+        private final Queue<Runnable> delayedTasks = new ConcurrentLinkedQueue<>();
+        private final AtomicReference<ResponseCompleteListener> responseCompleteListener = new AtomicReference<>();
+
+        @Override
+        public void setReadListener(RequestBodyListener readListener) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void complete() {
+        }
+
+        @Override
+        public void complete(Throwable throwable) {
+        }
+
+        @Override
+        public void write(ByteBuffer data, DoneCallback callback) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Future<Void> write(ByteBuffer data) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void executeApplicationTask(Runnable task) {
+            applicationTasks.add(task);
+        }
+
+        @Override
+        public Future<?> scheduleApplicationTask(Runnable task, long delay, TimeUnit unit) {
+            var delayed = new FutureTask<Void>(task, null);
+            delayedTasks.add(delayed);
+            return delayed;
+        }
+
+        @Override
+        public void addResponseCompleteHandler(ResponseCompleteListener listener) {
+            responseCompleteListener.set(listener);
+        }
+
+        private void runNextApplicationTask() {
+            Objects.requireNonNull(applicationTasks.poll(), "No application task queued").run();
+        }
+
+        private void runNextDelayedTask() {
+            Objects.requireNonNull(delayedTasks.poll(), "No delayed task queued").run();
+        }
     }
 
 }


### PR DESCRIPTION
## Summary

- add binary/source-compatible default `AsyncHandle` primitives for immediate and delayed application continuations
- make Mu Server handles dispatch those continuations through the configured handler domain (with the existing async fallback), while using the configured timer only to determine when delayed work is due
- process `CompletionStage` results and failures on an application executor; exceptional stages now resume instead of hanging
- replace `AsyncResponseAdapter`'s private static scheduler and racy volatile flags with a locked `SUSPENDED -> RESUMING -> DONE` state machine
- make concurrent resume single-winner, cancellation atomic/idempotent, timeout replacement generation-safe, callback registration safe, and client completion cancel pending timers

## Contract and compatibility

The new `AsyncHandle` methods are default methods, so existing implementations remain source and binary compatible. Mu Server-provided handles never run these continuations on the caller or timer thread; the default methods retain workable behavior for third-party test/custom implementations.

This follows Jakarta REST 3.1 asynchronous-processing rules: only a suspended response can be resumed, cancellation is idempotent, non-positive timeouts suspend indefinitely, and an unresolved timeout produces `ServiceUnavailableException` with status 503. The existing default timeout status, content type, and HTML body are preserved.

Specification: https://jakarta.ee/specifications/restful-ws/3.1/jakarta-restful-ws-spec-3.1.html#asynchronous_processing

## Validation

- `mise exec java@temurin-11 -- mvn test` (1,638 tests, 5 skipped)
- `mise exec java@temurin-11 -- mvn -Dtest=ExecutionDomainsTest,io.muserver.rest.AsynchronousProcessingTest test` (54 tests after stacking the latest parent fix)
- `mise exec java@temurin-21 -- mvn -Pnullaway -DskipTests test`
- deterministic tests cover external stage completion, exceptional stages, external resume, configured timers, 100 racing resumes, cancellation idempotency, indefinite timeouts, and unresolved custom timeout fallback