### PR TITLE
Keep HTTP/2 flow-control callbacks outside the body lock

### DIFF
--- a/HTTP2-CONCURRENCY.md
+++ b/HTTP2-CONCURRENCY.md
@@ -156,6 +156,7 @@ as defined by RFC 9113 Section 7.
 | State or resource | Owner |
 | --- | --- |
 | Socket input, input buffer, HPACK decoder | Connection reader |
+| Connection shutdown and new-stream admission gate | `Http2Connection` state lock |
 | RFC stream protocol state | Coordinator |
 | Live application/rejected stream identity index | `Http2StreamRegistry` lock |
 | Inbound END_STREAM and reset-seen fences | Connection reader, with monotonic publication where another domain reads them |
@@ -167,7 +168,8 @@ as defined by RFC 9113 Section 7.
 | HPACK encoder and socket output | Coordinator |
 | Request-body producer/consumer buffer and read deadline | `Http2BodyInputStream` lock and condition |
 | Response API call ordering | Application-side response/async handle |
-| Connection and exchange completion | Coordinator |
+| Protocol stream completion | Coordinator |
+| Application exchange completion | Serialized application completion path |
 
 Coordinator-owned state uses ordinary collections and fields. It must not use
 concurrent collections, volatile fields, or locks as substitutes for ownership.
@@ -278,7 +280,10 @@ request-body buffer. One short-held lock makes the connection and stream debit
 atomic with credit returned by body-consumer threads. This is intentionally not
 a write-coordinator round trip: the socket writer can block, and input must
 continue reading and processing HTTP/2 frames promptly as required by RFC 9113
-Section 5.2.2. No lock is held while queuing WINDOW_UPDATE output.
+Section 5.2.2. A body consumer commits its buffer offset and releases the body
+lock before returning credit to the inbound component or queuing WINDOW_UPDATE
+output. Coordinator contention therefore cannot prevent the reader from
+publishing the next DATA frame to that body.
 
 Credit is returned exactly once when bytes are consumed or discarded. The
 inbound component batches WINDOW_UPDATE increments at half of the advertised
@@ -338,6 +343,8 @@ Permitted cross-thread primitives are deliberately narrow:
 
 * a blocking mailbox for coordinator commands;
 * a small promise backed by a latch and a result or error;
+* one short-held connection state lock for shutdown, admission, and atomic
+  publication across the protocol components;
 * one short-held lock for atomic connection-and-stream inbound flow-control
   accounting;
 * one short-held lock for the live stream identity index;
@@ -354,6 +361,9 @@ identity index is cross-thread publication rather than RFC stream state, and
 therefore uses its explicit registry lock. Inbound receive windows are the
 other deliberate lock-based boundary: DATA debits happen on the reader while
 credit is returned by body-consumer threads, so both windows share one lock.
+The connection state lock may enter the registry, inbound-flow component, or
+coordinator mailbox while publishing one transition. None of those components
+enters the connection state lock while holding its own lock.
 
 No lock is held while:
 

--- a/src/main/java/io/muserver/Http2BodyInputStream.java
+++ b/src/main/java/io/muserver/Http2BodyInputStream.java
@@ -74,6 +74,8 @@ class Http2BodyInputStream extends InputStream implements RequestTrailersAccesso
             return 0;
         }
 
+        int readAmount;
+        int creditToReturn;
         lock.lock();
         try {
             long remainingNanos = TimeUnit.MILLISECONDS.toNanos(readTimeoutMillis);
@@ -107,8 +109,6 @@ class Http2BodyInputStream extends InputStream implements RequestTrailersAccesso
                         frames.remove();
                         continue;
                     }
-                    int readAmount;
-                    int creditToReturn;
                     if (remaining < len) {
                         // the user wants more than what is available in the first frame, so give all the rest of it
                         System.arraycopy(data.payload(), offset, b, off, remaining);
@@ -131,13 +131,7 @@ class Http2BodyInputStream extends InputStream implements RequestTrailersAccesso
                         creditToReturn += pending.flowControlSize - data.payloadLength();
                     }
                     pending.creditReturned += creditToReturn;
-
-                    try {
-                        onDataReadCallback.creditAvailable(creditToReturn);
-                    } catch (Http2Exception e) {
-                        throw new IOException("Http2 error updating flow control", e);
-                    }
-                    return readAmount;
+                    break;
                 } else if (frame == END_OF_STREAM || frame == DISCARDING) {
                     return -1;
                 } else if (frame instanceof IOException) {
@@ -150,6 +144,12 @@ class Http2BodyInputStream extends InputStream implements RequestTrailersAccesso
         } finally {
             lock.unlock();
         }
+        try {
+            onDataReadCallback.creditAvailable(creditToReturn);
+        } catch (Http2Exception e) {
+            throw new IOException("Http2 error updating flow control", e);
+        }
+        return readAmount;
     }
 
     public void onData(Http2DataFrame dataFrame) {
@@ -296,7 +296,12 @@ class Http2BodyInputStream extends InputStream implements RequestTrailersAccesso
 
     @Override
     public @org.jspecify.annotations.Nullable Headers trailers() {
-        return trailers;
+        lock.lock();
+        try {
+            return trailers;
+        } finally {
+            lock.unlock();
+        }
     }
 
 

--- a/src/test/java/io/muserver/Http2BodyInputStreamTest.java
+++ b/src/test/java/io/muserver/Http2BodyInputStreamTest.java
@@ -58,6 +58,42 @@ class Http2BodyInputStreamTest {
         }
     }
 
+    @Test
+    void returningFlowControlCreditDoesNotRetainTheBodyBufferLock() throws Exception {
+        var callbackStarted = new CountDownLatch(1);
+        var releaseCallback = new CountDownLatch(1);
+        var executor = Executors.newFixedThreadPool(2);
+
+        try (var stream = new Http2BodyInputStream(
+            10_000,
+            credit -> {
+                callbackStarted.countDown();
+                try {
+                    if (!releaseCallback.await(5, TimeUnit.SECONDS)) {
+                        throw new AssertionError("Timed out waiting to release credit callback");
+                    }
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    throw new AssertionError("Credit callback was interrupted", e);
+                }
+            },
+            credit -> {}
+        )) {
+            stream.onData(data("a", false));
+            var read = executor.submit(() -> stream.read());
+
+            assertThat(callbackStarted.await(5, TimeUnit.SECONDS), equalTo(true));
+            var producer = executor.submit(() -> stream.onData(data("b", true)));
+
+            assertThat(producer.get(1, TimeUnit.SECONDS), nullValue());
+            releaseCallback.countDown();
+            assertThat(read.get(5, TimeUnit.SECONDS), equalTo((int) 'a'));
+        } finally {
+            releaseCallback.countDown();
+            executor.shutdownNow();
+        }
+    }
+
     @ParameterizedTest
     @ValueSource(ints = {1, 2, 11, 1024})
     void readsWhenDataIsAvailable(int copyBufferSize) throws Exception {


### PR DESCRIPTION
This is the next concurrency re-architecture slice, stacked on #162.

The HTTP/2 request-body consumer used to retain the body-buffer lock while returning inbound flow-control credit. That callback crosses into the connection flow-control component and can contend with coordinator work. If it blocks, the socket reader cannot publish the next DATA frame to the body buffer.

This change:
- commits buffer offsets and exactly-once credit bookkeeping under the body lock, then releases it before returning credit
- protects trailer publication and reads with the same body lock
- documents the short-held connection state lock and the permitted lock ordering more precisely
- adds a deterministic concurrency test in which the credit callback is blocked and proves that the reader can still publish the next DATA frame

The new test times out against the previous implementation and passes with this change.

Validation:
- Java 11 full suite: 1,665 tests, 0 failures/errors, 5 skips
- Java 21 NullAway build: green
- HTTP/2/RFC/execution suite: 335 tests, 0 failures/errors, 1 skip

No public API or wire behavior changes are intended.