### PR TITLE
Make async response completion a terminal gate

### DIFF
--- a/HTTP2-CONCURRENCY.md
+++ b/HTTP2-CONCURRENCY.md
@@ -179,7 +179,7 @@ as defined by RFC 9113 Section 7.
 | Pending outbound frames and their ordering | Coordinator |
 | HPACK encoder and socket output | Coordinator |
 | Request-body producer/consumer buffer and read deadline | `Http2BodyInputStream` lock and condition |
-| Response API call ordering | Application-side response/async handle |
+| Response API call ordering and async completion terminal gate | Application-side response/async handle lock |
 | Protocol stream completion | Coordinator |
 | Application exchange completion | Serialized application completion path |
 
@@ -363,7 +363,9 @@ Permitted cross-thread primitives are deliberately narrow:
 * one short-held lock for the live stream identity index;
 * the request-body buffer lock and condition, including its monotonic blocking
   read deadline;
-* an application-side lock that orders async response submissions; and
+* an application-side lock that orders async response submissions with the
+  terminal completion gate, so completion observes every accepted write and
+  rejects every later write; and
 * a thread-confined FIFO that drains nested application work without recursive
   calls or executor resubmission; and
 * atomics for idempotent resource closure.

--- a/src/main/java/io/muserver/AsyncHandle.java
+++ b/src/main/java/io/muserver/AsyncHandle.java
@@ -40,6 +40,8 @@ public interface AsyncHandle {
      * <p>Writes data to the response asynchronously.</p>
      * <p>Note that even in async mode it is possible to use the blocking write methods on the {@link MuResponse}</p>
      * <p>See {@link #write(ByteBuffer)} for an alternative that returns a future.</p>
+     * <p>If {@link #complete()} or {@link #complete(Throwable)} has already been called, the callback is
+     * invoked with an {@link IllegalStateException}.</p>
      * @param data The data to write
      * @param callback The callback when the write succeeds or fails
      */
@@ -49,6 +51,8 @@ public interface AsyncHandle {
      * <p>Writes data to the response asynchronously.</p>
      * <p>Note that even in async mode it is possible to use the blocking write methods on the {@link MuResponse}</p>
      * <p>See {@link #write(ByteBuffer, DoneCallback)} for an alternative that uses a callback.</p>
+     * <p>If {@link #complete()} or {@link #complete(Throwable)} has already been called, the returned future
+     * fails with an {@link IllegalStateException}.</p>
      * @param data The data to write
      * @return A future that is resolved when the write succeeds or fails.
      */

--- a/src/main/java/io/muserver/Mu3AsyncHandleImpl.java
+++ b/src/main/java/io/muserver/Mu3AsyncHandleImpl.java
@@ -18,6 +18,8 @@ class Mu3AsyncHandleImpl implements AsyncHandle {
     private CompletableFuture<@Nullable Void> responseFuture = CompletableFuture.completedFuture(null);
     private final CompletableFuture<@Nullable Void> completionFuture = new CompletableFuture<>();
     private final Lock lock = new ReentrantLock();
+    // Guarded by lock. This is the terminal gate for response writes and exchange completion.
+    private boolean completionRequested;
     private final Mu3ServerImpl server;
     private final Executor asyncExecutor;
 
@@ -159,51 +161,73 @@ class Mu3AsyncHandleImpl implements AsyncHandle {
 
     @Override
     public void complete() {
-        if (!completionFuture.isDone()) {
-            completionFuture.complete(null);
-        }
+        completeOnce(null);
     }
 
     @Override
     public void complete(@Nullable Throwable throwable) {
-        if (throwable == null) {
-            complete();
-        } else {
-            if (!completionFuture.isDone()) {
-                completionFuture.completeExceptionally(throwable);
+        completeOnce(throwable);
+    }
+
+    private void completeOnce(@Nullable Throwable failure) {
+        lock.lock();
+        try {
+            if (completionRequested) {
+                return;
             }
+            completionRequested = true;
+        } finally {
+            lock.unlock();
+        }
+        if (failure == null) {
+            completionFuture.complete(null);
+        } else {
+            completionFuture.completeExceptionally(failure);
         }
     }
 
     @Override
     public void write(ByteBuffer data, DoneCallback callback) {
         var taskStarted = new AtomicBoolean();
-        CompletableFuture<@Nullable Void> writeFuture;
+        @Nullable CompletableFuture<@Nullable Void> writeFuture;
         lock.lock();
         try {
-            responseFuture = responseFuture.thenRunAsync(() -> {
-                taskStarted.set(true);
-                try {
-                    copyBufferToResponseOutput(data);
-                } catch (Throwable e) {
+            if (completionRequested) {
+                writeFuture = null;
+            } else {
+                responseFuture = responseFuture.thenRunAsync(() -> {
+                    taskStarted.set(true);
                     try {
-                        callback.onComplete(e);
-                    } catch (Throwable callbackFailure) {
-                        addSuppressedIfDifferent(e, callbackFailure);
+                        copyBufferToResponseOutput(data);
+                    } catch (Throwable e) {
+                        try {
+                            callback.onComplete(e);
+                        } catch (Throwable callbackFailure) {
+                            addSuppressedIfDifferent(e, callbackFailure);
+                        }
+                        complete(e);
+                        throw e instanceof RuntimeException ? (RuntimeException) e : new RuntimeException("Error while writing body", e);
                     }
-                    complete(e);
-                    throw e instanceof RuntimeException ? (RuntimeException) e : new RuntimeException("Error while writing body", e);
-                }
-                try {
-                    callback.onComplete(null);
-                } catch (Throwable e) {
-                    complete(e);
-                    throw e instanceof RuntimeException ? (RuntimeException) e : new RuntimeException("Error in write callback", e);
-                }
-            }, asyncExecutor).thenApply(ignored -> null);
-            writeFuture = responseFuture;
+                    try {
+                        callback.onComplete(null);
+                    } catch (Throwable e) {
+                        complete(e);
+                        throw e instanceof RuntimeException ? (RuntimeException) e : new RuntimeException("Error in write callback", e);
+                    }
+                }, asyncExecutor).thenApply(ignored -> null);
+                writeFuture = responseFuture;
+            }
         } finally {
             lock.unlock();
+        }
+        if (writeFuture == null) {
+            Throwable failure = completedResponseWriteFailure();
+            try {
+                callback.onComplete(failure);
+            } catch (Throwable callbackFailure) {
+                addSuppressedIfDifferent(failure, callbackFailure);
+            }
+            return;
         }
         writeFuture.whenComplete((ignored, failure) -> {
             if (failure != null && !taskStarted.get()) {
@@ -224,6 +248,9 @@ class Mu3AsyncHandleImpl implements AsyncHandle {
         CompletableFuture<@Nullable Void> writeFuture;
         lock.lock();
         try {
+            if (completionRequested) {
+                return CompletableFuture.failedFuture(completedResponseWriteFailure());
+            }
             writeFuture = responseFuture.thenRunAsync(() -> {
                 taskStarted.set(true);
                 try {
@@ -243,6 +270,10 @@ class Mu3AsyncHandleImpl implements AsyncHandle {
             }
         });
         return writeFuture;
+    }
+
+    private static IllegalStateException completedResponseWriteFailure() {
+        return new IllegalStateException("The asynchronous response is already complete");
     }
 
     @Override

--- a/src/test/java/io/muserver/ExecutionDomainsTest.java
+++ b/src/test/java/io/muserver/ExecutionDomainsTest.java
@@ -28,6 +28,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.Phaser;
@@ -765,6 +766,69 @@ class ExecutionDomainsTest {
             assertThat(client.readBody(client.readHeaders()), equalTo("done"));
         }
         assertThat(completionThread.get(5, TimeUnit.SECONDS), startsWith("async-"));
+    }
+
+    @Test
+    void asyncCompletionIsATerminalGateForLaterWrites() throws Exception {
+        var handlerExecutor = track(Executors.newSingleThreadExecutor(namedThreads("handler-")));
+        var asyncExecutor = track(Executors.newSingleThreadExecutor(namedThreads("async-")));
+        var blockerStarted = new CountDownLatch(1);
+        var releaseBlocker = new CountDownLatch(1);
+        Future<?> blocker = asyncExecutor.submit(() -> {
+            blockerStarted.countDown();
+            releaseBlocker.await();
+            return null;
+        });
+        assertThat(blockerStarted.await(5, TimeUnit.SECONDS), is(true));
+
+        var suspendedHandle = new CompletableFuture<AsyncHandle>();
+        server = httpServer()
+            .withHandlerExecutor(handlerExecutor)
+            .withAsyncExecutor(asyncExecutor)
+            .addHandler((request, response) -> {
+                suspendedHandle.complete(request.handleAsync());
+                return true;
+            })
+            .start();
+
+        try (var client = Http1Client.connect(server)) {
+            client.writeRequestLine(Method.GET, "/").flushHeaders();
+            AsyncHandle handle = suspendedHandle.get(5, TimeUnit.SECONDS);
+            handlerExecutor.submit(() -> {
+            }).get(5, TimeUnit.SECONDS);
+
+            Future<@Nullable Void> acceptedWrite = handle.write(ByteBuffer.wrap(new byte[]{'a'}));
+            handle.complete();
+            Future<@Nullable Void> lateWrite = handle.write(ByteBuffer.wrap(new byte[]{1}));
+            var callbackFailure = new CompletableFuture<Throwable>();
+            handle.write(ByteBuffer.wrap(new byte[]{2}), callbackFailure::complete);
+
+            assertThat(acceptedWrite.isDone(), is(false));
+            ExecutionException failedWrite = assertThrows(
+                ExecutionException.class,
+                () -> lateWrite.get(5, TimeUnit.SECONDS)
+            );
+            assertThat(failedWrite.getCause(), instanceOf(IllegalStateException.class));
+            assertThat(callbackFailure.get(5, TimeUnit.SECONDS), instanceOf(IllegalStateException.class));
+
+            releaseBlocker.countDown();
+            blocker.get(5, TimeUnit.SECONDS);
+            acceptedWrite.get(5, TimeUnit.SECONDS);
+            assertThat(client.readLine(), equalTo("HTTP/1.1 200 OK"));
+            assertThat(
+                client.readHeaders().contains(HeaderNames.TRANSFER_ENCODING, HeaderValues.CHUNKED, true),
+                is(true)
+            );
+            assertThat(client.readLine(), equalTo("1"));
+            assertThat(client.in().read(), is((int) 'a'));
+            assertThat(client.in().read(), is((int) '\r'));
+            assertThat(client.in().read(), is((int) '\n'));
+            assertThat(client.readLine(), equalTo("0"));
+            assertThat(client.readLine(), equalTo(""));
+        } finally {
+            releaseBlocker.countDown();
+            blocker.get(5, TimeUnit.SECONDS);
+        }
     }
 
     @Test


### PR DESCRIPTION
## Summary

- linearize asynchronous response writes and completion on the existing application-side lock
- accept every write that wins before completion and make exchange completion await it
- reject future- and callback-based writes that arrive after completion with `IllegalStateException`
- document the terminal behavior in the public `AsyncHandle` contract and concurrency model

## Why

`exchangeCompletion()` previously waited for `completionFuture` and then took a snapshot of the write chain. A concurrent `write()` could be accepted after that snapshot, so cleanup could race or strand work that the exchange no longer observed.

The lock now supplies one explicit linearization point: either the write joins the observed chain, or completion wins and the write fails immediately.

## Validation

- deterministic regression proves a pre-completion write is awaited while both write APIs reject post-completion work
- `mise exec java@temurin-11 -- mvn -q -Dtest=ExecutionDomainsTest test`
- async-focused Java 11 test selection
- `mise exec java@temurin-11 -- mvn -q test`
- `mise exec java@temurin-21 -- mvn -q -Pnullaway -DskipTests compile`

Stacked on #168. The merge commit only synchronizes the stack; the functional change is `043b5cdc`.