### PR TITLE
Use monotonic response durations

### DIFF
--- a/src/main/java/io/muserver/Http1Response.java
+++ b/src/main/java/io/muserver/Http1Response.java
@@ -12,7 +12,7 @@ class Http1Response extends BaseResponse implements MuResponse, ResponseInfo {
     @Nullable
     private WebsocketConnection websocket;
     @Nullable
-    private Long endMillis;
+    private Long endNanos;
     private boolean shouldCloseConnectionAfterResponse;
 
     Http1Response(Mu3Request muRequest, OutputStream socketOut) {
@@ -112,14 +112,16 @@ class Http1Response extends BaseResponse implements MuResponse, ResponseInfo {
     void setState(ResponseState newState) {
         super.setState(newState);
         if (newState.endState()) {
-            endMillis = System.currentTimeMillis();
+            endNanos = System.nanoTime();
         }
     }
 
     @Override
     public long duration() {
-        long endTime = endMillis != null ? endMillis : System.currentTimeMillis();
-        return endTime - request.startTime();
+        Long end = endNanos;
+        return end == null
+            ? MonotonicTime.elapsedMillisSince(request.startNanos())
+            : MonotonicTime.elapsedMillis(request.startNanos(), end);
     }
 
     @Override

--- a/src/main/java/io/muserver/Http2Stream.java
+++ b/src/main/java/io/muserver/Http2Stream.java
@@ -33,7 +33,8 @@ class Http2Stream implements ResponseInfo {
     // Writer-published after the complete END_STREAM frame is handed to output
     // and before flush, matching the stream-admission publication boundary.
     private volatile boolean localEndStreamPublished;
-    private long endTime = 0;
+    @Nullable
+    private Long endNanos;
     private final InputStream bodyInputStream;
     private final @Nullable Long declaredRequestBodyLength;
     private long receivedRequestBodyLength;
@@ -56,8 +57,10 @@ class Http2Stream implements ResponseInfo {
 
     @Override
     public long duration() {
-        var end = endTime;
-        return (end == 0L ? System.currentTimeMillis() : end) - request.startTime();
+        Long end = endNanos;
+        return end == null
+            ? MonotonicTime.elapsedMillisSince(request.startNanos())
+            : MonotonicTime.elapsedMillis(request.startNanos(), end);
     }
 
 
@@ -380,7 +383,7 @@ class Http2Stream implements ResponseInfo {
             request.cleanup();
             requiredResponse().cleanup();
         } finally {
-            endTime = System.currentTimeMillis();
+            endNanos = System.nanoTime();
         }
     }
 
@@ -388,7 +391,7 @@ class Http2Stream implements ResponseInfo {
         try {
             request.cleanup();
         } finally {
-            endTime = System.currentTimeMillis();
+            endNanos = System.nanoTime();
         }
     }
 

--- a/src/main/java/io/muserver/MonotonicTime.java
+++ b/src/main/java/io/muserver/MonotonicTime.java
@@ -28,6 +28,17 @@ final class MonotonicTime {
         return System.nanoTime() - startNanos;
     }
 
+    static long elapsedMillis(long startNanos, long endNanos) {
+        long elapsedNanos = endNanos - startNanos;
+        return elapsedNanos <= 0L
+            ? 0L
+            : TimeUnit.NANOSECONDS.toMillis(elapsedNanos);
+    }
+
+    static long elapsedMillisSince(long startNanos) {
+        return elapsedMillis(startNanos, System.nanoTime());
+    }
+
     static boolean isAfter(long candidateNanos, long referenceNanos) {
         return candidateNanos - referenceNanos > 0L;
     }

--- a/src/main/java/io/muserver/Mu3Request.java
+++ b/src/main/java/io/muserver/Mu3Request.java
@@ -25,6 +25,7 @@ class Mu3Request implements MuRequest {
     @Nullable
     private BaseResponse response;
     private final long startTime;
+    private final long startNanos;
     @Nullable private QueryString query;
     @Nullable private Map<String, Object> attributes;
     private String contextPath = "";
@@ -52,6 +53,7 @@ class Mu3Request implements MuRequest {
         this.bodySize = bodySize;
         this.body = body;
         this.startTime = System.currentTimeMillis();
+        this.startNanos = System.nanoTime();
         this.relativePath = requestUri.getRawPath();
     }
 
@@ -71,6 +73,10 @@ class Mu3Request implements MuRequest {
     @Override
     public long startTime() {
         return startTime;
+    }
+
+    long startNanos() {
+        return startNanos;
     }
 
     @Override

--- a/src/main/java/io/muserver/Mu3Request.java
+++ b/src/main/java/io/muserver/Mu3Request.java
@@ -52,8 +52,8 @@ class Mu3Request implements MuRequest {
         this.mu3Headers = mu3Headers;
         this.bodySize = bodySize;
         this.body = body;
-        this.startTime = System.currentTimeMillis();
         this.startNanos = System.nanoTime();
+        this.startTime = System.currentTimeMillis();
         this.relativePath = requestUri.getRawPath();
     }
 

--- a/src/test/java/io/muserver/MonotonicTimeTest.java
+++ b/src/test/java/io/muserver/MonotonicTimeTest.java
@@ -17,6 +17,7 @@ class MonotonicTimeTest {
         assertThat(deadline, is(Long.MIN_VALUE + 4L));
         assertThat(MonotonicTime.nanosUntil(deadline, now), is(10L));
         assertThat(MonotonicTime.isAfter(deadline, now), is(true));
+        assertThat(MonotonicTime.elapsedMillis(now, deadline), is(0L));
     }
 
     @Test
@@ -48,5 +49,14 @@ class MonotonicTimeTest {
             MonotonicTime.nanosUntil(deadline, 101L),
             is(999_999L)
         );
+    }
+
+    @Test
+    void elapsedMillisecondsAreCalculatedFromMonotonicPoints() {
+        long start = 123L;
+
+        assertThat(MonotonicTime.elapsedMillis(start, start + 999_999L), is(0L));
+        assertThat(MonotonicTime.elapsedMillis(start, start + 1_000_000L), is(1L));
+        assertThat(MonotonicTime.elapsedMillis(start, start - 1L), is(0L));
     }
 }


### PR DESCRIPTION
Stacked on #177.

## Summary
- preserve MuRequest.startTime() as epoch milliseconds
- calculate in-progress and completed ResponseInfo durations from monotonic clock points
- apply the same elapsed-time semantics to HTTP/1 and HTTP/2 responses
- clamp non-forward intervals to zero and test sub-millisecond and signed-wrap arithmetic

## Validation
- full Java 11 test suite: 1,683 tests, 0 failures/errors, 5 skipped
- Java 21 NullAway/Error Prone verify with tests skipped
- focused response/event/stream tests on Java 11