### PR TITLE
Report async request-body listener failures

### DIFF
--- a/HTTP2-CONCURRENCY.md
+++ b/HTTP2-CONCURRENCY.md
@@ -118,6 +118,9 @@ callbacks, request-rejection notifications, and deprecated asynchronous
 WebSocket adapters. Handler-oriented detached callbacks may use it as a
 fallback when the handler executor rejects them. Operations whose contract
 specifically requires the async executor fail when that executor rejects them.
+A failure thrown by a request-body data listener is reported through its
+`onError` callback in the same async application turn before the exchange is
+failed.
 A response write rejected by the async-completion terminal gate still dispatches
 its failure callback to this executor; if the executor itself rejects that
 notification, the caller delivers the required failure callback rather than

--- a/src/main/java/io/muserver/Mu3AsyncHandleImpl.java
+++ b/src/main/java/io/muserver/Mu3AsyncHandleImpl.java
@@ -125,7 +125,9 @@ class Mu3AsyncHandleImpl implements AsyncHandle {
                     }
                 });
             } catch (Throwable t) {
-                fail(t, false);
+                // onDataReceived runs in the async application domain, so its
+                // documented error callback belongs to the same turn.
+                fail(t, true);
             }
         }
 

--- a/src/main/java/io/muserver/RequestBodyListener.java
+++ b/src/main/java/io/muserver/RequestBodyListener.java
@@ -39,8 +39,8 @@ public interface RequestBodyListener {
 
     /**
      * <p>Called when request data is received from the client.</p>
-     * <p>NOTE: this method should not block as it runs on a socket acceptor thread. If you need to do any blocking operations
-     * it is recommended you process the data on another thread.</p>
+     * <p>This callback is dispatched on the server's asynchronous application executor.
+     * It should not block if other asynchronous application work shares that executor.</p>
      *
      * @param buffer       A buffer holding some of the request body data
      * @param doneCallback This must be called when the buffer is no longer needed

--- a/src/test/java/io/muserver/ExecutionDomainsTest.java
+++ b/src/test/java/io/muserver/ExecutionDomainsTest.java
@@ -1006,6 +1006,60 @@ class ExecutionDomainsTest {
     }
 
     @Test
+    void asyncBodyListenerFailuresAreReportedOnTheAsyncExecutor() throws Exception {
+        var asyncExecutor = track(Executors.newSingleThreadExecutor(namedThreads("async-")));
+        var dataThread = new CompletableFuture<String>();
+        var errorThread = new CompletableFuture<String>();
+        var reportedFailure = new CompletableFuture<Throwable>();
+        var completed = new AtomicBoolean();
+        var listenerFailure = new IllegalStateException("deliberate request-body listener failure");
+        server = httpServer()
+            .withAsyncExecutor(asyncExecutor)
+            .addHandler(Method.POST, "/", (request, response, pathParams) -> {
+                AsyncHandle handle = request.handleAsync();
+                handle.setReadListener(new RequestBodyListener() {
+                    @Override
+                    public void onDataReceived(ByteBuffer data, DoneCallback doneCallback) {
+                        dataThread.complete(Thread.currentThread().getName());
+                        throw listenerFailure;
+                    }
+
+                    @Override
+                    public void onComplete() {
+                        completed.set(true);
+                    }
+
+                    @Override
+                    public void onError(Throwable failure) {
+                        errorThread.complete(Thread.currentThread().getName());
+                        reportedFailure.complete(failure);
+                    }
+                });
+            })
+            .start();
+
+        RequestBody body = new RequestBody() {
+            @Override
+            public @Nullable MediaType contentType() {
+                return null;
+            }
+
+            @Override
+            public void writeTo(BufferedSink sink) throws IOException {
+                sink.writeUtf8("body");
+            }
+        };
+        try (Response response = call(request(server.uri()).post(body))) {
+            assertThat(response.code(), is(500));
+        }
+
+        assertThat(reportedFailure.get(5, TimeUnit.SECONDS), is(listenerFailure));
+        assertThat(dataThread.get(5, TimeUnit.SECONDS), startsWith("async-"));
+        assertThat(errorThread.get(5, TimeUnit.SECONDS), startsWith("async-"));
+        assertThat(completed.get(), is(false));
+    }
+
+    @Test
     void oneSharedNonQueueingWorkerCanReadAndEchoARequestBody() throws Exception {
         var applicationExecutor = track(new ThreadPoolExecutor(
             1,


### PR DESCRIPTION
## Summary

- report exceptions thrown by `RequestBodyListener.onDataReceived` through the listener's documented `onError` callback
- retain both callbacks in the same async application turn
- correct the stale public Javadoc that said body callbacks run on a socket acceptor thread

## Why

The async body reader already failed the exchange when `onDataReceived` threw, but passed `notifyListener=false`, so the public `onError` contract was silently skipped. This made failure notification depend on where an error originated even though all request-body listener work belongs to the async application domain.

## Tests

- deterministic regression: before the fix, the request receives a 500 but the `onError` future times out; after the fix, it receives the exact failure on the named async executor and `onComplete` is not called
- async/body/execution-domain suites: 69 tests, 0 failures, 0 errors, 1 skipped
- full Java 11 suite: 1,675 tests, 0 failures, 0 errors, 5 skipped
- Java 21 NullAway verify passes
- Java 11/17/21/25 CI is green after the lower-stack output-boundary refinement

No dependency, protocol, or wire changes. This aligns implementation with an existing public callback contract.

Stacked on #173.