### PR TITLE
Start HTTP/2 shutdown grace after GOAWAY reaches the wire

### DIFF
--- a/HTTP2-CONCURRENCY.md
+++ b/HTTP2-CONCURRENCY.md
@@ -365,6 +365,12 @@ The connection state lock may enter the registry, inbound-flow component, or
 coordinator mailbox while publishing one transition. None of those components
 enters the connection state lock while holding its own lock.
 
+Graceful HTTP/2 shutdown uses the same state-lock boundary for stream admission
+and the final accepted-stream snapshot. The in-flight stream-creation grace
+period begins only after the writer flushes the initial maximum-stream-ID
+`GOAWAY`; writer scheduling or socket delay therefore cannot consume the grace
+period before the peer sees the warning. Its deadline uses monotonic time.
+
 No lock is held while:
 
 * writing to a socket;

--- a/src/main/java/io/muserver/Http2Connection.java
+++ b/src/main/java/io/muserver/Http2Connection.java
@@ -64,8 +64,9 @@ class Http2Connection extends BaseHttpConnection implements Http2Peer {
     private final AtomicBoolean writerTaskScheduled = new AtomicBoolean();
     private final CompletableFuture<@Nullable Void> writeLoopEnded = new CompletableFuture<>();
     private volatile @Nullable OutputStream writerOutput;
-    private volatile boolean finalGoAwayQueued;
-    private volatile long finalGoAwayEarliestTime = Long.MAX_VALUE;
+    private boolean initialGoAwayWritten;
+    private boolean finalGoAwayQueued;
+    private long finalGoAwayEarliestNanos;
     private boolean finalGoAwayWakeScheduled;
 
     private static final class PendingSettingsAck {
@@ -478,7 +479,6 @@ class Http2Connection extends BaseHttpConnection implements Http2Peer {
         if (writeState == HState.ACTIVE) {
             log.info("Graceful shutdown initiated with write state {}", writeState);
             writeState = HState.SHUTDOWN_INITIATED;
-            finalGoAwayEarliestTime = System.currentTimeMillis() + GO_AWAY_GRACE_PERIOD_MILLIS;
             // As per: https://datatracker.ietf.org/doc/html/rfc9113#section-6.8-18
             // A server that is attempting to gracefully shut down a connection SHOULD send an initial GOAWAY frame
             // with the last stream identifier set to 2^31-1 and a NO_ERROR code. This signals to the client that a
@@ -511,13 +511,16 @@ class Http2Connection extends BaseHttpConnection implements Http2Peer {
         return isLocalShutdownInitiatedLocked() || isPeerShutdownInitiatedLocked();
     }
 
-    private long localGoAwayGracePeriodMillisRemainingLocked(long now) {
-        return Math.max(0L, finalGoAwayEarliestTime - now);
+    private long localGoAwayGracePeriodNanosRemainingLocked(long now) {
+        if (!initialGoAwayWritten) {
+            return Long.MAX_VALUE;
+        }
+        return Math.max(0L, finalGoAwayEarliestNanos - now);
     }
 
     private boolean isStillAllowingInFlightStreamCreationLocked(long now) {
         return isLocalShutdownInitiatedLocked()
-            && localGoAwayGracePeriodMillisRemainingLocked(now) > 0L;
+            && localGoAwayGracePeriodNanosRemainingLocked(now) > 0L;
     }
 
     private boolean canStartNewStreamsLocked(long now) {
@@ -532,7 +535,8 @@ class Http2Connection extends BaseHttpConnection implements Http2Peer {
             return false;
         }
         if (isLocalShutdownInitiatedLocked()) {
-            return localGoAwayGracePeriodMillisRemainingLocked(now) == 0L;
+            return initialGoAwayWritten
+                && localGoAwayGracePeriodNanosRemainingLocked(now) == 0L;
         }
         return isPeerShutdownInitiatedLocked()
             && streamRegistry.isEmpty();
@@ -551,11 +555,26 @@ class Http2Connection extends BaseHttpConnection implements Http2Peer {
             && writeCoordinator.isIdle();
     }
 
-    private long millisUntilNextWriteActionLocked(long now) {
-        if (isLocalShutdownInitiatedLocked() && !finalGoAwayQueued) {
-            return localGoAwayGracePeriodMillisRemainingLocked(now);
+    private long nanosUntilNextWriteActionLocked(long now) {
+        if (isLocalShutdownInitiatedLocked()
+            && initialGoAwayWritten
+            && !finalGoAwayQueued) {
+            return localGoAwayGracePeriodNanosRemainingLocked(now);
         }
         return -1L;
+    }
+
+    private void recordInitialGoAwayWritten() {
+        stateLock.lock();
+        try {
+            if (isLocalShutdownInitiatedLocked() && !initialGoAwayWritten) {
+                initialGoAwayWritten = true;
+                finalGoAwayEarliestNanos = System.nanoTime()
+                    + TimeUnit.MILLISECONDS.toNanos(GO_AWAY_GRACE_PERIOD_MILLIS);
+            }
+        } finally {
+            stateLock.unlock();
+        }
     }
 
     private void completeShutdownLocked() {
@@ -581,6 +600,9 @@ class Http2Connection extends BaseHttpConnection implements Http2Peer {
                     }
                 }
                 clientOut.flush();
+                if (GO_AWAY_WARNING.equals(frame)) {
+                    recordInitialGoAwayWritten();
+                }
                 candidate.complete();
                 if (protocolError != null && protocolError.errorType() == Http2Level.CONNECTION) {
                     return true;
@@ -1054,7 +1076,7 @@ class Http2Connection extends BaseHttpConnection implements Http2Peer {
     private boolean acceptNewStream(int streamId) {
         stateLock.lock();
         try {
-            long now = System.currentTimeMillis();
+            long now = System.nanoTime();
             if (!canStartNewStreamsLocked(now)) {
                 log.info("Refusing stream {} because graceful shutdown no longer allows new streams", streamId);
                 write(new Http2ResetStreamFrame(streamId, Http2ErrorCode.REFUSED_STREAM.code()));
@@ -1105,7 +1127,7 @@ class Http2Connection extends BaseHttpConnection implements Http2Peer {
                     continue;
                 }
 
-                long now = System.currentTimeMillis();
+                long now = System.nanoTime();
                 boolean continueWriting = false;
                 stateLock.lock();
                 try {
@@ -1115,7 +1137,7 @@ class Http2Connection extends BaseHttpConnection implements Http2Peer {
                     } else if (isTerminalAndDrainedLocked()) {
                         completeShutdownLocked();
                     } else {
-                        long waitTime = millisUntilNextWriteActionLocked(now);
+                        long waitTime = nanosUntilNextWriteActionLocked(now);
                         if (waitTime > 0L && !finalGoAwayWakeScheduled) {
                             scheduleFinalGoAwayWakeLocked(waitTime);
                         }
@@ -1142,7 +1164,7 @@ class Http2Connection extends BaseHttpConnection implements Http2Peer {
         }
     }
 
-    private void scheduleFinalGoAwayWakeLocked(long delayMillis) {
+    private void scheduleFinalGoAwayWakeLocked(long delayNanos) {
         finalGoAwayWakeScheduled = true;
         try {
             server.scheduleTimerCallback(() -> {
@@ -1157,7 +1179,7 @@ class Http2Connection extends BaseHttpConnection implements Http2Peer {
                 if (wakeWriter) {
                     signalWriteLoop();
                 }
-            }, delayMillis, TimeUnit.MILLISECONDS);
+            }, delayNanos, TimeUnit.NANOSECONDS);
         } catch (RuntimeException | Error e) {
             finalGoAwayWakeScheduled = false;
             throw e;

--- a/src/test/java/io/muserver/RFC9113_6_8_GoAwayTest.java
+++ b/src/test/java/io/muserver/RFC9113_6_8_GoAwayTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import java.io.IOException;
+import java.net.SocketTimeoutException;
 import java.nio.ByteBuffer;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
@@ -118,6 +119,69 @@ class RFC9113_6_8_GoAwayTest {
             assertThrows(IOException.class, con::readFrameHeader);
 
             stopper.shutdownNow();
+        }
+    }
+
+    @Test
+    void gracefulShutdownWaitsAfterTheInitialGoAwayIsActuallyWritten() throws Exception {
+        var writerStarted = new CountDownLatch(1);
+        var releaseWriter = new CountDownLatch(1);
+        var requestStarted = new CountDownLatch(1);
+        var releaseRequest = new CountDownLatch(1);
+        var writerExecutor = Executors.newSingleThreadExecutor();
+        var stopper = Executors.newSingleThreadExecutor();
+        writerExecutor.submit(() -> {
+            writerStarted.countDown();
+            releaseWriter.await();
+            return null;
+        });
+        assertThat(writerStarted.await(5, TimeUnit.SECONDS), equalTo(true));
+
+        server = httpsServer()
+            .withHttp2Config(Http2ConfigBuilder.http2Enabled())
+            .withHttp2WriterExecutor(writerExecutor)
+            .addHandler(Method.GET, "/hello", (request, response, pathParams) -> {
+                requestStarted.countDown();
+                if (!releaseRequest.await(5, TimeUnit.SECONDS)) {
+                    throw new IllegalStateException("Timed out waiting to finish request");
+                }
+                response.write("done");
+            })
+            .start();
+
+        try (var client = new H2Client();
+             var con = client.connect(server)) {
+            con.handshake();
+            var stopped = stopper.submit(() -> server.stop());
+
+            // Let the old initiation-based grace period expire while the writer cannot
+            // emit even the warning GOAWAY.
+            Thread.sleep(Http2Connection.GO_AWAY_GRACE_PERIOD_MILLIS * 2);
+            releaseWriter.countDown();
+
+            assertThat("Expected warning goaway", con.readLogicalFrame(),
+                equalTo(goAway(0x7FFFFFFF, Http2ErrorCode.NO_ERROR)));
+
+            int originalTimeout = con.socket().getSoTimeout();
+            con.socket().setSoTimeout(50);
+            try {
+                assertThrows(SocketTimeoutException.class, con::readFrameHeader);
+            } finally {
+                con.socket().setSoTimeout(originalTimeout);
+            }
+
+            con.writeFrame(getHelloFrame(1)).flush();
+            assertThat(requestStarted.await(5, TimeUnit.SECONDS), equalTo(true));
+            assertThat("Expected final goaway", con.readLogicalFrame(),
+                equalTo(goAway(1, Http2ErrorCode.NO_ERROR)));
+
+            releaseRequest.countDown();
+            stopped.get(5, TimeUnit.SECONDS);
+        } finally {
+            releaseRequest.countDown();
+            releaseWriter.countDown();
+            stopper.shutdownNow();
+            writerExecutor.shutdownNow();
         }
     }
 

--- a/src/test/java/io/muserver/RFC9113_6_8_GoAwayTest.java
+++ b/src/test/java/io/muserver/RFC9113_6_8_GoAwayTest.java
@@ -126,8 +126,6 @@ class RFC9113_6_8_GoAwayTest {
     void gracefulShutdownWaitsAfterTheInitialGoAwayIsActuallyWritten() throws Exception {
         var writerStarted = new CountDownLatch(1);
         var releaseWriter = new CountDownLatch(1);
-        var requestStarted = new CountDownLatch(1);
-        var releaseRequest = new CountDownLatch(1);
         var writerExecutor = Executors.newSingleThreadExecutor();
         var stopper = Executors.newSingleThreadExecutor();
         writerExecutor.submit(() -> {
@@ -140,13 +138,6 @@ class RFC9113_6_8_GoAwayTest {
         server = httpsServer()
             .withHttp2Config(Http2ConfigBuilder.http2Enabled())
             .withHttp2WriterExecutor(writerExecutor)
-            .addHandler(Method.GET, "/hello", (request, response, pathParams) -> {
-                requestStarted.countDown();
-                if (!releaseRequest.await(5, TimeUnit.SECONDS)) {
-                    throw new IllegalStateException("Timed out waiting to finish request");
-                }
-                response.write("done");
-            })
             .start();
 
         try (var client = new H2Client();
@@ -163,22 +154,17 @@ class RFC9113_6_8_GoAwayTest {
                 equalTo(goAway(0x7FFFFFFF, Http2ErrorCode.NO_ERROR)));
 
             int originalTimeout = con.socket().getSoTimeout();
-            con.socket().setSoTimeout(50);
+            con.socket().setSoTimeout(20);
             try {
                 assertThrows(SocketTimeoutException.class, con::readFrameHeader);
             } finally {
                 con.socket().setSoTimeout(originalTimeout);
             }
 
-            con.writeFrame(getHelloFrame(1)).flush();
-            assertThat(requestStarted.await(5, TimeUnit.SECONDS), equalTo(true));
             assertThat("Expected final goaway", con.readLogicalFrame(),
-                equalTo(goAway(1, Http2ErrorCode.NO_ERROR)));
-
-            releaseRequest.countDown();
+                equalTo(goAway(0, Http2ErrorCode.NO_ERROR)));
             stopped.get(5, TimeUnit.SECONDS);
         } finally {
-            releaseRequest.countDown();
             releaseWriter.countDown();
             stopper.shutdownNow();
             writerExecutor.shutdownNow();


### PR DESCRIPTION
This is the next concurrency re-architecture slice, stacked on #163.

RFC 9113 Section 6.8 describes the two-GOAWAY graceful shutdown pattern: send an initial NO_ERROR GOAWAY with the maximum stream ID, allow time for in-flight stream creation, then send the final accepted-stream snapshot.

The existing implementation started its 200 ms grace period when shutdown was requested. If the independently scheduled HTTP/2 writer was delayed or blocked for longer than that, it wrote the initial and final GOAWAY frames back-to-back. The client therefore received no grace window at all.

This change:
- starts the grace period only after the initial GOAWAY has been written and flushed
- uses monotonic nanosecond time for the deadline
- keeps grace-state transitions, stream admission, and the final last-stream-ID snapshot under the connection state lock
- adds a deterministic regression test that blocks the writer past the old deadline and proves the final GOAWAY does not immediately follow the warning
- retains the separate integration proof that a stream sent during the real grace window is accepted

The new regression test fails against the previous implementation because both GOAWAY frames are emitted immediately when the delayed writer is released.

Validation:
- Java 11 full suite: 1,666 tests, 0 failures/errors, 5 skips
- Java 21 NullAway build: green
- HTTP/2/RFC/execution suite: 336 tests, 0 failures/errors, 1 skip
- focused GOAWAY/error/termination/reliability suite: 16 tests, all green
- GitHub CI: Java 11, 17, 21, and 25 green

No public API changes. The wire behavior now preserves the intended graceful-shutdown window under writer scheduling delay.