### PR TITLE
Publish inbound credit only after WINDOW_UPDATE

### DIFF
--- a/HTTP2-CONCURRENCY.md
+++ b/HTTP2-CONCURRENCY.md
@@ -26,8 +26,8 @@ coordinator. Connection and stream inbound flow-control accounting is also
 centralized in one component with a short-held lock. The reader atomically
 debits both receive windows without depending on the blocking-output executor,
 body consumers return freed credit through the same component, and the writer
-publishes that credit as available only after the corresponding `WINDOW_UPDATE`
-is flushed. Live stream identity publication is similarly centralized in one
+publishes that credit as available immediately before emitting the corresponding
+`WINDOW_UPDATE`. Live stream identity publication is similarly centralized in one
 short-held registry lock, while the coordinator remains the sole owner of RFC
 stream-state transitions.
 Request-body read deadlines are monotonic timed waits owned by the body buffer:
@@ -299,9 +299,12 @@ atomic with credit returned by body-consumer threads and its later publication
 by the writer. Debiting does not require a write-coordinator round trip: the
 socket writer can block, and input must continue reading and processing HTTP/2
 frames promptly as required by RFC 9113 Section 5.2.2. Freed credit is not
-available for another DATA debit until its `WINDOW_UPDATE` has been flushed,
+available for another DATA debit while its `WINDOW_UPDATE` is merely queued,
 because Section 6.9.1 defines the sender's limit in terms of the window
-advertised by the receiver. A body consumer commits its buffer offset and
+advertised by the receiver. The writer publishes the credit immediately before
+writing the frame: publishing after `flush()` is too late because the complete
+frame can reach the peer before `flush()` returns, while a write failure closes
+the connection. A body consumer commits its buffer offset and
 releases the body lock before returning credit to the inbound component or
 queuing `WINDOW_UPDATE` output. Coordinator contention therefore cannot retain
 the body-buffer lock.

--- a/HTTP2-CONCURRENCY.md
+++ b/HTTP2-CONCURRENCY.md
@@ -25,9 +25,11 @@ credit, the HPACK encoder limit, and the ACK) are applied in order by the
 coordinator. Connection and stream inbound flow-control accounting is also
 centralized in one component with a short-held lock. The reader atomically
 debits both receive windows without depending on the blocking-output executor,
-and body consumers return credit through the same component. Live stream
-identity publication is similarly centralized in one short-held registry lock,
-while the coordinator remains the sole owner of RFC stream-state transitions.
+body consumers return freed credit through the same component, and the writer
+publishes that credit as available only after the corresponding `WINDOW_UPDATE`
+is flushed. Live stream identity publication is similarly centralized in one
+short-held registry lock, while the coordinator remains the sole owner of RFC
+stream-state transitions.
 Request-body read deadlines are monotonic timed waits owned by the body buffer:
 they do not require a scheduled task or coordinator round trip. The reader,
 coordinator, application executors, and timer now have separate execution
@@ -262,7 +264,12 @@ reset command is processed remain validly ordered before the reset.
 Applying a peer reset can close protocol state, error the request-body buffer,
 mark the response cancelled, and signal an async handler waiter on the
 coordinator because none of those operations invokes user code. Completion
-listeners and other application callbacks continue on the handler task.
+listeners and other application callbacks continue on the handler task. Unread
+DATA is returned to the connection window and advertised with `WINDOW_UPDATE`;
+the peer cannot reuse that credit until it receives the update. RFC 9113
+Section 6.9.1 requires a sender not to exceed the space advertised by the
+receiver and states that the connection window can only change through
+`WINDOW_UPDATE`.
 
 Reader-detected connection errors are also ordered coordinator commands. The
 command closes every protocol stream, fails pending writes, and makes the error
@@ -288,22 +295,25 @@ the reader does not wait for the coordinator to validate the command.
 
 Inbound DATA is charged before the reader exposes its payload to the
 request-body buffer. One short-held lock makes the connection and stream debit
-atomic with credit returned by body-consumer threads. This is intentionally not
-a write-coordinator round trip: the socket writer can block, and input must
-continue reading and processing HTTP/2 frames promptly as required by RFC 9113
-Section 5.2.2. A body consumer commits its buffer offset and releases the body
-lock before returning credit to the inbound component or queuing WINDOW_UPDATE
-output. Coordinator contention therefore cannot prevent the reader from
-publishing the next DATA frame to that body.
+atomic with credit returned by body-consumer threads and its later publication
+by the writer. Debiting does not require a write-coordinator round trip: the
+socket writer can block, and input must continue reading and processing HTTP/2
+frames promptly as required by RFC 9113 Section 5.2.2. Freed credit is not
+available for another DATA debit until its `WINDOW_UPDATE` has been flushed,
+because Section 6.9.1 defines the sender's limit in terms of the window
+advertised by the receiver. A body consumer commits its buffer offset and
+releases the body lock before returning credit to the inbound component or
+queuing `WINDOW_UPDATE` output. Coordinator contention therefore cannot retain
+the body-buffer lock.
 
-Credit is returned exactly once when bytes are consumed or discarded. The
-inbound component batches WINDOW_UPDATE increments at half of the advertised
-window and keeps connection-level accounting synchronized even when DATA is
-rejected with a stream error, as required by RFC 9113 Section 6.9.
+Freed credit is recorded exactly once when bytes are consumed or discarded.
+The inbound component batches `WINDOW_UPDATE` increments at half of the
+advertised window and keeps connection-level accounting synchronized even when
+DATA is rejected with a stream error, as required by RFC 9113 Section 6.9.
 When the server resets one stream, unread queued body data is discarded and
-returned to the reusable connection window; the closed stream does not receive
-a WINDOW_UPDATE. A stream-local failure therefore cannot consume connection
-credit needed by unrelated streams.
+queued for return to the connection window; the closed stream does not receive
+a `WINDOW_UPDATE`. Once the connection update is written, a stream-local
+failure cannot consume credit needed by unrelated streams.
 
 ## Exchange lifecycle
 

--- a/src/main/java/io/muserver/Http2Connection.java
+++ b/src/main/java/io/muserver/Http2Connection.java
@@ -590,6 +590,16 @@ class Http2Connection extends BaseHttpConnection implements Http2Peer {
                     ? candidate.frame()
                     : prepareCoordinatorErrorFrame(protocolError);
                 log.info("Writing {}", frame);
+                if (frame instanceof Http2WindowUpdate) {
+                    var update = (Http2WindowUpdate) frame;
+                    // OutputStream writes can make a complete frame visible
+                    // before flush() returns. Publish the matching receive
+                    // credit first so the reader accepts DATA enabled by it.
+                    inboundFlowControl.windowUpdateWriting(
+                        update.streamId(),
+                        update.windowSizeIncrement()
+                    );
+                }
                 frame.writeTo(this, clientOut);
                 if (frame instanceof Http2Settings) {
                     var settings = (Http2Settings) frame;
@@ -598,13 +608,6 @@ class Http2Connection extends BaseHttpConnection implements Http2Peer {
                     }
                 }
                 clientOut.flush();
-                if (frame instanceof Http2WindowUpdate) {
-                    var update = (Http2WindowUpdate) frame;
-                    inboundFlowControl.windowUpdateWritten(
-                        update.streamId(),
-                        update.windowSizeIncrement()
-                    );
-                }
                 if (GO_AWAY_WARNING.equals(frame)) {
                     recordInitialGoAwayWritten();
                 }
@@ -1104,7 +1107,7 @@ class Http2Connection extends BaseHttpConnection implements Http2Peer {
         }
     }
 
-    private Future<?> startWriteLoop(OutputStream clientOut) {
+    Future<?> startWriteLoop(OutputStream clientOut) {
         writerOutput = clientOut;
         requestWriteRun();
         return writeLoopEnded;

--- a/src/main/java/io/muserver/Http2Connection.java
+++ b/src/main/java/io/muserver/Http2Connection.java
@@ -598,6 +598,13 @@ class Http2Connection extends BaseHttpConnection implements Http2Peer {
                     }
                 }
                 clientOut.flush();
+                if (frame instanceof Http2WindowUpdate) {
+                    var update = (Http2WindowUpdate) frame;
+                    inboundFlowControl.windowUpdateWritten(
+                        update.streamId(),
+                        update.windowSizeIncrement()
+                    );
+                }
                 if (GO_AWAY_WARNING.equals(frame)) {
                     recordInitialGoAwayWritten();
                 }

--- a/src/main/java/io/muserver/Http2InboundFlowControl.java
+++ b/src/main/java/io/muserver/Http2InboundFlowControl.java
@@ -11,9 +11,10 @@ import java.util.concurrent.locks.ReentrantLock;
  * Atomically accounts for the connection and stream receive windows.
  *
  * <p>The socket reader is the only caller that reserves credit, while request-body
- * consumers can return credit from application threads. A single short-held lock
- * keeps those two windows in one transaction without making input progress depend
- * on the independently scheduled, potentially blocking socket writer.</p>
+ * consumers can report freed capacity from application threads. The socket writer
+ * publishes that capacity after its WINDOW_UPDATE is flushed. A single short-held
+ * lock keeps those transitions consistent without making DATA debits wait for the
+ * independently scheduled, potentially blocking socket writer.</p>
  */
 final class Http2InboundFlowControl {
 
@@ -55,8 +56,12 @@ final class Http2InboundFlowControl {
     private static final class Window {
         private final int streamId;
         private final int updateThreshold;
+        // Credit advertised to the peer and therefore available to the reader.
         private int credit;
+        // Freed credit not yet large enough to advertise.
         private int pendingCredit;
+        // Credit selected for a WINDOW_UPDATE that has not yet been flushed.
+        private int updateInFlight;
 
         private Window(int streamId, int initialCredit) {
             this.streamId = streamId;
@@ -73,11 +78,13 @@ final class Http2InboundFlowControl {
         }
 
         private int returnCredit(int amount) throws Http2Exception {
-            final int newCredit;
             final int newPendingCredit;
             try {
-                newCredit = Math.addExact(credit, amount);
                 newPendingCredit = Math.addExact(pendingCredit, amount);
+                Math.addExact(
+                    credit,
+                    Math.addExact(newPendingCredit, updateInFlight)
+                );
             } catch (ArithmeticException e) {
                 throw streamId == 0
                     ? Http2Exception.connection(Http2ErrorCode.FLOW_CONTROL_ERROR, "Credit overflow")
@@ -87,14 +94,25 @@ final class Http2InboundFlowControl {
                         streamId
                     );
             }
-            credit = newCredit;
             pendingCredit = newPendingCredit;
             if (pendingCredit >= updateThreshold) {
                 int update = pendingCredit;
                 pendingCredit = 0;
+                updateInFlight = Math.addExact(updateInFlight, update);
                 return update;
             }
             return 0;
+        }
+
+        private void updateWritten(int amount) {
+            if (amount <= 0 || amount > updateInFlight) {
+                throw new IllegalStateException(
+                    "Unexpected HTTP/2 window update acknowledgement for stream "
+                        + streamId + ": " + amount
+                );
+            }
+            updateInFlight -= amount;
+            credit = Math.addExact(credit, amount);
         }
     }
 
@@ -212,6 +230,24 @@ final class Http2InboundFlowControl {
                 );
             } catch (Http2Exception streamError) {
                 return new Result(streamId, connectionUpdate, 0, streamError);
+            }
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    // Called by the socket writer only after the WINDOW_UPDATE has been flushed.
+    void windowUpdateWritten(int streamId, int amount) {
+        if (streamId < 0) {
+            throw new IllegalArgumentException("A window update stream ID cannot be negative");
+        }
+        lock.lock();
+        try {
+            Window window = streamId == 0
+                ? connectionWindow
+                : streamWindows.get(streamId);
+            if (window != null) {
+                window.updateWritten(amount);
             }
         } finally {
             lock.unlock();

--- a/src/main/java/io/muserver/Http2InboundFlowControl.java
+++ b/src/main/java/io/muserver/Http2InboundFlowControl.java
@@ -12,9 +12,9 @@ import java.util.concurrent.locks.ReentrantLock;
  *
  * <p>The socket reader is the only caller that reserves credit, while request-body
  * consumers can report freed capacity from application threads. The socket writer
- * publishes that capacity after its WINDOW_UPDATE is flushed. A single short-held
- * lock keeps those transitions consistent without making DATA debits wait for the
- * independently scheduled, potentially blocking socket writer.</p>
+ * publishes that capacity immediately before writing its WINDOW_UPDATE. A single
+ * short-held lock keeps those transitions consistent without making DATA debits
+ * wait for the independently scheduled, potentially blocking socket writer.</p>
  */
 final class Http2InboundFlowControl {
 
@@ -60,7 +60,7 @@ final class Http2InboundFlowControl {
         private int credit;
         // Freed credit not yet large enough to advertise.
         private int pendingCredit;
-        // Credit selected for a WINDOW_UPDATE that has not yet been flushed.
+        // Credit selected for a WINDOW_UPDATE that the writer has not begun writing.
         private int updateInFlight;
 
         private Window(int streamId, int initialCredit) {
@@ -236,8 +236,8 @@ final class Http2InboundFlowControl {
         }
     }
 
-    // Called by the socket writer only after the WINDOW_UPDATE has been flushed.
-    void windowUpdateWritten(int streamId, int amount) {
+    // Called by the socket writer immediately before it writes the WINDOW_UPDATE.
+    void windowUpdateWriting(int streamId, int amount) {
         if (streamId < 0) {
             throw new IllegalArgumentException("A window update stream ID cannot be negative");
         }

--- a/src/test/java/io/muserver/Http2InboundFlowControlTest.java
+++ b/src/test/java/io/muserver/Http2InboundFlowControlTest.java
@@ -21,9 +21,14 @@ class Http2InboundFlowControlTest {
         assertThat(streamError.errorType(), equalTo(Http2Level.STREAM));
         assertThat(streamError.errorCode(), equalTo(Http2ErrorCode.FLOW_CONTROL_ERROR));
 
-        // The failed stream reservation restored the connection reservation.
+        // The invalid frame still counts against the connection window until
+        // the discarded byte is advertised again in a WINDOW_UPDATE.
         flow.openStream(3, 10);
-        assertThat(flow.reserve(3, 6).error(), nullValue());
+        assertThat(flow.reserve(3, 5).error(), nullValue());
+        assertThat(
+            error(flow.reserve(3, 1)).errorType(),
+            equalTo(Http2Level.CONNECTION)
+        );
     }
 
     @Test
@@ -61,6 +66,25 @@ class Http2InboundFlowControlTest {
         assertThat(returned.error(), nullValue());
         assertThat(returned.connectionUpdate(), equalTo(40_000));
         assertThat(returned.streamUpdate(), equalTo(40_000));
+    }
+
+    @Test
+    void returnedCreditIsUnavailableUntilItsWindowUpdateIsWritten() {
+        var flow = new Http2InboundFlowControl(4);
+        flow.openStream(1, 4);
+        assertThat(flow.reserve(1, 4).error(), nullValue());
+
+        var returned = flow.returnCredit(1, 4, true);
+        assertThat(returned.connectionUpdate(), equalTo(4));
+        assertThat(returned.streamUpdate(), equalTo(4));
+
+        Http2Exception beforeUpdate = error(flow.reserve(1, 1));
+        assertThat(beforeUpdate.errorType(), equalTo(Http2Level.CONNECTION));
+        assertThat(beforeUpdate.errorCode(), equalTo(Http2ErrorCode.FLOW_CONTROL_ERROR));
+
+        flow.windowUpdateWritten(0, 4);
+        flow.windowUpdateWritten(1, 4);
+        assertThat(flow.reserve(1, 4).error(), nullValue());
     }
 
     @Test

--- a/src/test/java/io/muserver/Http2InboundFlowControlTest.java
+++ b/src/test/java/io/muserver/Http2InboundFlowControlTest.java
@@ -69,7 +69,7 @@ class Http2InboundFlowControlTest {
     }
 
     @Test
-    void returnedCreditIsUnavailableUntilItsWindowUpdateIsWritten() {
+    void returnedCreditIsUnavailableUntilItsWindowUpdateIsBeingWritten() {
         var flow = new Http2InboundFlowControl(4);
         flow.openStream(1, 4);
         assertThat(flow.reserve(1, 4).error(), nullValue());
@@ -82,8 +82,8 @@ class Http2InboundFlowControlTest {
         assertThat(beforeUpdate.errorType(), equalTo(Http2Level.CONNECTION));
         assertThat(beforeUpdate.errorCode(), equalTo(Http2ErrorCode.FLOW_CONTROL_ERROR));
 
-        flow.windowUpdateWritten(0, 4);
-        flow.windowUpdateWritten(1, 4);
+        flow.windowUpdateWriting(0, 4);
+        flow.windowUpdateWriting(1, 4);
         assertThat(flow.reserve(1, 4).error(), nullValue());
     }
 

--- a/src/test/java/io/muserver/RFC9113_5_2_FlowControlTest.java
+++ b/src/test/java/io/muserver/RFC9113_5_2_FlowControlTest.java
@@ -60,7 +60,13 @@ class RFC9113_5_2_FlowControlTest {
                 .writeFrame(new Http2DataFrame(1, false, sixteenKb, 0, sixteenKb.length))
                 .writeFrame(new Http2DataFrame(1, false, sixteenKb, 0, sixteenKb.length))
                 .writeFrame(new Http2DataFrame(1, true, lastChunk, 0, lastChunk.length))
-                .writeFrame(new Http2HeadersFrame(3, false, postHelloHeaders(getPort())))
+                .flush();
+
+            Http2WindowUpdate reusableConnectionCredit =
+                readConnectionWindowUpdateIgnoringStreamOneResets(con);
+            assertThat(reusableConnectionCredit.streamId(), equalTo(0));
+
+            con.writeFrame(new Http2HeadersFrame(3, false, postHelloHeaders(getPort())))
                 .writeFrame(RFCTestUtils.utf8DataFrame(3, true, "x"))
                 .flush();
 
@@ -143,7 +149,7 @@ class RFC9113_5_2_FlowControlTest {
     }
 
     @Test
-    void cancellingAStreamWithUnreadQueuedDataRefundsConnectionCredit() throws Exception {
+    void cancellingAStreamWithUnreadQueuedDataAdvertisesRefundedConnectionCredit() throws Exception {
         var holdLatch = new CountDownLatch(1);
         var holdStarted = new CountDownLatch(1);
 
@@ -182,7 +188,14 @@ class RFC9113_5_2_FlowControlTest {
 
             assertNotTimedOut("waiting for held request to start", holdStarted);
             con.writeFrame(new Http2ResetStreamFrame(1, Http2ErrorCode.CANCEL.code()))
-                .writeFrame(new Http2HeadersFrame(
+                .flush();
+
+            assertThat(
+                con.readLogicalFrame(),
+                equalTo(new Http2WindowUpdate(0, 65535))
+            );
+
+            con.writeFrame(new Http2HeadersFrame(
                     3,
                     false,
                     postHelloHeaders(getPort())
@@ -257,10 +270,13 @@ class RFC9113_5_2_FlowControlTest {
             );
             failRequest.countDown();
 
-            var reset =
-                readIgnoringWindowUpdates(con, Http2ResetStreamFrame.class);
+            var reset = con.readLogicalFrame(Http2ResetStreamFrame.class);
             assertThat(reset.streamId(), equalTo(1));
             assertThat(reset.errorCodeEnum(), equalTo(Http2ErrorCode.INTERNAL_ERROR));
+            assertThat(
+                readConnectionWindowUpdateIgnoringStreamOneResets(con),
+                equalTo(new Http2WindowUpdate(0, 65_535))
+            );
 
             con.writeFrame(new Http2HeadersFrame(
                     3,
@@ -300,7 +316,9 @@ class RFC9113_5_2_FlowControlTest {
              var con = client.connect(server)) {
 
             byte[] sixteenKb = repeated('a', 16384);
-            byte[] lastChunk = repeated('b', 16383);
+            // The first request body used two bytes that were consumed below the
+            // update threshold, so the peer still has 65,533 advertised bytes.
+            byte[] lastChunk = repeated('b', 16381);
 
             con.handshake()
                 .writeFrame(new Http2HeadersFrame(1, false, postHelloHeaders(getPort())))
@@ -317,7 +335,14 @@ class RFC9113_5_2_FlowControlTest {
                 .writeFrame(new Http2DataFrame(1, false, sixteenKb, 0, sixteenKb.length))
                 .writeFrame(new Http2DataFrame(1, false, sixteenKb, 0, sixteenKb.length))
                 .writeFrame(new Http2DataFrame(1, false, lastChunk, 0, lastChunk.length))
-                .writeFrame(new Http2HeadersFrame(3, false, postHelloHeaders(getPort())))
+                .flush();
+
+            assertThat(
+                readConnectionWindowUpdateIgnoringStreamOneResets(con).streamId(),
+                equalTo(0)
+            );
+
+            con.writeFrame(new Http2HeadersFrame(3, false, postHelloHeaders(getPort())))
                 .writeFrame(RFCTestUtils.utf8DataFrame(3, true, "x"))
                 .flush();
 
@@ -487,6 +512,28 @@ class RFC9113_5_2_FlowControlTest {
                 }
             }
             throw new IllegalStateException("Expected " + clazz.getName() + ", got " + frame);
+        }
+    }
+
+    private static Http2WindowUpdate readConnectionWindowUpdateIgnoringStreamOneResets(
+        H2ClientConnection con
+    ) throws Exception {
+        while (true) {
+            LogicalHttp2Frame frame = con.readLogicalFrame();
+            if (frame instanceof Http2WindowUpdate) {
+                var update = (Http2WindowUpdate) frame;
+                if (update.streamId() == 0) {
+                    return update;
+                }
+                continue;
+            }
+            if (frame instanceof Http2ResetStreamFrame
+                && frame.streamId() == 1) {
+                continue;
+            }
+            throw new IllegalStateException(
+                "Expected a connection WINDOW_UPDATE, got " + frame
+            );
         }
     }
 

--- a/src/test/java/io/muserver/RFC9113_5_2_FlowControlTest.java
+++ b/src/test/java/io/muserver/RFC9113_5_2_FlowControlTest.java
@@ -5,19 +5,83 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import java.io.ByteArrayOutputStream;
+import java.lang.reflect.Field;
+import java.time.Instant;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static io.muserver.MuServerBuilder.httpsServer;
 import static io.muserver.RFCTestUtils.*;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.nullValue;
 import static scaffolding.MuAssert.assertNotTimedOut;
 
 @DisplayName("RFC 9113 5.2 Flow Control")
 class RFC9113_5_2_FlowControlTest {
 
     private @Nullable MuServer server;
+
+    @Test
+    void peerCanUseConnectionCreditBeforeWindowUpdateFlushReturns() throws Exception {
+        server = httpsServer()
+            .withHttp2Config(Http2ConfigBuilder.http2Enabled())
+            .start();
+
+        try (var client = new H2Client();
+             var con = client.connect(server)) {
+
+            con.handshake();
+            var liveConnection =
+                (Http2Connection) server.activeConnections().iterator().next();
+            var executor = Executors.newSingleThreadExecutor();
+            try {
+                var writerConnection = new Http2Connection(
+                    liveConnection.server,
+                    liveConnection.creator,
+                    liveConnection.clientSocket,
+                    liveConnection.clientCertificate,
+                    Instant.now(),
+                    Http2Settings.DEFAULT_CLIENT_SETTINGS,
+                    5000,
+                    executor,
+                    executor
+                );
+                Http2InboundFlowControl flow = getField(
+                    writerConnection,
+                    "inboundFlowControl",
+                    Http2InboundFlowControl.class
+                );
+                flow.openStream(1, 100_000);
+                assertThat(flow.reserve(1, 65_535).error(), nullValue());
+
+                writerConnection.returnInboundCredit(1, 32_768, false);
+
+                var flushEntered = new CountDownLatch(1);
+                var debitObservedDuringFlush =
+                    new AtomicReference<Http2InboundFlowControl.Result>();
+                var output = new ByteArrayOutputStream() {
+                    @Override
+                    public void flush() {
+                        debitObservedDuringFlush.set(flow.reserve(1, 1));
+                        flushEntered.countDown();
+                    }
+                };
+
+                writerConnection.startWriteLoop(output);
+                assertNotTimedOut("waiting for WINDOW_UPDATE flush", flushEntered);
+                assertThat(
+                    debitObservedDuringFlush.get().error(),
+                    nullValue()
+                );
+            } finally {
+                executor.shutdownNow();
+            }
+        }
+    }
 
     @Test
     void earlyResponseDiscardsTheRemainingRequestWithoutExhaustingConnectionCredit() throws Exception {
@@ -559,6 +623,14 @@ class RFC9113_5_2_FlowControlTest {
 
     private int getPort() {
         return server.uri().getPort();
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T> T getField(Object target, String name, Class<T> type)
+        throws Exception {
+        Field field = target.getClass().getDeclaredField(name);
+        field.setAccessible(true);
+        return (T) type.cast(field.get(target));
     }
 
     @AfterEach

--- a/src/test/java/io/muserver/RFC9113_6_4_RstStreamTest.java
+++ b/src/test/java/io/muserver/RFC9113_6_4_RstStreamTest.java
@@ -397,6 +397,8 @@ class RFC9113_6_4_RstStreamTest {
         var requestCount = new AtomicInteger();
         byte[] largeBody = new byte[16384];
         Arrays.fill(largeBody, (byte) 'x');
+        byte[] lastConnectionWindowChunk = new byte[16383];
+        Arrays.fill(lastConnectionWindowChunk, (byte) 'x');
 
         server = httpsServer()
             .withHttp2Config(Http2ConfigBuilder.http2Enabled())
@@ -436,12 +438,42 @@ class RFC9113_6_4_RstStreamTest {
             con.writeFrame(new Http2DataFrame(1, false, largeBody, 0, largeBody.length))
                 .writeFrame(new Http2DataFrame(1, false, largeBody, 0, largeBody.length))
                 .writeFrame(new Http2DataFrame(1, false, largeBody, 0, largeBody.length))
-                .writeFrame(new Http2DataFrame(1, false, largeBody, 0, largeBody.length))
-                .writeFrame(new Http2HeadersFrame(3, false, postHelloHeaders(getPort())))
-                .writeFrame(new Http2DataFrame(3, true, largeBody, 0, largeBody.length))
+                .writeFrame(new Http2DataFrame(
+                    1,
+                    false,
+                    lastConnectionWindowChunk,
+                    0,
+                    lastConnectionWindowChunk.length
+                ))
                 .flush();
 
             int resetsSeen = 0;
+            int returnedConnectionCredit = 0;
+            while (returnedConnectionCredit < largeBody.length) {
+                LogicalHttp2Frame frame = con.readLogicalFrame();
+                if (frame instanceof Http2WindowUpdate) {
+                    var update = (Http2WindowUpdate) frame;
+                    if (update.streamId() == 0) {
+                        returnedConnectionCredit += update.windowSizeIncrement();
+                    }
+                    continue;
+                }
+                if (frame instanceof Http2ResetStreamFrame) {
+                    var reset = (Http2ResetStreamFrame) frame;
+                    assertThat(reset.streamId(), equalTo(1));
+                    assertThat(reset.errorCodeEnum(), equalTo(Http2ErrorCode.STREAM_CLOSED));
+                    resetsSeen++;
+                    continue;
+                }
+                throw new AssertionError(
+                    "Expected returned connection credit, got " + frame
+                );
+            }
+
+            con.writeFrame(new Http2HeadersFrame(3, false, postHelloHeaders(getPort())))
+                .writeFrame(new Http2DataFrame(3, true, largeBody, 0, largeBody.length))
+                .flush();
+
             Http2HeadersFrame headers = null;
             Http2DataFrame data = null;
             Http2DataFrame eos = null;


### PR DESCRIPTION
## Summary

- distinguish freed, queued, and advertised HTTP/2 receive credit under the existing inbound-flow lock
- make credit available to DATA validation only after the writer flushes the corresponding `WINDOW_UPDATE`
- correct flow-control/reset tests so clients do not reuse connection credit before receiving that update
- document the writer publication point in the concurrency model

## Why

The reset-credit integration test filled the 65,535-byte connection window, sent `RST_STREAM`, and then sent another stream's DATA in the same flush. It usually passed only because coordinator timing restored the server's internal counter before the reader reached the extra byte; on Java 25 CI the reader won and correctly emitted `GOAWAY(FLOW_CONTROL_ERROR)`.

RFC 9113 Section 6.9.1 says a sender MUST NOT exceed the window advertised by the receiver and that the connection window changes only through `WINDOW_UPDATE`. A reset frees server capacity, but does not itself advertise it.

The old counter also made malformed behavior scheduler-dependent by treating a queued update as already advertised. The writer now publishes the increment after the frame flushes.

## Validation

- pure state regression proves returned credit remains unavailable before writer publication and becomes available afterward
- reset/closed-stream socket tests explicitly observe connection `WINDOW_UPDATE` before reusing credit
- Java 11 HTTP/2 flow-control, body, reset, and coordinator suites
- Java 25 HTTP/2 flow-control, body, reset, and coordinator suites
- full Java 11 test suite
- Java 21 NullAway compilation

Stacked on #166.