### PR TITLE
Serialize peer SETTINGS with HTTP/2 writes

### DIFF
--- a/HTTP2-CONCURRENCY.md
+++ b/HTTP2-CONCURRENCY.md
@@ -20,11 +20,14 @@ due work to a separate maintenance executor.
 
 SETTINGS acknowledgement expiry now runs on the server timer and is serialized
 as a coordinator connection-error command; it no longer changes the socket
-reader's blocking timeout. Still to be implemented are migration of the
-remaining connection settings, stream registry, inbound flow-control
-accounting, and request-body read deadlines to coordinator ownership. The
-reader and coordinator have separate execution capacity from handlers, but do
-not yet have all of the final single-owner boundaries described below.
+reader's blocking timeout. Peer SETTINGS are decoded into an immutable
+reader-published snapshot, while their outbound effects (existing-stream flow
+credit, the HPACK encoder limit, and the ACK) are applied in order by the
+coordinator. Still to be implemented are migration of the stream registry,
+inbound flow-control accounting, and request-body read deadlines to coordinator
+ownership. The reader and coordinator have separate execution capacity from
+handlers, but do not yet have all of the final single-owner boundaries described
+below.
 
 ## Goals
 
@@ -140,7 +143,8 @@ local blocking deadlines for now.
 | --- | --- |
 | Socket input, input buffer, HPACK decoder | Connection reader |
 | Stream map and stream protocol state | Coordinator |
-| Local and peer settings after decoding | Coordinator |
+| Peer settings snapshot after decoding | Connection reader (volatile publication) |
+| Outbound effects of peer settings and local settings lifecycle | Coordinator |
 | Connection and stream outbound flow-control credit | Coordinator |
 | Connection and stream inbound flow-control accounting | Coordinator |
 | Pending outbound frames and their ordering | Coordinator |

--- a/src/main/java/io/muserver/FieldBlockEncoder.java
+++ b/src/main/java/io/muserver/FieldBlockEncoder.java
@@ -6,12 +6,15 @@ import java.io.OutputStream;
 class FieldBlockEncoder {
 
     private final HpackTable table;
+    private int pendingMinimumTableSize = -1;
+    private int pendingFinalTableSize = -1;
 
     FieldBlockEncoder(HpackTable table) {
         this.table = table;
     }
 
     void encodeTo(FieldBlock block, OutputStream out) throws IOException {
+        writePendingTableSizeChanges(out);
         for (FieldLine line : block.lineIterator()) {
             int lineCode = table.codeFor(line);
             if (lineCode > 0) {
@@ -36,6 +39,21 @@ class FieldBlockEncoder {
                 out.write(line.value().bytes);
             }
         }
+    }
+
+    private void writePendingTableSizeChanges(OutputStream out) throws IOException {
+        if (pendingMinimumTableSize < 0) {
+            return;
+        }
+
+        // RFC 7541 Section 4.2 requires the smallest size followed by the final
+        // size when the limit changes more than once between field blocks.
+        writeHpackInt(5, (byte) 0b00100000, out, pendingMinimumTableSize);
+        if (pendingFinalTableSize != pendingMinimumTableSize) {
+            writeHpackInt(5, (byte) 0b00100000, out, pendingFinalTableSize);
+        }
+        pendingMinimumTableSize = -1;
+        pendingFinalTableSize = -1;
     }
 
     static int writeHpackInt(int n, byte prefix, OutputStream out, int I) throws IOException {
@@ -74,7 +92,19 @@ class FieldBlockEncoder {
         }
     }
 
-    public void changeTableSize(int headerTableSize) {
+    void changeTableSize(int headerTableSize) {
+        if (headerTableSize < 0) {
+            throw new IllegalArgumentException("The HPACK table size cannot be negative");
+        }
+        if (headerTableSize == table.maxSize()) {
+            return;
+        }
         table.changeMaxSize(headerTableSize);
+        if (pendingMinimumTableSize < 0) {
+            pendingMinimumTableSize = headerTableSize;
+        } else {
+            pendingMinimumTableSize = Math.min(pendingMinimumTableSize, headerTableSize);
+        }
+        pendingFinalTableSize = headerTableSize;
     }
 }

--- a/src/main/java/io/muserver/Http2Connection.java
+++ b/src/main/java/io/muserver/Http2Connection.java
@@ -47,7 +47,7 @@ class Http2Connection extends BaseHttpConnection implements Http2Peer, CreditAva
     private static final Logger log = LoggerFactory.getLogger(Http2Connection.class);
 
     private final Http2Settings serverSettings;
-    private Http2Settings clientSettings = Http2Settings.DEFAULT_CLIENT_SETTINGS;
+    private volatile Http2Settings clientSettings = Http2Settings.DEFAULT_CLIENT_SETTINGS;
     private final ByteBuffer buffer;
     private volatile int maxAllowedStreamId = MAX_POSSIBLE_STREAM_ID;
     private volatile int lastStreamId = 0;
@@ -68,8 +68,6 @@ class Http2Connection extends BaseHttpConnection implements Http2Peer, CreditAva
     private volatile boolean finalGoAwayQueued;
     private volatile long finalGoAwayEarliestTime = Long.MAX_VALUE;
     private boolean finalGoAwayWakeScheduled;
-
-    final FieldBlockEncoder fieldBlockEncoder;
 
     private static final class PendingSettingsAck {
         private final AtomicBoolean pending = new AtomicBoolean(true);
@@ -106,7 +104,6 @@ class Http2Connection extends BaseHttpConnection implements Http2Peer, CreditAva
         this.writerExecutor = writerExecutor;
         this.writeCoordinator = new Http2WriteCoordinator(65535, this::requestWriteRun);
         this.buffer = ByteBuffer.allocate(serverSettings.maxFrameSize).flip();
-        this.fieldBlockEncoder = new FieldBlockEncoder(new HpackTable(clientSettings.headerTableSize));
     }
 
     @Override
@@ -116,7 +113,7 @@ class Http2Connection extends BaseHttpConnection implements Http2Peer, CreditAva
 
     @Override
     public FieldBlockEncoder fieldBlockEncoder() {
-        return fieldBlockEncoder;
+        return writeCoordinator.fieldBlockEncoder();
     }
 
     @Override
@@ -313,12 +310,14 @@ class Http2Connection extends BaseHttpConnection implements Http2Peer, CreditAva
         }
     }
 
-    private void applyInitialWindowSizeChange(int difference) throws Http2Exception {
+    private void applyPeerSettingsChange(Http2Settings oldSettings, Http2Settings newSettings)
+        throws Http2Exception {
         stateLock.lock();
         try {
             if (writeState.canSendFrames) {
-                writeCoordinator.applyInitialWindowSizeChange(
-                    difference,
+                writeCoordinator.applyPeerSettingsChange(
+                    newSettings.initialWindowSize - oldSettings.initialWindowSize,
+                    newSettings.headerTableSize,
                     new WriteTask(Http2Settings.ACK, false),
                     lastStreamId
                 );
@@ -328,6 +327,14 @@ class Http2Connection extends BaseHttpConnection implements Http2Peer, CreditAva
         } finally {
             stateLock.unlock();
         }
+    }
+
+    void initializeHandshakePeerSettings(Http2Settings settings) {
+        if (writerOutput != null) {
+            throw new IllegalStateException("The HTTP/2 writer has already started");
+        }
+        clientSettings = settings;
+        writeCoordinator.initializePeerHeaderTableSize(settings.headerTableSize);
     }
 
     private void failConnection(WriteTask goAway, IOException reason) {
@@ -581,7 +588,6 @@ class Http2Connection extends BaseHttpConnection implements Http2Peer, CreditAva
             // do the handshake
             clientSettings = Http2Handshaker.handshake(this, serverSettings, clientSettings, buffer, clientIn, clientOut);
 
-            fieldBlockEncoder.changeTableSize(clientSettings.headerTableSize);
             queuePendingSettingsAck();
 
             var fieldBlockDecoder = new FieldBlockDecoder(new HpackTable(serverSettings.headerTableSize), server.maxUrlSize(), server.maxRequestHeadersSize());
@@ -810,19 +816,14 @@ class Http2Connection extends BaseHttpConnection implements Http2Peer, CreditAva
             // copyIfChanged returns the input instance when no setting changed.
             @SuppressWarnings("ReferenceEquality")
             boolean settingsChanged = newSettings != oldSettings;
-            boolean initialWindowSizeChanged = settingsChanged
-                && newSettings.initialWindowSize != oldSettings.initialWindowSize;
             if (settingsChanged) {
                 clientSettings = newSettings;
             }
 
-            // The ACK is ordered ahead of DATA that the new initial window size might unblock.
-            if (initialWindowSizeChanged) {
-                int difference = newSettings.initialWindowSize - oldSettings.initialWindowSize;
-                applyInitialWindowSizeChange(difference);
-            } else {
-                writeFirst(Http2Settings.ACK);
-            }
+            // RFC 9113 Section 6.5.3 says an ACK confirms application, not only
+            // receipt. The coordinator therefore applies outbound flow credit
+            // and HPACK encoder limits before making the ACK writable.
+            applyPeerSettingsChange(oldSettings, newSettings);
         }
     }
 

--- a/src/main/java/io/muserver/Http2Handshaker.java
+++ b/src/main/java/io/muserver/Http2Handshaker.java
@@ -39,6 +39,7 @@ class Http2Handshaker {
         // handshake start
         readClientPreface(clientIn);
         var newClientSettings = readClientSettings(buffer, clientIn, clientSettings);
+        connection.initializeHandshakePeerSettings(newClientSettings);
         serverSettings.writeTo(connection, clientOut);
         Http2Settings.ACK.writeTo(connection, clientOut);
         clientOut.flush();

--- a/src/main/java/io/muserver/Http2Settings.java
+++ b/src/main/java/io/muserver/Http2Settings.java
@@ -168,13 +168,23 @@ class Http2Settings implements LogicalHttp2Frame {
     Http2Settings copyIfChanged(Http2Settings existingSettings) {
         assert !existingSettings.isAck;
         int newHeaderTableSize = updatedValue(existingSettings.headerTableSize, headerTableSize);
+        int newMaxConcurrentStreams = updatedValue(
+            existingSettings.maxConcurrentStreams,
+            maxConcurrentStreams
+        );
         int newInitialWindowSize = updatedValue(existingSettings.initialWindowSize, initialWindowSize);
         int newMaxFrameSize = updatedValue(existingSettings.maxFrameSize, maxFrameSize);
+        int newMaxHeaderListSize = updatedValue(
+            existingSettings.maxHeaderListSize,
+            maxHeaderListSize
+        );
         if (newHeaderTableSize != existingSettings.headerTableSize
-        || newInitialWindowSize != existingSettings.initialWindowSize
-        || newMaxFrameSize != existingSettings.maxFrameSize) {
-            return new Http2Settings(false, newHeaderTableSize, existingSettings.maxConcurrentStreams,
-                newInitialWindowSize, newMaxFrameSize, existingSettings.maxHeaderListSize);
+            || newMaxConcurrentStreams != existingSettings.maxConcurrentStreams
+            || newInitialWindowSize != existingSettings.initialWindowSize
+            || newMaxFrameSize != existingSettings.maxFrameSize
+            || newMaxHeaderListSize != existingSettings.maxHeaderListSize) {
+            return new Http2Settings(false, newHeaderTableSize, newMaxConcurrentStreams,
+                newInitialWindowSize, newMaxFrameSize, newMaxHeaderListSize);
         }
         return existingSettings;
     }

--- a/src/main/java/io/muserver/Http2WriteCoordinator.java
+++ b/src/main/java/io/muserver/Http2WriteCoordinator.java
@@ -152,13 +152,20 @@ final class Http2WriteCoordinator {
         }
     }
 
-    private static final class InitialWindowSizeChange implements Command {
-        private final int difference;
+    private static final class PeerSettingsChange implements Command {
+        private final int initialWindowDifference;
+        private final int headerTableSize;
         private final WriteTask acknowledgement;
         private final int lastStreamId;
 
-        private InitialWindowSizeChange(int difference, WriteTask acknowledgement, int lastStreamId) {
-            this.difference = difference;
+        private PeerSettingsChange(
+            int initialWindowDifference,
+            int headerTableSize,
+            WriteTask acknowledgement,
+            int lastStreamId
+        ) {
+            this.initialWindowDifference = initialWindowDifference;
+            this.headerTableSize = headerTableSize;
             this.acknowledgement = acknowledgement;
             this.lastStreamId = lastStreamId;
         }
@@ -194,6 +201,8 @@ final class Http2WriteCoordinator {
     private final Map<Integer, Http2Stream> applicationStreams = new HashMap<>();
     private final ArrayList<Command> commandBatch = new ArrayList<>();
     private final AtomicBoolean wakeUpQueued = new AtomicBoolean();
+    private final FieldBlockEncoder fieldBlockEncoder =
+        new FieldBlockEncoder(new HpackTable(Http2Settings.DEFAULT_CLIENT_SETTINGS.headerTableSize));
     private int connectionCredit;
     private boolean connectionErrorPendingGoAway;
     private @Nullable IOException connectionFailureReason;
@@ -294,11 +303,32 @@ final class Http2WriteCoordinator {
         enqueue(new StreamWindowUpdate(streamId, increment));
     }
 
-    void applyInitialWindowSizeChange(int difference, WriteTask acknowledgement, int lastStreamId) {
+    void initializePeerHeaderTableSize(int headerTableSize) {
+        fieldBlockEncoder.changeTableSize(headerTableSize);
+    }
+
+    FieldBlockEncoder fieldBlockEncoder() {
+        return fieldBlockEncoder;
+    }
+
+    void applyPeerSettingsChange(
+        int initialWindowDifference,
+        int headerTableSize,
+        WriteTask acknowledgement,
+        int lastStreamId
+    ) {
+        if (headerTableSize < 0) {
+            throw new IllegalArgumentException("The peer header table size cannot be negative");
+        }
         if (lastStreamId < 0) {
             throw new IllegalArgumentException("The last stream ID cannot be negative");
         }
-        enqueue(new InitialWindowSizeChange(difference, acknowledgement, lastStreamId));
+        enqueue(new PeerSettingsChange(
+            initialWindowDifference,
+            headerTableSize,
+            acknowledgement,
+            lastStreamId
+        ));
     }
 
     void settingsTimedOut() {
@@ -483,22 +513,27 @@ final class Http2WriteCoordinator {
                     queueStreamError(e);
                 }
             }
-        } else if (command instanceof InitialWindowSizeChange) {
-            InitialWindowSizeChange change = (InitialWindowSizeChange) command;
+        } else if (command instanceof PeerSettingsChange) {
+            PeerSettingsChange change = (PeerSettingsChange) command;
             if (connectionErrorPendingGoAway) {
                 return;
             }
             try {
-                if (change.difference != 0) {
+                if (change.initialWindowDifference != 0) {
                     Map<Integer, Integer> changedCredits = new HashMap<>(streamCredits.size());
                     for (Map.Entry<Integer, Integer> entry : streamCredits.entrySet()) {
                         changedCredits.put(
                             entry.getKey(),
-                            addCredit(entry.getValue(), change.difference, entry.getKey())
+                            addCredit(
+                                entry.getValue(),
+                                change.initialWindowDifference,
+                                entry.getKey()
+                            )
                         );
                     }
                     streamCredits.putAll(changedCredits);
                 }
+                fieldBlockEncoder.changeTableSize(change.headerTableSize);
                 queue(change.acknowledgement, true, false);
             } catch (Http2Exception e) {
                 queueConnectionError(

--- a/src/test/java/io/muserver/FieldBlockEncoderTest.java
+++ b/src/test/java/io/muserver/FieldBlockEncoderTest.java
@@ -21,6 +21,30 @@ class FieldBlockEncoderTest {
     private final FieldBlockDecoder decoder = new FieldBlockDecoder(table, 8192, 4 * 8192);
 
     @Test
+    void tableSizeDecreaseIsSignalledAtTheStartOfTheNextFieldBlock() throws IOException {
+        encoder.changeTableSize(0);
+
+        assertThat(toHex(new FieldBlock()), equalTo("20"));
+        assertThat(toHex(new FieldBlock()), equalTo(""));
+    }
+
+    @Test
+    void smallestAndFinalTableSizesAreSignalledWhenChangedMoreThanOnce() throws IOException {
+        encoder.changeTableSize(100);
+        encoder.changeTableSize(200);
+
+        assertThat(toHex(new FieldBlock()), equalTo("3f453fa901"));
+        assertThat(toHex(new FieldBlock()), equalTo(""));
+    }
+
+    @Test
+    void unchangedTableSizeIsNotSignalled() throws IOException {
+        encoder.changeTableSize(4096);
+
+        assertThat(toHex(new FieldBlock()), equalTo(""));
+    }
+
+    @Test
     public void rfc7541ExampleC_2_1_literalHeaderWithIndexing() throws IOException, Http2Exception {
         byte[] array = hexToByteArray("400a637573746f6d2d6b65790d637573746f6d2d686561646572");
         var decoded = decoder.decodeFrom(ByteBuffer.wrap(array));

--- a/src/test/java/io/muserver/H2Client.java
+++ b/src/test/java/io/muserver/H2Client.java
@@ -119,6 +119,17 @@ class H2ClientConnection implements Http2Peer, Closeable {
         return Http2FrameHeader.readFrom(readBuffer);
     }
 
+    byte[] readRawPayload(Http2FrameHeader header) throws IOException {
+        Mutils.readAtLeast(readBuffer, inputStream, header.length());
+        byte[] payload = new byte[header.length()];
+        readBuffer.get(payload);
+        return payload;
+    }
+
+    void changeResponseHeaderTableSizeLimit(int headerTableSize) {
+        fieldBlockDecoder.changeTableSize(headerTableSize);
+    }
+
     LogicalHttp2Frame readLogicalFrame(Http2FrameHeader header) throws IOException, Http2Exception {
         Mutils.readAtLeast(readBuffer, inputStream, header.length());
         switch (header.frameType()) {
@@ -169,8 +180,12 @@ class H2ClientConnection implements Http2Peer, Closeable {
     }
 
     public H2ClientConnection handshake() throws IOException, Http2Exception {
+        return handshake(Http2Settings.DEFAULT_CLIENT_SETTINGS);
+    }
+
+    H2ClientConnection handshake(Http2Settings initialSettings) throws IOException, Http2Exception {
         writePreface();
-        writeFrame(Http2Settings.DEFAULT_CLIENT_SETTINGS);
+        writeFrame(initialSettings);
         flush();
         var settings1 = readLogicalFrame(Http2Settings.class);
         var settings2 = readLogicalFrame(Http2Settings.class);

--- a/src/test/java/io/muserver/Http2SettingsTest.java
+++ b/src/test/java/io/muserver/Http2SettingsTest.java
@@ -91,4 +91,12 @@ public class Http2SettingsTest {
         assertThat(settings1.equals(settings2), equalTo(true));
         assertThat(settings1.hashCode(), equalTo(settings2.hashCode()));
     }
+
+    @Test
+    void copyIfChangedAppliesEveryPeerSetting() {
+        var existing = new Http2Settings(false, 4096, 100, 65535, 16384, 32768);
+        var update = new Http2Settings(false, 1024, 7, 1234, 20000, 8192);
+
+        assertThat(update.copyIfChanged(existing), equalTo(update));
+    }
 }

--- a/src/test/java/io/muserver/Http2WriteCoordinatorTest.java
+++ b/src/test/java/io/muserver/Http2WriteCoordinatorTest.java
@@ -2,6 +2,7 @@ package io.muserver;
 
 import org.junit.jupiter.api.Test;
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 
@@ -260,7 +261,12 @@ class Http2WriteCoordinatorTest {
         assertThat(coordinator.pollWritable(), nullValue());
 
         var ack = task(Http2Settings.ACK);
-        coordinator.applyInitialWindowSizeChange("newly writable".length(), ack, 1);
+        coordinator.applyPeerSettingsChange(
+            "newly writable".length(),
+            4096,
+            ack,
+            1
+        );
         coordinator.processAvailableCommands();
 
         assertThat(
@@ -281,7 +287,7 @@ class Http2WriteCoordinatorTest {
         coordinator.processAvailableCommands();
         coordinator.pollWritable().complete();
 
-        coordinator.applyInitialWindowSizeChange(-800, task(Http2Settings.ACK), 1);
+        coordinator.applyPeerSettingsChange(-800, 4096, task(Http2Settings.ACK), 1);
         coordinator.processAvailableCommands();
         assertThat(coordinator.pollWritable().frame(), equalTo(Http2Settings.ACK));
 
@@ -364,7 +370,7 @@ class Http2WriteCoordinatorTest {
     @Test
     void settingsWindowOverflowIsAConnectionFlowControlErrorAndIsNotAcknowledged() {
         var coordinator = coordinator(0, 1, Integer.MAX_VALUE - 1);
-        coordinator.applyInitialWindowSizeChange(2, task(Http2Settings.ACK), 5);
+        coordinator.applyPeerSettingsChange(2, 4096, task(Http2Settings.ACK), 5);
         coordinator.processAvailableCommands();
 
         var writable = coordinator.pollWritable();
@@ -377,6 +383,21 @@ class Http2WriteCoordinatorTest {
         );
         writable.complete();
         assertThat(coordinator.pollWritable(), nullValue());
+    }
+
+    @Test
+    void peerSettingsChangeAppliesEncoderLimitBeforeAcknowledgement() throws Exception {
+        var coordinator = new Http2WriteCoordinator(65_535);
+        coordinator.applyPeerSettingsChange(0, 0, task(Http2Settings.ACK), 0);
+        coordinator.processAvailableCommands();
+
+        assertThat(coordinator.pollWritable().frame(), equalTo(Http2Settings.ACK));
+        var encoded = new ByteArrayOutputStream();
+        coordinator.fieldBlockEncoder().encodeTo(new FieldBlock(), encoded);
+        assertThat(
+            FieldBlockEncoderTest.bytesToHex(encoded.toByteArray()),
+            equalTo("20")
+        );
     }
 
     @Test

--- a/src/test/java/io/muserver/RFC9113_5_5_ExtensionsTest.java
+++ b/src/test/java/io/muserver/RFC9113_5_5_ExtensionsTest.java
@@ -213,6 +213,9 @@ class RFC9113_5_5_ExtensionsTest {
             final int maxFrameSize = 32768;
             final int maxHeaderListSize = 4000;
             final int anUnknownSetting = 88;
+            // This raw frame advertises the limit enforced by the test
+            // client's response decoder.
+            con.changeResponseHeaderTableSizeLimit(headerTableSize);
             con.writeRaw(new byte[] {
                 // header - 6 settings of 6 bytes each
                 0, 0, 6 * 6, 4, 0, 0, 0, 0, 0,

--- a/src/test/java/io/muserver/RFC9113_6_5_SettingsTest.java
+++ b/src/test/java/io/muserver/RFC9113_6_5_SettingsTest.java
@@ -212,6 +212,67 @@ class RFC9113_6_5_SettingsTest {
     }
 
     @Test
+    void initialHeaderTableSizeIsAppliedBeforeTheHandshakeAck() throws Exception {
+        server = httpsServer()
+            .withHttp2Config(Http2ConfigBuilder.http2Enabled())
+            .addHandler(Method.GET, "/hello", (request, response, pathParams) -> {
+                response.status(204);
+            })
+            .start();
+
+        try (var client = new H2Client();
+             var con = client.connect(server)) {
+
+            con.handshake(new Http2Settings(false, 0, 100, 65535, 16384, 32768))
+                .writeFrame(new Http2HeadersFrame(1, true, getHelloHeaders(getPort())))
+                .flush();
+
+            var header = con.readFrameHeader();
+            assertThat(header.frameType(), equalTo(Http2FrameType.HEADERS));
+            byte[] payload = con.readRawPayload(header);
+            assertThat(payload[0], equalTo((byte) 0x20));
+        }
+    }
+
+    @Test
+    void repeatedHeaderTableSizeChangesAreSignalledInTheNextFieldBlock() throws Exception {
+        server = httpsServer()
+            .withHttp2Config(Http2ConfigBuilder.http2Enabled())
+            .addHandler(Method.GET, "/hello", (request, response, pathParams) -> {
+                response.status(204);
+            })
+            .start();
+
+        try (var client = new H2Client();
+             var con = client.connect(server)) {
+
+            con.handshake()
+                .writeRaw(settingsFrame(1, 100))
+                .flush();
+            assertThat(con.readLogicalFrame(), equalTo(Http2Settings.ACK));
+
+            con.writeRaw(settingsFrame(1, 200))
+                .flush();
+            assertThat(con.readLogicalFrame(), equalTo(Http2Settings.ACK));
+
+            con.writeFrame(new Http2HeadersFrame(1, true, getHelloHeaders(getPort())))
+                .flush();
+
+            var header = con.readFrameHeader();
+            assertThat(header.frameType(), equalTo(Http2FrameType.HEADERS));
+            assertThat(header.streamId(), equalTo(1));
+            byte[] payload = con.readRawPayload(header);
+
+            // RFC 7541 Section 4.2: the smallest value since the previous
+            // field block (100) is followed by the final value (200).
+            assertThat(
+                Arrays.copyOf(payload, 5),
+                equalTo(new byte[] { 0x3f, 0x45, 0x3f, (byte) 0xa9, 0x01 })
+            );
+        }
+    }
+
+    @Test
     void maxFrameSizeChangesAffectSubsequentResponses() throws Exception {
         byte[] body = new byte[20001];
         Arrays.fill(body, (byte) 'x');


### PR DESCRIPTION
## Summary

- publish decoded peer SETTINGS as an immutable volatile snapshot while applying their outbound effects through the serialized HTTP/2 write coordinator
- move the connection's HPACK encoder under coordinator ownership
- apply existing-stream window changes and HPACK limits before making the SETTINGS ACK writable
- apply the initial peer header-table limit before the handshake ACK is written
- emit RFC 7541 dynamic table-size updates at the start of the next field block, including the required smallest-then-final sequence when the limit changes repeatedly
- preserve every recognized peer setting in the decoded snapshot
- update the concurrency design contract with the implemented ownership boundary

## Protocol contract

RFC 9113 Section 6.5.3 defines a SETTINGS ACK as acknowledgement of receipt and application. The coordinator command applies outbound flow credit and the HPACK encoder limit before queueing that ACK.

RFC 7541 Section 4.2 requires a dynamic table-size update at the beginning of the first header block after a size change. If the maximum changes more than once between header blocks, the smallest value and then the final value must be signalled. The encoder now retains exactly that pending state.

- https://www.rfc-editor.org/rfc/rfc9113.html#section-6.5.3
- https://www.rfc-editor.org/rfc/rfc7541.html#section-4.2

## Validation

- deterministic encoder unit tests for decrease, no-op, and repeated smallest/final changes
- coordinator test proving the encoder limit is applied before its ACK becomes writable
- wire tests proving both initial-handshake and subsequent repeated table-size changes are signalled in response HEADERS
- existing SETTINGS, flow-control, and extension tests
- `mise exec java@temurin-11 -- mvn test` (1,653 tests, 5 skipped)
- `mise exec java@temurin-21 -- mvn -Pnullaway -DskipTests test`