### PR TITLE
Publish HTTP/2 output state at observable boundaries

### DIFF
--- a/HTTP2-CONCURRENCY.md
+++ b/HTTP2-CONCURRENCY.md
@@ -340,6 +340,13 @@ The following are distinct events:
 
 A handler finishing does not remove the stream.
 
+The writer publishes the reader-facing local `END_STREAM` fence immediately
+before emitting the terminal frame. A complete frame can reach the peer before
+`flush()` returns, so publishing only after flush could make the reader
+temporarily count a stream that the peer already knows is closed. Protocol
+closure, write promises, and successful response completion still advance only
+after the write succeeds; a failed terminal write closes the connection.
+
 If a handler completes a response while the peer request side is still open,
 the input enters discard mode. Already-buffered and future request DATA is
 discarded with both connection and stream credit returned. This allows a client

--- a/HTTP2-CONCURRENCY.md
+++ b/HTTP2-CONCURRENCY.md
@@ -307,9 +307,12 @@ frames promptly as required by RFC 9113 Section 5.2.2. Freed credit is not
 available for another DATA debit while its `WINDOW_UPDATE` is merely queued,
 because Section 6.9.1 defines the sender's limit in terms of the window
 advertised by the receiver. The writer publishes the credit immediately before
-writing the frame: publishing after `flush()` is too late because the complete
-frame can reach the peer before `flush()` returns, while a write failure closes
-the connection. A body consumer commits its buffer offset and
+`flush()`, after the complete frame has been handed to the output stream.
+Publishing before the first output write could release credit indefinitely while
+that write is blocked and the peer has received nothing; publishing after
+`flush()` is too late because the complete frame can reach the peer before
+`flush()` returns. A failure after publication closes the connection. A body
+consumer commits its buffer offset and
 releases the body lock before returning credit to the inbound component or
 queuing `WINDOW_UPDATE` output. Coordinator contention therefore cannot retain
 the body-buffer lock.
@@ -340,12 +343,13 @@ The following are distinct events:
 
 A handler finishing does not remove the stream.
 
-The writer publishes the reader-facing local `END_STREAM` fence immediately
-before emitting the terminal frame. A complete frame can reach the peer before
-`flush()` returns, so publishing only after flush could make the reader
-temporarily count a stream that the peer already knows is closed. Protocol
-closure, write promises, and successful response completion still advance only
-after the write succeeds; a failed terminal write closes the connection.
+The writer publishes the reader-facing local `END_STREAM` fence after handing
+the complete terminal frame to the output stream and before flushing it. This
+keeps the stream counted while an output write is blocked before making any
+progress, while avoiding a flush-time interval in which the peer can observe the
+frame before the reader sees the fence. Protocol closure, write promises, and
+successful response completion still advance only after the flush succeeds; a
+failed terminal write closes the connection.
 
 If a handler completes a response while the peer request side is still open,
 the input enters discard mode. Already-buffered and future request DATA is

--- a/HTTP2-CONCURRENCY.md
+++ b/HTTP2-CONCURRENCY.md
@@ -307,12 +307,16 @@ frames promptly as required by RFC 9113 Section 5.2.2. Freed credit is not
 available for another DATA debit while its `WINDOW_UPDATE` is merely queued,
 because Section 6.9.1 defines the sender's limit in terms of the window
 advertised by the receiver. The writer publishes the credit immediately before
-`flush()`, after the complete frame has been handed to the output stream.
-Publishing before the first output write could release credit indefinitely while
-that write is blocked and the peer has received nothing; publishing after
-`flush()` is too late because the complete frame can reach the peer before
-`flush()` returns. A failure after publication closes the connection. A body
-consumer commits its buffer offset and
+writing the frame. Raw JDK socket output can expose the frame to the peer while
+the blocking write call is still in progress, so publication after that call
+can incorrectly reject DATA from a compliant peer. Conversely, the socket API
+provides no local boundary that distinguishes such DATA from premature DATA
+sent before the peer observed the update. The implementation chooses
+interoperability at that unavoidable boundary: early availability is bounded by
+credit the application has actually freed, and a write failure closes the
+connection. This differs from the local `END_STREAM` fence, whose early
+publication can independently over-admit new peer streams. A body consumer
+commits its buffer offset and
 releases the body lock before returning credit to the inbound component or
 queuing `WINDOW_UPDATE` output. Coordinator contention therefore cannot retain
 the body-buffer lock.

--- a/src/main/java/io/muserver/Http2Connection.java
+++ b/src/main/java/io/muserver/Http2Connection.java
@@ -611,20 +611,23 @@ class Http2Connection extends BaseHttpConnection implements Http2Peer {
                         pendingSettingsAck = registerPendingSettingsAck();
                     }
                 }
-                frame.writeTo(this, clientOut);
-                // Publish reader-facing monotonic output fences after the
-                // complete frame has been handed to the OutputStream, but
-                // before flush can expose it and block. Publishing before the
-                // first write would release state while output had made no
-                // progress. Protocol completion still occurs only after flush.
-                candidate.publishAfterWrite(frame);
                 if (frame instanceof Http2WindowUpdate) {
                     var update = (Http2WindowUpdate) frame;
+                    // Raw socket output can expose the complete frame while
+                    // writeTo is still inside its blocking write call. Publish
+                    // the advertised credit first so a compliant peer cannot
+                    // race the local receive-window accounting.
                     inboundFlowControl.windowUpdateWriting(
                         update.streamId(),
                         update.windowSizeIncrement()
                     );
                 }
+                frame.writeTo(this, clientOut);
+                // Releasing a local END_STREAM fence before output makes any
+                // progress can over-admit peer streams indefinitely. Publish
+                // it after the complete frame has been handed to the output,
+                // while protocol completion still waits for a successful flush.
+                candidate.publishAfterWrite(frame);
                 clientOut.flush();
                 if (pendingSettingsAck != null) {
                     // The peer cannot be late until the SETTINGS frame has

--- a/src/main/java/io/muserver/Http2Connection.java
+++ b/src/main/java/io/muserver/Http2Connection.java
@@ -602,6 +602,10 @@ class Http2Connection extends BaseHttpConnection implements Http2Peer {
                     ? candidate.frame()
                     : prepareCoordinatorErrorFrame(protocolError);
                 log.info("Writing {}", frame);
+                // Publish reader-facing monotonic output fences before bytes
+                // can reach the peer. Protocol completion still occurs only
+                // in candidate.complete() after flush.
+                candidate.publishBeforeWrite(frame);
                 PendingSettingsAck pendingSettingsAck = null;
                 if (frame instanceof Http2WindowUpdate) {
                     var update = (Http2WindowUpdate) frame;

--- a/src/main/java/io/muserver/Http2Connection.java
+++ b/src/main/java/io/muserver/Http2Connection.java
@@ -602,21 +602,7 @@ class Http2Connection extends BaseHttpConnection implements Http2Peer {
                     ? candidate.frame()
                     : prepareCoordinatorErrorFrame(protocolError);
                 log.info("Writing {}", frame);
-                // Publish reader-facing monotonic output fences before bytes
-                // can reach the peer. Protocol completion still occurs only
-                // in candidate.complete() after flush.
-                candidate.publishBeforeWrite(frame);
                 PendingSettingsAck pendingSettingsAck = null;
-                if (frame instanceof Http2WindowUpdate) {
-                    var update = (Http2WindowUpdate) frame;
-                    // OutputStream writes can make a complete frame visible
-                    // before flush() returns. Publish the matching receive
-                    // credit first so the reader accepts DATA enabled by it.
-                    inboundFlowControl.windowUpdateWriting(
-                        update.streamId(),
-                        update.windowSizeIncrement()
-                    );
-                }
                 if (frame instanceof Http2Settings) {
                     var settings = (Http2Settings) frame;
                     if (!settings.isAck) {
@@ -626,6 +612,19 @@ class Http2Connection extends BaseHttpConnection implements Http2Peer {
                     }
                 }
                 frame.writeTo(this, clientOut);
+                // Publish reader-facing monotonic output fences after the
+                // complete frame has been handed to the OutputStream, but
+                // before flush can expose it and block. Publishing before the
+                // first write would release state while output had made no
+                // progress. Protocol completion still occurs only after flush.
+                candidate.publishAfterWrite(frame);
+                if (frame instanceof Http2WindowUpdate) {
+                    var update = (Http2WindowUpdate) frame;
+                    inboundFlowControl.windowUpdateWriting(
+                        update.streamId(),
+                        update.windowSizeIncrement()
+                    );
+                }
                 clientOut.flush();
                 if (pendingSettingsAck != null) {
                     // The peer cannot be late until the SETTINGS frame has

--- a/src/main/java/io/muserver/Http2Stream.java
+++ b/src/main/java/io/muserver/Http2Stream.java
@@ -30,8 +30,8 @@ class Http2Stream implements ResponseInfo {
     private volatile boolean resetInitiated;
     private volatile boolean applicationExchangeEnded;
     private volatile boolean protocolStateClosed;
-    // Writer-published immediately before END_STREAM output so the reader never
-    // lags behind a frame that the peer can already have observed.
+    // Writer-published after the complete END_STREAM frame is handed to output
+    // and before flush, matching the stream-admission publication boundary.
     private volatile boolean localEndStreamPublished;
     private long endTime = 0;
     private final InputStream bodyInputStream;

--- a/src/main/java/io/muserver/Http2Stream.java
+++ b/src/main/java/io/muserver/Http2Stream.java
@@ -30,9 +30,9 @@ class Http2Stream implements ResponseInfo {
     private volatile boolean resetInitiated;
     private volatile boolean applicationExchangeEnded;
     private volatile boolean protocolStateClosed;
-    // Writer-published so the reader can recognize a fully closed stream as soon
-    // as it observes the peer's END_STREAM, before that command is applied.
-    private volatile boolean localEndStreamWritten;
+    // Writer-published immediately before END_STREAM output so the reader never
+    // lags behind a frame that the peer can already have observed.
+    private volatile boolean localEndStreamPublished;
     private long endTime = 0;
     private final InputStream bodyInputStream;
     private final @Nullable Long declaredRequestBodyLength;
@@ -102,8 +102,8 @@ class Http2Stream implements ResponseInfo {
         protocolStateClosed = true;
     }
 
-    void onLocalEndStreamWritten() {
-        localEndStreamWritten = true;
+    void onLocalEndStreamPublished() {
+        localEndStreamPublished = true;
     }
 
     boolean protocolStateClosed() {
@@ -113,7 +113,7 @@ class Http2Stream implements ResponseInfo {
     boolean countsTowardsMaxConcurrentStreams() {
         return !protocolStateClosed
             && !peerResetRead
-            && !(remoteEndStreamRead && localEndStreamWritten);
+            && !(remoteEndStreamRead && localEndStreamPublished);
     }
 
     void onProtocolStreamRetired() {

--- a/src/main/java/io/muserver/Http2WriteCoordinator.java
+++ b/src/main/java/io/muserver/Http2WriteCoordinator.java
@@ -48,9 +48,9 @@ final class Http2WriteCoordinator {
             return protocolError;
         }
 
-        void publishBeforeWrite(LogicalHttp2Frame frameToWrite) {
-            if (frameToWrite.endStream()) {
-                Http2Stream stream = applicationStreams.get(frameToWrite.streamId());
+        void publishAfterWrite(LogicalHttp2Frame frameWritten) {
+            if (frameWritten.endStream()) {
+                Http2Stream stream = applicationStreams.get(frameWritten.streamId());
                 if (stream != null) {
                     stream.onLocalEndStreamPublished();
                 }

--- a/src/main/java/io/muserver/Http2WriteCoordinator.java
+++ b/src/main/java/io/muserver/Http2WriteCoordinator.java
@@ -48,6 +48,15 @@ final class Http2WriteCoordinator {
             return protocolError;
         }
 
+        void publishBeforeWrite(LogicalHttp2Frame frameToWrite) {
+            if (frameToWrite.endStream()) {
+                Http2Stream stream = applicationStreams.get(frameToWrite.streamId());
+                if (stream != null) {
+                    stream.onLocalEndStreamPublished();
+                }
+            }
+        }
+
         void complete() {
             if (completesTask) {
                 onWriteCompleted(frame);
@@ -735,7 +744,7 @@ final class Http2WriteCoordinator {
         if (frame.endStream()) {
             Http2Stream stream = applicationStreams.get(streamId);
             if (stream != null) {
-                stream.onLocalEndStreamWritten();
+                stream.onLocalEndStreamPublished();
             }
         }
         if (frame instanceof Http2ResetStreamFrame

--- a/src/test/java/io/muserver/RFC9113_5_1_StreamStatesTest.java
+++ b/src/test/java/io/muserver/RFC9113_5_1_StreamStatesTest.java
@@ -6,11 +6,15 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.time.Instant;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.Lock;
 
 import static io.muserver.MuServerBuilder.httpServer;
@@ -28,6 +32,86 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 class RFC9113_5_1_StreamStatesTest {
 
     private @Nullable MuServer server;
+
+    @Test
+    void localEndStreamStopsCountingBeforeFlushReturns() throws Exception {
+        server = httpsServer()
+            .withHttp2Config(Http2ConfigBuilder.http2Enabled())
+            .start();
+
+        try (var client = new H2Client();
+             var con = client.connect(server)) {
+
+            con.handshake();
+            var liveConnection =
+                (Http2Connection) server.activeConnections().iterator().next();
+            var executor = Executors.newSingleThreadExecutor();
+            try {
+                var writerConnection = new Http2Connection(
+                    liveConnection.server,
+                    liveConnection.creator,
+                    liveConnection.clientSocket,
+                    liveConnection.clientCertificate,
+                    Instant.now(),
+                    Http2Settings.DEFAULT_CLIENT_SETTINGS,
+                    5000,
+                    executor,
+                    executor
+                );
+                var requestUri = server.uri().resolve("/synthetic");
+                var request = new Mu3Request(
+                    writerConnection,
+                    Method.GET,
+                    requestUri,
+                    server.uri(),
+                    HttpVersion.HTTP_2,
+                    new FieldBlock(),
+                    BodySize.NONE,
+                    EmptyInputStream.INSTANCE
+                );
+                var stream = new Http2Stream(
+                    1,
+                    writerConnection,
+                    Http2StreamState.HALF_CLOSED_REMOTE,
+                    request,
+                    EmptyInputStream.INSTANCE
+                );
+                Http2WriteCoordinator coordinator = getField(
+                    writerConnection,
+                    "writeCoordinator",
+                    Http2WriteCoordinator.class
+                );
+                coordinator.openStream(
+                    1,
+                    65_535,
+                    Http2StreamState.HALF_CLOSED_REMOTE,
+                    stream
+                );
+                writerConnection.write(
+                    new Http2HeadersFrame(1, true, new FieldBlock())
+                );
+
+                assertThat(stream.countsTowardsMaxConcurrentStreams(), equalTo(true));
+                var flushEntered = new CountDownLatch(1);
+                var countedDuringFlush = new AtomicReference<Boolean>();
+                var output = new ByteArrayOutputStream() {
+                    @Override
+                    public void flush() {
+                        countedDuringFlush.set(
+                            stream.countsTowardsMaxConcurrentStreams()
+                        );
+                        flushEntered.countDown();
+                    }
+                };
+
+                writerConnection.startWriteLoop(output);
+                assertThat(flushEntered.await(5, TimeUnit.SECONDS), equalTo(true));
+                assertThat(countedDuringFlush.get(), equalTo(false));
+            } finally {
+                executor.shutdownNow();
+            }
+        }
+    }
 
     @Test
     public void streamIDsFromClientsCannotBeRepeated() throws Exception {

--- a/src/test/java/io/muserver/RFC9113_5_1_StreamStatesTest.java
+++ b/src/test/java/io/muserver/RFC9113_5_1_StreamStatesTest.java
@@ -34,7 +34,7 @@ class RFC9113_5_1_StreamStatesTest {
     private @Nullable MuServer server;
 
     @Test
-    void localEndStreamStopsCountingBeforeFlushReturns() throws Exception {
+    void localEndStreamPublicationBracketsOutputAndFlush() throws Exception {
         server = httpsServer()
             .withHttp2Config(Http2ConfigBuilder.http2Enabled())
             .start();
@@ -92,9 +92,19 @@ class RFC9113_5_1_StreamStatesTest {
                 );
 
                 assertThat(stream.countsTowardsMaxConcurrentStreams(), equalTo(true));
+                var countedDuringFirstWrite = new AtomicReference<Boolean>();
                 var flushEntered = new CountDownLatch(1);
                 var countedDuringFlush = new AtomicReference<Boolean>();
                 var output = new ByteArrayOutputStream() {
+                    @Override
+                    public synchronized void write(byte[] data, int offset, int length) {
+                        countedDuringFirstWrite.compareAndSet(
+                            null,
+                            stream.countsTowardsMaxConcurrentStreams()
+                        );
+                        super.write(data, offset, length);
+                    }
+
                     @Override
                     public void flush() {
                         countedDuringFlush.set(
@@ -106,6 +116,7 @@ class RFC9113_5_1_StreamStatesTest {
 
                 writerConnection.startWriteLoop(output);
                 assertThat(flushEntered.await(5, TimeUnit.SECONDS), equalTo(true));
+                assertThat(countedDuringFirstWrite.get(), equalTo(true));
                 assertThat(countedDuringFlush.get(), equalTo(false));
             } finally {
                 executor.shutdownNow();

--- a/src/test/java/io/muserver/RFC9113_5_2_FlowControlTest.java
+++ b/src/test/java/io/muserver/RFC9113_5_2_FlowControlTest.java
@@ -17,6 +17,7 @@ import static io.muserver.MuServerBuilder.httpsServer;
 import static io.muserver.RFCTestUtils.*;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static scaffolding.MuAssert.assertNotTimedOut;
 
@@ -60,10 +61,21 @@ class RFC9113_5_2_FlowControlTest {
 
                 writerConnection.returnInboundCredit(1, 32_768, false);
 
+                var debitObservedDuringWrite =
+                    new AtomicReference<Http2InboundFlowControl.Result>();
                 var flushEntered = new CountDownLatch(1);
                 var debitObservedDuringFlush =
                     new AtomicReference<Http2InboundFlowControl.Result>();
                 var output = new ByteArrayOutputStream() {
+                    @Override
+                    public synchronized void write(byte[] data, int offset, int length) {
+                        debitObservedDuringWrite.compareAndSet(
+                            null,
+                            flow.reserve(1, 1)
+                        );
+                        super.write(data, offset, length);
+                    }
+
                     @Override
                     public void flush() {
                         debitObservedDuringFlush.set(flow.reserve(1, 1));
@@ -73,6 +85,10 @@ class RFC9113_5_2_FlowControlTest {
 
                 writerConnection.startWriteLoop(output);
                 assertNotTimedOut("waiting for WINDOW_UPDATE flush", flushEntered);
+                assertThat(
+                    debitObservedDuringWrite.get().error(),
+                    notNullValue()
+                );
                 assertThat(
                     debitObservedDuringFlush.get().error(),
                     nullValue()

--- a/src/test/java/io/muserver/RFC9113_5_2_FlowControlTest.java
+++ b/src/test/java/io/muserver/RFC9113_5_2_FlowControlTest.java
@@ -17,7 +17,6 @@ import static io.muserver.MuServerBuilder.httpsServer;
 import static io.muserver.RFCTestUtils.*;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static scaffolding.MuAssert.assertNotTimedOut;
 
@@ -87,7 +86,7 @@ class RFC9113_5_2_FlowControlTest {
                 assertNotTimedOut("waiting for WINDOW_UPDATE flush", flushEntered);
                 assertThat(
                     debitObservedDuringWrite.get().error(),
-                    notNullValue()
+                    nullValue()
                 );
                 assertThat(
                     debitObservedDuringFlush.get().error(),


### PR DESCRIPTION
## Summary

- publish the reader-facing local `END_STREAM` fence after the complete terminal frame is handed to output, before flush
- publish inbound flow-control credit before writing `WINDOW_UPDATE`, because raw socket output can expose the frame during the blocking write call
- leave authoritative protocol completion, write promises, and successful response completion after flush
- document why these two publication fences require different boundaries

## Why

The reader admits streams and validates inbound DATA concurrently with blocking output. Releasing local `END_STREAM` before output progresses can over-admit streams indefinitely. Conversely, waiting until a `WINDOW_UPDATE` write returns can reject DATA from a compliant peer that already observed the frame while the write call was in progress.

The JDK socket API has no exact peer-visibility callback. For inbound credit, pre-write publication is the interoperable boundary: any early availability is bounded by credit the application actually freed, and a write failure closes the connection.

## Tests

- deterministic output hook proves a half-closed-remote stream remains counted inside the first terminal-frame write and is released inside flush
- deterministic output hook proves returned receive credit is already usable inside the first `WINDOW_UPDATE` write and remains usable during flush
- the old local-END_STREAM pre-write ordering fails the first stream-count assertion
- the old post-write WINDOW_UPDATE ordering fails the in-write receive-credit assertion
- targeted stream/flow-control/coordinator suite: 54 tests, 0 failures, 0 errors
- four-version CI was green before the latest boundary refinement; replacement CI is running

No public API or dependency changes. Wire behavior becomes correctly ordered with concurrent input.

Stacked on #170.