### PR TITLE
Honor HTTP/2 request body deadlines

### DIFF
--- a/HTTP2-CONCURRENCY.md
+++ b/HTTP2-CONCURRENCY.md
@@ -284,6 +284,10 @@ Credit is returned exactly once when bytes are consumed or discarded. The
 inbound component batches WINDOW_UPDATE increments at half of the advertised
 window and keeps connection-level accounting synchronized even when DATA is
 rejected with a stream error, as required by RFC 9113 Section 6.9.
+When the server resets one stream, unread queued body data is discarded and
+returned to the reusable connection window; the closed stream does not receive
+a WINDOW_UPDATE. A stream-local failure therefore cannot consume connection
+credit needed by unrelated streams.
 
 ## Exchange lifecycle
 

--- a/HTTP2-CONCURRENCY.md
+++ b/HTTP2-CONCURRENCY.md
@@ -29,7 +29,8 @@ debits both receive windows without depending on the blocking-output executor,
 and body consumers return credit through the same component. Live stream
 identity publication is similarly centralized in one short-held registry lock,
 while the coordinator remains the sole owner of RFC stream-state transitions.
-Still to be implemented are request-body read deadlines. The reader and
+Request-body read deadlines are monotonic timed waits owned by the body buffer:
+they do not require a scheduled task or coordinator round trip. The reader and
 coordinator have separate execution capacity from handlers, but do not yet have
 all of the final ownership boundaries described below.
 
@@ -138,8 +139,17 @@ protocol state, perform socket I/O, or invoke user code.
 Connection idle-timeout scans, WebSocket pings, and HTTP/2 SETTINGS
 acknowledgement deadlines use this facility. SETTINGS expiry atomically wins
 or loses a race with its ACK, then enqueues a connection-error command without
-mutating protocol state on the timer thread. Request-body read deadlines remain
-local blocking deadlines for now.
+mutating protocol state on the timer thread.
+
+Request-body read deadlines are intentionally not server timer tasks. They
+bound an application thread's blocking read on `Http2BodyInputStream`, so the
+body-buffer condition performs a monotonic timed wait. A zero request timeout
+waits indefinitely, as required by the public builder contract. Expiry raises
+the documented 408 response without the HTTP/1-only `Connection: close` field;
+RFC 9113 Section 8.2.2 prohibits connection-specific fields in HTTP/2. If a
+response has already started, the status cannot be replaced, so the coordinator
+resets only that stream with `CANCEL`, meaning the stream is no longer needed
+as defined by RFC 9113 Section 7.
 
 ## Ownership
 
@@ -155,7 +165,7 @@ local blocking deadlines for now.
 | Connection and stream inbound flow-control accounting | `Http2InboundFlowControl` lock |
 | Pending outbound frames and their ordering | Coordinator |
 | HPACK encoder and socket output | Coordinator |
-| Request-body producer/consumer buffer | `Http2BodyInputStream` lock |
+| Request-body producer/consumer buffer and read deadline | `Http2BodyInputStream` lock and condition |
 | Response API call ordering | Application-side response/async handle |
 | Connection and exchange completion | Coordinator |
 
@@ -327,7 +337,8 @@ Permitted cross-thread primitives are deliberately narrow:
 * one short-held lock for atomic connection-and-stream inbound flow-control
   accounting;
 * one short-held lock for the live stream identity index;
-* the existing request-body buffer lock and condition;
+* the request-body buffer lock and condition, including its monotonic blocking
+  read deadline;
 * an application-side lock that orders async response submissions; and
 * a thread-confined FIFO that drains nested application work without recursive
   calls or executor resubmission; and

--- a/src/main/java/io/muserver/Http2BodyInputStream.java
+++ b/src/main/java/io/muserver/Http2BodyInputStream.java
@@ -69,14 +69,25 @@ class Http2BodyInputStream extends InputStream implements RequestTrailersAccesso
 
     @Override
     public int read(byte[] b, int off, int len) throws IOException {
+        Objects.checkFromIndexSize(off, len, b.length);
+        if (len == 0) {
+            return 0;
+        }
+
         lock.lock();
         try {
+            long remainingNanos = TimeUnit.MILLISECONDS.toNanos(readTimeoutMillis);
             while (true) {
                 Object frame;
                 while ((frame = frames.peek()) == null) {
                     try {
-                        if (!hasData.await(readTimeoutMillis, TimeUnit.MILLISECONDS)) {
-                            throw new IOException("Timed out waiting for data");
+                        if (readTimeoutMillis == 0) {
+                            hasData.await();
+                        } else {
+                            if (remainingNanos <= 0) {
+                                throw new HttpException(HttpStatus.REQUEST_TIMEOUT_408);
+                            }
+                            remainingNanos = hasData.awaitNanos(remainingNanos);
                         }
                     } catch (InterruptedException e) {
                         throw new InterruptedIOException("Interrupted waiting for data");

--- a/src/main/java/io/muserver/Http2Connection.java
+++ b/src/main/java/io/muserver/Http2Connection.java
@@ -1293,7 +1293,12 @@ class Http2Connection extends BaseHttpConnection implements Http2Peer {
                 && !stream.resetWasInitiated()
                 && !stream.response().responseState().endState()) {
                 stream.response().setState(ResponseState.ERRORED);
-                write(new Http2ResetStreamFrame(stream.id, Http2ErrorCode.INTERNAL_ERROR.code()));
+                Http2ErrorCode errorCode =
+                    e instanceof HttpException
+                        && ((HttpException) e).status().sameCode(HttpStatus.REQUEST_TIMEOUT_408)
+                        ? Http2ErrorCode.CANCEL
+                        : Http2ErrorCode.INTERNAL_ERROR;
+                write(new Http2ResetStreamFrame(stream.id, errorCode.code()));
                 stream.cancel(new IOException("Unhandled stream exception", e), false);
             }
         } finally {

--- a/src/main/java/io/muserver/Http2Connection.java
+++ b/src/main/java/io/muserver/Http2Connection.java
@@ -1263,8 +1263,7 @@ class Http2Connection extends BaseHttpConnection implements Http2Peer {
                 response.setState(ResponseState.ERRORED);
                 write(new Http2ResetStreamFrame(stream.id, Http2ErrorCode.INTERNAL_ERROR.code()));
                 stream.cancel(
-                    new IOException("Application executors rejected HTTP/2 stream completion", dispatchFailure),
-                    false
+                    new IOException("Application executors rejected HTTP/2 stream completion", dispatchFailure)
                 );
             }
             stream.abandonApplicationExchange();
@@ -1299,7 +1298,7 @@ class Http2Connection extends BaseHttpConnection implements Http2Peer {
                         ? Http2ErrorCode.CANCEL
                         : Http2ErrorCode.INTERNAL_ERROR;
                 write(new Http2ResetStreamFrame(stream.id, errorCode.code()));
-                stream.cancel(new IOException("Unhandled stream exception", e), false);
+                stream.cancel(new IOException("Unhandled stream exception", e));
             }
         } finally {
             onExchangeEnded(stream);

--- a/src/test/java/io/muserver/Http2BodyInputStreamTest.java
+++ b/src/test/java/io/muserver/Http2BodyInputStreamTest.java
@@ -8,12 +8,55 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicLong;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class Http2BodyInputStreamTest {
+
+    @Test
+    void zeroLengthReadReturnsImmediatelyWithoutWaitingForData() throws Exception {
+        try (var stream = new Http2BodyInputStream(1, credit -> {}, credit -> {})) {
+            assertThat(stream.read(new byte[1], 0, 0), equalTo(0));
+        }
+    }
+
+    @Test
+    void zeroTimeoutWaitsUntilDataArrives() throws Exception {
+        var executor = Executors.newSingleThreadExecutor();
+        try (var stream = new Http2BodyInputStream(0, credit -> {}, credit -> {})) {
+            var aboutToRead = new CountDownLatch(1);
+            var read = executor.submit(() -> {
+                aboutToRead.countDown();
+                return stream.read();
+            });
+
+            assertThat(aboutToRead.await(5, TimeUnit.SECONDS), equalTo(true));
+            assertThrows(TimeoutException.class, () -> read.get(50, TimeUnit.MILLISECONDS));
+            stream.onData(data("x", true));
+
+            assertThat(read.get(5, TimeUnit.SECONDS), equalTo((int) 'x'));
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    @Test
+    void finiteTimeoutThrows408WithoutAnHttp1ConnectionHeader() throws Exception {
+        try (var stream = new Http2BodyInputStream(1, credit -> {}, credit -> {})) {
+            var timeout = assertThrows(HttpException.class, stream::read);
+
+            assertThat(timeout.status(), equalTo(HttpStatus.REQUEST_TIMEOUT_408));
+            assertThat(timeout.responseHeaders().get(HeaderNames.CONNECTION), nullValue());
+        }
+    }
 
     @ParameterizedTest
     @ValueSource(ints = {1, 2, 11, 1024})

--- a/src/test/java/io/muserver/Http2RequestBodyTimeoutTest.java
+++ b/src/test/java/io/muserver/Http2RequestBodyTimeoutTest.java
@@ -1,0 +1,194 @@
+package io.muserver;
+
+import org.jspecify.annotations.Nullable;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static io.muserver.MuServerBuilder.httpsServer;
+import static io.muserver.RFCTestUtils.assertNothingToRead;
+import static io.muserver.RFCTestUtils.readIgnoringWindowUpdates;
+import static io.muserver.RFCTestUtils.utf8DataFrame;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.nullValue;
+
+class Http2RequestBodyTimeoutTest {
+
+    private @Nullable MuServer server;
+
+    @Test
+    void zeroRequestTimeoutDisablesTheHttp2BodyDeadline() throws Exception {
+        var handlerStarted = new CountDownLatch(1);
+        server = httpsServer()
+            .withHttp2Config(Http2ConfigBuilder.http2Enabled())
+            .withRequestTimeout(0, TimeUnit.MILLISECONDS)
+            .addHandler(Method.POST, "/hello", (request, response, pathParams) -> {
+                handlerStarted.countDown();
+                response.write(request.readBodyAsString());
+            })
+            .start();
+
+        try (var client = new H2Client();
+             var con = client.connect(server)) {
+            con.handshake()
+                .writeFrame(new Http2HeadersFrame(
+                    1,
+                    false,
+                    requestHeaders("POST", "/hello", server.uri().getPort())
+                ))
+                .flush();
+
+            assertThat(handlerStarted.await(5, TimeUnit.SECONDS), equalTo(true));
+            assertNothingToRead(con.socket());
+
+            con.writeFrame(utf8DataFrame(1, true, "hello"))
+                .flush();
+
+            var responseHeaders =
+                readIgnoringWindowUpdates(con, Http2HeadersFrame.class);
+            assertThat(responseHeaders.headers().get(":status"), equalTo("200"));
+            assertThat(
+                readIgnoringWindowUpdates(con, Http2DataFrame.class).toUTF8(),
+                equalTo("hello")
+            );
+            assertThat(
+                readIgnoringWindowUpdates(con, Http2DataFrame.class),
+                equalTo(Http2DataFrame.eos(1))
+            );
+        }
+    }
+
+    @Test
+    void expiredRequestTimeoutReturns408WithoutClosingTheHttp2Connection()
+        throws Exception {
+        var handlerStarted = new CountDownLatch(1);
+        server = httpsServer()
+            .withHttp2Config(Http2ConfigBuilder.http2Enabled())
+            .withRequestTimeout(50, TimeUnit.MILLISECONDS)
+            .addHandler(Method.POST, "/slow", (request, response, pathParams) -> {
+                handlerStarted.countDown();
+                request.readBodyAsString();
+            })
+            .addHandler(Method.GET, "/after", (request, response, pathParams) -> {
+                response.status(204);
+            })
+            .start();
+
+        try (var client = new H2Client();
+             var con = client.connect(server)) {
+            con.handshake()
+                .writeFrame(new Http2HeadersFrame(
+                    1,
+                    false,
+                    requestHeaders("POST", "/slow", server.uri().getPort())
+                ))
+                .flush();
+
+            assertThat(handlerStarted.await(5, TimeUnit.SECONDS), equalTo(true));
+            var timeoutHeaders =
+                readIgnoringWindowUpdates(con, Http2HeadersFrame.class);
+            assertThat(timeoutHeaders.headers().get(":status"), equalTo("408"));
+            assertThat(timeoutHeaders.headers().get("connection"), nullValue());
+            drainResponse(con, timeoutHeaders);
+
+            con.writeFrame(new Http2HeadersFrame(
+                    3,
+                    true,
+                    requestHeaders("GET", "/after", server.uri().getPort())
+                ))
+                .flush();
+
+            var afterResponse =
+                readIgnoringWindowUpdates(con, Http2HeadersFrame.class);
+            assertThat(afterResponse.streamId(), equalTo(3));
+            assertThat(afterResponse.headers().get(":status"), equalTo("204"));
+
+            con.writeFrame(Http2DataFrame.eos(1)).flush();
+        }
+    }
+
+    @Test
+    void expiredRequestTimeoutResetsOnlyAStreamWhoseResponseHasStarted()
+        throws Exception {
+        server = httpsServer()
+            .withHttp2Config(Http2ConfigBuilder.http2Enabled())
+            .withRequestTimeout(50, TimeUnit.MILLISECONDS)
+            .addHandler(Method.POST, "/slow", (request, response, pathParams) -> {
+                response.sendChunk("partial");
+                request.readBodyAsString();
+            })
+            .addHandler(Method.GET, "/after", (request, response, pathParams) -> {
+                response.status(204);
+            })
+            .start();
+
+        try (var client = new H2Client();
+             var con = client.connect(server)) {
+            con.handshake()
+                .writeFrame(new Http2HeadersFrame(
+                    1,
+                    false,
+                    requestHeaders("POST", "/slow", server.uri().getPort())
+                ))
+                .flush();
+
+            var initialHeaders =
+                readIgnoringWindowUpdates(con, Http2HeadersFrame.class);
+            assertThat(initialHeaders.headers().get(":status"), equalTo("200"));
+            assertThat(
+                readIgnoringWindowUpdates(con, Http2DataFrame.class).toUTF8(),
+                equalTo("partial")
+            );
+            var reset =
+                readIgnoringWindowUpdates(con, Http2ResetStreamFrame.class);
+            assertThat(reset.streamId(), equalTo(1));
+            assertThat(reset.errorCodeEnum(), equalTo(Http2ErrorCode.CANCEL));
+
+            con.writeFrame(new Http2HeadersFrame(
+                    3,
+                    true,
+                    requestHeaders("GET", "/after", server.uri().getPort())
+                ))
+                .flush();
+
+            var afterResponse =
+                readIgnoringWindowUpdates(con, Http2HeadersFrame.class);
+            assertThat(afterResponse.streamId(), equalTo(3));
+            assertThat(afterResponse.headers().get(":status"), equalTo("204"));
+        }
+    }
+
+    private static void drainResponse(
+        H2ClientConnection connection,
+        Http2HeadersFrame initialHeaders
+    ) throws Exception {
+        if (initialHeaders.endStream()) {
+            return;
+        }
+        while (true) {
+            LogicalHttp2Frame frame = connection.readLogicalFrame();
+            if (frame.streamId() == initialHeaders.streamId() && frame.endStream()) {
+                return;
+            }
+        }
+    }
+
+    private static FieldBlock requestHeaders(String method, String path, int port) {
+        var headers = new FieldBlock();
+        headers.add(":scheme", "https");
+        headers.add(":authority", "localhost:" + port);
+        headers.add(":method", method);
+        headers.add(":path", path);
+        return headers;
+    }
+
+    @AfterEach
+    void stop() {
+        if (server != null) {
+            server.stop();
+        }
+    }
+}

--- a/src/test/java/io/muserver/RFC9113_5_2_FlowControlTest.java
+++ b/src/test/java/io/muserver/RFC9113_5_2_FlowControlTest.java
@@ -145,10 +145,12 @@ class RFC9113_5_2_FlowControlTest {
     @Test
     void cancellingAStreamWithUnreadQueuedDataRefundsConnectionCredit() throws Exception {
         var holdLatch = new CountDownLatch(1);
+        var holdStarted = new CountDownLatch(1);
 
         server = httpsServer()
             .withHttp2Config(Http2ConfigBuilder.http2Enabled())
             .addHandler(Method.POST, "/hold", (request, response, pathParams) -> {
+                holdStarted.countDown();
                 assertNotTimedOut("waiting for hold request to finish", holdLatch);
                 try {
                     request.readBodyAsString();
@@ -163,24 +165,28 @@ class RFC9113_5_2_FlowControlTest {
         try (var client = new H2Client();
              var con = client.connect(server)) {
 
-            var holdHeaders = postHelloHeaders(getPort());
-            holdHeaders.set(":path", "/hold");
-
-            var echoHeaders = postHelloHeaders(getPort());
-
             byte[] sixteenKb = repeated('a', 16384);
             byte[] lastChunk = repeated('b', 16383);
 
             con.handshake()
-                .writeFrame(new Http2HeadersFrame(1, false, holdHeaders))
+                .writeFrame(new Http2HeadersFrame(
+                    1,
+                    false,
+                    postHeaders(getPort(), "/hold")
+                ))
                 .writeFrame(new Http2DataFrame(1, false, sixteenKb, 0, sixteenKb.length))
                 .writeFrame(new Http2DataFrame(1, false, sixteenKb, 0, sixteenKb.length))
                 .writeFrame(new Http2DataFrame(1, false, sixteenKb, 0, sixteenKb.length))
                 .writeFrame(new Http2DataFrame(1, false, lastChunk, 0, lastChunk.length))
                 .flush();
 
+            assertNotTimedOut("waiting for held request to start", holdStarted);
             con.writeFrame(new Http2ResetStreamFrame(1, Http2ErrorCode.CANCEL.code()))
-                .writeFrame(new Http2HeadersFrame(3, false, echoHeaders))
+                .writeFrame(new Http2HeadersFrame(
+                    3,
+                    false,
+                    postHelloHeaders(getPort())
+                ))
                 .writeFrame(RFCTestUtils.utf8DataFrame(3, true, "x"))
                 .flush();
 

--- a/src/test/java/io/muserver/RFC9113_5_2_FlowControlTest.java
+++ b/src/test/java/io/muserver/RFC9113_5_2_FlowControlTest.java
@@ -206,6 +206,88 @@ class RFC9113_5_2_FlowControlTest {
     }
 
     @Test
+    void locallyResettingAStreamRefundsUnreadConnectionCredit() throws Exception {
+        var failRequest = new CountDownLatch(1);
+
+        server = httpsServer()
+            .withHttp2Config(Http2ConfigBuilder.http2Enabled())
+            .addHandler(Method.POST, "/fail", (request, response, pathParams) -> {
+                response.sendChunk("partial");
+                assertNotTimedOut("waiting to fail request", failRequest);
+                throw new IllegalStateException("expected test failure");
+            })
+            .addHandler(Method.POST, "/hello", (request, response, pathParams) -> {
+                response.write(request.readBodyAsString());
+            })
+            .start();
+
+        try (var client = new H2Client();
+             var con = client.connect(server)) {
+            con.handshake()
+                .writeFrame(new Http2HeadersFrame(
+                    1,
+                    false,
+                    postHeaders(getPort(), "/fail")
+                ))
+                .flush();
+
+            assertThat(
+                readIgnoringWindowUpdates(con, Http2HeadersFrame.class)
+                    .headers().get(":status"),
+                equalTo("200")
+            );
+            assertThat(
+                readIgnoringWindowUpdates(con, Http2DataFrame.class).toUTF8(),
+                equalTo("partial")
+            );
+
+            byte[] sixteenKb = repeated('a', 16_384);
+            byte[] lastChunk = repeated('b', 16_383);
+            byte[] pingData = new byte[] {1, 2, 3, 4, 5, 6, 7, 8};
+            con.writeFrame(new Http2DataFrame(1, false, sixteenKb, 0, sixteenKb.length))
+                .writeFrame(new Http2DataFrame(1, false, sixteenKb, 0, sixteenKb.length))
+                .writeFrame(new Http2DataFrame(1, false, sixteenKb, 0, sixteenKb.length))
+                .writeFrame(new Http2DataFrame(1, false, lastChunk, 0, lastChunk.length))
+                .writeFrame(new Http2Ping(false, pingData))
+                .flush();
+
+            assertThat(
+                con.readLogicalFrame(Http2Ping.class),
+                equalTo(new Http2Ping(true, pingData))
+            );
+            failRequest.countDown();
+
+            var reset =
+                readIgnoringWindowUpdates(con, Http2ResetStreamFrame.class);
+            assertThat(reset.streamId(), equalTo(1));
+            assertThat(reset.errorCodeEnum(), equalTo(Http2ErrorCode.INTERNAL_ERROR));
+
+            con.writeFrame(new Http2HeadersFrame(
+                    3,
+                    false,
+                    postHelloHeaders(getPort())
+                ))
+                .writeFrame(utf8DataFrame(3, true, "x"))
+                .flush();
+
+            var headers =
+                readIgnoringWindowUpdates(con, Http2HeadersFrame.class);
+            assertThat(headers.streamId(), equalTo(3));
+            assertThat(headers.headers().get(":status"), equalTo("200"));
+            assertThat(
+                readIgnoringWindowUpdates(con, Http2DataFrame.class).toUTF8(),
+                equalTo("x")
+            );
+            assertThat(
+                readIgnoringWindowUpdates(con, Http2DataFrame.class),
+                equalTo(Http2DataFrame.eos(3))
+            );
+        } finally {
+            failRequest.countDown();
+        }
+    }
+
+    @Test
     void dataFramesRejectedAtStreamLevelStillRefundConnectionCredit() throws Exception {
         server = httpsServer()
             .withHttp2Config(Http2ConfigBuilder.http2Enabled())

--- a/src/test/java/io/muserver/RFCTestUtils.java
+++ b/src/test/java/io/muserver/RFCTestUtils.java
@@ -127,9 +127,13 @@ class RFCTestUtils {
     }
 
     static @NonNull FieldBlock postHelloHeaders(int port) {
+        return postHeaders(port, "/hello");
+    }
+
+    static @NonNull FieldBlock postHeaders(int port, String path) {
         FieldBlock headers = baseHeaders("https", port);
         headers.add(":method", "POST");
-        headers.add(":path", "/hello");
+        headers.add(":path", path);
         headers.add("content-type", "text/plain; charset=utf-8");
         return headers;
     }


### PR DESCRIPTION
## Summary

- honor the public `withRequestTimeout(0, ...)` contract for HTTP/2 by waiting indefinitely instead of timing out immediately
- keep request-body deadlines local to the body-buffer condition and use a monotonic `awaitNanos` budget across condition wakeups
- turn an expired blocking body read into the documented 408 response
- omit HTTP/1's `Connection: close` field from HTTP/2 timeout responses
- reset only a timed-out stream with `CANCEL` when its response has already started, leaving the connection and unrelated streams usable
- refund unread request-body bytes to the connection receive window on every locally initiated stream reset
- make zero-length body reads obey the `InputStream` contract
- repair an existing flow-control test whose mutated pseudo-header order caused a false-positive protocol reset

This is stacked on #161.

## Concurrency and protocol contract

The deadline belongs to `Http2BodyInputStream`, where the blocking operation and producer/consumer condition already live. It does not add one scheduled task per read and does not route an application wait through the timer or write coordinator. A finite read has one monotonic budget even if the condition wakes spuriously; a configured value of zero uses an untimed condition wait.

The 408 behavior is the existing public builder contract rather than an HTTP/2 requirement. RFC 9113 Section 8.2.2 prohibits connection-specific fields in HTTP/2, so the HTTP/1-only close header is not copied. If final response headers already started, replacing the status is impossible; RFC 9113 Section 7's `CANCEL` code describes the expected local outcome more accurately than `INTERNAL_ERROR`.

A local reset closes the stream receive window, but unread flow-controlled bytes still have to be returned to the connection window. The new regression fills all 65,535 bytes of connection credit, fences reader progress with PING/ACK, triggers a server-side reset, and proves another stream can upload. Before the fix, that request deterministically received `GOAWAY(FLOW_CONTROL_ERROR)`.

The raw timeout tests also prove that another stream succeeds before the timed-out request sends END_STREAM and after an already-started response is reset.

## Validation

- `mise exec java@temurin-11 -- mvn test` — 1,663 tests, 0 failures, 0 errors
- `mise exec java@temurin-21 -- mvn -Pnullaway -DskipTests test`
- HTTP/2/RFC/execution-domain suite after the reset-credit fix — 334 tests, 0 failures, 0 errors
- focused timeout/body/flow-control and executor-rejection suites
