### PR TITLE
Isolate request-rejection listener failures

### DIFF
--- a/HTTP2-CONCURRENCY.md
+++ b/HTTP2-CONCURRENCY.md
@@ -120,7 +120,8 @@ fallback when the handler executor rejects them. Operations whose contract
 specifically requires the async executor fail when that executor rejects them.
 A failure thrown by a request-body data listener is reported through its
 `onError` callback in the same async application turn before the exchange is
-failed.
+failed. Request-rejection listener failures are isolated so one listener cannot
+skip later listeners for the same rejected request.
 A response write rejected by the async-completion terminal gate still dispatches
 its failure callback to this executor; if the executor itself rejects that
 notification, the caller delivers the required failure callback rather than

--- a/src/main/java/io/muserver/Mu3ServerImpl.java
+++ b/src/main/java/io/muserver/Mu3ServerImpl.java
@@ -640,8 +640,8 @@ class Mu3ServerImpl implements MuServer {
         for (var listener : requestRejectListeners) {
             try {
                 listener.onRejected(info);
-            } catch (Exception e) {
-                log.error("Error from request reject listener", e);
+            } catch (Throwable failure) {
+                log.error("Error from request reject listener", failure);
             }
         }
     }

--- a/src/main/java/io/muserver/RequestRejectListener.java
+++ b/src/main/java/io/muserver/RequestRejectListener.java
@@ -8,7 +8,8 @@ package io.muserver;
  * <p>Because no {@link MuRequest} or {@link MuResponse} is created for these requests, they are
  * never reported to a {@link ResponseCompleteListener}.</p>
  * <p>Listeners are dispatched asynchronously on the server's async executor after the rejection
- * response has been sent or queued.</p>
+ * response has been sent or queued. A failure from one listener is logged and does not prevent
+ * other listeners from being notified.</p>
  * @see MuServerBuilder#addRequestRejectListener(RequestRejectListener)
  */
 public interface RequestRejectListener {

--- a/src/test/java/io/muserver/ExecutionDomainsTest.java
+++ b/src/test/java/io/muserver/ExecutionDomainsTest.java
@@ -312,6 +312,35 @@ class ExecutionDomainsTest {
     }
 
     @Test
+    void requestRejectionListenerFailureDoesNotSkipLaterListeners() throws Exception {
+        var asyncExecutor = track(Executors.newSingleThreadExecutor(namedThreads("async-")));
+        var firstListenerCalls = new AtomicInteger();
+        var laterListenerThread = new CompletableFuture<String>();
+        server = httpServer()
+            .withMaxHeadersSize(1024)
+            .withAsyncExecutor(asyncExecutor)
+            .addRequestRejectListener(info -> {
+                firstListenerCalls.incrementAndGet();
+                throw new AssertionError("deliberate request rejection listener failure");
+            })
+            .addRequestRejectListener(info ->
+                laterListenerThread.complete(Thread.currentThread().getName())
+            )
+            .start();
+
+        try (var client = Http1Client.connect(server)) {
+            client.writeRequestLine(Method.GET, "/")
+                .writeHeader("x-big", "a".repeat(2000))
+                .flushHeaders();
+            assertThat(client.readLine(), startsWith("HTTP/1.1 431"));
+            client.readBody(client.readHeaders());
+        }
+
+        assertThat(laterListenerThread.get(5, TimeUnit.SECONDS), startsWith("async-"));
+        assertThat(firstListenerCalls.get(), is(1));
+    }
+
+    @Test
     void http1RejectionResponsePrecedesFallbackListenerDelivery() throws Exception {
         var rejectedAsyncExecutor =
             track(Executors.newSingleThreadExecutor(namedThreads("rejected-async-")));


### PR DESCRIPTION
## Summary

- catch all throwables from each `RequestRejectListener` independently
- keep notifying later listeners for the same rejected request
- document listener failure isolation

## Why

Request-rejection notifications are a multi-listener detached application callback. The loop caught `Exception` but not `Error`, so an `AssertionError` from one listener escaped the application turn and skipped every later listener for that rejection. This was the remaining unisolated multi-listener fan-out found in the execution-domain audit.

## Tests

- deterministic regression registers an `AssertionError`-throwing listener followed by a recording listener; the old code skips the second listener and the test times out, while the fixed code delivers it on the async executor
- rejection/execution-domain/header suites: 121 tests, 0 failures, 0 errors
- full Java 11 suite: 1,676 tests, 0 failures, 0 errors, 5 skipped
- Java 21 NullAway verify passes
- Java 11/17/21/25 CI is green

No public API, dependency, protocol, or wire changes.

Stacked on #174.