### PR TITLE
Centralize HTTP/2 live stream identity

### DIFF
--- a/HTTP2-CONCURRENCY.md
+++ b/HTTP2-CONCURRENCY.md
@@ -26,11 +26,12 @@ credit, the HPACK encoder limit, and the ACK) are applied in order by the
 coordinator. Connection and stream inbound flow-control accounting is also
 centralized in one component with a short-held lock. The reader atomically
 debits both receive windows without depending on the blocking-output executor,
-and body consumers return credit through the same component. Still to be
-implemented are migration of the stream registry and request-body read
-deadlines. The reader and coordinator have separate execution capacity from
-handlers, but do not yet have all of the final ownership boundaries described
-below.
+and body consumers return credit through the same component. Live stream
+identity publication is similarly centralized in one short-held registry lock,
+while the coordinator remains the sole owner of RFC stream-state transitions.
+Still to be implemented are request-body read deadlines. The reader and
+coordinator have separate execution capacity from handlers, but do not yet have
+all of the final ownership boundaries described below.
 
 ## Goals
 
@@ -145,7 +146,9 @@ local blocking deadlines for now.
 | State or resource | Owner |
 | --- | --- |
 | Socket input, input buffer, HPACK decoder | Connection reader |
-| Stream map and stream protocol state | Coordinator |
+| RFC stream protocol state | Coordinator |
+| Live application/rejected stream identity index | `Http2StreamRegistry` lock |
+| Inbound END_STREAM and reset-seen fences | Connection reader, with monotonic publication where another domain reads them |
 | Peer settings snapshot after decoding | Connection reader (volatile publication) |
 | Outbound effects of peer settings and local settings lifecycle | Coordinator |
 | Connection and stream outbound flow-control credit | Coordinator |
@@ -160,6 +163,13 @@ Coordinator-owned state uses ordinary collections and fields. It must not use
 concurrent collections, volatile fields, or locks as substitutes for ownership.
 Published diagnostic snapshots may use volatile or atomic fields, but they are
 not authoritative protocol state.
+
+The live identity index is not a second stream state machine. It answers whether
+a live peer stream currently names an application exchange, a rejected request
+body that still needs draining, or nothing. A single registry operation
+atomically converts an accepted stream to a rejected-body stream when handler
+submission is refused; connection shutdown and diagnostics cannot observe an
+artificially empty gap between those identities.
 
 ## Coordinator commands
 
@@ -316,17 +326,19 @@ Permitted cross-thread primitives are deliberately narrow:
 * a small promise backed by a latch and a result or error;
 * one short-held lock for atomic connection-and-stream inbound flow-control
   accounting;
+* one short-held lock for the live stream identity index;
 * the existing request-body buffer lock and condition;
 * an application-side lock that orders async response submissions; and
 * a thread-confined FIFO that drains nested application work without recursive
   calls or executor resubmission; and
 * atomics for idempotent resource closure.
 
-Protocol state, stream maps, outbound flow-control windows, and pending-write
-queues are not protected by independent locks because they have a single owner.
-Inbound receive windows are the deliberate exception: DATA debits happen on
-the reader while credit is returned by body-consumer threads, so both windows
-share the one lock described above.
+RFC stream state, outbound flow-control windows, and pending-write queues are
+not protected by independent locks because they have a single owner. The live
+identity index is cross-thread publication rather than RFC stream state, and
+therefore uses its explicit registry lock. Inbound receive windows are the
+other deliberate lock-based boundary: DATA debits happen on the reader while
+credit is returned by body-consumer threads, so both windows share one lock.
 
 No lock is held while:
 
@@ -343,7 +355,8 @@ execution-domain phases identified above.
 1. Inbound frame events from the reader are processed in wire order.
 2. Every protocol state mutation has an explicit linearization point: the
    coordinator for stream and output state, and the inbound-flow lock for
-   receive-window accounting.
+   receive-window accounting. Live stream identity changes linearize at the
+   registry lock.
 3. No frame other than permitted priority information or a permitted additional
    `RST_STREAM` is emitted after `RST_STREAM`.
 4. No DATA is emitted unless both connection and stream credit were reserved.

--- a/src/main/java/io/muserver/Http2Connection.java
+++ b/src/main/java/io/muserver/Http2Connection.java
@@ -54,8 +54,7 @@ class Http2Connection extends BaseHttpConnection implements Http2Peer {
     private volatile int peerGoAwayLastStreamId = MAX_POSSIBLE_STREAM_ID;
     private final Http2InboundFlowControl inboundFlowControl = new Http2InboundFlowControl(65_535);
     private final ConcurrentLinkedQueue<PendingSettingsAck> settingsAckQueue = new ConcurrentLinkedQueue<>();
-    private final ConcurrentHashMap<Integer, Http2Stream> streams = new ConcurrentHashMap<>();
-    private final Set<Integer> rejectedRequestBodies = ConcurrentHashMap.newKeySet();
+    private final Http2StreamRegistry streamRegistry = new Http2StreamRegistry();
     private final ExecutorService handlerExecutor;
     private final ExecutorService writerExecutor;
     private final long settingsAckTimeoutMillis;
@@ -168,9 +167,9 @@ class Http2Connection extends BaseHttpConnection implements Http2Peer {
             if (writeState.canSendFrames && canWriteFrame(writeTask.frame())) {
                 LogicalHttp2Frame frame = writeTask.frame();
                 boolean retireRejectedStream = frame instanceof Http2ResetStreamFrame
-                    && rejectedRequestBodies.remove(frame.streamId());
+                    && streamRegistry.removeRejectedRequestBody(frame.streamId());
                 boolean retainResetState = frame instanceof Http2ResetStreamFrame
-                    && streams.containsKey(frame.streamId());
+                    && streamRegistry.containsApplicationStream(frame.streamId());
                 if (frame instanceof Http2ResetStreamFrame) {
                     inboundFlowControl.closeStream(frame.streamId());
                 }
@@ -191,7 +190,7 @@ class Http2Connection extends BaseHttpConnection implements Http2Peer {
         if (streamId == 0 || frame instanceof Http2ResetStreamFrame) {
             return true;
         }
-        Http2Stream stream = streams.get(streamId);
+        Http2Stream stream = streamRegistry.applicationStream(streamId);
         return stream == null
             ? streamId > lastStreamId
             : !stream.resetWasInitiated();
@@ -225,7 +224,8 @@ class Http2Connection extends BaseHttpConnection implements Http2Peer {
         stateLock.lock();
         try {
             if (writeState.canSendFrames) {
-                boolean retireRejectedStream = rejectedRequestBodies.remove(resetFrame.streamId());
+                boolean retireRejectedStream =
+                    streamRegistry.removeRejectedRequestBody(resetFrame.streamId());
                 inboundFlowControl.closeStream(resetFrame.streamId());
                 writeCoordinator.resetStream(resetFrame, reason, stream);
                 if (retireRejectedStream) {
@@ -244,13 +244,28 @@ class Http2Connection extends BaseHttpConnection implements Http2Peer {
         int initialCredit,
         Http2StreamState initialState,
         Http2HeadersFrame headers,
-        Http2DataFrame body
+        Http2DataFrame body,
+        @Nullable Http2Stream replacedApplicationStream
     ) {
         stateLock.lock();
         try {
             if (writeState.canSendFrames) {
                 // Rejected headers do not create an application-facing Http2Stream, so queue
                 // their complete protocol exchange directly as one ordered coordinator transaction.
+                if (initialState.canReceiveEndStream()) {
+                    if (replacedApplicationStream == null) {
+                        streamRegistry.registerRejectedRequestBody(streamId);
+                    } else {
+                        streamRegistry.convertApplicationStreamToRejectedRequestBody(
+                            replacedApplicationStream
+                        );
+                    }
+                } else if (replacedApplicationStream != null) {
+                    streamRegistry.removeApplicationStream(replacedApplicationStream);
+                }
+                if (replacedApplicationStream != null) {
+                    inboundFlowControl.closeStream(streamId);
+                }
                 inboundFlowControl.openStream(streamId, serverSettings.initialWindowSize);
                 writeCoordinator.openStream(
                     streamId,
@@ -260,12 +275,13 @@ class Http2Connection extends BaseHttpConnection implements Http2Peer {
                 );
                 writeCoordinator.submit(new WriteTask(headers, false));
                 writeCoordinator.submit(new WriteTask(body, false));
-                if (initialState.canReceiveEndStream()) {
-                    rejectedRequestBodies.add(streamId);
-                } else {
+                if (!initialState.canReceiveEndStream()) {
                     inboundFlowControl.closeStream(streamId);
                     writeCoordinator.forgetStream(streamId);
                 }
+            } else if (replacedApplicationStream != null) {
+                inboundFlowControl.closeStream(streamId);
+                streamRegistry.removeApplicationStream(replacedApplicationStream);
             }
         } finally {
             stateLock.unlock();
@@ -276,7 +292,7 @@ class Http2Connection extends BaseHttpConnection implements Http2Peer {
         stateLock.lock();
         try {
             if (writeState.canSendFrames) {
-                rejectedRequestBodies.remove(streamId);
+                streamRegistry.removeRejectedRequestBody(streamId);
                 inboundFlowControl.closeStream(streamId);
                 writeCoordinator.remoteEndStream(streamId);
                 writeCoordinator.forgetStream(streamId);
@@ -448,7 +464,7 @@ class Http2Connection extends BaseHttpConnection implements Http2Peer {
         } finally {
             stateLock.unlock();
         }
-        for (Http2Stream stream : streams.values()) {
+        for (Http2Stream stream : streamRegistry.applicationStreams()) {
             stream.cancel(reason, false);
         }
         signalWriteLoop();
@@ -519,8 +535,7 @@ class Http2Connection extends BaseHttpConnection implements Http2Peer {
             return localGoAwayGracePeriodMillisRemainingLocked(now) == 0L;
         }
         return isPeerShutdownInitiatedLocked()
-            && streams.isEmpty()
-            && rejectedRequestBodies.isEmpty();
+            && streamRegistry.isEmpty();
     }
 
     private void queueFinalGoAwayLocked() {
@@ -532,8 +547,7 @@ class Http2Connection extends BaseHttpConnection implements Http2Peer {
 
     private boolean isTerminalAndDrainedLocked() {
         return (isReadTerminalLocked() || (isShutdownInitiatedLocked() && finalGoAwayQueued))
-            && streams.isEmpty()
-            && rejectedRequestBodies.isEmpty()
+            && streamRegistry.isEmpty()
             && writeCoordinator.isIdle();
     }
 
@@ -585,7 +599,7 @@ class Http2Connection extends BaseHttpConnection implements Http2Peer {
             error
         );
         if (error.errorType() == Http2Level.STREAM) {
-            Http2Stream stream = streams.get(error.streamId());
+            Http2Stream stream = streamRegistry.applicationStream(error.streamId());
             if (stream != null) {
                 stream.cancel(reason);
             }
@@ -603,7 +617,7 @@ class Http2Connection extends BaseHttpConnection implements Http2Peer {
         } finally {
             stateLock.unlock();
         }
-        for (Http2Stream stream : streams.values()) {
+        for (Http2Stream stream : streamRegistry.applicationStreams()) {
             stream.cancel(reason, false);
         }
         return new Http2GoAway(acceptedLastStreamId, error.errorCode().code(), null);
@@ -692,7 +706,7 @@ class Http2Connection extends BaseHttpConnection implements Http2Peer {
                     if (h2e.errorType() == Http2Level.CONNECTION) {
                         throw h2e;
                     }
-                    var stream = streams.get(h2e.streamId());
+                    var stream = streamRegistry.applicationStream(h2e.streamId());
                     if (stream != null && !stream.peerResetWasRead()) {
                         stream.recordLocalResetFromReader();
                     }
@@ -744,14 +758,14 @@ class Http2Connection extends BaseHttpConnection implements Http2Peer {
                     // Order the connection failure before waking body readers. Any response
                     // work triggered by cancellation is then rejected behind this command.
                     failConnection(writeTask, connectionError);
-                    for (var stream : streams.values()) {
+                    for (var stream : streamRegistry.applicationStreams()) {
                         stream.cancel(connectionError, false);
                     }
                     writeTask.await(30, TimeUnit.SECONDS);
                     setReadStateAndSignal(HState.ERRORED);
                     writeEndedFuture.get(1, TimeUnit.MINUTES);
                 } else {
-                    for (var stream : streams.values()) {
+                    for (var stream : streamRegistry.applicationStreams()) {
                         stream.cancel(connectionError, false);
                     }
                     goAway.writeTo(this, clientOut);
@@ -769,7 +783,7 @@ class Http2Connection extends BaseHttpConnection implements Http2Peer {
     private void readResetStreamFrame(Http2FrameHeader fh) throws Http2Exception {
         var rstStream = Http2ResetStreamFrame.readFrom(fh, buffer);
         int streamId = rstStream.streamId();
-        var stream = streams.get(streamId);
+        var stream = streamRegistry.applicationStream(streamId);
         log.info("Reset stream " + rstStream + " for " + stream);
         if (stream == null && (streamId > lastStreamId || streamId % 2 == 0)) {
             throw Http2Exception.connection(Http2ErrorCode.PROTOCOL_ERROR, "Invalid stream ID on rst_stream");
@@ -865,8 +879,9 @@ class Http2Connection extends BaseHttpConnection implements Http2Peer {
     private void readDataFrame(Http2FrameHeader fh) throws Http2Exception {
         var dataFrame = Http2DataFrame.readFrom(fh, buffer);
         int streamId = dataFrame.streamId();
-        boolean rejectedBody = rejectedRequestBodies.contains(streamId);
-        var stream = streams.get(streamId);
+        Http2StreamRegistry.Lookup registered = streamRegistry.lookup(streamId);
+        boolean rejectedBody = registered.rejectedRequestBody();
+        var stream = registered.applicationStream();
         if (streamId == 0 || (streamId % 2) == 0
             || (stream == null && !rejectedBody && streamId > lastStreamId)) {
             throw Http2Exception.connection(
@@ -918,8 +933,7 @@ class Http2Connection extends BaseHttpConnection implements Http2Peer {
     }
 
     private boolean noProtocolStreamsAreActive() {
-        return rejectedRequestBodies.isEmpty()
-            && streams.values().stream().noneMatch(Http2Stream::countsTowardsMaxConcurrentStreams);
+        return !streamRegistry.hasActiveProtocolStreams();
     }
 
     private void readHeaders(InputStream clientIn, Http2FrameHeader fh, FieldBlockDecoder fieldBlockDecoder) throws Http2Exception, IOException {
@@ -929,7 +943,9 @@ class Http2Connection extends BaseHttpConnection implements Http2Peer {
         try {
             var headerFragment = Http2HeadersFrame.readLogicalFrame(fh, fieldBlockDecoder, buffer, clientIn);
             log.info("Got headers " + headerFragment);
-            if (rejectedRequestBodies.contains(headerFragment.streamId())) {
+            Http2StreamRegistry.Lookup registered =
+                streamRegistry.lookup(headerFragment.streamId());
+            if (registered.rejectedRequestBody()) {
                 if (!headerFragment.endStream()) {
                     throw new Http2Exception(
                         Http2ErrorCode.PROTOCOL_ERROR,
@@ -940,7 +956,7 @@ class Http2Connection extends BaseHttpConnection implements Http2Peer {
                 finishRejectedRequestBody(headerFragment.streamId());
                 return;
             }
-            var existing = streams.get(headerFragment.streamId());
+            var existing = registered.applicationStream();
             if (existing != null) {
                 if (existing.peerResetWasRead()) {
                     throw new Http2Exception(
@@ -973,7 +989,8 @@ class Http2Connection extends BaseHttpConnection implements Http2Peer {
             // The header block could not be decoded (for example a 431 rejected during HPACK
             // decoding), so the method and target are not available here.
             String rejectReason = e.getMessage() != null ? e.getMessage() : e.status().toString();
-            if (rejectedRequestBodies.contains(fh.streamId())) {
+            Http2StreamRegistry.Lookup registered = streamRegistry.lookup(fh.streamId());
+            if (registered.rejectedRequestBody()) {
                 if ((fh.flags() & 0b00000001) == 0) {
                     throw new Http2Exception(
                         Http2ErrorCode.PROTOCOL_ERROR,
@@ -984,7 +1001,7 @@ class Http2Connection extends BaseHttpConnection implements Http2Peer {
                 finishRejectedRequestBody(fh.streamId());
                 return;
             }
-            var existing = streams.get(fh.streamId());
+            var existing = registered.applicationStream();
             if (existing != null) {
                 if (existing.peerResetWasRead()) {
                     throw new Http2Exception(
@@ -1027,7 +1044,8 @@ class Http2Connection extends BaseHttpConnection implements Http2Peer {
                 clientSettings.initialWindowSize,
                 initialState,
                 new Http2HeadersFrame(fh.streamId(), false, errorHeaders),
-                new Http2DataFrame(fh.streamId(), true, message, 0, message.length)
+                new Http2DataFrame(fh.streamId(), true, message, 0, message.length),
+                null
             );
             server.onRequestRejected(rejectedRequest);
         }
@@ -1042,10 +1060,7 @@ class Http2Connection extends BaseHttpConnection implements Http2Peer {
                 write(new Http2ResetStreamFrame(streamId, Http2ErrorCode.REFUSED_STREAM.code()));
                 return false;
             }
-            long activeStreams = rejectedRequestBodies.size()
-                + streams.values().stream()
-                    .filter(Http2Stream::countsTowardsMaxConcurrentStreams)
-                    .count();
+            long activeStreams = streamRegistry.concurrentStreamCount();
             if (activeStreams >= serverSettings.maxConcurrentStreams) {
                 log.info("Max concurrent streams reached");
                 write(new Http2ResetStreamFrame(streamId, Http2ErrorCode.REFUSED_STREAM.code()));
@@ -1191,7 +1206,7 @@ class Http2Connection extends BaseHttpConnection implements Http2Peer {
                     initialState,
                     stream
                 );
-                streams.put(frame.streamId(), stream);
+                streamRegistry.registerApplicationStream(stream);
             }
         } finally {
             stateLock.unlock();
@@ -1298,11 +1313,6 @@ class Http2Connection extends BaseHttpConnection implements Http2Peer {
     private void rejectRequestDueToHandlerOverload(Http2HeadersFrame frame, Http2Stream stream) {
         rejectedDueToOverload.incrementAndGet();
         server.getStatsImpl().onRejectedDueToOverload();
-        streams.remove(frame.streamId(), stream);
-        // The application stream was registered before handler submission. Retire
-        // that receive-window identity before queueRejectedResponse installs the
-        // rejected-body identity for the same protocol stream.
-        inboundFlowControl.closeStream(frame.streamId());
         stream.cancel(new IOException("Request handler executor rejected the HTTP/2 stream"), false);
 
         String rejectionReason = "503 Service Unavailable";
@@ -1325,7 +1335,8 @@ class Http2Connection extends BaseHttpConnection implements Http2Peer {
             clientSettings.initialWindowSize,
             initialState,
             new Http2HeadersFrame(frame.streamId(), false, headers),
-            new Http2DataFrame(frame.streamId(), true, message, 0, message.length)
+            new Http2DataFrame(frame.streamId(), true, message, 0, message.length),
+            stream
         );
         // Queue the response before invoking application code so the independent writer can
         // make progress even if a reject listener is slow.
@@ -1404,7 +1415,7 @@ class Http2Connection extends BaseHttpConnection implements Http2Peer {
 
     @Override
     public Set<MuRequest> activeRequests() {
-        return streams.values().stream()
+        return streamRegistry.applicationStreams().stream()
             .filter(stream -> !stream.applicationExchangeEnded())
             .map(stream -> stream.request)
             .collect(Collectors.toSet());
@@ -1435,7 +1446,7 @@ class Http2Connection extends BaseHttpConnection implements Http2Peer {
 
     void removeProtocolStream(Http2Stream stream) {
         inboundFlowControl.closeStream(stream.id);
-        streams.remove(stream.id, stream);
+        streamRegistry.removeApplicationStream(stream);
     }
 }
 

--- a/src/main/java/io/muserver/Http2StreamRegistry.java
+++ b/src/main/java/io/muserver/Http2StreamRegistry.java
@@ -1,0 +1,204 @@
+package io.muserver;
+
+import org.jspecify.annotations.Nullable;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
+/**
+ * Publishes the identity associated with each live peer-initiated stream.
+ *
+ * <p>This is not the HTTP/2 stream state machine, which is owned by
+ * {@link Http2WriteCoordinator}. The reader, coordinator, application threads,
+ * and connection diagnostics all need to find a live application exchange,
+ * while rejected requests have protocol lifetime without an application
+ * exchange. One short-held lock makes those identities mutually exclusive and
+ * makes accepted-to-rejected conversion atomic.</p>
+ */
+final class Http2StreamRegistry {
+
+    static final class Lookup {
+        private static final Lookup ABSENT = new Lookup(null, false);
+        private static final Lookup REJECTED = new Lookup(null, true);
+
+        private final @Nullable Http2Stream applicationStream;
+        private final boolean rejectedRequestBody;
+
+        private Lookup(
+            @Nullable Http2Stream applicationStream,
+            boolean rejectedRequestBody
+        ) {
+            this.applicationStream = applicationStream;
+            this.rejectedRequestBody = rejectedRequestBody;
+        }
+
+        @Nullable Http2Stream applicationStream() {
+            return applicationStream;
+        }
+
+        boolean rejectedRequestBody() {
+            return rejectedRequestBody;
+        }
+    }
+
+    private final Lock lock = new ReentrantLock();
+    private final Map<Integer, Lookup> entries = new HashMap<>();
+
+    void registerApplicationStream(Http2Stream stream) {
+        lock.lock();
+        try {
+            if (entries.putIfAbsent(stream.id, new Lookup(stream, false)) != null) {
+                throw new IllegalStateException(
+                    "Stream identity already exists for " + stream.id
+                );
+            }
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    void registerRejectedRequestBody(int streamId) {
+        requirePositiveStreamId(streamId);
+        lock.lock();
+        try {
+            if (entries.putIfAbsent(streamId, Lookup.REJECTED) != null) {
+                throw new IllegalStateException(
+                    "Stream identity already exists for " + streamId
+                );
+            }
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    @SuppressWarnings("ReferenceEquality")
+    void convertApplicationStreamToRejectedRequestBody(Http2Stream stream) {
+        lock.lock();
+        try {
+            Lookup current = entries.get(stream.id);
+            if (current == null || current.applicationStream() != stream) {
+                throw new IllegalStateException(
+                    "Application stream identity does not exist for " + stream.id
+                );
+            }
+            entries.put(stream.id, Lookup.REJECTED);
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    Lookup lookup(int streamId) {
+        lock.lock();
+        try {
+            Lookup entry = entries.get(streamId);
+            if (entry == null) {
+                return Lookup.ABSENT;
+            }
+            return entry;
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    @Nullable Http2Stream applicationStream(int streamId) {
+        lock.lock();
+        try {
+            Lookup entry = entries.get(streamId);
+            return entry == null ? null : entry.applicationStream();
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    boolean containsApplicationStream(int streamId) {
+        lock.lock();
+        try {
+            Lookup entry = entries.get(streamId);
+            return entry != null && entry.applicationStream() != null;
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    boolean removeRejectedRequestBody(int streamId) {
+        lock.lock();
+        try {
+            Lookup entry = entries.get(streamId);
+            if (entry == null || !entry.rejectedRequestBody()) {
+                return false;
+            }
+            entries.remove(streamId);
+            return true;
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    @SuppressWarnings("ReferenceEquality")
+    void removeApplicationStream(Http2Stream stream) {
+        lock.lock();
+        try {
+            Lookup current = entries.get(stream.id);
+            if (current != null && current.applicationStream() == stream) {
+                entries.remove(stream.id);
+            }
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    List<Http2Stream> applicationStreams() {
+        lock.lock();
+        try {
+            List<Http2Stream> result = new ArrayList<>(entries.size());
+            for (Lookup entry : entries.values()) {
+                Http2Stream stream = entry.applicationStream();
+                if (stream != null) {
+                    result.add(stream);
+                }
+            }
+            return result;
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    long concurrentStreamCount() {
+        lock.lock();
+        try {
+            long result = 0;
+            for (Lookup entry : entries.values()) {
+                Http2Stream stream = entry.applicationStream();
+                if (stream == null || stream.countsTowardsMaxConcurrentStreams()) {
+                    result++;
+                }
+            }
+            return result;
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    boolean hasActiveProtocolStreams() {
+        return concurrentStreamCount() != 0;
+    }
+
+    boolean isEmpty() {
+        lock.lock();
+        try {
+            return entries.isEmpty();
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    private static void requirePositiveStreamId(int streamId) {
+        if (streamId <= 0) {
+            throw new IllegalArgumentException("A stream ID must be positive");
+        }
+    }
+}

--- a/src/test/java/io/muserver/ExecutionDomainsTest.java
+++ b/src/test/java/io/muserver/ExecutionDomainsTest.java
@@ -139,6 +139,15 @@ class ExecutionDomainsTest {
             assertThat(server.stats().completedRequests(), equalTo(0L));
             assertThat(completedResponses.get(), equalTo(0));
 
+            var connection =
+                (Http2Connection) server.activeConnections().iterator().next();
+            Http2StreamRegistry streamRegistry =
+                getField(connection, "streamRegistry", Http2StreamRegistry.class);
+            assertThat(
+                streamRegistry.lookup(1).rejectedRequestBody(),
+                is(true)
+            );
+
             var rejection = rejectedRequest.get(5, TimeUnit.SECONDS);
             assertThat(rejection.status(), equalTo(503));
             assertThat(rejection.reason(), equalTo("503 Service Unavailable"));
@@ -152,6 +161,10 @@ class ExecutionDomainsTest {
                 .writeFrame(new Http2Ping(false, secondPing))
                 .flush();
             assertThat(con.readLogicalFrame(Http2Ping.class), equalTo(new Http2Ping(true, secondPing)));
+            assertThat(
+                streamRegistry.lookup(1).rejectedRequestBody(),
+                is(false)
+            );
             releaseRejectListener.countDown();
 
             releaseBlocker.countDown();

--- a/src/test/java/io/muserver/Http2StreamRegistryTest.java
+++ b/src/test/java/io/muserver/Http2StreamRegistryTest.java
@@ -1,0 +1,44 @@
+package io.muserver;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class Http2StreamRegistryTest {
+
+    @Test
+    void rejectedRequestBodyHasOneExplicitIdentity() {
+        var registry = new Http2StreamRegistry();
+
+        registry.registerRejectedRequestBody(1);
+
+        var registered = registry.lookup(1);
+        assertThat(registered.applicationStream(), nullValue());
+        assertThat(registered.rejectedRequestBody(), equalTo(true));
+        assertThat(registry.concurrentStreamCount(), equalTo(1L));
+        assertThat(registry.isEmpty(), equalTo(false));
+
+        assertThat(registry.removeRejectedRequestBody(1), equalTo(true));
+        assertThat(registry.removeRejectedRequestBody(1), equalTo(false));
+        assertThat(registry.lookup(1).rejectedRequestBody(), equalTo(false));
+        assertThat(registry.isEmpty(), equalTo(true));
+    }
+
+    @Test
+    void duplicateAndInvalidRejectedIdentitiesAreRejected() {
+        var registry = new Http2StreamRegistry();
+        registry.registerRejectedRequestBody(1);
+
+        assertThrows(
+            IllegalStateException.class,
+            () -> registry.registerRejectedRequestBody(1)
+        );
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> registry.registerRejectedRequestBody(0)
+        );
+    }
+}

--- a/src/test/java/io/muserver/RFC9113_5_1_StreamStatesTest.java
+++ b/src/test/java/io/muserver/RFC9113_5_1_StreamStatesTest.java
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.List;
-import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Lock;
@@ -413,8 +413,9 @@ class RFC9113_5_1_StreamStatesTest {
             assertThat(exchangeCompleted.await(5, TimeUnit.SECONDS), equalTo(true));
 
             var connection = (Http2Connection) server.activeConnections().iterator().next();
-            Map<?, ?> streams = getField(connection, "streams", Map.class);
-            var stream = (Http2Stream) streams.get(1);
+            Http2StreamRegistry streamRegistry =
+                getField(connection, "streamRegistry", Http2StreamRegistry.class);
+            var stream = Objects.requireNonNull(streamRegistry.applicationStream(1));
             Lock stateLock = getField(connection, "stateLock", Lock.class);
             stateLock.lock();
             try {
@@ -518,8 +519,9 @@ class RFC9113_5_1_StreamStatesTest {
             assertThat(readIgnoringWindowUpdates(con, Http2DataFrame.class).endStream(), equalTo(true));
 
             var connection = (Http2Connection) server.activeConnections().iterator().next();
-            Map<?, ?> streams = getField(connection, "streams", Map.class);
-            var stream = (Http2Stream) streams.get(1);
+            Http2StreamRegistry streamRegistry =
+                getField(connection, "streamRegistry", Http2StreamRegistry.class);
+            var stream = Objects.requireNonNull(streamRegistry.applicationStream(1));
             assertEventually(stream::protocolStateClosed, equalTo(true));
 
             con.socket().shutdownOutput();

--- a/src/test/java/io/muserver/RFC9113_6_2_HeadersTest.java
+++ b/src/test/java/io/muserver/RFC9113_6_2_HeadersTest.java
@@ -6,7 +6,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayOutputStream;
-import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
@@ -14,7 +13,6 @@ import static io.muserver.MuServerBuilder.httpsServer;
 import static io.muserver.RFCTestUtils.*;
 import static io.muserver.FieldBlockEncoderTest.hexToByteArray;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.anEmptyMap;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.nullValue;
 import static scaffolding.MuAssert.assertEventually;
@@ -359,7 +357,8 @@ class RFC9113_6_2_HeadersTest {
             assertThat(handlerStarted.await(5, TimeUnit.SECONDS), equalTo(true));
 
             var connection = (Http2Connection) server.activeConnections().iterator().next();
-            Map<?, ?> streams = getField(connection, "streams", Map.class);
+            Http2StreamRegistry streamRegistry =
+                getField(connection, "streamRegistry", Http2StreamRegistry.class);
             var trailers = new FieldBlock();
             trailers.add("checksum", "x".repeat(1024));
             con.writeFrame(new Http2HeadersFrame(1, true, trailers)).flush();
@@ -370,7 +369,7 @@ class RFC9113_6_2_HeadersTest {
 
             releaseHandler.countDown();
             assertThat(exchangeCompleted.await(5, TimeUnit.SECONDS), equalTo(true));
-            assertEventually(() -> streams, anEmptyMap());
+            assertEventually(streamRegistry::isEmpty, equalTo(true));
         } finally {
             releaseHandler.countDown();
         }

--- a/src/test/java/io/muserver/RFC9113_6_4_RstStreamTest.java
+++ b/src/test/java/io/muserver/RFC9113_6_4_RstStreamTest.java
@@ -10,7 +10,7 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
@@ -178,8 +178,10 @@ class RFC9113_6_4_RstStreamTest {
             assertThat("The request did not start", requestStarted.await(5, TimeUnit.SECONDS), is(true));
 
             Http2Connection connection = connectionRef.get();
-            Map<?, ?> streams = getField(connection, "streams", Map.class);
-            Http2Stream stream = (Http2Stream) streams.get(1);
+            Http2StreamRegistry streamRegistry =
+                getField(connection, "streamRegistry", Http2StreamRegistry.class);
+            Http2Stream stream =
+                Objects.requireNonNull(streamRegistry.applicationStream(1));
             Lock stateLock = getField(connection, "stateLock", Lock.class);
             stateLock.lock();
             try {
@@ -228,8 +230,10 @@ class RFC9113_6_4_RstStreamTest {
             assertThat("The request did not start", requestStarted.await(5, TimeUnit.SECONDS), is(true));
 
             Http2Connection connection = (Http2Connection) server.activeConnections().iterator().next();
-            Map<?, ?> streams = getField(connection, "streams", Map.class);
-            Http2Stream stream = (Http2Stream) streams.get(1);
+            Http2StreamRegistry streamRegistry =
+                getField(connection, "streamRegistry", Http2StreamRegistry.class);
+            Http2Stream stream =
+                Objects.requireNonNull(streamRegistry.applicationStream(1));
             var stateAtWriteFailure = new AtomicReference<ResponseState>();
             var blockedWrite = new WriteTask(utf8DataFrame(1, false, "blocked"), true) {
                 @Override


### PR DESCRIPTION
## Summary

- replace the separate concurrent application-stream map and rejected-request set with one `Http2StreamRegistry`
- represent each live peer stream as exactly one of application exchange, rejected body awaiting drain, or absent
- atomically convert handler-overload rejections from application identity to rejected-body identity
- keep the registry distinct from the RFC 9113 stream state machine, which remains coordinator-owned
- preserve reader-owned wire-order fences and avoid any writer/coordinator barrier on inbound progress
- snapshot application streams before cancellation and diagnostics, with no user callbacks under the registry lock
- avoid per-frame allocation by storing immutable lookup entries directly

This is stacked on #160.

## Concurrency contract

The registry uses one short-held `ReentrantLock`. `stateLock` may enter the registry; registry operations never enter connection state, wait, write sockets, or invoke application code. The accepted-to-rejected conversion has one registry linearization point, so shutdown and diagnostics cannot observe the artificial empty gap that existed between removing the application stream and adding the rejected-body marker.

No public API, dependency, or wire-behaviour change.

## Validation

- `mise exec java@temurin-11 -- mvn test` — 1,657 tests, 0 failures, 0 errors
- `mise exec java@temurin-21 -- mvn -Pnullaway -DskipTests test`
- HTTP/2/RFC/execution-domain suite — 327 tests, 0 failures, 0 errors
- focused stream registry, stream-state, HEADERS, RST_STREAM, and saturated-handler tests
- overload regression asserts the rejected identity is visible while the rejection callback is blocked and is retired after peer END_STREAM