### PR TITLE
Model nested application execution turns

### DIFF
--- a/HTTP2-CONCURRENCY.md
+++ b/HTTP2-CONCURRENCY.md
@@ -10,13 +10,13 @@ this model.
 
 The outbound coordinator, outbound flow-control ownership, stream-state
 transitions, reset ordering, and separation of protocol lifetime from
-application exchange lifetime are implemented. Connection setup and the two
-long-lived HTTP/2 I/O tasks now use a connection executor that is independent
-of `MuServerBuilder.withHandlerExecutor`. Handler-executor rejection is handled
-as a 503 response on the affected stream while the connection remains usable.
-Scheduled connection maintenance and connection idle-timeout scans now use a
-server timer that is independent of both executors; when work becomes due, the
-timer dispatches it to the connection executor.
+application exchange lifetime are implemented. Connection setup and HTTP/2
+readers use a connection executor that is independent of
+`MuServerBuilder.withHandlerExecutor`; serialized HTTP/2 writer drains use
+their own executor. Handler-executor rejection is handled as a 503 response on
+the affected stream while the connection remains usable. Scheduled connection
+maintenance and connection idle-timeout scans use a server timer that dispatches
+due work to a separate maintenance executor.
 
 SETTINGS acknowledgement expiry now runs on the server timer and is serialized
 as a coordinator connection-error command; it no longer changes the socket
@@ -40,11 +40,18 @@ The model must:
 
 ## Execution domains
 
-The executor allocation in this section is implemented. Routing every
-application callback to the application executor and some finer-grained
-ownership rules remain the target for later phases, as called out below.
+The executor allocation and application-turn rules in this section are
+implemented. Some finer-grained protocol ownership rules remain the target for
+later phases, as called out below.
 
-There are two execution domains and one timer facility.
+There are five execution domains and one timer facility:
+
+* connection input;
+* HTTP/2 output;
+* connection maintenance;
+* request handling and application continuations;
+* asynchronous application I/O; and
+* timer scheduling.
 
 ### Connection I/O
 
@@ -53,51 +60,71 @@ Each HTTP/2 connection has:
 * one blocking socket reader; and
 * one protocol coordinator that also owns socket writes.
 
-These tasks run independently of request handlers. The connection reader owns
-the input stream, read buffer, and HPACK decoder. The target end state is for it
-to turn every logical frame into a coordinator command without mutating
-connection or stream protocol state; migration of the remaining reader-owned
-protocol mutations is not complete.
+These tasks run independently of request handlers and independently of each
+other. The connection reader is a long-lived task on the executor configured
+by `MuServerBuilder.withConnectionExecutor`. It owns the input stream, read
+buffer, and HPACK decoder. The target end state is for it to turn every logical
+frame into a coordinator command without mutating connection or stream protocol
+state; migration of the remaining reader-owned protocol mutations is not
+complete.
 
 The coordinator already serializes outbound protocol state and is the only code
-that writes to the socket. It will become the sole owner of all connection and
-stream protocol state as the remaining state is migrated.
+that writes to the socket. It schedules short serialized drains on the executor
+configured by `MuServerBuilder.withHttp2WriterExecutor`; an idle or
+flow-control-blocked connection does not retain a writer worker. The coordinator
+will become the sole owner of all connection and stream protocol state as the
+remaining state is migrated.
 
-Connection I/O uses a server-owned executor whose default provides prompt
-execution for long-lived tasks: virtual threads where available, otherwise a
-separate cached thread pool. A custom executor can be supplied through
-`MuServerBuilder.withConnectionExecutor`; it must provide independent progress
-for both long-lived tasks of every active HTTP/2 connection, plus short
-connection setup and timed maintenance tasks. Supplying a bounded executor
-without that capacity can starve connection work.
+Timed connection work runs on
+`MuServerBuilder.withConnectionMaintenanceExecutor`, not on a reader or writer.
+The three executors have independent defaults. Sharing a bounded executor
+between long-lived readers and work needed to make output or maintenance
+progress can starve the latter and is unsupported.
 
 ### Application work
 
-The executor configured by `MuServerBuilder.withHandlerExecutor` runs user and
-application work:
+The executor configured by `MuServerBuilder.withHandlerExecutor` runs:
 
 * request handlers;
-* asynchronous request-body listeners;
-* asynchronous response work and callbacks;
 * exception handlers; and
-* response-completion listeners.
+* response-completion listeners;
+* serialized WebSocket callbacks; and
+* application continuations such as JAX-RS asynchronous response processing.
 
-It never runs a connection reader or coordinator. Rejection by this executor is
-handled as rejection of an individual request, not failure of the HTTP/2
-connection.
+The executor configured by `MuServerBuilder.withAsyncExecutor` runs
+asynchronous request-body listeners, asynchronous response writes and their
+callbacks, request-rejection notifications, and deprecated asynchronous
+WebSocket adapters. Handler-oriented detached callbacks may use it as a
+fallback when the handler executor rejects them. Operations whose contract
+specifically requires the async executor fail when that executor rejects them.
 
-Callback routing is not yet complete: in particular, some request-rejection and
-connection-timeout notifications can still be made from connection work. Those
-paths must move to the application executor without making protocol progress
-depend on callback completion.
+Neither application executor runs a connection reader, writer, or timer
+callback. Rejection of a new handler is handled as rejection of that individual
+request, not failure of the HTTP/2 connection. Rejection of continuation work
+for an already accepted exchange completes or aborts that exchange explicitly;
+it must not silently strand the stream.
+
+Application callbacks execute in a per-server application turn. A turn records
+both the requested executor and any fallback executor that actually accepted
+the task. Work submitted from that turn to either occupied executor is appended
+to a thread-confined FIFO and drained before the worker is released. It is not
+recursively invoked and is not submitted back to an executor whose only worker
+may be the current thread. Work targeting a distinct required executor is still
+dispatched there.
+
+This rule makes a shared single-worker non-queueing executor usable without
+collapsing the handler and async domains when separate executors are configured.
+The turn marker is installed only around application work and is always removed
+before returning a caller-owned worker to its executor.
 
 ### Timers
 
-A single server timer determines when scheduled connection work is due. The
-default is one server-owned platform thread, and a custom
+A single server timer determines when scheduled work is due. The default is one
+server-owned platform thread, and a custom
 `ScheduledExecutorService` can be supplied through
-`MuServerBuilder.withTimerExecutor`. Timer callbacks dispatch due work to the
-connection executor; periodic dispatch is coalesced so a delayed connection
+`MuServerBuilder.withTimerExecutor`. Timer callbacks dispatch due connection
+work to the maintenance executor and due application work to an application
+executor. Periodic connection dispatch is coalesced so a delayed maintenance
 executor does not accumulate duplicate work. Timer threads do not mutate
 protocol state, perform socket I/O, or invoke user code.
 
@@ -272,6 +299,8 @@ Permitted cross-thread primitives are deliberately narrow:
 * a small promise backed by a latch and a result or error;
 * the existing request-body buffer lock and condition;
 * an application-side lock that orders async response submissions; and
+* a thread-confined FIFO that drains nested application work without recursive
+  calls or executor resubmission; and
 * atomics for idempotent resource closure.
 
 Protocol state, stream maps, flow-control windows, and pending-write queues are

--- a/src/main/java/io/muserver/AsyncHandle.java
+++ b/src/main/java/io/muserver/AsyncHandle.java
@@ -58,9 +58,11 @@ public interface AsyncHandle {
      * Executes an application continuation for this exchange.
      *
      * <p>Handles supplied by Mu Server dispatch the task to the request-handler
-     * execution domain and never run it on the calling thread. This is useful when an
-     * asynchronous result becomes available on an executor that should not perform
-     * response serialization or invoke application callbacks.</p>
+     * execution domain when called from outside a Mu Server application callback.
+     * Tasks submitted by an application callback stay in the same execution turn and
+     * run after the current callback returns. This is useful when an asynchronous
+     * result becomes available on an executor that should not perform response
+     * serialization or invoke application callbacks.</p>
      *
      * <p>The default implementation runs the task immediately to retain compatibility
      * with custom implementations of this interface.</p>

--- a/src/main/java/io/muserver/Http1Connection.java
+++ b/src/main/java/io/muserver/Http1Connection.java
@@ -223,17 +223,19 @@ class Http1Connection extends BaseHttpConnection {
 
     private HandlerExecution handleExchangeOnHandlerExecutor(Mu3Request request, Http1Response response) throws Throwable {
         if (handlersRunOnConnectionTask) {
-            return HandlerExecution.accepted(handleExchange(request, response));
+            return HandlerExecution.accepted(
+                server.callHandlerApplicationTask(() -> handleExchange(request, response))
+            );
         }
         CompletableFuture<@Nullable CompletableFuture<@Nullable Void>> completion = new CompletableFuture<>();
         try {
-            handlerExecutor.execute(() -> {
+            handlerExecutor.execute(server.handlerApplicationTask(() -> {
                 try {
                     completion.complete(handleExchange(request, response));
                 } catch (Throwable t) {
                     completion.completeExceptionally(t);
                 }
-            });
+            }));
         } catch (RejectedExecutionException rejected) {
             return HandlerExecution.rejected();
         }
@@ -260,7 +262,10 @@ class Http1Connection extends BaseHttpConnection {
     private void handleAsyncExceptionOnHandler(Mu3Request request, Http1Response response,
                                                Exception failure) throws Throwable {
         if (handlersRunOnConnectionTask) {
-            handleExchangeException(request, response, failure);
+            server.callHandlerApplicationTask(() -> {
+                handleExchangeException(request, response, failure);
+                return null;
+            });
             return;
         }
         CompletableFuture<@Nullable Void> handled = new CompletableFuture<>();
@@ -286,7 +291,7 @@ class Http1Connection extends BaseHttpConnection {
     private void onExchangeEndedOnHandler(Http1Response response) {
         recordExchangeEnded(response);
         if (handlersRunOnConnectionTask) {
-            notifyExchangeEnded(response);
+            server.runHandlerApplicationTask(() -> notifyExchangeEnded(response));
             return;
         }
         server.executeResponseCompletionTask(() -> notifyExchangeEnded(response));
@@ -461,10 +466,6 @@ class Http1Connection extends BaseHttpConnection {
         if (cur != null && cur.websocket != null) {
             cur.websocket.onTimeout();
         }
-    }
-
-    ExecutorService webSocketHandlerExecutor() {
-        return handlerExecutor;
     }
 
     void wakeWebSocketReader() {

--- a/src/main/java/io/muserver/Http2Connection.java
+++ b/src/main/java/io/muserver/Http2Connection.java
@@ -1170,7 +1170,7 @@ class Http2Connection extends BaseHttpConnection implements Http2Peer, CreditAva
 
         onRequestStarted(stream.request);
         try {
-            handlerExecutor.submit(() -> startHandledStream(stream));
+            handlerExecutor.submit(server.handlerApplicationTask(() -> startHandledStream(stream)));
         } catch (RejectedExecutionException e) {
             server.onRequestSubmissionRejected(stream.request);
             rejectRequestDueToHandlerOverload(frame, stream);
@@ -1221,7 +1221,7 @@ class Http2Connection extends BaseHttpConnection implements Http2Peer, CreditAva
             }
             stream.abandonApplicationExchange();
         } finally {
-            onExchangeEnded(stream, false);
+            onExchangeEnded(stream);
         }
     }
 
@@ -1249,7 +1249,7 @@ class Http2Connection extends BaseHttpConnection implements Http2Peer, CreditAva
                 stream.cancel(new IOException("Unhandled stream exception", e), false);
             }
         } finally {
-            onExchangeEnded(stream, true);
+            onExchangeEnded(stream);
         }
     }
 
@@ -1385,21 +1385,15 @@ class Http2Connection extends BaseHttpConnection implements Http2Peer, CreditAva
 
     @Override
     protected void onExchangeEnded(ResponseInfo exchange) {
-        onExchangeEnded((Http2Stream) exchange, false);
+        onExchangeEnded((Http2Stream) exchange);
     }
 
-    private void onExchangeEnded(
-        Http2Stream stream,
-        boolean alreadyOnApplicationExecutor
-    ) {
+    private void onExchangeEnded(Http2Stream stream) {
         stream.onApplicationExchangeEnded();
         applicationExchangeEndedForWrites(stream.id);
         signalWriteLoop();
         recordExchangeEnded(stream);
-        server.executeResponseCompletionTask(
-            () -> notifyExchangeEnded(stream),
-            alreadyOnApplicationExecutor
-        );
+        server.executeResponseCompletionTask(() -> notifyExchangeEnded(stream));
     }
 
     void removeProtocolStream(Http2Stream stream) {

--- a/src/main/java/io/muserver/Mu3AsyncHandleImpl.java
+++ b/src/main/java/io/muserver/Mu3AsyncHandleImpl.java
@@ -19,13 +19,13 @@ class Mu3AsyncHandleImpl implements AsyncHandle {
     private final CompletableFuture<@Nullable Void> completionFuture = new CompletableFuture<>();
     private final Lock lock = new ReentrantLock();
     private final Mu3ServerImpl server;
-    private final ExecutorService asyncExecutor;
+    private final Executor asyncExecutor;
 
     Mu3AsyncHandleImpl(Mu3Request request, BaseResponse response, Mu3ServerImpl server) {
         this.request = request;
         this.response = response;
         this.server = server;
-        this.asyncExecutor = server.asyncExecutor();
+        this.asyncExecutor = server::executeAsyncApplicationTask;
     }
 
     CompletableFuture<@Nullable Void> exchangeCompletion() {
@@ -73,9 +73,9 @@ class Mu3AsyncHandleImpl implements AsyncHandle {
                 return;
             }
             try {
-                asyncExecutor.execute(this::readNext);
-            } catch (RuntimeException t) {
-                fail(t, false);
+                server.executeAsyncApplicationTask(this::readNext);
+            } catch (RejectedExecutionException rejected) {
+                fail(rejected, false);
             }
         }
 

--- a/src/main/java/io/muserver/Mu3ServerImpl.java
+++ b/src/main/java/io/muserver/Mu3ServerImpl.java
@@ -50,6 +50,7 @@ class Mu3ServerImpl implements MuServer {
     private final boolean ownsConnectionMaintenanceExecutor;
     private final ScheduledExecutorService timerExecutor;
     private final boolean ownsTimerExecutor;
+    private final ThreadLocal<ApplicationTaskContext> applicationTaskContext = new ThreadLocal<>();
     private final Phaser detachedApplicationTasks = new Phaser() {
         @Override
         protected boolean onAdvance(int phase, int registeredParties) {
@@ -168,15 +169,10 @@ class Mu3ServerImpl implements MuServer {
     }
 
     void executeResponseCompletionTask(Runnable task) {
-        executeResponseCompletionTask(task, false);
-    }
-
-    void executeResponseCompletionTask(Runnable task, boolean alreadyOnApplicationExecutor) {
         executeTrackedApplicationTask(
             task,
             true,
-            "response completion callback",
-            alreadyOnApplicationExecutor
+            "response completion callback"
         );
     }
 
@@ -184,15 +180,6 @@ class Mu3ServerImpl implements MuServer {
         Runnable task,
         boolean preferHandlerExecutor,
         String description
-    ) {
-        executeTrackedApplicationTask(task, preferHandlerExecutor, description, false);
-    }
-
-    private void executeTrackedApplicationTask(
-        Runnable task,
-        boolean preferHandlerExecutor,
-        String description,
-        boolean alreadyOnApplicationExecutor
     ) {
         detachedApplicationTasks.register();
         Runnable trackedTask = () -> {
@@ -202,10 +189,6 @@ class Mu3ServerImpl implements MuServer {
                 detachedApplicationTasks.arriveAndDeregister();
             }
         };
-        if (alreadyOnApplicationExecutor) {
-            trackedTask.run();
-            return;
-        }
         RejectedExecutionException rejected = preferHandlerExecutor
             ? tryExecuteHandlerTask(trackedTask)
             : tryExecuteAsyncTask(trackedTask);
@@ -224,23 +207,54 @@ class Mu3ServerImpl implements MuServer {
         return tryExecuteApplicationTask(task, handlerExecutor, asyncExecutor);
     }
 
-    private @Nullable RejectedExecutionException tryExecuteAsyncTask(Runnable task) {
+    @Nullable RejectedExecutionException tryExecuteAsyncTask(Runnable task) {
         return tryExecuteApplicationTask(task, asyncExecutor, handlerExecutor);
     }
 
+    void executeAsyncApplicationTask(Runnable task) {
+        RejectedExecutionException rejected = tryExecuteRequiredAsyncTask(task);
+        if (rejected != null) {
+            throw rejected;
+        }
+    }
+
     @SuppressWarnings("ReferenceEquality") // Execution-domain identity belongs to the exact executor instance.
-    private static @Nullable RejectedExecutionException tryExecuteApplicationTask(
+    private @Nullable RejectedExecutionException tryExecuteRequiredAsyncTask(Runnable task) {
+        ApplicationTaskContext currentContext = applicationTaskContext.get();
+        if (currentContext != null && currentContext.includes(asyncExecutor)) {
+            currentContext.tasks.add(task);
+            return null;
+        }
+        try {
+            asyncExecutor.execute(applicationTask(asyncExecutor, asyncExecutor, task));
+            return null;
+        } catch (RejectedExecutionException rejected) {
+            return rejected;
+        }
+    }
+
+    @SuppressWarnings("ReferenceEquality") // Execution-domain identity belongs to the exact executor instance.
+    private @Nullable RejectedExecutionException tryExecuteApplicationTask(
         Runnable task,
         ExecutorService primaryExecutor,
         ExecutorService fallbackExecutor
     ) {
+        ApplicationTaskContext currentContext = applicationTaskContext.get();
+        if (currentContext != null && currentContext.includes(primaryExecutor)) {
+            currentContext.tasks.add(task);
+            return null;
+        }
         try {
-            primaryExecutor.execute(task);
+            primaryExecutor.execute(applicationTask(primaryExecutor, primaryExecutor, task));
             return null;
         } catch (RejectedExecutionException primaryRejected) {
             if (fallbackExecutor != primaryExecutor) {
+                if (currentContext != null && currentContext.includes(fallbackExecutor)) {
+                    currentContext.tasks.add(task);
+                    return null;
+                }
                 try {
-                    fallbackExecutor.execute(task);
+                    fallbackExecutor.execute(applicationTask(primaryExecutor, fallbackExecutor, task));
                     return null;
                 } catch (RejectedExecutionException fallbackRejected) {
                     fallbackRejected.addSuppressed(primaryRejected);
@@ -248,6 +262,138 @@ class Mu3ServerImpl implements MuServer {
                 }
             }
             return primaryRejected;
+        }
+    }
+
+    Runnable handlerApplicationTask(Runnable task) {
+        return applicationTask(handlerExecutor, handlerExecutor, task);
+    }
+
+    private Runnable applicationTask(
+        ExecutorService requestedExecutor,
+        ExecutorService executingExecutor,
+        Runnable task
+    ) {
+        Objects.requireNonNull(task, "task");
+        return () -> runApplicationTask(requestedExecutor, executingExecutor, task);
+    }
+
+    void runHandlerApplicationTask(Runnable task) {
+        runApplicationTask(handlerExecutor, handlerExecutor, task);
+    }
+
+    private void runApplicationTask(
+        ExecutorService requestedExecutor,
+        ExecutorService executingExecutor,
+        Runnable task
+    ) {
+        Objects.requireNonNull(task, "task");
+        ApplicationTaskContext currentContext = applicationTaskContext.get();
+        if (currentContext != null) {
+            if (currentContext.includes(requestedExecutor)) {
+                currentContext.tasks.add(task);
+                return;
+            }
+            throw new IllegalStateException("Cannot enter a different application execution domain");
+        }
+
+        ApplicationTaskContext newContext =
+            new ApplicationTaskContext(requestedExecutor, executingExecutor);
+        newContext.tasks.add(task);
+        applicationTaskContext.set(newContext);
+        @Nullable Throwable failure = null;
+        try {
+            failure = drainApplicationTasks(newContext, null);
+        } finally {
+            applicationTaskContext.remove();
+        }
+        if (failure != null) {
+            throwUnchecked(failure);
+        }
+    }
+
+    <T> @Nullable T callHandlerApplicationTask(ApplicationCallable<T> task) throws Throwable {
+        Objects.requireNonNull(task, "task");
+        ApplicationTaskContext currentContext = applicationTaskContext.get();
+        if (currentContext != null) {
+            if (currentContext.includes(handlerExecutor)) {
+                return task.call();
+            }
+            throw new IllegalStateException("Cannot enter the handler execution domain from another application domain");
+        }
+
+        ApplicationTaskContext newContext =
+            new ApplicationTaskContext(handlerExecutor, handlerExecutor);
+        applicationTaskContext.set(newContext);
+        @Nullable T result = null;
+        @Nullable Throwable failure = null;
+        try {
+            try {
+                result = task.call();
+            } catch (Throwable taskFailure) {
+                failure = taskFailure;
+            }
+            failure = drainApplicationTasks(newContext, failure);
+        } finally {
+            applicationTaskContext.remove();
+        }
+        if (failure != null) {
+            throw failure;
+        }
+        return result;
+    }
+
+    @SuppressWarnings("ReferenceEquality") // Throwable forbids suppressing itself; identity is required.
+    private static @Nullable Throwable drainApplicationTasks(
+        ApplicationTaskContext context,
+        @Nullable Throwable failure
+    ) {
+        Runnable task;
+        while ((task = context.tasks.poll()) != null) {
+            try {
+                task.run();
+            } catch (Throwable taskFailure) {
+                if (failure == null) {
+                    failure = taskFailure;
+                } else if (failure != taskFailure) {
+                    failure.addSuppressed(taskFailure);
+                }
+            }
+        }
+        return failure;
+    }
+
+    private static void throwUnchecked(Throwable failure) {
+        if (failure instanceof RuntimeException) {
+            throw (RuntimeException) failure;
+        }
+        if (failure instanceof Error) {
+            throw (Error) failure;
+        }
+        throw new MuException("Application task failed", failure);
+    }
+
+    @FunctionalInterface
+    interface ApplicationCallable<T> {
+        @Nullable T call() throws Throwable;
+    }
+
+    private static final class ApplicationTaskContext {
+        private final ExecutorService requestedExecutor;
+        private final ExecutorService executingExecutor;
+        private final Queue<Runnable> tasks = new ArrayDeque<>();
+
+        private ApplicationTaskContext(
+            ExecutorService requestedExecutor,
+            ExecutorService executingExecutor
+        ) {
+            this.requestedExecutor = requestedExecutor;
+            this.executingExecutor = executingExecutor;
+        }
+
+        @SuppressWarnings("ReferenceEquality") // Execution-domain identity belongs to the exact executor instance.
+        private boolean includes(ExecutorService executor) {
+            return requestedExecutor == executor || executingExecutor == executor;
         }
     }
 

--- a/src/main/java/io/muserver/WebsocketConnection.java
+++ b/src/main/java/io/muserver/WebsocketConnection.java
@@ -34,8 +34,8 @@ class WebsocketConnection implements MuWebSocketSession {
 
     private volatile WebsocketSessionState state = WebsocketSessionState.NOT_STARTED;
     private final Http1Connection httpConnection;
+    private final Mu3ServerImpl server;
     private final MuWebSocket webSocket;
-    private final ExecutorService handlerExecutor;
     private final boolean eventsRunOnConnectionTask;
     private final Queue<ApplicationEventTask> applicationEvents = new ConcurrentLinkedQueue<>();
     private final AtomicBoolean applicationEventRunnerScheduled = new AtomicBoolean();
@@ -73,9 +73,9 @@ class WebsocketConnection implements MuWebSocketSession {
 
     WebsocketConnection(Http1Connection httpConnection, MuWebSocket webSocket, WebSocketHandlerBuilder.Settings settings) {
         this.httpConnection = httpConnection;
+        this.server = httpConnection.serverImpl();
         this.webSocket = webSocket;
         this.settings = settings;
-        this.handlerExecutor = httpConnection.webSocketHandlerExecutor();
         this.eventsRunOnConnectionTask = httpConnection.webSocketEventsRunOnConnectionTask();
         if (settings.pingIntervalMillis == 0) {
             pingBuffer = null;
@@ -95,9 +95,8 @@ class WebsocketConnection implements MuWebSocketSession {
     }
 
     ExecutorService asyncExecutor() {
-        return httpConnection.serverImpl().asyncExecutor();
+        return server.asyncExecutor();
     }
-
 
     private void startPinging() {
         pingFuture = httpConnection.serverImpl().scheduleConnectionTask(() -> {
@@ -405,7 +404,7 @@ class WebsocketConnection implements MuWebSocketSession {
     private void invokeApplicationEvent(ApplicationEvent event) throws Exception {
         if (eventsRunOnConnectionTask) {
             try {
-                event.run();
+                callApplicationEvent(event);
             } finally {
                 // A terminal event can be queued by a write attempted inside a callback.
                 // Drain it before returning to the blocking socket read.
@@ -428,6 +427,19 @@ class WebsocketConnection implements MuWebSocketSession {
                 throw (Error) cause;
             }
             throw new MuException("Unexpected WebSocket callback failure", cause);
+        }
+    }
+
+    private void callApplicationEvent(ApplicationEvent event) throws Exception {
+        try {
+            server.callHandlerApplicationTask(() -> {
+                event.run();
+                return null;
+            });
+        } catch (Exception | Error failure) {
+            throw failure;
+        } catch (Throwable failure) {
+            throw new MuException("Unexpected WebSocket callback failure", failure);
         }
     }
 
@@ -470,26 +482,13 @@ class WebsocketConnection implements MuWebSocketSession {
         return task.completion;
     }
 
-    @SuppressWarnings("ReferenceEquality") // Execution-domain identity belongs to the exact executor instance.
     private void scheduleApplicationEventRunner() {
         if (!applicationEventRunnerScheduled.compareAndSet(false, true)) {
             return;
         }
-        try {
-            handlerExecutor.execute(this::runApplicationEvents);
-        } catch (RejectedExecutionException handlerRejected) {
-            ExecutorService fallbackExecutor = asyncExecutor();
-            if (fallbackExecutor != handlerExecutor) {
-                try {
-                    fallbackExecutor.execute(this::runApplicationEvents);
-                    return;
-                } catch (RejectedExecutionException asyncRejected) {
-                    asyncRejected.addSuppressed(handlerRejected);
-                    failApplicationEvents(asyncRejected);
-                    return;
-                }
-            }
-            failApplicationEvents(handlerRejected);
+        RejectedExecutionException rejected = server.tryExecuteHandlerTask(this::runApplicationEvents);
+        if (rejected != null) {
+            failApplicationEvents(rejected);
         }
     }
 
@@ -516,7 +515,7 @@ class WebsocketConnection implements MuWebSocketSession {
         ApplicationEventTask task;
         while ((task = applicationEvents.poll()) != null) {
             try {
-                task.event.run();
+                callApplicationEvent(task.event);
                 task.completion.complete(null);
             } catch (Throwable t) {
                 task.completion.completeExceptionally(t);

--- a/src/test/java/io/muserver/ExecutionDomainsTest.java
+++ b/src/test/java/io/muserver/ExecutionDomainsTest.java
@@ -1075,8 +1075,8 @@ class ExecutionDomainsTest {
                 handle.addResponseCompleteHandler(info ->
                     completionThread.complete(Thread.currentThread().getName())
                 );
-                suspendedHandle.complete(handle);
                 handlerExecutor.shutdown();
+                suspendedHandle.complete(handle);
                 return true;
             })
             .start();
@@ -1090,7 +1090,9 @@ class ExecutionDomainsTest {
                 true,
                 RFCTestUtils.getHelloHeaders("http", server.uri().getPort())
             )).flush();
-            suspendedHandle.get(5, TimeUnit.SECONDS).complete(new IOException("async failure"));
+            AsyncHandle handle = suspendedHandle.get(5, TimeUnit.SECONDS);
+            assertThat(handlerExecutor.awaitTermination(5, TimeUnit.SECONDS), equalTo(true));
+            handle.complete(new IOException("async failure"));
 
             Http2HeadersFrame responseHeaders =
                 RFCTestUtils.readIgnoringWindowUpdates(connection, Http2HeadersFrame.class);

--- a/src/test/java/io/muserver/ExecutionDomainsTest.java
+++ b/src/test/java/io/muserver/ExecutionDomainsTest.java
@@ -575,6 +575,70 @@ class ExecutionDomainsTest {
     }
 
     @Test
+    void oneSharedNonQueueingWorkerCanReadAndEchoARequestBody() throws Exception {
+        var applicationExecutor = track(new ThreadPoolExecutor(
+            1,
+            1,
+            0,
+            TimeUnit.MILLISECONDS,
+            new SynchronousQueue<>(),
+            namedThreads("application-")
+        ));
+        var callbackThreads = new CopyOnWriteArrayList<String>();
+        byte[] payload = new byte[20_000];
+        for (int i = 0; i < payload.length; i++) {
+            payload[i] = (byte) ('a' + (i % 26));
+        }
+        server = httpServer()
+            .withHandlerExecutor(applicationExecutor)
+            .withAsyncExecutor(applicationExecutor)
+            .addHandler(Method.POST, "/", (request, response, pathParams) -> {
+                AsyncHandle handle = request.handleAsync();
+                handle.setReadListener(new RequestBodyListener() {
+                    @Override
+                    public void onDataReceived(ByteBuffer data, DoneCallback doneCallback) {
+                        callbackThreads.add(Thread.currentThread().getName());
+                        handle.write(data, error -> {
+                            callbackThreads.add(Thread.currentThread().getName());
+                            doneCallback.onComplete(error);
+                        });
+                    }
+
+                    @Override
+                    public void onComplete() {
+                        callbackThreads.add(Thread.currentThread().getName());
+                        handle.complete();
+                    }
+
+                    @Override
+                    public void onError(Throwable t) {
+                        handle.complete(t);
+                    }
+                });
+            })
+            .start();
+
+        RequestBody body = new RequestBody() {
+            @Override
+            public MediaType contentType() {
+                return null;
+            }
+
+            @Override
+            public void writeTo(BufferedSink sink) throws IOException {
+                sink.write(payload);
+            }
+        };
+        try (Response response = call(request(server.uri()).post(body))) {
+            assertThat(response.body().bytes(), equalTo(payload));
+        }
+        assertThat(callbackThreads.size(), greaterThanOrEqualTo(3));
+        for (String callbackThread : callbackThreads) {
+            assertThat(callbackThread, startsWith("application-"));
+        }
+    }
+
+    @Test
     void rejectedAsyncWritesFailTheRequestAndInvokeTheCallback() throws Exception {
         var asyncExecutor = track(Executors.newSingleThreadExecutor(namedThreads("async-")));
         asyncExecutor.shutdown();

--- a/src/test/java/io/muserver/ExecutionDomainsTest.java
+++ b/src/test/java/io/muserver/ExecutionDomainsTest.java
@@ -899,6 +899,104 @@ class ExecutionDomainsTest {
     }
 
     @Test
+    void http2CompletionOnTheAsyncWorkerDoesNotResubmitWhenHandlersAreSaturated() throws Exception {
+        var handlerExecutor = track(new ThreadPoolExecutor(
+            1,
+            1,
+            0,
+            TimeUnit.MILLISECONDS,
+            new ArrayBlockingQueue<>(1),
+            namedThreads("handler-")
+        ));
+        var asyncExecutor = track(new ThreadPoolExecutor(
+            1,
+            1,
+            0,
+            TimeUnit.MILLISECONDS,
+            new SynchronousQueue<>(),
+            namedThreads("async-")
+        ));
+        var writeCallbackEntered = new CountDownLatch(1);
+        var releaseWriteCallback = new CountDownLatch(1);
+        var blockerStarted = new CountDownLatch(1);
+        var releaseBlockers = new CountDownLatch(1);
+        var completionThread = new CompletableFuture<String>();
+        server = httpServer()
+            .withHttp2Config(Http2ConfigBuilder.http2Enabled())
+            .withHandlerExecutor(handlerExecutor)
+            .withAsyncExecutor(asyncExecutor)
+            .addResponseCompleteListener(info ->
+                completionThread.complete(Thread.currentThread().getName())
+            )
+            .addHandler(Method.GET, "/hello", (request, response, pathParams) -> {
+                AsyncHandle handle = request.handleAsync();
+                handle.write(ByteBuffer.wrap(new byte[]{1}), error -> {
+                    if (error != null) {
+                        handle.complete(error);
+                        return;
+                    }
+                    writeCallbackEntered.countDown();
+                    releaseWriteCallback.await();
+                    handle.complete();
+                });
+            })
+            .start();
+
+        Future<?> blocker = null;
+        Future<?> queuedBlocker = null;
+        try (var h2Client = new H2Client();
+             var connection = h2Client.connectClearText(server)) {
+            connection.handshake();
+            connection.socket().setSoTimeout(2000);
+            connection.writeFrame(new Http2HeadersFrame(
+                1,
+                true,
+                RFCTestUtils.getHelloHeaders("http", server.uri().getPort())
+            )).flush();
+
+            assertThat(writeCallbackEntered.await(5, TimeUnit.SECONDS), is(true));
+            blocker = handlerExecutor.submit(() -> {
+                blockerStarted.countDown();
+                try {
+                    releaseBlockers.await();
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+            });
+            assertThat(blockerStarted.await(5, TimeUnit.SECONDS), is(true));
+            queuedBlocker = handlerExecutor.submit(() -> {
+                try {
+                    releaseBlockers.await();
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+            });
+            releaseWriteCallback.countDown();
+
+            Http2HeadersFrame responseHeaders =
+                RFCTestUtils.readIgnoringWindowUpdates(connection, Http2HeadersFrame.class);
+            assertThat(responseHeaders.headers().get(":status"), equalTo("200"));
+            Http2DataFrame responseData =
+                RFCTestUtils.readIgnoringWindowUpdates(connection, Http2DataFrame.class);
+            assertThat(responseData.payloadLength(), is(1));
+            assertThat(
+                RFCTestUtils.readIgnoringWindowUpdates(connection, Http2DataFrame.class).endStream(),
+                is(true)
+            );
+            assertThat(completionThread.get(5, TimeUnit.SECONDS), startsWith("async-"));
+        } finally {
+            releaseWriteCallback.countDown();
+            releaseBlockers.countDown();
+            if (blocker != null) {
+                blocker.get(5, TimeUnit.SECONDS);
+            }
+            if (queuedBlocker != null) {
+                queuedBlocker.get(5, TimeUnit.SECONDS);
+            }
+        }
+    }
+
+    @Test
     void rejectedHandlerDispatchesHttp2AsyncCompletionToTheAsyncExecutor() throws Exception {
         var handlerExecutor = track(Executors.newSingleThreadExecutor(namedThreads("handler-")));
         var asyncExecutor = track(Executors.newSingleThreadExecutor(namedThreads("async-")));

--- a/src/test/java/io/muserver/rest/AsynchronousProcessingTest.java
+++ b/src/test/java/io/muserver/rest/AsynchronousProcessingTest.java
@@ -245,6 +245,83 @@ public class AsynchronousProcessingTest {
         }
     }
 
+    @Test
+    public void completedStagesDoNotResubmitFromTheApplicationWorker() throws Exception {
+        var applicationExecutor = track(nonQueueingApplicationExecutor());
+
+        @Path("samples")
+        class Sample {
+            @GET
+            public CompletionStage<ThreadReportingEntity> go() {
+                return CompletableFuture.completedFuture(new ThreadReportingEntity());
+            }
+        }
+
+        server = ServerUtils.httpsServerForTest("http")
+            .withHandlerExecutor(applicationExecutor)
+            .withAsyncExecutor(applicationExecutor)
+            .addHandler(restHandler(new Sample()).addCustomWriter(threadReportingWriter()))
+            .start();
+
+        try (Response response = call(request().url(server.uri().resolve("/samples").toString()))) {
+            assertThat(response.code(), is(200));
+            assertThat(response.body().string(), startsWith("application-"));
+        }
+    }
+
+    @Test
+    public void inlineResumeDoesNotResubmitFromTheApplicationWorker() throws Exception {
+        var applicationExecutor = track(nonQueueingApplicationExecutor());
+
+        @Path("samples")
+        class Sample {
+            @GET
+            public void go(@Suspended AsyncResponse response) {
+                assertThat(response.resume(new ThreadReportingEntity()), is(true));
+            }
+        }
+
+        server = ServerUtils.httpsServerForTest("http")
+            .withHandlerExecutor(applicationExecutor)
+            .withAsyncExecutor(applicationExecutor)
+            .addHandler(restHandler(new Sample()).addCustomWriter(threadReportingWriter()))
+            .start();
+
+        try (Response response = call(request().url(server.uri().resolve("/samples").toString()))) {
+            assertThat(response.code(), is(200));
+            assertThat(response.body().string(), startsWith("application-"));
+        }
+    }
+
+    @Test
+    public void timeoutResumeDoesNotResubmitFromTheApplicationWorker() throws Exception {
+        var applicationExecutor = track(nonQueueingApplicationExecutor());
+        var timerExecutor = track(Executors.newSingleThreadScheduledExecutor(namedThreads("timer-")));
+
+        @Path("samples")
+        class Sample {
+            @GET
+            public void go(@Suspended AsyncResponse response) {
+                response.setTimeoutHandler(timedOut ->
+                    timedOut.resume(new ThreadReportingEntity())
+                );
+                response.setTimeout(1, TimeUnit.MILLISECONDS);
+            }
+        }
+
+        server = ServerUtils.httpsServerForTest("http")
+            .withHandlerExecutor(applicationExecutor)
+            .withAsyncExecutor(applicationExecutor)
+            .withTimerExecutor(timerExecutor)
+            .addHandler(restHandler(new Sample()).addCustomWriter(threadReportingWriter()))
+            .start();
+
+        try (Response response = call(request().url(server.uri().resolve("/samples").toString()))) {
+            assertThat(response.code(), is(200));
+            assertThat(response.body().string(), startsWith("application-"));
+        }
+    }
+
 
     @Test
     public void ifResumedWithExceptionThenItIsHandledNormally() throws Exception {
@@ -533,6 +610,17 @@ public class AsynchronousProcessingTest {
     private static ThreadFactory namedThreads(String prefix) {
         var count = new AtomicInteger();
         return runnable -> new Thread(runnable, prefix + count.incrementAndGet());
+    }
+
+    private static ThreadPoolExecutor nonQueueingApplicationExecutor() {
+        return new ThreadPoolExecutor(
+            1,
+            1,
+            0,
+            TimeUnit.MILLISECONDS,
+            new SynchronousQueue<>(),
+            namedThreads("application-")
+        );
     }
 
     private static MessageBodyWriter<ThreadReportingEntity> threadReportingWriter() {


### PR DESCRIPTION
## Summary

- introduce a per-server application execution turn with a thread-confined FIFO for nested continuations
- preserve the handler and async execution domains, including the executor that accepted fallback work
- queue nested work behind the current callback instead of recursively invoking it or resubmitting to an occupied non-queueing executor
- route HTTP/1 and HTTP/2 handler entry, async body/write callbacks, completion listeners, and WebSocket event runners through the same execution-turn boundary
- replace the HTTP/2-specific `alreadyOnApplicationExecutor` hint with the general rule
- update `HTTP2-CONCURRENCY.md` with the five executor domains, timer facility, and re-entry contract

## Why

A shared single-worker executor backed by `SynchronousQueue` exposed the underlying issue in several independent paths: completed JAX-RS stages, inline `AsyncResponse.resume`, timeout handlers, HTTP/2 completion listeners, and async body read/write chains all attempted to submit work back to the worker they were already occupying. Depending on the path this produced a dropped callback, a 500 response, or a stalled exchange.

The turn is executor-aware. A task targeting a distinct configured async executor still dispatches there, and strict async I/O still fails if that executor rejects it. Only work targeting an executor already occupied by the current server application turn is queued locally.

## Validation

- deterministic JAX-RS regressions for completed stages, inline resume, and timeout resume on one shared non-queueing worker
- deterministic HTTP/1 async body read/write echo regression on the same executor shape
- existing HTTP/2 synchronous completion regression
- `ExecutionDomainsTest`, `AsynchronousProcessingTest`, `WebSocketTest`, and `AsyncTest`
- Java 21 NullAway compilation

No wire behavior or protocol requirement changes in this increment.