### PR TITLE
Close the accepted-connection shutdown race

### DIFF
--- a/HTTP2-CONCURRENCY.md
+++ b/HTTP2-CONCURRENCY.md
@@ -31,7 +31,10 @@ while the coordinator remains the sole owner of RFC stream-state transitions.
 Request-body read deadlines are monotonic timed waits owned by the body buffer:
 they do not require a scheduled task or coordinator round trip. The reader,
 coordinator, application executors, and timer now have separate execution
-capacity, and the deliberate cross-domain boundaries are listed below.
+capacity. Accepted sockets, live-connection publication, and listener shutdown
+admission share one lifecycle lock, so work queued on the connection executor
+cannot start a connection after server shutdown. The deliberate cross-domain
+boundaries are listed below.
 
 ## Goals
 
@@ -62,6 +65,12 @@ There are five execution domains and one timer facility:
 * timer scheduling.
 
 ### Connection I/O
+
+Before protocol selection, the listener lifecycle lock owns the transition from
+an accepted socket to a published live connection. Shutdown closes accepted
+sockets that have not crossed that boundary and prevents their queued connection
+tasks from later being promoted. Live-connection retirement signals a condition
+used by graceful shutdown; it is not discovered by polling.
 
 Each HTTP/2 connection has:
 
@@ -157,6 +166,7 @@ as defined by RFC 9113 Section 7.
 
 | State or resource | Owner |
 | --- | --- |
+| Listener state, accepted socket admission, and live connection index | `ConnectionAcceptor` lifecycle lock |
 | Socket input, input buffer, HPACK decoder | Connection reader |
 | Connection shutdown and new-stream admission gate | `Http2Connection` state lock |
 | RFC stream protocol state | Coordinator |
@@ -344,6 +354,8 @@ Permitted cross-thread primitives are deliberately narrow:
 
 * a blocking mailbox for coordinator commands;
 * a small promise backed by a latch and a result or error;
+* one listener lifecycle lock and condition for accepted/live connection
+  admission and graceful-shutdown draining;
 * one short-held connection state lock for shutdown, admission, and atomic
   publication across the protocol components;
 * one short-held lock for atomic connection-and-stream inbound flow-control

--- a/src/main/java/io/muserver/ConnectionAcceptor.java
+++ b/src/main/java/io/muserver/ConnectionAcceptor.java
@@ -15,15 +15,18 @@ import java.net.*;
 import java.nio.charset.StandardCharsets;
 import java.security.cert.Certificate;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.Condition;
+import java.util.concurrent.locks.ReentrantLock;
 
 class ConnectionAcceptor {
     private static final Logger log = LoggerFactory.getLogger(ConnectionAcceptor.class);
@@ -61,15 +64,25 @@ class ConnectionAcceptor {
 
     private enum State { NOT_STARTED, STARTED, STOPPING, STOPPED }
 
-    private final ConcurrentHashMap.KeySetView<BaseHttpConnection, Boolean> connections = ConcurrentHashMap.newKeySet();
+    // Owns listener state, accepted-to-live connection promotion, and shutdown
+    // drain signalling. Socket close and connection callbacks happen outside it.
+    private final ReentrantLock lifecycleLock = new ReentrantLock();
+    private final Condition connectionRetired = lifecycleLock.newCondition();
+    private final Set<Socket> acceptedSockets = new HashSet<>();
+    private final Set<BaseHttpConnection> connections = new HashSet<>();
 
     public Set<HttpConnection> activeConnections() {
-        return Set.copyOf(connections);
+        lifecycleLock.lock();
+        try {
+            return Set.copyOf(connections);
+        } finally {
+            lifecycleLock.unlock();
+        }
     }
 
     private volatile State state = State.NOT_STARTED;
     private volatile long gracefulShutdownTimeoutMillis = 20_000;
-    private volatile long gracefulShutdownDeadlineMillis = Long.MAX_VALUE;
+    private volatile long gracefulShutdownDeadlineNanos = Long.MAX_VALUE;
     private volatile boolean lastStopWasGraceful = true;
 
     private final boolean isHttps;
@@ -104,21 +117,26 @@ class ConnectionAcceptor {
             try {
                 Socket clientSocket = socketServer.accept();
                 clientSocket.setTcpNoDelay(true);
+                if (!registerAcceptedSocket(clientSocket)) {
+                    closeQuietly(clientSocket);
+                    continue;
+                }
                 Instant startTime = Instant.now();
                 try {
-                    connectionExecutor.submit(() -> {
-                        handleClientSocket(clientSocket, startTime, h2, false);
-                    });
+                    connectionExecutor.submit(
+                        () -> runAcceptedSocket(clientSocket, startTime, h2, false)
+                    );
                 } catch (RejectedExecutionException e) {
-                    int oldTimeout = clientSocket.getSoTimeout();
                     try {
                         clientSocket.setSoTimeout(2000);
-                        handleClientSocket(clientSocket, startTime, false, true);
+                        runAcceptedSocket(clientSocket, startTime, false, true);
                     } catch (Exception e2) {
-                        log.info("Exception while writing 503 when executor is full: {}", e.getMessage());
-                    } finally {
-                        clientSocket.setSoTimeout(oldTimeout);
+                        log.info("Exception while writing 503 when executor is full: {}", e2.getMessage());
                     }
+                } catch (RuntimeException | Error submissionFailure) {
+                    retireAcceptedSocket(clientSocket);
+                    closeQuietly(clientSocket);
+                    throw submissionFailure;
                 }
             } catch (Throwable e) {
                 if (Thread.interrupted() || e instanceof SocketException) {
@@ -132,31 +150,72 @@ class ConnectionAcceptor {
             }
         }
         lastStopWasGraceful = shutdownConnections();
-        state = State.STOPPED;
+        lifecycleLock.lock();
+        try {
+            state = State.STOPPED;
+            connectionRetired.signalAll();
+        } finally {
+            lifecycleLock.unlock();
+        }
+    }
+
+    private boolean registerAcceptedSocket(Socket socket) {
+        lifecycleLock.lock();
+        try {
+            if (state != State.STARTED) {
+                return false;
+            }
+            acceptedSockets.add(socket);
+            return true;
+        } finally {
+            lifecycleLock.unlock();
+        }
+    }
+
+    private void runAcceptedSocket(
+        Socket socket,
+        Instant startTime,
+        boolean http2Enabled,
+        boolean rejectDueToOverload
+    ) {
+        try {
+            handleClientSocket(
+                socket,
+                startTime,
+                http2Enabled,
+                rejectDueToOverload
+            );
+        } finally {
+            retireAcceptedSocket(socket);
+            closeQuietly(socket);
+        }
+    }
+
+    private void retireAcceptedSocket(Socket socket) {
+        lifecycleLock.lock();
+        try {
+            acceptedSockets.remove(socket);
+        } finally {
+            lifecycleLock.unlock();
+        }
     }
 
     private boolean shutdownConnections() {
-        log.info("Closing server with " + connections.size() + " connected connections");
-        long waitUntil = gracefulShutdownDeadlineMillis;
-        if (waitUntil == Long.MAX_VALUE) {
-            waitUntil = System.currentTimeMillis() + gracefulShutdownTimeoutMillis;
+        closePendingAcceptedSockets();
+        List<BaseHttpConnection> active = connectionSnapshot();
+        log.info("Closing server with " + active.size() + " connected connections");
+        if (gracefulShutdownDeadlineNanos == Long.MAX_VALUE) {
+            gracefulShutdownDeadlineNanos =
+                deadlineAfterMillis(gracefulShutdownTimeoutMillis);
         }
-        for (BaseHttpConnection connection : connections) {
+        for (BaseHttpConnection connection : active) {
             try {
                 connection.initiateGracefulShutdown();
             } catch (IOException ignored) {
             }
         }
-        while (!connections.isEmpty() && System.currentTimeMillis() < waitUntil) {
-            try {
-                Thread.sleep(10);
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-                break;
-            }
-        }
-        boolean drainedCleanly = connections.isEmpty();
-        for (BaseHttpConnection connection : connections) {
+        boolean drainedCleanly = awaitConnectionsRetired();
+        for (BaseHttpConnection connection : connectionSnapshot()) {
             log.info("Force closure of active connection {} with requests {}", connection, connection.activeRequests());
             try {
                 connection.abort();
@@ -173,13 +232,57 @@ class ConnectionAcceptor {
         return drainedCleanly;
     }
 
+    private void closePendingAcceptedSockets() {
+        List<Socket> pending;
+        lifecycleLock.lock();
+        try {
+            pending = new ArrayList<>(acceptedSockets);
+            acceptedSockets.clear();
+        } finally {
+            lifecycleLock.unlock();
+        }
+        for (Socket socket : pending) {
+            closeQuietly(socket);
+        }
+    }
+
+    private List<BaseHttpConnection> connectionSnapshot() {
+        lifecycleLock.lock();
+        try {
+            return new ArrayList<>(connections);
+        } finally {
+            lifecycleLock.unlock();
+        }
+    }
+
+    private boolean awaitConnectionsRetired() {
+        lifecycleLock.lock();
+        try {
+            while (!connections.isEmpty()) {
+                long remaining = nanosUntil(gracefulShutdownDeadlineNanos);
+                if (remaining <= 0L) {
+                    return false;
+                }
+                try {
+                    connectionRetired.awaitNanos(remaining);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    return false;
+                }
+            }
+            return true;
+        } finally {
+            lifecycleLock.unlock();
+        }
+    }
+
     private void checkIdleTimeouts() {
         if (state != State.STARTED) {
             return;
         }
         try {
             long cutoff = System.currentTimeMillis() - server.idleTimeoutMillis();
-            for (BaseHttpConnection con : connections) {
+            for (BaseHttpConnection con : connectionSnapshot()) {
                 if (con.lastIO() < cutoff) {
                     log.info("Timing out {}", con);
                     con.abortWithTimeout();
@@ -264,7 +367,14 @@ class ConnectionAcceptor {
         if (rejectDueToOverload) {
             handleOverload(socket);
         } else {
-            handleRequest(socket, clientCert, startTime, httpVersion, inputStream);
+            handleRequest(
+                clientSocket,
+                socket,
+                clientCert,
+                startTime,
+                httpVersion,
+                inputStream
+            );
         }
     }
 
@@ -318,7 +428,14 @@ class ConnectionAcceptor {
     }
 
     @SuppressWarnings("ReferenceEquality") // Sharing is defined by the exact configured executor instance.
-    private void handleRequest(Socket socket, @Nullable Certificate clientCert, Instant startTime, HttpVersion httpVersion, @Nullable InputStream providedInputStream) {
+    private void handleRequest(
+        Socket acceptedSocket,
+        Socket socket,
+        @Nullable Certificate clientCert,
+        Instant startTime,
+        HttpVersion httpVersion,
+        @Nullable InputStream providedInputStream
+    ) {
         BaseHttpConnection con;
         if (httpVersion == HttpVersion.HTTP_2) {
             if (http2Config == null) {
@@ -347,7 +464,9 @@ class ConnectionAcceptor {
             );
         }
 
-        connections.add(con);
+        if (!promoteAcceptedSocket(acceptedSocket, con)) {
+            return;
+        }
         server.getStatsImpl().onConnectionOpened(con);
         try {
             InputStream requestIn = providedInputStream == null ? socket.getInputStream() : providedInputStream;
@@ -359,16 +478,49 @@ class ConnectionAcceptor {
             log.error("Unhandled exception for {}", con, t);
         } finally {
             server.getStatsImpl().onConnectionClosed(con);
-            connections.remove(con);
+            retireConnection(con);
+        }
+    }
+
+    private boolean promoteAcceptedSocket(
+        Socket acceptedSocket,
+        BaseHttpConnection connection
+    ) {
+        lifecycleLock.lock();
+        try {
+            acceptedSockets.remove(acceptedSocket);
+            if (state != State.STARTED) {
+                return false;
+            }
+            connections.add(connection);
+            return true;
+        } finally {
+            lifecycleLock.unlock();
+        }
+    }
+
+    private void retireConnection(BaseHttpConnection connection) {
+        lifecycleLock.lock();
+        try {
+            if (connections.remove(connection)) {
+                connectionRetired.signalAll();
+            }
+        } finally {
+            lifecycleLock.unlock();
         }
     }
 
     public void start() {
-        if (state != State.STOPPED && state != State.NOT_STARTED) {
-            throw new IllegalStateException("Cannot start with state " + state);
+        lifecycleLock.lock();
+        try {
+            if (state != State.STOPPED && state != State.NOT_STARTED) {
+                throw new IllegalStateException("Cannot start with state " + state);
+            }
+            state = State.STARTED;
+        } finally {
+            lifecycleLock.unlock();
         }
         acceptorThread.setDaemon(false);
-        state = State.STARTED;
         try {
             if (server.idleTimeoutMillis() > 0) {
                 timeoutTask = server.scheduleConnectionTaskAtFixedRate(
@@ -385,20 +537,39 @@ class ConnectionAcceptor {
                 currentTimeoutTask.cancel(false);
                 timeoutTask = null;
             }
-            state = State.NOT_STARTED;
+            lifecycleLock.lock();
+            try {
+                state = State.NOT_STARTED;
+            } finally {
+                lifecycleLock.unlock();
+            }
             throw e;
         }
     }
 
     public boolean stop(long timeoutMillis) {
-        if (state == State.STOPPED) {
-            return lastStopWasGraceful;
+        long stopTimeoutMillis = Math.max(0L, timeoutMillis);
+        long callerDeadlineNanos = deadlineAfterMillis(stopTimeoutMillis);
+        lifecycleLock.lock();
+        try {
+            if (state == State.STOPPED) {
+                return lastStopWasGraceful;
+            }
+            log.info("Stopping server 1");
+            if (state != State.STOPPING) {
+                gracefulShutdownTimeoutMillis = stopTimeoutMillis;
+                gracefulShutdownDeadlineNanos = callerDeadlineNanos;
+                state = State.STOPPING;
+            } else if (callerDeadlineNanos > gracefulShutdownDeadlineNanos) {
+                // A callback-local stop can have a shorter deadline than a concurrent
+                // external stop. Preserve the longer opportunity to drain.
+                gracefulShutdownDeadlineNanos = callerDeadlineNanos;
+                connectionRetired.signalAll();
+            }
+        } finally {
+            lifecycleLock.unlock();
         }
-        log.info("Stopping server 1");
-        state = State.STOPPING;
-        gracefulShutdownTimeoutMillis = Math.max(0L, timeoutMillis);
-        long deadline = System.currentTimeMillis() + gracefulShutdownTimeoutMillis;
-        gracefulShutdownDeadlineMillis = deadline;
+        closePendingAcceptedSockets();
         ScheduledFuture<?> currentTimeoutTask = timeoutTask;
         if (currentTimeoutTask != null) {
             currentTimeoutTask.cancel(false);
@@ -409,21 +580,61 @@ class ConnectionAcceptor {
         } catch (IOException e) {
             log.warn("Error closing server socket", e);
         }
-        long remaining = Math.max(0L, deadline - System.currentTimeMillis());
-        if (remaining > 0) {
-            try {
-                acceptorThread.join(remaining);
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-            }
-        }
+        joinAcceptorUntil(callerDeadlineNanos);
         if (acceptorThread.isAlive()) {
             log.warn("Could not kill " + this + " after " + timeoutMillis + " ms");
             lastStopWasGraceful = false;
             return false;
         }
-        state = State.STOPPED;
-        return lastStopWasGraceful;
+        lifecycleLock.lock();
+        try {
+            state = State.STOPPED;
+            return lastStopWasGraceful;
+        } finally {
+            lifecycleLock.unlock();
+        }
+    }
+
+    private void joinAcceptorUntil(long deadlineNanos) {
+        while (acceptorThread.isAlive()) {
+            long remaining = nanosUntil(deadlineNanos);
+            if (remaining <= 0L) {
+                return;
+            }
+            long millis = TimeUnit.NANOSECONDS.toMillis(remaining);
+            int nanos = (int) (
+                remaining - TimeUnit.MILLISECONDS.toNanos(millis)
+            );
+            try {
+                acceptorThread.join(millis, nanos);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                return;
+            }
+        }
+    }
+
+    private static long deadlineAfterMillis(long timeoutMillis) {
+        long now = System.nanoTime();
+        long duration = TimeUnit.MILLISECONDS.toNanos(timeoutMillis);
+        long deadline = now + duration;
+        if (duration > 0L && deadline < now) {
+            return Long.MAX_VALUE;
+        }
+        return deadline;
+    }
+
+    private static long nanosUntil(long deadlineNanos) {
+        return deadlineNanos == Long.MAX_VALUE
+            ? Long.MAX_VALUE
+            : deadlineNanos - System.nanoTime();
+    }
+
+    private static void closeQuietly(Socket socket) {
+        try {
+            socket.close();
+        } catch (IOException ignored) {
+        }
     }
 
     @Override

--- a/src/test/java/io/muserver/ExecutionDomainsTest.java
+++ b/src/test/java/io/muserver/ExecutionDomainsTest.java
@@ -16,7 +16,9 @@ import scaffolding.Http1Client;
 import java.io.EOFException;
 import java.io.IOException;
 import java.net.ServerSocket;
+import java.net.Socket;
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -56,6 +58,69 @@ class ExecutionDomainsTest {
 
     private @Nullable MuServer server;
     private final List<ExecutorService> executors = new ArrayList<>();
+
+    @Test
+    void anAcceptedConnectionQueuedBeforeStopCannotStartAfterStop() throws Exception {
+        var connectionExecutor = track(new ThreadPoolExecutor(
+            1,
+            1,
+            0,
+            TimeUnit.MILLISECONDS,
+            new ArrayBlockingQueue<>(1),
+            namedThreads("connection-")
+        ));
+        var handlerExecutor = track(Executors.newSingleThreadExecutor(namedThreads("handler-")));
+        var blockerStarted = new CountDownLatch(1);
+        var releaseBlocker = new CountDownLatch(1);
+        var handledRequests = new AtomicInteger();
+        Future<?> blocker = connectionExecutor.submit(() -> {
+            blockerStarted.countDown();
+            releaseBlocker.await();
+            return null;
+        });
+        assertThat(blockerStarted.await(5, TimeUnit.SECONDS), is(true));
+
+        server = httpServer()
+            .withConnectionExecutor(connectionExecutor)
+            .withHandlerExecutor(handlerExecutor)
+            .addHandler((request, response) -> {
+                handledRequests.incrementAndGet();
+                response.write("late response");
+                return true;
+            })
+            .start();
+
+        try (var client = new Socket(server.uri().getHost(), server.uri().getPort())) {
+            client.getOutputStream().write((
+                "GET / HTTP/1.1\r\n"
+                    + "Host: " + server.uri().getHost() + "\r\n"
+                    + "Connection: close\r\n"
+                    + "\r\n"
+            ).getBytes(StandardCharsets.US_ASCII));
+            client.getOutputStream().flush();
+
+            assertEventually(
+                () -> connectionExecutor.getQueue().size(),
+                equalTo(1)
+            );
+
+            server.stop();
+            server = null;
+
+            releaseBlocker.countDown();
+            blocker.get(5, TimeUnit.SECONDS);
+            assertEventually(
+                () -> connectionExecutor.getQueue().size(),
+                equalTo(0)
+            );
+            connectionExecutor.submit(() -> {
+            }).get(5, TimeUnit.SECONDS);
+
+            assertThat(handledRequests.get(), equalTo(0));
+        } finally {
+            releaseBlocker.countDown();
+        }
+    }
 
     @Test
     void http2IoRemainsResponsiveWhenTheHandlerExecutorIsSaturated() throws Exception {


### PR DESCRIPTION
## Summary

- put listener state, accepted sockets, and live-connection publication behind one lifecycle lock
- atomically promote an accepted socket to a tracked connection only while the listener is started
- close accepted sockets still queued on the connection executor when shutdown begins
- replace shutdown polling with a condition signalled by connection retirement
- use monotonic shutdown deadlines and preserve the longer deadline across concurrent stop callers

This is stacked on #165.

## Bug

Previously, an accepted socket was not tracked until its connection-executor task started. If that task was queued behind other work, `stop()` could observe zero connections and return. Releasing the executor afterward created a connection and served a request on the already-stopped server.

The deterministic regression test occupies the only connection worker, queues an accepted request, stops the server, then releases the worker. It fails before this change because the handler runs after shutdown.

## Compatibility

No public API changes. The intentional behavioral change is that accepted sockets which have not started protocol processing are closed during shutdown instead of being allowed to start later.

## Validation

- `mise exec java@temurin-11 -- mvn test` — 1,667 tests, 0 failures, 5 skipped
- shutdown/execution-domain focused suite — 63 tests, 0 failures
- `mise exec java@temurin-21 -- mvn -Pnullaway -DskipTests verify` — green
