### PR TITLE
Make HTTP/2 reader ownership explicit

### DIFF
--- a/HTTP2-CONCURRENCY.md
+++ b/HTTP2-CONCURRENCY.md
@@ -1,10 +1,9 @@
 # HTTP/2 concurrency model
 
-This document defines the target concurrency and ownership rules for the direct
-HTTP/2 implementation. It is the design contract for a staged migration, not an
-inventory of guarantees that have all landed: completed slices must preserve the
-rules they implement, and later changes must move the remaining code towards
-this model.
+This document defines the concurrency and ownership rules for the direct HTTP/2
+implementation. It is the design contract for the staged migration: completed
+slices must preserve the rules they implement, and later changes must keep each
+piece of mutable state within one of the ownership boundaries described here.
 
 ## Implementation status
 
@@ -30,9 +29,9 @@ and body consumers return credit through the same component. Live stream
 identity publication is similarly centralized in one short-held registry lock,
 while the coordinator remains the sole owner of RFC stream-state transitions.
 Request-body read deadlines are monotonic timed waits owned by the body buffer:
-they do not require a scheduled task or coordinator round trip. The reader and
-coordinator have separate execution capacity from handlers, but do not yet have
-all of the final ownership boundaries described below.
+they do not require a scheduled task or coordinator round trip. The reader,
+coordinator, application executors, and timer now have separate execution
+capacity, and the deliberate cross-domain boundaries are listed below.
 
 ## Goals
 
@@ -49,8 +48,9 @@ The model must:
 ## Execution domains
 
 The executor allocation and application-turn rules in this section are
-implemented. Some finer-grained protocol ownership rules remain the target for
-later phases, as called out below.
+implemented. The ownership boundaries below describe both the current design
+and the constraint on later phases; individual call sites can still be
+simplified within those boundaries.
 
 There are five execution domains and one timer facility:
 
@@ -71,17 +71,19 @@ Each HTTP/2 connection has:
 These tasks run independently of request handlers and independently of each
 other. The connection reader is a long-lived task on the executor configured
 by `MuServerBuilder.withConnectionExecutor`. It owns the input stream, read
-buffer, and HPACK decoder. The target end state is for it to turn every logical
-frame into a coordinator command without mutating connection or stream protocol
-state; migration of the remaining reader-owned protocol mutations is not
-complete.
+buffer, HPACK decoder, wire-order validation, and monotonic inbound
+`END_STREAM`/reset-seen fences. It directly debits receive credit and publishes
+validated DATA to the request-body buffer. Making either operation wait for the
+writer would let a blocked socket output stall input and can deadlock
+bidirectional exchanges.
 
-The coordinator already serializes outbound protocol state and is the only code
-that writes to the socket. It schedules short serialized drains on the executor
-configured by `MuServerBuilder.withHttp2WriterExecutor`; an idle or
-flow-control-blocked connection does not retain a writer worker. The coordinator
-will become the sole owner of all connection and stream protocol state as the
-remaining state is migrated.
+The coordinator serializes the RFC stream-state machine, outbound flow control,
+pending frames, and socket output. The reader enqueues each inbound transition
+before publishing an application-visible terminal event, but its wire-order
+fences are intentionally not a second RFC state machine. The coordinator
+schedules short serialized drains on the executor configured by
+`MuServerBuilder.withHttp2WriterExecutor`; an idle or flow-control-blocked
+connection does not retain a writer worker.
 
 Timed connection work runs on
 `MuServerBuilder.withConnectionMaintenanceExecutor`, not on a reader or writer.
@@ -191,7 +193,7 @@ single-consumer mailbox.
 
 Command categories include:
 
-* decoded inbound frames;
+* protocol transitions and outbound effects of decoded inbound frames;
 * outbound headers, data, and informational responses;
 * application handler completion or failure;
 * WINDOW_UPDATE output produced after request-body credit is returned;
@@ -231,11 +233,10 @@ and peer `RST_STREAM` commands are one-way. The reader enqueues a valid
 awakened by EOF is necessarily ordered after the inbound transition. Local
 `END_STREAM` is reserved when the coordinator accepts its outbound frame.
 
-Until all inbound stream frames are coordinator commands, the reader records
-monotonic "remote end seen" and "reset seen" fences on the stream. This is
-input-ordering state, not a protocol-state transition: it only prevents later
-wire-ordered DATA or trailers from reaching the request body before the
-coordinator applies the corresponding transition.
+The reader records monotonic "remote end seen" and "reset seen" fences on the
+stream. This is input-ordering state, not a protocol-state transition: it only
+prevents later wire-ordered DATA or trailers from reaching the request body
+before the coordinator applies the corresponding transition.
 
 An outbound frame command is validated and its state transition reserved by the
 coordinator before it becomes pending for socket output. A reset closes the

--- a/src/main/java/io/muserver/Http2Connection.java
+++ b/src/main/java/io/muserver/Http2Connection.java
@@ -47,11 +47,16 @@ class Http2Connection extends BaseHttpConnection implements Http2Peer {
     private static final Logger log = LoggerFactory.getLogger(Http2Connection.class);
 
     private final Http2Settings serverSettings;
+    // Immutable reader-published snapshot used by application and writer domains.
     private volatile Http2Settings clientSettings = Http2Settings.DEFAULT_CLIENT_SETTINGS;
     private final ByteBuffer buffer;
+    // The writer freezes this boundary when it queues final GOAWAY; the reader
+    // observes it before dispatching subsequent frames.
     private volatile int maxAllowedStreamId = MAX_POSSIBLE_STREAM_ID;
-    private volatile int lastStreamId = 0;
-    private volatile int peerGoAwayLastStreamId = MAX_POSSIBLE_STREAM_ID;
+    // State-lock-owned admission and shutdown data. The reader is the only code
+    // that reads lastStreamId without the lock, and it is also the only writer.
+    private int lastStreamId;
+    private int peerGoAwayLastStreamId = MAX_POSSIBLE_STREAM_ID;
     private final Http2InboundFlowControl inboundFlowControl = new Http2InboundFlowControl(65_535);
     private final ConcurrentLinkedQueue<PendingSettingsAck> settingsAckQueue = new ConcurrentLinkedQueue<>();
     private final Http2StreamRegistry streamRegistry = new Http2StreamRegistry();
@@ -165,24 +170,33 @@ class Http2Connection extends BaseHttpConnection implements Http2Peer {
     void write(WriteTask writeTask) {
         stateLock.lock();
         try {
-            if (writeState.canSendFrames && canWriteFrame(writeTask.frame())) {
-                LogicalHttp2Frame frame = writeTask.frame();
-                boolean retireRejectedStream = frame instanceof Http2ResetStreamFrame
-                    && streamRegistry.removeRejectedRequestBody(frame.streamId());
-                boolean retainResetState = frame instanceof Http2ResetStreamFrame
-                    && streamRegistry.containsApplicationStream(frame.streamId());
-                if (frame instanceof Http2ResetStreamFrame) {
-                    inboundFlowControl.closeStream(frame.streamId());
-                }
-                writeCoordinator.submit(writeTask, retainResetState);
-                if (retireRejectedStream) {
-                    writeCoordinator.forgetStream(frame.streamId());
-                }
-            } else {
-                writeTask.fail(new IOException("HTTP/2 connection or stream is closed"));
-            }
+            writeLocked(writeTask);
         } finally {
             stateLock.unlock();
+        }
+    }
+
+    private void writeLocked(LogicalHttp2Frame frame) {
+        writeLocked(new WriteTask(frame, false));
+    }
+
+    // The caller holds stateLock, making admission and command publication one transition.
+    private void writeLocked(WriteTask writeTask) {
+        if (writeState.canSendFrames && canWriteFrame(writeTask.frame())) {
+            LogicalHttp2Frame frame = writeTask.frame();
+            boolean retireRejectedStream = frame instanceof Http2ResetStreamFrame
+                && streamRegistry.removeRejectedRequestBody(frame.streamId());
+            boolean retainResetState = frame instanceof Http2ResetStreamFrame
+                && streamRegistry.containsApplicationStream(frame.streamId());
+            if (frame instanceof Http2ResetStreamFrame) {
+                inboundFlowControl.closeStream(frame.streamId());
+            }
+            writeCoordinator.submit(writeTask, retainResetState);
+            if (retireRejectedStream) {
+                writeCoordinator.forgetStream(frame.streamId());
+            }
+        } else {
+            writeTask.fail(new IOException("HTTP/2 connection or stream is closed"));
         }
     }
 
@@ -197,24 +211,8 @@ class Http2Connection extends BaseHttpConnection implements Http2Peer {
             : !stream.resetWasInitiated();
     }
 
-    private void writeFirst(LogicalHttp2Frame frame) {
-        stateLock.lock();
-        try {
-            if (writeState.canSendFrames) {
-                writeCoordinator.submitFirst(new WriteTask(frame, false));
-            }
-        } finally {
-            stateLock.unlock();
-        }
-    }
-
     private void signalWriteLoop() {
-        stateLock.lock();
-        try {
-            writeCoordinator.wakeUp();
-        } finally {
-            stateLock.unlock();
-        }
+        writeCoordinator.wakeUp();
     }
 
     private void resetPendingWritesForStream(
@@ -486,7 +484,7 @@ class Http2Connection extends BaseHttpConnection implements Http2Peer {
             // in-flight stream creation (at least one round-trip time), the server MAY send another GOAWAY frame
             // with an updated last stream identifier. This ensures that a connection can be cleanly shut down
             // without losing requests.
-            write(GO_AWAY_WARNING);
+            writeLocked(GO_AWAY_WARNING);
         }
     }
 
@@ -546,7 +544,7 @@ class Http2Connection extends BaseHttpConnection implements Http2Peer {
         finalGoAwayQueued = true;
         maxAllowedStreamId = lastStreamId;
         log.info("Queuing final go away with last stream id {}", maxAllowedStreamId);
-        write(new Http2GoAway(maxAllowedStreamId, 0, null));
+        writeLocked(new Http2GoAway(maxAllowedStreamId, 0, null));
     }
 
     private boolean isTerminalAndDrainedLocked() {
@@ -1079,13 +1077,13 @@ class Http2Connection extends BaseHttpConnection implements Http2Peer {
             long now = System.nanoTime();
             if (!canStartNewStreamsLocked(now)) {
                 log.info("Refusing stream {} because graceful shutdown no longer allows new streams", streamId);
-                write(new Http2ResetStreamFrame(streamId, Http2ErrorCode.REFUSED_STREAM.code()));
+                writeLocked(new Http2ResetStreamFrame(streamId, Http2ErrorCode.REFUSED_STREAM.code()));
                 return false;
             }
             long activeStreams = streamRegistry.concurrentStreamCount();
             if (activeStreams >= serverSettings.maxConcurrentStreams) {
                 log.info("Max concurrent streams reached");
-                write(new Http2ResetStreamFrame(streamId, Http2ErrorCode.REFUSED_STREAM.code()));
+                writeLocked(new Http2ResetStreamFrame(streamId, Http2ErrorCode.REFUSED_STREAM.code()));
                 return false;
             }
             // An HTTP error response also means the stream was processed. Record every

--- a/src/main/java/io/muserver/Http2WriteCoordinator.java
+++ b/src/main/java/io/muserver/Http2WriteCoordinator.java
@@ -65,12 +65,10 @@ final class Http2WriteCoordinator {
 
     private static final class QueueWrite implements Command {
         private final WriteTask task;
-        private final boolean first;
         private final boolean retainResetState;
 
-        private QueueWrite(WriteTask task, boolean first, boolean retainResetState) {
+        private QueueWrite(WriteTask task, boolean retainResetState) {
             this.task = task;
-            this.first = first;
             this.retainResetState = retainResetState;
         }
     }
@@ -225,11 +223,7 @@ final class Http2WriteCoordinator {
     }
 
     void submit(WriteTask task, boolean retainResetState) {
-        enqueue(new QueueWrite(task, false, retainResetState));
-    }
-
-    void submitFirst(WriteTask task) {
-        enqueue(new QueueWrite(task, true, false));
+        enqueue(new QueueWrite(task, retainResetState));
     }
 
     void resetStream(Http2ResetStreamFrame resetFrame, IOException reason, @Nullable Http2Stream stream) {
@@ -458,7 +452,7 @@ final class Http2WriteCoordinator {
     private void apply(Command command) {
         if (command instanceof QueueWrite) {
             QueueWrite write = (QueueWrite) command;
-            queue(write.task, write.first, write.retainResetState);
+            queue(write.task, false, write.retainResetState);
         } else if (command instanceof ResetStream) {
             ResetStream reset = (ResetStream) command;
             peerResetStreams.add(reset.streamId);


### PR DESCRIPTION
## Summary

- formalize the deliberate ownership split between the blocking reader, connection state lock, and write coordinator
- keep wire-order validation, inbound terminal fences, receive-window debits, and body publication reader-side so blocked output cannot stall input
- remove redundant volatility from lock/reader-owned shutdown fields
- make already-locked write publication explicit and remove the dead front-of-queue submission mode
- wake the thread-safe coordinator mailbox directly instead of acquiring an unrelated lifecycle lock

This is stacked on #164. It does not change public API or intended wire behavior.

## Validation

- `mise exec java@temurin-11 -- mvn test` — 1,666 tests, 0 failures, 5 skipped
- `mvn -Dtest='Http2*,RFC9113_*,ExecutionDomainsTest' test` — 336 tests, 0 failures, 1 skipped
- `mise exec java@temurin-21 -- mvn -Pnullaway -DskipTests verify` — green
