### PR TITLE
Start SETTINGS acknowledgement timeout after output

### DIFF
--- a/HTTP2-CONCURRENCY.md
+++ b/HTTP2-CONCURRENCY.md
@@ -152,7 +152,10 @@ protocol state, perform socket I/O, or invoke user code.
 Connection idle-timeout scans, WebSocket pings, and HTTP/2 SETTINGS
 acknowledgement deadlines use this facility. SETTINGS expiry atomically wins
 or loses a race with its ACK, then enqueues a connection-error command without
-mutating protocol state on the timer thread.
+mutating protocol state on the timer thread. The writer registers each local
+SETTINGS frame in the acknowledgement FIFO before writing any of its bytes, so
+a fast ACK cannot be missed, but arms its deadline only after the frame is
+flushed, so blocked output does not consume the peer's acknowledgement period.
 
 Request-body read deadlines are intentionally not server timer tasks. They
 bound an application thread's blocking read on `Http2BodyInputStream`, so the
@@ -175,7 +178,8 @@ as defined by RFC 9113 Section 7.
 | Live application/rejected stream identity index | `Http2StreamRegistry` lock |
 | Inbound END_STREAM and reset-seen fences | Connection reader, with monotonic publication where another domain reads them |
 | Peer settings snapshot after decoding | Connection reader (volatile publication) |
-| Outbound effects of peer settings and local settings lifecycle | Coordinator |
+| Outbound effects of peer settings | Coordinator |
+| Local SETTINGS acknowledgement lifecycle | Writer registration and post-flush deadline publication; reader FIFO consumption; atomic ACK/timeout gate |
 | Connection and stream outbound flow-control credit | Coordinator |
 | Connection and stream inbound flow-control accounting | `Http2InboundFlowControl` lock |
 | Pending outbound frames and their ordering | Coordinator |

--- a/src/main/java/io/muserver/Http2Connection.java
+++ b/src/main/java/io/muserver/Http2Connection.java
@@ -403,9 +403,13 @@ class Http2Connection extends BaseHttpConnection implements Http2Peer {
         }
     }
 
-    private void queuePendingSettingsAck() throws IOException {
+    private PendingSettingsAck registerPendingSettingsAck() {
         var pendingAck = new PendingSettingsAck();
         settingsAckQueue.add(pendingAck);
+        return pendingAck;
+    }
+
+    private void startSettingsAckTimeout(PendingSettingsAck pendingAck) throws IOException {
         try {
             pendingAck.timeoutTask(server.scheduleTimerCallback(
                 () -> {
@@ -417,10 +421,18 @@ class Http2Connection extends BaseHttpConnection implements Http2Peer {
                 TimeUnit.MILLISECONDS
             ));
         } catch (RuntimeException | Error e) {
-            settingsAckQueue.remove(pendingAck);
-            pendingAck.acknowledge();
-            throw new IOException("Could not schedule SETTINGS acknowledgement timeout", e);
+            // The reader can consume and acknowledge this entry as soon as its
+            // bytes reach the peer, including before flush() returns. Only fail
+            // the connection if this writer still owns the pending entry.
+            if (settingsAckQueue.remove(pendingAck)) {
+                pendingAck.acknowledge();
+                throw new IOException("Could not schedule SETTINGS acknowledgement timeout", e);
+            }
         }
+    }
+
+    private void registerInitialSettingsAck() throws IOException {
+        startSettingsAckTimeout(registerPendingSettingsAck());
     }
 
     private void cancelPendingSettingsAckTimeouts() {
@@ -590,14 +602,22 @@ class Http2Connection extends BaseHttpConnection implements Http2Peer {
                     ? candidate.frame()
                     : prepareCoordinatorErrorFrame(protocolError);
                 log.info("Writing {}", frame);
-                frame.writeTo(this, clientOut);
+                PendingSettingsAck pendingSettingsAck = null;
                 if (frame instanceof Http2Settings) {
                     var settings = (Http2Settings) frame;
                     if (!settings.isAck) {
-                        queuePendingSettingsAck();
+                        // Register before any bytes can reach the peer so a fast
+                        // ACK always has a FIFO entry to consume.
+                        pendingSettingsAck = registerPendingSettingsAck();
                     }
                 }
+                frame.writeTo(this, clientOut);
                 clientOut.flush();
+                if (pendingSettingsAck != null) {
+                    // The peer cannot be late until the SETTINGS frame has
+                    // actually crossed the writer's publication boundary.
+                    startSettingsAckTimeout(pendingSettingsAck);
+                }
                 if (frame instanceof Http2WindowUpdate) {
                     var update = (Http2WindowUpdate) frame;
                     inboundFlowControl.windowUpdateWritten(
@@ -657,7 +677,9 @@ class Http2Connection extends BaseHttpConnection implements Http2Peer {
             // do the handshake
             clientSettings = Http2Handshaker.handshake(this, serverSettings, clientSettings, buffer, clientIn, clientOut);
 
-            queuePendingSettingsAck();
+            // The handshake flushes the initial SETTINGS before the reader is
+            // started, so no ACK can race this registration.
+            registerInitialSettingsAck();
 
             var fieldBlockDecoder = new FieldBlockDecoder(new HpackTable(serverSettings.headerTableSize), server.maxUrlSize(), server.maxRequestHeadersSize());
             writeEndedFuture = startWriteLoop(clientOut);
@@ -1104,7 +1126,7 @@ class Http2Connection extends BaseHttpConnection implements Http2Peer {
         }
     }
 
-    private Future<?> startWriteLoop(OutputStream clientOut) {
+    Future<?> startWriteLoop(OutputStream clientOut) {
         writerOutput = clientOut;
         requestWriteRun();
         return writeLoopEnded;

--- a/src/test/java/io/muserver/RFC9113_6_5_SettingsTest.java
+++ b/src/test/java/io/muserver/RFC9113_6_5_SettingsTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.lang.reflect.Field;
 import java.time.Instant;
@@ -22,7 +23,10 @@ import static io.muserver.RFCTestUtils.readIgnoringWindowUpdates;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static scaffolding.MuAssert.assertEventually;
 import static scaffolding.MuAssert.assertNotTimedOut;
 
 @DisplayName("RFC 9113 6.5 Frame Definitions: SETTINGS")
@@ -682,7 +686,7 @@ class RFC9113_6_5_SettingsTest {
     }
 
     @Test
-    void serverSettingsAreOnlyAckPendingAfterTheyAreSent() throws Exception {
+    void serverSettingsAckTimeoutStartsOnlyAfterTheSettingsAreFlushed() throws Exception {
         server = httpsServer()
             .withHttp2Config(Http2ConfigBuilder.http2Enabled().withSettingsAckTimeoutMillis(5000))
             .start();
@@ -711,8 +715,30 @@ class RFC9113_6_5_SettingsTest {
                 assertThat(settingsAckQueue.size(), equalTo(0));
 
                 queuedOnlyConnection.write(new Http2Settings(false, 8192, 123, 65535, 16384, 32768));
-
                 assertThat(settingsAckQueue.size(), equalTo(0));
+
+                var flushEntered = new CountDownLatch(1);
+                var releaseFlush = new CountDownLatch(1);
+                var blockedOutput = new ByteArrayOutputStream() {
+                    @Override
+                    public void flush() {
+                        flushEntered.countDown();
+                        assertNotTimedOut("waiting to release SETTINGS flush", releaseFlush);
+                    }
+                };
+
+                queuedOnlyConnection.startWriteLoop(blockedOutput);
+                assertNotTimedOut("waiting for SETTINGS flush", flushEntered);
+
+                assertThat(settingsAckQueue.size(), equalTo(1));
+                Object pendingAck = settingsAckQueue.peek();
+                assertThat(getField(pendingAck, "timeoutTask", Object.class), nullValue());
+
+                releaseFlush.countDown();
+                assertEventually(
+                    () -> getField(pendingAck, "timeoutTask", Object.class),
+                    notNullValue()
+                );
             } finally {
                 executor.shutdownNow();
             }


### PR DESCRIPTION
## Summary

- split local SETTINGS acknowledgement registration from timeout activation
- register the FIFO entry before any SETTINGS bytes can reach the peer, so a fast ACK is never treated as unsolicited
- arm the SETTINGS_TIMEOUT deadline only after the writer flushes the frame, so blocked output does not consume the peer's acknowledgement period
- preserve the ACK-before-timeout-publication race: the later timer task is immediately cancelled if the reader already acknowledged the entry
- document the writer/reader/timer ownership boundary

## Why

RFC 9113 section 6.5.3 permits a SETTINGS_TIMEOUT connection error when the peer does not acknowledge within a reasonable amount of time. The old writer started that period before flush. A blocked socket could therefore expire a peer deadline before the peer had received the SETTINGS frame.

Registration cannot simply move after flush, because the independent reader could process a fast ACK in between. This change uses a two-phase lifecycle: register before output, activate the deadline after output.

## Tests

- deterministic regression blocks OutputStream.flush and verifies the ACK entry is registered while no timeout task exists; releasing flush publishes the timeout
- combined SETTINGS, inbound-flow, coordinator, and execution-domain suite: 106 tests pass
- full Java 11 suite: 1,671 tests, 0 failures, 0 errors
- Java 21 NullAway passes

No public API or dependency changes. Wire behavior changes only by eliminating a premature SETTINGS_TIMEOUT.

Stacked on #169.