### PR TITLE
Account for connection write activity

### DIFF
--- a/HTTP2-CONCURRENCY.md
+++ b/HTTP2-CONCURRENCY.md
@@ -74,6 +74,12 @@ sockets that have not crossed that boundary and prevents their queued connection
 tasks from later being promoted. Live-connection retirement signals a condition
 used by graceful shutdown; it is not discovered by polling.
 
+The accepted connection wraps socket input and output once, below every
+protocol implementation. Successful reads and writes publish monotonic
+connection activity and update byte statistics at that boundary. Protocol
+layers do not duplicate this bookkeeping; the wrappers account for transport
+activity but do not own protocol serialization.
+
 Each HTTP/2 connection has:
 
 * one blocking socket reader; and
@@ -183,6 +189,7 @@ as defined by RFC 9113 Section 7.
 | --- | --- |
 | Listener state, accepted socket admission, and live connection index | `ConnectionAcceptor` lifecycle lock |
 | Socket input, input buffer, HPACK decoder | Connection reader |
+| Connection byte accounting and idle-activity publication | Socket input/output wrappers |
 | Connection shutdown and new-stream admission gate | `Http2Connection` state lock |
 | RFC stream protocol state | Coordinator |
 | Live application/rejected stream identity index | `Http2StreamRegistry` lock |

--- a/src/main/java/io/muserver/BaseHttpConnection.java
+++ b/src/main/java/io/muserver/BaseHttpConnection.java
@@ -31,7 +31,7 @@ abstract class BaseHttpConnection implements HttpConnection {
     protected final long connectionStartTime = System.currentTimeMillis();
     protected final InetSocketAddress remoteAddress;
     protected final InetSocketAddress localAddress;
-    protected volatile long lastIONanos = System.nanoTime();
+    protected final AtomicLong lastIONanos = new AtomicLong(System.nanoTime());
     protected final AtomicLong completedRequests = new AtomicLong(0);
     protected final AtomicLong invalidHttpRequests = new AtomicLong(0);
     protected final AtomicLong rejectedDueToOverload = new AtomicLong(0);
@@ -114,7 +114,7 @@ abstract class BaseHttpConnection implements HttpConnection {
 
     @Override
     public long idleTimeMillis() {
-        long idleNanos = MonotonicTime.elapsedNanosSince(lastIONanos);
+        long idleNanos = MonotonicTime.elapsedNanosSince(lastIONanos.get());
         return idleNanos <= 0L
             ? 0L
             : java.util.concurrent.TimeUnit.NANOSECONDS.toMillis(idleNanos);
@@ -189,22 +189,22 @@ abstract class BaseHttpConnection implements HttpConnection {
         return activeRequests().isEmpty() && activeWebsockets().isEmpty();
     }
 
-    protected void onBytesRead(int read) {
+    void onBytesRead(int read) {
         onIO();
         server.getStatsImpl().onBytesRead(read);
     }
 
-    protected void onBytesRead(byte[] buffer, int off, int len) {
+    void onBytesSent(int sent) {
         onIO();
-        server.getStatsImpl().onBytesRead(len);
+        server.getStatsImpl().onBytesSent(sent);
     }
 
     private void onIO() {
-        lastIONanos = System.nanoTime();
+        MonotonicTime.publishLatest(lastIONanos, System.nanoTime());
     }
 
     boolean hasBeenIdleFor(long nowNanos, long timeoutNanos) {
-        return nowNanos - lastIONanos >= timeoutNanos;
+        return nowNanos - lastIONanos.get() >= timeoutNanos;
     }
 
     @Override

--- a/src/main/java/io/muserver/ConnectionAcceptor.java
+++ b/src/main/java/io/muserver/ConnectionAcceptor.java
@@ -477,7 +477,10 @@ class ConnectionAcceptor {
         server.getStatsImpl().onConnectionOpened(con);
         try {
             InputStream requestIn = providedInputStream == null ? socket.getInputStream() : providedInputStream;
-            try (OutputStream clientOut = socket.getOutputStream();
+            try (OutputStream clientOut = new HttpConnectionOutputStream(
+                     con,
+                     socket.getOutputStream()
+                 );
                  InputStream clientIn = new HttpConnectionInputStream(con, requestIn)) {
                 con.start(clientIn, clientOut);
             }

--- a/src/main/java/io/muserver/HttpConnectionInputStream.java
+++ b/src/main/java/io/muserver/HttpConnectionInputStream.java
@@ -31,7 +31,7 @@ class HttpConnectionInputStream extends FilterInputStream {
     public int read(byte[] b, int off, int len) throws IOException {
         if (httpConnection.isClosed()) throw new IOException("The connection is closed");
         int read = in.read(b, off, len);
-        if (read != -1) {
+        if (read > 0) {
             httpConnection.onBytesRead(read);
         }
         return read;

--- a/src/main/java/io/muserver/HttpConnectionOutputStream.java
+++ b/src/main/java/io/muserver/HttpConnectionOutputStream.java
@@ -1,0 +1,39 @@
+package io.muserver;
+
+import java.io.FilterOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+
+/**
+ * Owns successful socket-write accounting for a connection.
+ */
+class HttpConnectionOutputStream extends FilterOutputStream {
+    private final BaseHttpConnection httpConnection;
+
+    HttpConnectionOutputStream(
+        BaseHttpConnection httpConnection,
+        OutputStream out
+    ) {
+        super(out);
+        this.httpConnection = httpConnection;
+    }
+
+    @Override
+    public void write(int b) throws IOException {
+        out.write(b);
+        httpConnection.onBytesSent(1);
+    }
+
+    @Override
+    public void write(byte[] b) throws IOException {
+        write(b, 0, b.length);
+    }
+
+    @Override
+    public void write(byte[] b, int off, int len) throws IOException {
+        out.write(b, off, len);
+        if (len > 0) {
+            httpConnection.onBytesSent(len);
+        }
+    }
+}

--- a/src/main/java/io/muserver/MonotonicTime.java
+++ b/src/main/java/io/muserver/MonotonicTime.java
@@ -1,6 +1,7 @@
 package io.muserver;
 
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * Monotonic elapsed-time arithmetic. Values returned by {@link System#nanoTime()}
@@ -29,6 +30,14 @@ final class MonotonicTime {
 
     static boolean isAfter(long candidateNanos, long referenceNanos) {
         return candidateNanos - referenceNanos > 0L;
+    }
+
+    static void publishLatest(AtomicLong destination, long candidateNanos) {
+        long current = destination.get();
+        while (isAfter(candidateNanos, current)
+            && !destination.compareAndSet(current, candidateNanos)) {
+            current = destination.get();
+        }
     }
 
     static long deadlineAfter(long nowNanos, long durationNanos) {

--- a/src/main/java/io/muserver/WebsocketConnection.java
+++ b/src/main/java/io/muserver/WebsocketConnection.java
@@ -350,8 +350,6 @@ class WebsocketConnection implements MuWebSocketSession {
                 readBuffer.capacity() - readBuffer.limit());
             if (read == -1) {
                 throw new ClientDisconnectedException();
-            } else {
-                httpConnection.onBytesRead(read);
             }
             readBuffer.limit(readBuffer.limit() + read);
         }

--- a/src/test/java/io/muserver/HttpConnectionTest.java
+++ b/src/test/java/io/muserver/HttpConnectionTest.java
@@ -2,6 +2,8 @@ package io.muserver;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import scaffolding.ServerUtils;
 
 import java.time.Instant;
@@ -95,6 +97,37 @@ public class HttpConnectionTest {
         call(request(server.uri().resolve("/blah"))).close();
         call(request(server.uri())).close();
         assertThat(error.get(), is(nullValue()));
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void successfulSocketWritesRefreshIdleTimeAndByteStats(
+        boolean http2
+    ) throws Exception {
+        AtomicReference<Long> idleAfterWrite = new AtomicReference<>();
+        server = ServerUtils.httpsServerForTest(http2 ? "h2" : "http")
+            .addHandler(Method.GET, "/", (request, response, pathParams) -> {
+                var connection = (BaseHttpConnection) request.connection();
+                connection.lastIONanos.set(
+                    System.nanoTime() - TimeUnit.SECONDS.toNanos(2)
+                );
+
+                response.write("written");
+
+                assertThat(
+                    connection.httpVersion(),
+                    is(http2 ? HttpVersion.HTTP_2 : HttpVersion.HTTP_1_1)
+                );
+                idleAfterWrite.set(connection.idleTimeMillis());
+            })
+            .start();
+
+        try (var response = call(request(server.uri()))) {
+            assertThat(response.body().string(), is("written"));
+        }
+
+        assertThat(idleAfterWrite.get(), lessThan(1000L));
+        assertThat(server.stats().bytesSent(), greaterThan(0L));
     }
 
     @AfterEach

--- a/src/test/java/io/muserver/HttpConnectionTest.java
+++ b/src/test/java/io/muserver/HttpConnectionTest.java
@@ -104,21 +104,16 @@ public class HttpConnectionTest {
     public void successfulSocketWritesRefreshIdleTimeAndByteStats(
         boolean http2
     ) throws Exception {
-        AtomicReference<Long> idleAfterWrite = new AtomicReference<>();
+        AtomicReference<BaseHttpConnection> connectionRef = new AtomicReference<>();
         server = ServerUtils.httpsServerForTest(http2 ? "h2" : "http")
             .addHandler(Method.GET, "/", (request, response, pathParams) -> {
                 var connection = (BaseHttpConnection) request.connection();
                 connection.lastIONanos.set(
                     System.nanoTime() - TimeUnit.SECONDS.toNanos(2)
                 );
+                connectionRef.set(connection);
 
                 response.write("written");
-
-                assertThat(
-                    connection.httpVersion(),
-                    is(http2 ? HttpVersion.HTTP_2 : HttpVersion.HTTP_1_1)
-                );
-                idleAfterWrite.set(connection.idleTimeMillis());
             })
             .start();
 
@@ -126,7 +121,13 @@ public class HttpConnectionTest {
             assertThat(response.body().string(), is("written"));
         }
 
-        assertThat(idleAfterWrite.get(), lessThan(1000L));
+        BaseHttpConnection connection = connectionRef.get();
+        assertThat(connection, notNullValue());
+        assertThat(
+            connection.httpVersion(),
+            is(http2 ? HttpVersion.HTTP_2 : HttpVersion.HTTP_1_1)
+        );
+        assertThat(connection.idleTimeMillis(), lessThan(1000L));
         assertThat(server.stats().bytesSent(), greaterThan(0L));
     }
 

--- a/src/test/java/io/muserver/MonotonicTimeTest.java
+++ b/src/test/java/io/muserver/MonotonicTimeTest.java
@@ -2,6 +2,8 @@ package io.muserver;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.concurrent.atomic.AtomicLong;
+
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
@@ -20,5 +22,21 @@ class MonotonicTimeTest {
     @Test
     void negativeDurationsExpireImmediately() {
         assertThat(MonotonicTime.deadlineAfter(123L, -1L), is(123L));
+    }
+
+    @Test
+    void anOlderConcurrentPublicationCannotMoveActivityBackwards() {
+        var latest = new AtomicLong(100L);
+
+        MonotonicTime.publishLatest(latest, 200L);
+        MonotonicTime.publishLatest(latest, 150L);
+
+        assertThat(latest.get(), is(200L));
+
+        latest.set(Long.MAX_VALUE - 5L);
+        MonotonicTime.publishLatest(latest, Long.MIN_VALUE + 4L);
+        MonotonicTime.publishLatest(latest, Long.MAX_VALUE - 2L);
+
+        assertThat(latest.get(), is(Long.MIN_VALUE + 4L));
     }
 }

--- a/src/test/java/io/muserver/WebSocketsTest.java
+++ b/src/test/java/io/muserver/WebSocketsTest.java
@@ -269,6 +269,56 @@ public class WebSocketsTest {
     }
 
     @Test
+    public void incomingWebSocketBytesAreCountedOnceByTheConnection() throws Exception {
+        server = httpServer()
+            .addHandler(webSocketHandler(
+                (request, responseHeaders) -> serverSocket
+            ))
+            .start();
+
+        try (Socket socket = new Socket(
+                 server.uri().getHost(),
+                 server.uri().getPort()
+             );
+             OutputStream out = socket.getOutputStream();
+             InputStream in = socket.getInputStream()) {
+            int handshakeBytes = handshake(out, in);
+            assertEventually(
+                () -> server.stats().bytesRead(),
+                equalTo((long) handshakeBytes)
+            );
+
+            // A masked "hi" text frame. A zero mask leaves the payload unchanged.
+            byte[] frame = {
+                (byte) 0x81, (byte) 0x82,
+                0, 0, 0, 0,
+                'h', 'i'
+            };
+            out.write(frame);
+            out.flush();
+
+            assertEventually(
+                () -> serverSocket.received,
+                contains("connected", "onText: hi")
+            );
+            assertThat(
+                server.stats().bytesRead(),
+                equalTo((long) handshakeBytes + frame.length)
+            );
+
+            sendMaskedFrame(
+                out,
+                true,
+                0x8,
+                new byte[]{0x03, (byte) 0xE8},
+                new byte[4]
+            );
+            out.flush();
+            assertNotTimedOut("closing server socket", serverSocket.closedLatch);
+        }
+    }
+
+    @Test
     public void invalidUTF8MessagesResultInErrors() throws Exception {
         server = MuServerBuilder.httpServer()
             .addHandler(webSocketHandler((request, responseHeaders) -> serverSocket))
@@ -570,7 +620,7 @@ public class WebSocketsTest {
     }
 
 
-    private void handshake(OutputStream out, InputStream in) throws IOException {
+    private int handshake(OutputStream out, InputStream in) throws IOException {
         // Perform WebSocket handshake
         String request = "GET / HTTP/1.1\r\n" +
             "Host: " + server.uri().getAuthority() + "\r\n" +
@@ -585,6 +635,7 @@ public class WebSocketsTest {
         var reader = new BufferedReader(new InputStreamReader(in, StandardCharsets.US_ASCII));
         while (!reader.readLine().isEmpty()) {
         }
+        return request.getBytes(StandardCharsets.US_ASCII).length;
     }
 
 


### PR DESCRIPTION
## Summary
- wrap accepted socket output once so successful HTTP/1, HTTP/2, and WebSocket writes refresh connection idleness and update `MuStats.bytesSent()`
- make the shared read/write activity marker a wrap-safe CAS publication so a stale producer cannot move time backwards
- remove duplicate WebSocket read accounting and ignore zero-byte transport operations
- document the socket-wrapper ownership boundary

This is stacked on #176. Public signatures and HTTP wire behavior are unchanged; the documented idle-time and byte-stat contracts now include successful writes.

## Proof
- the old implementation leaves `idleTimeMillis()` about two seconds stale and `bytesSent()` at zero after forced HTTP/1 and HTTP/2 response writes
- a raw masked WebSocket frame was counted twice before the duplicate protocol-layer update was removed
- a deterministic arithmetic test proves stale concurrent publication cannot overwrite newer activity, including across signed `nanoTime` wrap

## Validation
- `mise exec java@temurin-11 -- mvn -Dtest=MonotonicTimeTest,HttpConnectionTest,WebSocketsTest,ExecutionDomainsTest,StopTest test` (93 tests)
- `mise exec java@temurin-11 -- mvn test` (1,683 tests, 5 skipped)
- `mise exec java@temurin-25 -- mvn -Pnullaway -DskipTests compile`