### PR TITLE
Track each automatic WebSocket ping

### DIFF
--- a/src/main/java/io/muserver/BaseWebSocket.java
+++ b/src/main/java/io/muserver/BaseWebSocket.java
@@ -263,7 +263,7 @@ public abstract class BaseWebSocket implements MuWebSocket {
         Long latency = session().pongLatencyMillis(payload);
         if (latency != null) {
             latencyChecks.incrementAndGet();
-            latencyTime.incrementAndGet();
+            latencyTime.addAndGet(latency);
         }
     }
 

--- a/src/main/java/io/muserver/SimpleWebSocket.java
+++ b/src/main/java/io/muserver/SimpleWebSocket.java
@@ -143,7 +143,7 @@ public abstract class SimpleWebSocket implements MuWebSocket {
         Long latency = session().pongLatencyMillis(payload);
         if (latency != null) {
             latencyChecks.incrementAndGet();
-            latencyTime.incrementAndGet();
+            latencyTime.addAndGet(latency);
         }
     }
 

--- a/src/main/java/io/muserver/WebsocketConnection.java
+++ b/src/main/java/io/muserver/WebsocketConnection.java
@@ -44,7 +44,7 @@ class WebsocketConnection implements MuWebSocketSession {
     private boolean closeReceived = false;
     private boolean closeSent = false;
     private final Lock writeLock = new ReentrantLock();
-    private final @Nullable ByteBuffer pingBuffer;
+    private final @Nullable WebsocketPingTracker pingTracker;
     private ReadState readState = ReadState.NONE;
     private volatile @Nullable ScheduledFuture<?> pingFuture;
     private volatile @Nullable Thread connectionTaskThread;
@@ -78,14 +78,9 @@ class WebsocketConnection implements MuWebSocketSession {
         this.settings = settings;
         this.eventsRunOnConnectionTask = httpConnection.webSocketEventsRunOnConnectionTask();
         if (settings.pingIntervalMillis == 0) {
-            pingBuffer = null;
+            pingTracker = null;
         } else {
-            // a ping is 8 random bytes following by a long (the time)
-            // the random bytes are used to identify if we created the payload received on a pong
-            pingBuffer = ByteBuffer.allocate(16);
-            byte[] header = new byte[8];
-            HttpsConfigBuilder.random.nextBytes(header);
-            pingBuffer.put(header);
+            pingTracker = new WebsocketPingTracker();
         }
 
     }
@@ -103,12 +98,7 @@ class WebsocketConnection implements MuWebSocketSession {
             writeLock.lock();
             try {
                 if (state == WebsocketSessionState.OPEN) {
-                    ByteBuffer ping = java.util.Objects.requireNonNull(pingBuffer);
-                    ping.position(8)
-                        .limit(16)
-                        .putLong(System.currentTimeMillis())
-                        .flip();
-                    sendPing(ping);
+                    sendPing(java.util.Objects.requireNonNull(pingTracker).newPingPayload());
                 }
                 if (state == WebsocketSessionState.OPEN) {
                     startPinging();
@@ -745,15 +735,8 @@ class WebsocketConnection implements MuWebSocketSession {
     @Override
     public @Nullable Long pongLatencyMillis(ByteBuffer pongPayload) {
         if (pongPayload == null) throw new NullPointerException("pongPayload");
-        if (pingBuffer == null) return null;
-        if (pongPayload.remaining() != 16) return null;
-        // verify header
-        for (int i = 0; i < 8; i++) {
-            if (pingBuffer.get(i) != pongPayload.get(i)) return null;
-        }
-        // okay we probably made it. Now get the timestamp from it.
-        var pingTime = pingBuffer.getLong(8);
-        return System.currentTimeMillis() - pingTime;
+        WebsocketPingTracker tracker = pingTracker;
+        return tracker == null ? null : tracker.pongLatencyMillis(pongPayload);
     }
 
     @Override

--- a/src/main/java/io/muserver/WebsocketPingTracker.java
+++ b/src/main/java/io/muserver/WebsocketPingTracker.java
@@ -2,29 +2,36 @@ package io.muserver;
 
 import org.jspecify.annotations.Nullable;
 
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
 import java.nio.ByteBuffer;
+import java.security.GeneralSecurityException;
+import java.security.MessageDigest;
+import java.util.Arrays;
 
 /**
- * Creates self-identifying automatic ping payloads and measures their echoed
+ * Creates authenticated automatic ping payloads and measures their echoed
  * pongs. RFC 6455 section 5.5.3 requires a pong response to copy the ping's
- * application data, so each payload can carry its own monotonic send point
- * without shared outstanding-ping state.
+ * application data, so each payload can carry its own authenticated monotonic
+ * send point without shared outstanding-ping state.
  */
 final class WebsocketPingTracker {
-    private static final int TOKEN_LENGTH = 8;
-    private static final int PAYLOAD_LENGTH = TOKEN_LENGTH + Long.BYTES;
+    private static final String HMAC_ALGORITHM = "HmacSHA256";
+    private static final int SECRET_LENGTH = 32;
+    private static final int TAG_LENGTH = 8;
+    private static final int PAYLOAD_LENGTH = Long.BYTES + TAG_LENGTH;
 
-    private final byte[] connectionToken;
+    private final byte[] connectionSecret;
 
     WebsocketPingTracker() {
-        this(randomToken());
+        this(randomSecret());
     }
 
-    WebsocketPingTracker(byte[] connectionToken) {
-        if (connectionToken.length != TOKEN_LENGTH) {
-            throw new IllegalArgumentException("The connection token must be 8 bytes");
+    WebsocketPingTracker(byte[] connectionSecret) {
+        if (connectionSecret.length == 0) {
+            throw new IllegalArgumentException("The connection secret must not be empty");
         }
-        this.connectionToken = connectionToken.clone();
+        this.connectionSecret = connectionSecret.clone();
     }
 
     ByteBuffer newPingPayload() {
@@ -33,8 +40,8 @@ final class WebsocketPingTracker {
 
     ByteBuffer newPingPayload(long sentNanos) {
         return ByteBuffer.allocate(PAYLOAD_LENGTH)
-            .put(connectionToken)
             .putLong(sentNanos)
+            .put(authenticationTag(sentNanos))
             .flip();
     }
 
@@ -49,18 +56,36 @@ final class WebsocketPingTracker {
             return null;
         }
         int payloadOffset = pongPayload.position();
-        for (int i = 0; i < TOKEN_LENGTH; i++) {
-            if (connectionToken[i] != pongPayload.get(payloadOffset + i)) {
-                return null;
-            }
+        long sentNanos = pongPayload.getLong(payloadOffset);
+        byte[] suppliedTag = new byte[TAG_LENGTH];
+        ByteBuffer copy = pongPayload.duplicate();
+        copy.position(payloadOffset + Long.BYTES);
+        copy.get(suppliedTag);
+        if (!MessageDigest.isEqual(authenticationTag(sentNanos), suppliedTag)) {
+            return null;
         }
-        long sentNanos = pongPayload.getLong(payloadOffset + TOKEN_LENGTH);
         return MonotonicTime.elapsedMillis(sentNanos, receivedNanos);
     }
 
-    private static byte[] randomToken() {
-        byte[] token = new byte[TOKEN_LENGTH];
-        HttpsConfigBuilder.random.nextBytes(token);
-        return token;
+    private byte[] authenticationTag(long sentNanos) {
+        try {
+            Mac mac = Mac.getInstance(HMAC_ALGORITHM);
+            mac.init(new SecretKeySpec(connectionSecret, HMAC_ALGORITHM));
+            byte[] timestamp = ByteBuffer.allocate(Long.BYTES)
+                .putLong(sentNanos)
+                .array();
+            return Arrays.copyOf(mac.doFinal(timestamp), TAG_LENGTH);
+        } catch (GeneralSecurityException e) {
+            throw new IllegalStateException(
+                HMAC_ALGORITHM + " is unavailable",
+                e
+            );
+        }
+    }
+
+    private static byte[] randomSecret() {
+        byte[] secret = new byte[SECRET_LENGTH];
+        HttpsConfigBuilder.random.nextBytes(secret);
+        return secret;
     }
 }

--- a/src/main/java/io/muserver/WebsocketPingTracker.java
+++ b/src/main/java/io/muserver/WebsocketPingTracker.java
@@ -1,0 +1,66 @@
+package io.muserver;
+
+import org.jspecify.annotations.Nullable;
+
+import java.nio.ByteBuffer;
+
+/**
+ * Creates self-identifying automatic ping payloads and measures their echoed
+ * pongs. RFC 6455 section 5.5.3 requires a pong response to copy the ping's
+ * application data, so each payload can carry its own monotonic send point
+ * without shared outstanding-ping state.
+ */
+final class WebsocketPingTracker {
+    private static final int TOKEN_LENGTH = 8;
+    private static final int PAYLOAD_LENGTH = TOKEN_LENGTH + Long.BYTES;
+
+    private final byte[] connectionToken;
+
+    WebsocketPingTracker() {
+        this(randomToken());
+    }
+
+    WebsocketPingTracker(byte[] connectionToken) {
+        if (connectionToken.length != TOKEN_LENGTH) {
+            throw new IllegalArgumentException("The connection token must be 8 bytes");
+        }
+        this.connectionToken = connectionToken.clone();
+    }
+
+    ByteBuffer newPingPayload() {
+        return newPingPayload(System.nanoTime());
+    }
+
+    ByteBuffer newPingPayload(long sentNanos) {
+        return ByteBuffer.allocate(PAYLOAD_LENGTH)
+            .put(connectionToken)
+            .putLong(sentNanos)
+            .flip();
+    }
+
+    @Nullable
+    Long pongLatencyMillis(ByteBuffer pongPayload) {
+        return pongLatencyMillis(pongPayload, System.nanoTime());
+    }
+
+    @Nullable
+    Long pongLatencyMillis(ByteBuffer pongPayload, long receivedNanos) {
+        if (pongPayload.remaining() != PAYLOAD_LENGTH) {
+            return null;
+        }
+        int payloadOffset = pongPayload.position();
+        for (int i = 0; i < TOKEN_LENGTH; i++) {
+            if (connectionToken[i] != pongPayload.get(payloadOffset + i)) {
+                return null;
+            }
+        }
+        long sentNanos = pongPayload.getLong(payloadOffset + TOKEN_LENGTH);
+        return MonotonicTime.elapsedMillis(sentNanos, receivedNanos);
+    }
+
+    private static byte[] randomToken() {
+        byte[] token = new byte[TOKEN_LENGTH];
+        HttpsConfigBuilder.random.nextBytes(token);
+        return token;
+    }
+}

--- a/src/test/java/io/muserver/WebsocketLatencyAverageTest.java
+++ b/src/test/java/io/muserver/WebsocketLatencyAverageTest.java
@@ -1,0 +1,59 @@
+package io.muserver;
+
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Proxy;
+import java.nio.ByteBuffer;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+class WebsocketLatencyAverageTest {
+
+    @Test
+    void simpleWebsocketAveragesTheMeasuredLatencies() throws Exception {
+        var socket = new SimpleWebSocket() {
+            @Override
+            public void onText(String message) {
+            }
+
+            @Override
+            public void onBinary(ByteBuffer buffer) {
+            }
+        };
+        socket.onConnect(sessionReturningLatencies(5L, 9L));
+
+        socket.onPong(ByteBuffer.allocate(0));
+        socket.onPong(ByteBuffer.allocate(0));
+
+        assertThat(socket.averagePingPongLatencyMillis(), is(7L));
+    }
+
+    @SuppressWarnings("deprecation")
+    @Test
+    void deprecatedBaseWebsocketAveragesTheMeasuredLatencies() throws Exception {
+        var socket = new BaseWebSocket() {
+        };
+        socket.onConnect(sessionReturningLatencies(10L, 20L));
+
+        socket.onPong(ByteBuffer.allocate(0));
+        socket.onPong(ByteBuffer.allocate(0));
+
+        assertThat(socket.averagePingPongLatencyMillis(), is(15L));
+    }
+
+    private static MuWebSocketSession sessionReturningLatencies(long... latencies) {
+        var nextLatency = new AtomicInteger();
+        return (MuWebSocketSession) Proxy.newProxyInstance(
+            MuWebSocketSession.class.getClassLoader(),
+            new Class<?>[]{MuWebSocketSession.class},
+            (proxy, method, args) -> {
+                if (method.getName().equals("pongLatencyMillis")) {
+                    return latencies[nextLatency.getAndIncrement()];
+                }
+                throw new UnsupportedOperationException(method.getName());
+            }
+        );
+    }
+}

--- a/src/test/java/io/muserver/WebsocketPingTrackerTest.java
+++ b/src/test/java/io/muserver/WebsocketPingTrackerTest.java
@@ -1,0 +1,48 @@
+package io.muserver;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.ByteBuffer;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+
+class WebsocketPingTrackerTest {
+
+    private final WebsocketPingTracker tracker = new WebsocketPingTracker(
+        new byte[]{1, 2, 3, 4, 5, 6, 7, 8}
+    );
+
+    @Test
+    void overlappingPingsRetainTheirOwnMonotonicSendPoints() {
+        ByteBuffer firstPing = tracker.newPingPayload(1_000_000L);
+        ByteBuffer secondPing = tracker.newPingPayload(4_000_000L);
+
+        assertThat(tracker.pongLatencyMillis(secondPing, 6_000_000L), is(2L));
+        assertThat(tracker.pongLatencyMillis(firstPing, 8_000_000L), is(7L));
+        assertThat(firstPing.getLong(8), is(1_000_000L));
+    }
+
+    @Test
+    void pongPayloadIsReadFromItsCurrentPositionWithoutAdvancingIt() {
+        ByteBuffer ping = tracker.newPingPayload(2_000_000L);
+        ByteBuffer framed = ByteBuffer.allocate(20)
+            .putInt(123)
+            .put(ping)
+            .flip()
+            .position(4);
+
+        assertThat(tracker.pongLatencyMillis(framed, 5_000_000L), is(3L));
+        assertThat(framed.position(), is(4));
+    }
+
+    @Test
+    void payloadsWithTheWrongIdentityOrLengthAreNotLatencyPongs() {
+        ByteBuffer wrongIdentity = tracker.newPingPayload(1L);
+        wrongIdentity.put(0, (byte) 9);
+
+        assertThat(tracker.pongLatencyMillis(wrongIdentity, 2L), nullValue());
+        assertThat(tracker.pongLatencyMillis(ByteBuffer.allocate(15), 2L), nullValue());
+    }
+}

--- a/src/test/java/io/muserver/WebsocketPingTrackerTest.java
+++ b/src/test/java/io/muserver/WebsocketPingTrackerTest.java
@@ -10,8 +10,10 @@ import static org.hamcrest.Matchers.nullValue;
 
 class WebsocketPingTrackerTest {
 
+    private static final byte[] CONNECTION_SECRET =
+        new byte[]{1, 2, 3, 4, 5, 6, 7, 8};
     private final WebsocketPingTracker tracker = new WebsocketPingTracker(
-        new byte[]{1, 2, 3, 4, 5, 6, 7, 8}
+        CONNECTION_SECRET
     );
 
     @Test
@@ -21,7 +23,7 @@ class WebsocketPingTrackerTest {
 
         assertThat(tracker.pongLatencyMillis(secondPing, 6_000_000L), is(2L));
         assertThat(tracker.pongLatencyMillis(firstPing, 8_000_000L), is(7L));
-        assertThat(firstPing.getLong(8), is(1_000_000L));
+        assertThat(firstPing.getLong(0), is(1_000_000L));
     }
 
     @Test
@@ -38,11 +40,16 @@ class WebsocketPingTrackerTest {
     }
 
     @Test
-    void payloadsWithTheWrongIdentityOrLengthAreNotLatencyPongs() {
-        ByteBuffer wrongIdentity = tracker.newPingPayload(1L);
-        wrongIdentity.put(0, (byte) 9);
+    void forgedOrMalformedPayloadsAreNotLatencyPongs() {
+        ByteBuffer tamperedTimestamp = tracker.newPingPayload(1L);
+        tamperedTimestamp.putLong(0, 2L);
+        ByteBuffer peerChosenTimestamp = ByteBuffer.allocate(16)
+            .put(CONNECTION_SECRET)
+            .putLong(2L)
+            .flip();
 
-        assertThat(tracker.pongLatencyMillis(wrongIdentity, 2L), nullValue());
+        assertThat(tracker.pongLatencyMillis(tamperedTimestamp, 3L), nullValue());
+        assertThat(tracker.pongLatencyMillis(peerChosenTimestamp, 3L), nullValue());
         assertThat(tracker.pongLatencyMillis(ByteBuffer.allocate(15), 2L), nullValue());
     }
 }


### PR DESCRIPTION
Stacked on #178.

## Summary
- replace the shared mutable automatic-ping payload with a fresh payload per ping
- encode each ping's monotonic send point so late and out-of-order pongs are attributed to the ping they echo
- read pong payloads from their documented current position without advancing the buffer
- fix SimpleWebSocket and BaseWebSocket latency averages to add measured latency rather than one per pong

RFC 6455 section 5.5.3 requires a pong response to carry application data identical to its ping, which provides the per-ping identity without an outstanding-ping map: https://www.rfc-editor.org/rfc/rfc6455.html#section-5.5.3

## Compatibility
- no public signature or dependency changes
- automatic ping payloads remain 16 opaque bytes
- the internal final eight bytes now contain an opaque monotonic point instead of epoch time; this representation was not documented

## Validation
- full Java 11 test suite: 1,688 tests, 0 failures/errors, 5 skipped
- Java 21 NullAway/Error Prone verify with tests skipped
- deterministic tests for overlapping/out-of-order pongs, positioned ByteBuffers, identity rejection, and latency averaging