### PR TITLE
Use monotonic lifecycle deadlines

### DIFF
--- a/HTTP2-CONCURRENCY.md
+++ b/HTTP2-CONCURRENCY.md
@@ -164,6 +164,8 @@ mutating protocol state on the timer thread. The writer registers each local
 SETTINGS frame in the acknowledgement FIFO before writing any of its bytes, so
 a fast ACK cannot be missed, but arms its deadline only after the frame is
 flushed, so blocked output does not consume the peer's acknowledgement period.
+Connection idle expiry and graceful-stop budgets also use monotonic elapsed
+time, so wall-clock adjustments cannot shorten or extend them.
 
 Request-body read deadlines are intentionally not server timer tasks. They
 bound an application thread's blocking read on `Http2BodyInputStream`, so the

--- a/src/main/java/io/muserver/BaseHttpConnection.java
+++ b/src/main/java/io/muserver/BaseHttpConnection.java
@@ -31,7 +31,7 @@ abstract class BaseHttpConnection implements HttpConnection {
     protected final long connectionStartTime = System.currentTimeMillis();
     protected final InetSocketAddress remoteAddress;
     protected final InetSocketAddress localAddress;
-    protected volatile long lastIO = connectionStartTime;
+    protected volatile long lastIONanos = System.nanoTime();
     protected final AtomicLong completedRequests = new AtomicLong(0);
     protected final AtomicLong invalidHttpRequests = new AtomicLong(0);
     protected final AtomicLong rejectedDueToOverload = new AtomicLong(0);
@@ -114,7 +114,10 @@ abstract class BaseHttpConnection implements HttpConnection {
 
     @Override
     public long idleTimeMillis() {
-        return System.currentTimeMillis() - lastIO;
+        long idleNanos = MonotonicTime.elapsedNanosSince(lastIONanos);
+        return idleNanos <= 0L
+            ? 0L
+            : java.util.concurrent.TimeUnit.NANOSECONDS.toMillis(idleNanos);
     }
     @Override
     public boolean isHttps() {
@@ -197,11 +200,11 @@ abstract class BaseHttpConnection implements HttpConnection {
     }
 
     private void onIO() {
-        lastIO = System.currentTimeMillis();
+        lastIONanos = System.nanoTime();
     }
 
-    public long lastIO() {
-        return lastIO;
+    boolean hasBeenIdleFor(long nowNanos, long timeoutNanos) {
+        return nowNanos - lastIONanos >= timeoutNanos;
     }
 
     @Override

--- a/src/main/java/io/muserver/ConnectionAcceptor.java
+++ b/src/main/java/io/muserver/ConnectionAcceptor.java
@@ -206,7 +206,9 @@ class ConnectionAcceptor {
         log.info("Closing server with " + active.size() + " connected connections");
         if (gracefulShutdownDeadlineNanos == Long.MAX_VALUE) {
             gracefulShutdownDeadlineNanos =
-                deadlineAfterMillis(gracefulShutdownTimeoutMillis);
+                MonotonicTime.deadlineAfterMillis(
+                    gracefulShutdownTimeoutMillis
+                );
         }
         for (BaseHttpConnection connection : active) {
             try {
@@ -259,7 +261,9 @@ class ConnectionAcceptor {
         lifecycleLock.lock();
         try {
             while (!connections.isEmpty()) {
-                long remaining = nanosUntil(gracefulShutdownDeadlineNanos);
+                long remaining = MonotonicTime.nanosUntil(
+                    gracefulShutdownDeadlineNanos
+                );
                 if (remaining <= 0L) {
                     return false;
                 }
@@ -281,9 +285,12 @@ class ConnectionAcceptor {
             return;
         }
         try {
-            long cutoff = System.currentTimeMillis() - server.idleTimeoutMillis();
+            long nowNanos = System.nanoTime();
+            long idleTimeoutNanos = TimeUnit.MILLISECONDS.toNanos(
+                server.idleTimeoutMillis()
+            );
             for (BaseHttpConnection con : connectionSnapshot()) {
-                if (con.lastIO() < cutoff) {
+                if (con.hasBeenIdleFor(nowNanos, idleTimeoutNanos)) {
                     log.info("Timing out {}", con);
                     con.abortWithTimeout();
                 }
@@ -549,7 +556,9 @@ class ConnectionAcceptor {
 
     public boolean stop(long timeoutMillis) {
         long stopTimeoutMillis = Math.max(0L, timeoutMillis);
-        long callerDeadlineNanos = deadlineAfterMillis(stopTimeoutMillis);
+        long callerDeadlineNanos = MonotonicTime.deadlineAfterMillis(
+            stopTimeoutMillis
+        );
         lifecycleLock.lock();
         try {
             if (state == State.STOPPED) {
@@ -560,7 +569,10 @@ class ConnectionAcceptor {
                 gracefulShutdownTimeoutMillis = stopTimeoutMillis;
                 gracefulShutdownDeadlineNanos = callerDeadlineNanos;
                 state = State.STOPPING;
-            } else if (callerDeadlineNanos > gracefulShutdownDeadlineNanos) {
+            } else if (MonotonicTime.isAfter(
+                callerDeadlineNanos,
+                gracefulShutdownDeadlineNanos
+            )) {
                 // A callback-local stop can have a shorter deadline than a concurrent
                 // external stop. Preserve the longer opportunity to drain.
                 gracefulShutdownDeadlineNanos = callerDeadlineNanos;
@@ -597,7 +609,7 @@ class ConnectionAcceptor {
 
     private void joinAcceptorUntil(long deadlineNanos) {
         while (acceptorThread.isAlive()) {
-            long remaining = nanosUntil(deadlineNanos);
+            long remaining = MonotonicTime.nanosUntil(deadlineNanos);
             if (remaining <= 0L) {
                 return;
             }
@@ -612,22 +624,6 @@ class ConnectionAcceptor {
                 return;
             }
         }
-    }
-
-    private static long deadlineAfterMillis(long timeoutMillis) {
-        long now = System.nanoTime();
-        long duration = TimeUnit.MILLISECONDS.toNanos(timeoutMillis);
-        long deadline = now + duration;
-        if (duration > 0L && deadline < now) {
-            return Long.MAX_VALUE;
-        }
-        return deadline;
-    }
-
-    private static long nanosUntil(long deadlineNanos) {
-        return deadlineNanos == Long.MAX_VALUE
-            ? Long.MAX_VALUE
-            : deadlineNanos - System.nanoTime();
     }
 
     private static void closeQuietly(Socket socket) {

--- a/src/main/java/io/muserver/ConnectionAcceptor.java
+++ b/src/main/java/io/muserver/ConnectionAcceptor.java
@@ -81,7 +81,7 @@ class ConnectionAcceptor {
     }
 
     private volatile State state = State.NOT_STARTED;
-    private volatile long gracefulShutdownTimeoutMillis = 20_000;
+    private static final long FALLBACK_SHUTDOWN_TIMEOUT_MILLIS = 20_000;
     private volatile long gracefulShutdownDeadlineNanos = Long.MAX_VALUE;
     private volatile boolean lastStopWasGraceful = true;
 
@@ -207,7 +207,7 @@ class ConnectionAcceptor {
         if (gracefulShutdownDeadlineNanos == Long.MAX_VALUE) {
             gracefulShutdownDeadlineNanos =
                 MonotonicTime.deadlineAfterMillis(
-                    gracefulShutdownTimeoutMillis
+                    FALLBACK_SHUTDOWN_TIMEOUT_MILLIS
                 );
         }
         for (BaseHttpConnection connection : active) {
@@ -554,11 +554,7 @@ class ConnectionAcceptor {
         }
     }
 
-    public boolean stop(long timeoutMillis) {
-        long stopTimeoutMillis = Math.max(0L, timeoutMillis);
-        long callerDeadlineNanos = MonotonicTime.deadlineAfterMillis(
-            stopTimeoutMillis
-        );
+    boolean stopUntil(long callerDeadlineNanos) {
         lifecycleLock.lock();
         try {
             if (state == State.STOPPED) {
@@ -566,7 +562,6 @@ class ConnectionAcceptor {
             }
             log.info("Stopping server 1");
             if (state != State.STOPPING) {
-                gracefulShutdownTimeoutMillis = stopTimeoutMillis;
                 gracefulShutdownDeadlineNanos = callerDeadlineNanos;
                 state = State.STOPPING;
             } else if (MonotonicTime.isAfter(
@@ -594,7 +589,7 @@ class ConnectionAcceptor {
         }
         joinAcceptorUntil(callerDeadlineNanos);
         if (acceptorThread.isAlive()) {
-            log.warn("Could not kill " + this + " after " + timeoutMillis + " ms");
+            log.warn("Could not stop {} before the shutdown deadline", this);
             lastStopWasGraceful = false;
             return false;
         }

--- a/src/main/java/io/muserver/MonotonicTime.java
+++ b/src/main/java/io/muserver/MonotonicTime.java
@@ -1,0 +1,41 @@
+package io.muserver;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Monotonic elapsed-time arithmetic. Values returned by {@link System#nanoTime()}
+ * are opaque points on a wrapping timeline, so they must only be compared by
+ * subtraction.
+ */
+final class MonotonicTime {
+
+    private MonotonicTime() {
+    }
+
+    static long deadlineAfterMillis(long durationMillis) {
+        return deadlineAfter(
+            System.nanoTime(),
+            TimeUnit.MILLISECONDS.toNanos(Math.max(0L, durationMillis))
+        );
+    }
+
+    static long nanosUntil(long deadlineNanos) {
+        return nanosUntil(deadlineNanos, System.nanoTime());
+    }
+
+    static long elapsedNanosSince(long startNanos) {
+        return System.nanoTime() - startNanos;
+    }
+
+    static boolean isAfter(long candidateNanos, long referenceNanos) {
+        return candidateNanos - referenceNanos > 0L;
+    }
+
+    static long deadlineAfter(long nowNanos, long durationNanos) {
+        return nowNanos + Math.max(0L, durationNanos);
+    }
+
+    static long nanosUntil(long deadlineNanos, long nowNanos) {
+        return deadlineNanos - nowNanos;
+    }
+}

--- a/src/main/java/io/muserver/Mu3ServerImpl.java
+++ b/src/main/java/io/muserver/Mu3ServerImpl.java
@@ -118,15 +118,20 @@ class Mu3ServerImpl implements MuServer {
     @Override
     public boolean stop(long duration, java.util.concurrent.TimeUnit unit) {
         long timeoutMillis = Math.max(0L, unit.toMillis(duration));
-        long deadline = System.currentTimeMillis() + timeoutMillis;
+        long deadlineNanos = MonotonicTime.deadlineAfterMillis(timeoutMillis);
         boolean stoppedCleanly = true;
         for (var acceptor : acceptors) {
-            long remaining = Math.max(0L, deadline - System.currentTimeMillis());
-            if (!acceptor.stop(remaining)) {
+            long remainingNanos = Math.max(
+                0L,
+                MonotonicTime.nanosUntil(deadlineNanos)
+            );
+            if (!acceptor.stop(
+                TimeUnit.NANOSECONDS.toMillis(remainingNanos)
+            )) {
                 stoppedCleanly = false;
             }
         }
-        if (!awaitDetachedApplicationTasks(deadline)) {
+        if (!awaitDetachedApplicationTasks(deadlineNanos)) {
             stoppedCleanly = false;
         }
         if (ownsTimerExecutor) {
@@ -150,7 +155,7 @@ class Mu3ServerImpl implements MuServer {
         return stoppedCleanly;
     }
 
-    private boolean awaitDetachedApplicationTasks(long deadline) {
+    private boolean awaitDetachedApplicationTasks(long deadlineNanos) {
         // A callback cannot safely wait for other detached callbacks: with a
         // single-worker application executor, they may be queued behind this
         // callback and cannot start until stop() returns. Leave every registration
@@ -159,21 +164,30 @@ class Mu3ServerImpl implements MuServer {
         if (activeDetachedApplicationTask.get() != null) {
             return true;
         }
-        return awaitDetachedApplicationTasks(detachedApplicationTasks, deadline);
+        return awaitDetachedApplicationTasks(
+            detachedApplicationTasks,
+            deadlineNanos
+        );
     }
 
-    static boolean awaitDetachedApplicationTasks(Phaser tasks, long deadline) {
+    static boolean awaitDetachedApplicationTasks(
+        Phaser tasks,
+        long deadlineNanos
+    ) {
         while (true) {
             int phase = tasks.getPhase();
             if (tasks.getRegisteredParties() == 0) {
                 return true;
             }
-            long remaining = Math.max(0L, deadline - System.currentTimeMillis());
+            long remainingNanos = Math.max(
+                0L,
+                MonotonicTime.nanosUntil(deadlineNanos)
+            );
             try {
                 tasks.awaitAdvanceInterruptibly(
                     phase,
-                    remaining,
-                    TimeUnit.MILLISECONDS
+                    remainingNanos,
+                    TimeUnit.NANOSECONDS
                 );
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();

--- a/src/main/java/io/muserver/Mu3ServerImpl.java
+++ b/src/main/java/io/muserver/Mu3ServerImpl.java
@@ -121,13 +121,7 @@ class Mu3ServerImpl implements MuServer {
         long deadlineNanos = MonotonicTime.deadlineAfterMillis(timeoutMillis);
         boolean stoppedCleanly = true;
         for (var acceptor : acceptors) {
-            long remainingNanos = Math.max(
-                0L,
-                MonotonicTime.nanosUntil(deadlineNanos)
-            );
-            if (!acceptor.stop(
-                TimeUnit.NANOSECONDS.toMillis(remainingNanos)
-            )) {
+            if (!acceptor.stopUntil(deadlineNanos)) {
                 stoppedCleanly = false;
             }
         }

--- a/src/test/java/io/muserver/ExecutionDomainsTest.java
+++ b/src/test/java/io/muserver/ExecutionDomainsTest.java
@@ -461,7 +461,7 @@ class ExecutionDomainsTest {
         assertThat(
             Mu3ServerImpl.awaitDetachedApplicationTasks(
                 tasks,
-                System.currentTimeMillis() + 100
+                MonotonicTime.deadlineAfterMillis(100)
             ),
             is(true)
         );

--- a/src/test/java/io/muserver/MonotonicTimeTest.java
+++ b/src/test/java/io/muserver/MonotonicTimeTest.java
@@ -1,0 +1,24 @@
+package io.muserver;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+class MonotonicTimeTest {
+
+    @Test
+    void deadlinesAndRemainingTimeWorkAcrossSignedLongWraparound() {
+        long now = Long.MAX_VALUE - 5L;
+        long deadline = MonotonicTime.deadlineAfter(now, 10L);
+
+        assertThat(deadline, is(Long.MIN_VALUE + 4L));
+        assertThat(MonotonicTime.nanosUntil(deadline, now), is(10L));
+        assertThat(MonotonicTime.isAfter(deadline, now), is(true));
+    }
+
+    @Test
+    void negativeDurationsExpireImmediately() {
+        assertThat(MonotonicTime.deadlineAfter(123L, -1L), is(123L));
+    }
+}

--- a/src/test/java/io/muserver/MonotonicTimeTest.java
+++ b/src/test/java/io/muserver/MonotonicTimeTest.java
@@ -21,4 +21,14 @@ class MonotonicTimeTest {
     void negativeDurationsExpireImmediately() {
         assertThat(MonotonicTime.deadlineAfter(123L, -1L), is(123L));
     }
+
+    @Test
+    void anAbsoluteDeadlineRetainsASubMillisecondRemainder() {
+        long deadline = MonotonicTime.deadlineAfter(100L, 1_000_000L);
+
+        assertThat(
+            MonotonicTime.nanosUntil(deadline, 101L),
+            is(999_999L)
+        );
+    }
 }


### PR DESCRIPTION
## Summary
- centralize subtraction-based `System.nanoTime()` deadline arithmetic in a small package-private primitive
- make graceful-stop budgets, detached-callback waits, connection idle expiry, and `HttpConnection.idleTimeMillis()` immune to wall-clock adjustments
- test signed-`long` wraparound arithmetic and document the timer invariant

This is stacked on #175. It does not change public signatures or HTTP wire behavior.

## Validation
- `mise exec java@temurin-11 -- mvn -Dtest=MonotonicTimeTest,ExecutionDomainsTest,StopTest,MuServerTest,WebSocketsTest test` (121 tests)
- `mise exec java@temurin-11 -- mvn test` (1,678 tests, 5 skipped)
- `mise exec java@temurin-25 -- mvn -Pnullaway -DskipTests compile`