### PR TITLE
Isolate response completion listener failures

### DIFF
--- a/HTTP2-CONCURRENCY.md
+++ b/HTTP2-CONCURRENCY.md
@@ -372,6 +372,8 @@ half-closed protocol streams, not handler tasks.
 Completion listeners are notified exactly once, outside the coordinator, after
 the outcome is known. A successful outcome requires the request to have reached
 EOF or successful discard and the response END_STREAM to have been written.
+Failure from one listener is logged and isolated so it cannot strand later
+listeners or prevent the notification gate from reaching its completed state.
 
 ## Locking and signalling
 

--- a/src/main/java/io/muserver/BaseResponse.java
+++ b/src/main/java/io/muserver/BaseResponse.java
@@ -214,7 +214,9 @@ abstract class BaseResponse implements MuResponse {
                 return;
             }
         }
-        request.serverImpl().executeResponseCompletionTask(() -> listener.onComplete(completed));
+        request.serverImpl().executeResponseCompletionTask(() ->
+            request.serverImpl().invokeResponseCompletionListener(listener, completed)
+        );
     }
 
     void notifyCompletionListeners(ResponseInfo completed) {
@@ -234,7 +236,7 @@ abstract class BaseResponse implements MuResponse {
                     return;
                 }
             }
-            listener.onComplete(completed);
+            request.serverImpl().invokeResponseCompletionListener(listener, completed);
         }
     }
 }

--- a/src/main/java/io/muserver/Mu3ServerImpl.java
+++ b/src/main/java/io/muserver/Mu3ServerImpl.java
@@ -610,7 +610,18 @@ class Mu3ServerImpl implements MuServer {
 
     void notifyExchangeEnded(ResponseInfo exchange) {
         for (var listener : responseCompleteListeners) {
+            invokeResponseCompletionListener(listener, exchange);
+        }
+    }
+
+    void invokeResponseCompletionListener(
+        ResponseCompleteListener listener,
+        ResponseInfo exchange
+    ) {
+        try {
             listener.onComplete(exchange);
+        } catch (Exception failure) {
+            log.error("Error from response completion listener", failure);
         }
     }
 

--- a/src/main/java/io/muserver/Mu3ServerImpl.java
+++ b/src/main/java/io/muserver/Mu3ServerImpl.java
@@ -620,7 +620,7 @@ class Mu3ServerImpl implements MuServer {
     ) {
         try {
             listener.onComplete(exchange);
-        } catch (Exception failure) {
+        } catch (Throwable failure) {
             log.error("Error from response completion listener", failure);
         }
     }

--- a/src/test/java/io/muserver/ExecutionDomainsTest.java
+++ b/src/test/java/io/muserver/ExecutionDomainsTest.java
@@ -710,6 +710,62 @@ class ExecutionDomainsTest {
     }
 
     @Test
+    void completionListenerFailureDoesNotStrandOtherListeners() throws Exception {
+        var handlerExecutor = track(Executors.newSingleThreadExecutor(namedThreads("handler-")));
+        var connectionExecutor = track(Executors.newSingleThreadExecutor(namedThreads("connection-")));
+        var responseRef = new CompletableFuture<MuResponse>();
+        var events = new CopyOnWriteArrayList<String>();
+        var serverListenersFinished = new CompletableFuture<Void>();
+        server = httpServer()
+            .withHandlerExecutor(handlerExecutor)
+            .withConnectionExecutor(connectionExecutor)
+            .addResponseCompleteListener(info -> {
+                events.add("server-failing");
+                throw new IllegalStateException("deliberate server listener failure");
+            })
+            .addResponseCompleteListener(info -> {
+                events.add("server-second");
+                serverListenersFinished.complete(null);
+            })
+            .addHandler(Method.GET, "/", (request, response, pathParams) -> {
+                response.addCompletionListener(info -> {
+                    events.add("response-failing");
+                    response.addCompletionListener(nested ->
+                        events.add("response-nested")
+                    );
+                    throw new IllegalStateException("deliberate response listener failure");
+                });
+                response.addCompletionListener(info ->
+                    events.add("response-second")
+                );
+                responseRef.complete(response);
+                response.write("done");
+            })
+            .start();
+
+        try (var client = Http1Client.connect(server)) {
+            client.writeRequestLine(Method.GET, "/").flushHeaders();
+            assertThat(client.readLine(), equalTo("HTTP/1.1 200 OK"));
+            assertThat(client.readBody(client.readHeaders()), equalTo("done"));
+        }
+
+        serverListenersFinished.get(5, TimeUnit.SECONDS);
+        assertThat(events, equalTo(List.of(
+            "response-failing",
+            "response-second",
+            "response-nested",
+            "server-failing",
+            "server-second"
+        )));
+
+        var postCompletionListenerFinished = new CompletableFuture<Void>();
+        responseRef.get(5, TimeUnit.SECONDS).addCompletionListener(info ->
+            postCompletionListenerFinished.complete(null)
+        );
+        postCompletionListenerFinished.get(5, TimeUnit.SECONDS);
+    }
+
+    @Test
     void aSlowHttp1CompletionListenerDoesNotDelayTheNextRequest() throws Exception {
         var handlerExecutor = track(Executors.newFixedThreadPool(2, namedThreads("handler-")));
         var connectionExecutor = track(Executors.newSingleThreadExecutor(namedThreads("connection-")));

--- a/src/test/java/io/muserver/ExecutionDomainsTest.java
+++ b/src/test/java/io/muserver/ExecutionDomainsTest.java
@@ -721,7 +721,7 @@ class ExecutionDomainsTest {
             .withConnectionExecutor(connectionExecutor)
             .addResponseCompleteListener(info -> {
                 events.add("server-failing");
-                throw new IllegalStateException("deliberate server listener failure");
+                throw new AssertionError("deliberate server listener failure");
             })
             .addResponseCompleteListener(info -> {
                 events.add("server-second");
@@ -733,7 +733,7 @@ class ExecutionDomainsTest {
                     response.addCompletionListener(nested ->
                         events.add("response-nested")
                     );
-                    throw new IllegalStateException("deliberate response listener failure");
+                    throw new AssertionError("deliberate response listener failure");
                 });
                 response.addCompletionListener(info ->
                     events.add("response-second")


### PR DESCRIPTION
## Summary

- centralize response-completion listener invocation and isolate every listener throwable
- allow the ordered per-response listener drain to continue after a listener throws
- preserve delivery to later server listeners and allow the registration gate to reach its drained state
- document the failure-isolation rule

## Why

The ordered registration gate introduced in #169 left `completionListenersDrained` false if a listener threw. Listeners already queued, listeners registered during notification, and server-level completion listeners were then stranded; later registrations joined a queue that could never be drained.

The established mu-server implementation already logs and isolates server response-completion listener exceptions. This applies that policy consistently to both per-response and server-level listeners while retaining their application-executor domain and ordering. The isolation boundary catches `Throwable`, because an unchecked `Error` otherwise leaves the gate in the same stranded state.

## Tests

- deterministic regression proves the previous implementation times out after the first response listener throws an `AssertionError`
- verifies a pre-registered listener, a listener registered from the failing callback, and both server listeners still run in order
- verifies registration after notification is still dispatched after the gate drains
- execution-domain suite: 48 tests pass after the review refinement
- full Java 11 suite and Java 21 NullAway passed before the refinement; refreshed four-version CI validates the final commit

No public API, dependency, protocol, or wire changes.

Stacked on #171.