### PR TITLE
Dispatch late async write callbacks

### DIFF
--- a/HTTP2-CONCURRENCY.md
+++ b/HTTP2-CONCURRENCY.md
@@ -118,6 +118,10 @@ callbacks, request-rejection notifications, and deprecated asynchronous
 WebSocket adapters. Handler-oriented detached callbacks may use it as a
 fallback when the handler executor rejects them. Operations whose contract
 specifically requires the async executor fail when that executor rejects them.
+A response write rejected by the async-completion terminal gate still dispatches
+its failure callback to this executor; if the executor itself rejects that
+notification, the caller delivers the required failure callback rather than
+dropping it.
 
 Neither application executor runs a connection reader, writer, or timer
 callback. Rejection of a new handler is handled as rejection of that individual

--- a/src/main/java/io/muserver/Mu3AsyncHandleImpl.java
+++ b/src/main/java/io/muserver/Mu3AsyncHandleImpl.java
@@ -223,9 +223,13 @@ class Mu3AsyncHandleImpl implements AsyncHandle {
         if (writeFuture == null) {
             Throwable failure = completedResponseWriteFailure();
             try {
-                callback.onComplete(failure);
-            } catch (Throwable callbackFailure) {
-                addSuppressedIfDifferent(failure, callbackFailure);
+                server.executeAsyncApplicationTask(() ->
+                    invokeWriteCallback(callback, failure)
+                );
+            } catch (RejectedExecutionException rejected) {
+                // The callback contract still needs an outcome when the
+                // required async executor cannot accept the notification.
+                invokeWriteCallback(callback, failure);
             }
             return;
         }
@@ -270,6 +274,14 @@ class Mu3AsyncHandleImpl implements AsyncHandle {
             }
         });
         return writeFuture;
+    }
+
+    private static void invokeWriteCallback(DoneCallback callback, Throwable failure) {
+        try {
+            callback.onComplete(failure);
+        } catch (Throwable callbackFailure) {
+            addSuppressedIfDifferent(failure, callbackFailure);
+        }
     }
 
     private static IllegalStateException completedResponseWriteFailure() {

--- a/src/test/java/io/muserver/ExecutionDomainsTest.java
+++ b/src/test/java/io/muserver/ExecutionDomainsTest.java
@@ -913,19 +913,25 @@ class ExecutionDomainsTest {
             handle.complete();
             Future<@Nullable Void> lateWrite = handle.write(ByteBuffer.wrap(new byte[]{1}));
             var callbackFailure = new CompletableFuture<Throwable>();
-            handle.write(ByteBuffer.wrap(new byte[]{2}), callbackFailure::complete);
+            var callbackThread = new CompletableFuture<String>();
+            handle.write(ByteBuffer.wrap(new byte[]{2}), failure -> {
+                callbackThread.complete(Thread.currentThread().getName());
+                callbackFailure.complete(failure);
+            });
 
             assertThat(acceptedWrite.isDone(), is(false));
+            assertThat(callbackFailure.isDone(), is(false));
             ExecutionException failedWrite = assertThrows(
                 ExecutionException.class,
                 () -> lateWrite.get(5, TimeUnit.SECONDS)
             );
             assertThat(failedWrite.getCause(), instanceOf(IllegalStateException.class));
-            assertThat(callbackFailure.get(5, TimeUnit.SECONDS), instanceOf(IllegalStateException.class));
 
             releaseBlocker.countDown();
             blocker.get(5, TimeUnit.SECONDS);
             acceptedWrite.get(5, TimeUnit.SECONDS);
+            assertThat(callbackFailure.get(5, TimeUnit.SECONDS), instanceOf(IllegalStateException.class));
+            assertThat(callbackThread.get(5, TimeUnit.SECONDS), startsWith("async-"));
             assertThat(client.readLine(), equalTo("HTTP/1.1 200 OK"));
             assertThat(
                 client.readHeaders().contains(HeaderNames.TRANSFER_ENCODING, HeaderValues.CHUNKED, true),
@@ -1084,6 +1090,33 @@ class ExecutionDomainsTest {
             assertThat(response.code(), is(500));
         }
         assertThat(callbackFailure.get(5, TimeUnit.SECONDS), instanceOf(RejectedExecutionException.class));
+    }
+
+    @Test
+    void rejectedAsyncExecutorDoesNotDropALateWriteCallback() throws Exception {
+        var handlerExecutor = track(Executors.newSingleThreadExecutor(namedThreads("handler-")));
+        var asyncExecutor = track(Executors.newSingleThreadExecutor(namedThreads("async-")));
+        asyncExecutor.shutdown();
+        var callbackFailure = new CompletableFuture<Throwable>();
+        var callbackThread = new CompletableFuture<String>();
+        server = httpServer()
+            .withHandlerExecutor(handlerExecutor)
+            .withAsyncExecutor(asyncExecutor)
+            .addHandler(Method.GET, "/", (request, response, pathParams) -> {
+                AsyncHandle handle = request.handleAsync();
+                handle.complete();
+                handle.write(ByteBuffer.wrap(new byte[]{1}), failure -> {
+                    callbackThread.complete(Thread.currentThread().getName());
+                    callbackFailure.complete(failure);
+                });
+            })
+            .start();
+
+        try (Response response = call(request(server.uri()))) {
+            assertThat(response.code(), is(200));
+        }
+        assertThat(callbackFailure.get(5, TimeUnit.SECONDS), instanceOf(IllegalStateException.class));
+        assertThat(callbackThread.get(5, TimeUnit.SECONDS), startsWith("handler-"));
     }
 
     @Test


### PR DESCRIPTION
## Summary

- dispatch callback-based writes rejected by the async terminal gate to the async application executor
- retain callback delivery in the current application turn when that required executor rejects the notification
- document the terminal-gate callback rule

## Why

After `AsyncHandle.complete()`, `write(ByteBuffer, DoneCallback)` correctly rejected the write but invoked the callback synchronously on whichever thread called `write`. Every other accepted async write callback belongs to the async application domain, so this was an execution-domain leak and made callback threading depend on whether the terminal gate happened to win.

## Tests

- deterministic held-worker proof: the old code completes the callback immediately on the caller; the fixed code waits for and runs on the named async worker
- verifies the callback still receives `IllegalStateException` when the async executor is shut down and cannot accept the failure notification
- async and execution-domain suites: 59 tests, 0 failures, 0 errors
- full Java 11 suite: 1,674 tests, 0 failures, 0 errors
- Java 21 NullAway verify passes

No public API, dependency, protocol, or wire changes.

Stacked on #172.