### PR TITLE
Order response completion listener registration

### DIFF
--- a/HTTP2-CONCURRENCY.md
+++ b/HTTP2-CONCURRENCY.md
@@ -180,6 +180,7 @@ as defined by RFC 9113 Section 7.
 | HPACK encoder and socket output | Coordinator |
 | Request-body producer/consumer buffer and read deadline | `Http2BodyInputStream` lock and condition |
 | Response API call ordering and async completion terminal gate | Application-side response/async handle lock |
+| Response completion-listener registration and notification gate | `BaseResponse` completion-listener lock |
 | Protocol stream completion | Coordinator |
 | Application exchange completion | Serialized application completion path |
 
@@ -366,6 +367,8 @@ Permitted cross-thread primitives are deliberately narrow:
 * an application-side lock that orders async response submissions with the
   terminal completion gate, so completion observes every accepted write and
   rejects every later write; and
+* one short-held response lock that orders completion-listener registration
+  against the notification snapshot; and
 * a thread-confined FIFO that drains nested application work without recursive
   calls or executor resubmission; and
 * atomics for idempotent resource closure.

--- a/src/main/java/io/muserver/BaseHttpConnection.java
+++ b/src/main/java/io/muserver/BaseHttpConnection.java
@@ -107,9 +107,7 @@ abstract class BaseHttpConnection implements HttpConnection {
 
     protected void notifyExchangeEnded(ResponseInfo exchange) {
         BaseResponse resp = (BaseResponse) exchange.response();
-        for (var listener : resp.completionListeners()) {
-            listener.onComplete(exchange);
-        }
+        resp.notifyCompletionListeners(exchange);
         server.notifyExchangeEnded(exchange);
     }
 

--- a/src/main/java/io/muserver/BaseResponse.java
+++ b/src/main/java/io/muserver/BaseResponse.java
@@ -9,9 +9,8 @@ import java.io.UncheckedIOException;
 import java.net.URI;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
-import java.util.concurrent.ConcurrentLinkedQueue;
-
-import static java.util.Collections.emptyList;
+import java.util.ArrayDeque;
+import java.util.Queue;
 
 abstract class BaseResponse implements MuResponse {
 
@@ -22,8 +21,11 @@ abstract class BaseResponse implements MuResponse {
     @Nullable
     protected volatile OutputStream wrappedOut;
 
+    private final Object completionListenersLock = new Object();
+    private final Queue<ResponseCompleteListener> completionListeners = new ArrayDeque<>();
     @Nullable
-    private ConcurrentLinkedQueue<ResponseCompleteListener> completionListeners = null;
+    private ResponseInfo completionInfo;
+    private boolean completionListenersDrained;
 
     private volatile ResponseState state = ResponseState.NOTHING;
 
@@ -204,16 +206,35 @@ abstract class BaseResponse implements MuResponse {
         if (listener == null) {
             throw new NullPointerException("Null completion listener");
         }
-        if (completionListeners == null) {
-            completionListeners = new ConcurrentLinkedQueue<>();
+        ResponseInfo completed;
+        synchronized (completionListenersLock) {
+            completed = completionInfo;
+            if (completed == null || !completionListenersDrained) {
+                completionListeners.add(listener);
+                return;
+            }
         }
-        completionListeners.add(listener);
+        request.serverImpl().executeResponseCompletionTask(() -> listener.onComplete(completed));
     }
 
-    Iterable<ResponseCompleteListener> completionListeners() {
-        var cl = completionListeners;
-        return cl == null ? emptyList() : cl;
+    void notifyCompletionListeners(ResponseInfo completed) {
+        synchronized (completionListenersLock) {
+            if (completionInfo != null) {
+                return;
+            }
+            completionInfo = completed;
+        }
+
+        while (true) {
+            ResponseCompleteListener listener;
+            synchronized (completionListenersLock) {
+                listener = completionListeners.poll();
+                if (listener == null) {
+                    completionListenersDrained = true;
+                    return;
+                }
+            }
+            listener.onComplete(completed);
+        }
     }
-
-
 }

--- a/src/main/java/io/muserver/Mu3Request.java
+++ b/src/main/java/io/muserver/Mu3Request.java
@@ -253,10 +253,9 @@ class Mu3Request implements MuRequest {
     @Override
     public synchronized AsyncHandle handleAsync() {
         if (asyncHandle == null) {
-            Mu3ServerImpl server = (Mu3ServerImpl) connection.server();
             asyncHandle = new Mu3AsyncHandleImpl(this,
                 Objects.requireNonNull(response, "The response has not been initialized"),
-                server);
+                serverImpl());
         }
         if (clientCancelled) {
             asyncHandle.complete();
@@ -341,6 +340,10 @@ class Mu3Request implements MuRequest {
     @Nullable
     public Mu3AsyncHandleImpl getAsyncHandle() {
         return asyncHandle;
+    }
+
+    Mu3ServerImpl serverImpl() {
+        return (Mu3ServerImpl) connection.server();
     }
 
     public void setResponse(BaseResponse response) {

--- a/src/main/java/io/muserver/MuResponse.java
+++ b/src/main/java/io/muserver/MuResponse.java
@@ -148,6 +148,7 @@ public interface MuResponse {
 
     /**
      * Adds a completion listener which will be called at the end of this response
+     * (including when registration races with completion notification).
      * @param listener a completion listener
      * @throws NullPointerException completion listener is null
      */

--- a/src/test/java/io/muserver/ExecutionDomainsTest.java
+++ b/src/test/java/io/muserver/ExecutionDomainsTest.java
@@ -654,6 +654,62 @@ class ExecutionDomainsTest {
     }
 
     @Test
+    void completionListenerRegistrationIsOrderedAgainstNotification() throws Exception {
+        var handlerExecutor = track(Executors.newFixedThreadPool(2, namedThreads("handler-")));
+        var connectionExecutor = track(Executors.newSingleThreadExecutor(namedThreads("connection-")));
+        var responseRef = new CompletableFuture<MuResponse>();
+        var firstListenerStarted = new CountDownLatch(1);
+        var releaseFirstListener = new CountDownLatch(1);
+        var firstListenerThread = new CompletableFuture<String>();
+        var lateListenerThread = new CompletableFuture<String>();
+        var serverListenerFinished = new CompletableFuture<Void>();
+        server = httpServer()
+            .withHandlerExecutor(handlerExecutor)
+            .withConnectionExecutor(connectionExecutor)
+            .addResponseCompleteListener(info -> serverListenerFinished.complete(null))
+            .addHandler(Method.GET, "/", (request, response, pathParams) -> {
+                response.addCompletionListener(info -> {
+                    firstListenerThread.complete(Thread.currentThread().getName());
+                    firstListenerStarted.countDown();
+                    try {
+                        releaseFirstListener.await();
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                    }
+                });
+                responseRef.complete(response);
+                response.write("done");
+            })
+            .start();
+
+        try (var client = Http1Client.connect(server)) {
+            client.writeRequestLine(Method.GET, "/").flushHeaders();
+            assertThat(client.readLine(), equalTo("HTTP/1.1 200 OK"));
+            assertThat(client.readBody(client.readHeaders()), equalTo("done"));
+            assertThat(firstListenerStarted.await(5, TimeUnit.SECONDS), is(true));
+
+            responseRef.get(5, TimeUnit.SECONDS).addCompletionListener(info ->
+                lateListenerThread.complete(Thread.currentThread().getName())
+            );
+            releaseFirstListener.countDown();
+
+            assertThat(
+                lateListenerThread.get(5, TimeUnit.SECONDS),
+                equalTo(firstListenerThread.get(5, TimeUnit.SECONDS))
+            );
+            serverListenerFinished.get(5, TimeUnit.SECONDS);
+
+            var postCompletionThread = new CompletableFuture<String>();
+            responseRef.get(5, TimeUnit.SECONDS).addCompletionListener(info ->
+                postCompletionThread.complete(Thread.currentThread().getName())
+            );
+            assertThat(postCompletionThread.get(5, TimeUnit.SECONDS), startsWith("handler-"));
+        } finally {
+            releaseFirstListener.countDown();
+        }
+    }
+
+    @Test
     void aSlowHttp1CompletionListenerDoesNotDelayTheNextRequest() throws Exception {
         var handlerExecutor = track(Executors.newFixedThreadPool(2, namedThreads("handler-")));
         var connectionExecutor = track(Executors.newSingleThreadExecutor(namedThreads("connection-")));


### PR DESCRIPTION
## Summary

- replace the lazily-published completion-listener queue with one explicit per-response synchronization boundary
- linearize listener registration against completion notification without running application code under the monitor
- keep listeners registered during notification on the same response-completion application turn, and dispatch post-completion registrations through the application executor
- document the callback ownership rule in `HTTP2-CONCURRENCY.md` and the public `MuResponse` contract

## Why

A listener registered concurrently with completion could be missed by the weakly-consistent queue iterator. The result depended on timing even though the response had exactly one completion event. This change gives registration and completion an explicit happens-before relationship while preserving application-executor dispatch.

## Tests

- deterministic race test blocks one completion listener, registers another during notification, and verifies both execution and application-thread ownership
- related execution-domain, async, reset, stop, and JAX-RS tests pass
- full Java 11 suite: 1,670 tests, 0 failures, 0 errors
- Java 21 NullAway passes

No public signature or wire-level behavior changes.

Stacked on #167.