### PR TITLE
Use monotonic handshake durations

### DIFF
--- a/src/main/java/io/muserver/BaseHttpConnection.java
+++ b/src/main/java/io/muserver/BaseHttpConnection.java
@@ -27,8 +27,8 @@ abstract class BaseHttpConnection implements HttpConnection {
     protected final Socket clientSocket;
     @Nullable
     protected final Certificate clientCertificate;
-    protected final Instant handshakeStartTime;
-    protected final long connectionStartTime = System.currentTimeMillis();
+    private final ConnectionAcceptedTime acceptedTime;
+    private final long connectionReadyNanos = System.nanoTime();
     protected final InetSocketAddress remoteAddress;
     protected final InetSocketAddress localAddress;
     protected final AtomicLong lastIONanos = new AtomicLong(System.nanoTime());
@@ -38,12 +38,18 @@ abstract class BaseHttpConnection implements HttpConnection {
     protected final AtomicBoolean closed = new AtomicBoolean(false);
     protected final int requestTimeout;
 
-    BaseHttpConnection(Mu3ServerImpl server, ConnectionAcceptor creator, Socket clientSocket, @Nullable Certificate clientCertificate, Instant handshakeStartTime) {
+    BaseHttpConnection(
+        Mu3ServerImpl server,
+        ConnectionAcceptor creator,
+        Socket clientSocket,
+        @Nullable Certificate clientCertificate,
+        ConnectionAcceptedTime acceptedTime
+    ) {
         this.server = server;
         this.creator = creator;
         this.clientSocket = clientSocket;
         this.clientCertificate = clientCertificate;
-        this.handshakeStartTime = handshakeStartTime;
+        this.acceptedTime = acceptedTime;
         remoteAddress = (InetSocketAddress) clientSocket.getRemoteSocketAddress();
         localAddress = (InetSocketAddress) clientSocket.getLocalSocketAddress();
         requestTimeout = (int) Math.min(Integer.MAX_VALUE, server.requestIdleTimeoutMillis());
@@ -142,12 +148,12 @@ abstract class BaseHttpConnection implements HttpConnection {
 
     @Override
     public Instant startTime() {
-        return this.handshakeStartTime;
+        return acceptedTime.instant();
     }
 
     @Override
     public long handshakeDurationMillis() {
-        return connectionStartTime - handshakeStartTime.toEpochMilli();
+        return acceptedTime.elapsedMillisUntil(connectionReadyNanos);
     }
 
     @Override

--- a/src/main/java/io/muserver/ConnectionAcceptedTime.java
+++ b/src/main/java/io/muserver/ConnectionAcceptedTime.java
@@ -1,0 +1,36 @@
+package io.muserver;
+
+import java.time.Instant;
+
+/**
+ * The socket-accept event represented in the two clock domains that consume it.
+ * The epoch timestamp is exposed to callers, while only the monotonic point is
+ * used for elapsed-time calculations.
+ */
+final class ConnectionAcceptedTime {
+    private final Instant instant;
+    private final long monotonicNanos;
+
+    private ConnectionAcceptedTime(Instant instant, long monotonicNanos) {
+        this.instant = instant;
+        this.monotonicNanos = monotonicNanos;
+    }
+
+    static ConnectionAcceptedTime now() {
+        long monotonicNanos = System.nanoTime();
+        Instant instant = Instant.now();
+        return new ConnectionAcceptedTime(instant, monotonicNanos);
+    }
+
+    static ConnectionAcceptedTime of(Instant instant, long monotonicNanos) {
+        return new ConnectionAcceptedTime(instant, monotonicNanos);
+    }
+
+    Instant instant() {
+        return instant;
+    }
+
+    long elapsedMillisUntil(long endNanos) {
+        return MonotonicTime.elapsedMillis(monotonicNanos, endNanos);
+    }
+}

--- a/src/main/java/io/muserver/ConnectionAcceptor.java
+++ b/src/main/java/io/muserver/ConnectionAcceptor.java
@@ -14,7 +14,6 @@ import java.io.PushbackInputStream;
 import java.net.*;
 import java.nio.charset.StandardCharsets;
 import java.security.cert.Certificate;
-import java.time.Instant;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -121,15 +120,15 @@ class ConnectionAcceptor {
                     closeQuietly(clientSocket);
                     continue;
                 }
-                Instant startTime = Instant.now();
+                ConnectionAcceptedTime acceptedTime = ConnectionAcceptedTime.now();
                 try {
                     connectionExecutor.submit(
-                        () -> runAcceptedSocket(clientSocket, startTime, h2, false)
+                        () -> runAcceptedSocket(clientSocket, acceptedTime, h2, false)
                     );
                 } catch (RejectedExecutionException e) {
                     try {
                         clientSocket.setSoTimeout(2000);
-                        runAcceptedSocket(clientSocket, startTime, false, true);
+                        runAcceptedSocket(clientSocket, acceptedTime, false, true);
                     } catch (Exception e2) {
                         log.info("Exception while writing 503 when executor is full: {}", e2.getMessage());
                     }
@@ -174,14 +173,14 @@ class ConnectionAcceptor {
 
     private void runAcceptedSocket(
         Socket socket,
-        Instant startTime,
+        ConnectionAcceptedTime acceptedTime,
         boolean http2Enabled,
         boolean rejectDueToOverload
     ) {
         try {
             handleClientSocket(
                 socket,
-                startTime,
+                acceptedTime,
                 http2Enabled,
                 rejectDueToOverload
             );
@@ -302,7 +301,12 @@ class ConnectionAcceptor {
         }
     }
 
-    private void handleClientSocket(Socket clientSocket, Instant startTime, boolean http2Enabled, boolean rejectDueToOverload) {
+    private void handleClientSocket(
+        Socket clientSocket,
+        ConnectionAcceptedTime acceptedTime,
+        boolean http2Enabled,
+        boolean rejectDueToOverload
+    ) {
         Socket socket = clientSocket;
         Certificate clientCert = null;
         PushbackInputStream inputStream = null;
@@ -378,7 +382,7 @@ class ConnectionAcceptor {
                 clientSocket,
                 socket,
                 clientCert,
-                startTime,
+                acceptedTime,
                 httpVersion,
                 inputStream
             );
@@ -439,7 +443,7 @@ class ConnectionAcceptor {
         Socket acceptedSocket,
         Socket socket,
         @Nullable Certificate clientCert,
-        Instant startTime,
+        ConnectionAcceptedTime acceptedTime,
         HttpVersion httpVersion,
         @Nullable InputStream providedInputStream
     ) {
@@ -453,7 +457,7 @@ class ConnectionAcceptor {
                 this,
                 socket,
                 clientCert,
-                startTime,
+                acceptedTime,
                 http2Config.initialSettings(),
                 http2Config.settingsAckTimeoutMillis(),
                 handlerExecutor,
@@ -465,7 +469,7 @@ class ConnectionAcceptor {
                 this,
                 socket,
                 clientCert,
-                startTime,
+                acceptedTime,
                 handlerExecutor,
                 handlerExecutor == connectionExecutor
             );

--- a/src/main/java/io/muserver/Http1Connection.java
+++ b/src/main/java/io/muserver/Http1Connection.java
@@ -11,7 +11,6 @@ import java.net.Socket;
 import java.net.SocketTimeoutException;
 import java.net.URI;
 import java.security.cert.Certificate;
-import java.time.Instant;
 import java.util.Queue;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
@@ -74,9 +73,9 @@ class Http1Connection extends BaseHttpConnection {
     }
 
     Http1Connection(Mu3ServerImpl server, ConnectionAcceptor creator, Socket clientSocket,
-                    @Nullable Certificate clientCertificate, Instant handshakeStartTime,
+                    @Nullable Certificate clientCertificate, ConnectionAcceptedTime acceptedTime,
                     ExecutorService handlerExecutor, boolean handlersRunOnConnectionTask) {
-        super(server, creator, clientSocket, clientCertificate, handshakeStartTime);
+        super(server, creator, clientSocket, clientCertificate, acceptedTime);
         this.handlerExecutor = handlerExecutor;
         this.handlersRunOnConnectionTask = handlersRunOnConnectionTask;
     }

--- a/src/main/java/io/muserver/Http2Connection.java
+++ b/src/main/java/io/muserver/Http2Connection.java
@@ -10,7 +10,6 @@ import java.net.SocketException;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.security.cert.Certificate;
-import java.time.Instant;
 import java.util.*;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -101,8 +100,18 @@ class Http2Connection extends BaseHttpConnection implements Http2Peer {
         }
     }
 
-    Http2Connection(Mu3ServerImpl server, ConnectionAcceptor creator, Socket clientSocket, @Nullable Certificate clientCertificate, Instant handshakeStartTime, Http2Settings initialServerSettings, long settingsAckTimeoutMillis, ExecutorService handlerExecutor, ExecutorService writerExecutor) {
-        super(server, creator, clientSocket, clientCertificate, handshakeStartTime);
+    Http2Connection(
+        Mu3ServerImpl server,
+        ConnectionAcceptor creator,
+        Socket clientSocket,
+        @Nullable Certificate clientCertificate,
+        ConnectionAcceptedTime acceptedTime,
+        Http2Settings initialServerSettings,
+        long settingsAckTimeoutMillis,
+        ExecutorService handlerExecutor,
+        ExecutorService writerExecutor
+    ) {
+        super(server, creator, clientSocket, clientCertificate, acceptedTime);
         this.serverSettings = initialServerSettings;
         this.settingsAckTimeoutMillis = settingsAckTimeoutMillis;
         this.handlerExecutor = handlerExecutor;

--- a/src/test/java/io/muserver/ConnectionAcceptedTimeTest.java
+++ b/src/test/java/io/muserver/ConnectionAcceptedTimeTest.java
@@ -1,0 +1,24 @@
+package io.muserver;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.concurrent.TimeUnit;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+class ConnectionAcceptedTimeTest {
+
+    @Test
+    void exposesEpochTimeButCalculatesElapsedTimeMonotonically() {
+        Instant epochTime = Instant.parse("2026-07-28T00:00:00Z");
+        long acceptedNanos = Long.MAX_VALUE - 500_000L;
+        long readyNanos = acceptedNanos + TimeUnit.MILLISECONDS.toNanos(2L);
+        ConnectionAcceptedTime accepted =
+            ConnectionAcceptedTime.of(epochTime, acceptedNanos);
+
+        assertThat(accepted.instant(), is(epochTime));
+        assertThat(accepted.elapsedMillisUntil(readyNanos), is(2L));
+    }
+}

--- a/src/test/java/io/muserver/HttpConnectionTest.java
+++ b/src/test/java/io/muserver/HttpConnectionTest.java
@@ -77,6 +77,7 @@ public class HttpConnectionTest {
                 try {
                     HttpConnection con = request.connection();
                     assertThat(con.startTime().toEpochMilli(), lessThanOrEqualTo(Instant.now().toEpochMilli()));
+                    assertThat(con.handshakeDurationMillis(), greaterThanOrEqualTo(0L));
                     assertThat(con.remoteAddress().getAddress().getHostAddress(), is("127.0.0.1"));
 
                     assertThat(con.activeRequests(), contains(request));

--- a/src/test/java/io/muserver/RFC9113_5_1_StreamStatesTest.java
+++ b/src/test/java/io/muserver/RFC9113_5_1_StreamStatesTest.java
@@ -8,7 +8,6 @@ import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.time.Instant;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.CountDownLatch;
@@ -52,7 +51,7 @@ class RFC9113_5_1_StreamStatesTest {
                     liveConnection.creator,
                     liveConnection.clientSocket,
                     liveConnection.clientCertificate,
-                    Instant.now(),
+                    ConnectionAcceptedTime.now(),
                     Http2Settings.DEFAULT_CLIENT_SETTINGS,
                     5000,
                     executor,

--- a/src/test/java/io/muserver/RFC9113_5_2_FlowControlTest.java
+++ b/src/test/java/io/muserver/RFC9113_5_2_FlowControlTest.java
@@ -7,7 +7,6 @@ import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayOutputStream;
 import java.lang.reflect.Field;
-import java.time.Instant;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
@@ -44,7 +43,7 @@ class RFC9113_5_2_FlowControlTest {
                     liveConnection.creator,
                     liveConnection.clientSocket,
                     liveConnection.clientCertificate,
-                    Instant.now(),
+                    ConnectionAcceptedTime.now(),
                     Http2Settings.DEFAULT_CLIENT_SETTINGS,
                     5000,
                     executor,

--- a/src/test/java/io/muserver/RFC9113_6_5_SettingsTest.java
+++ b/src/test/java/io/muserver/RFC9113_6_5_SettingsTest.java
@@ -8,7 +8,6 @@ import org.junit.jupiter.api.Test;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.lang.reflect.Field;
-import java.time.Instant;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Queue;
@@ -704,7 +703,7 @@ class RFC9113_6_5_SettingsTest {
                     liveConnection.creator,
                     liveConnection.clientSocket,
                     liveConnection.clientCertificate,
-                    Instant.now(),
+                    ConnectionAcceptedTime.now(),
                     Http2Settings.DEFAULT_CLIENT_SETTINGS,
                     5000,
                     executor,


### PR DESCRIPTION
Stacked on #179.

## Summary
- represent the socket-accept event once in both epoch and monotonic clock domains
- carry that immutable value through accepted-socket handling, TLS/cleartext protocol detection, and connection promotion
- preserve HttpConnection.startTime() as an Instant while calculating handshakeDurationMillis() only from monotonic points
- capture the monotonic point before the epoch sample so scheduler/GC delay between clock reads is included rather than omitted

## Compatibility
- no public signature, dependency, or protocol changes
- the existing accept-to-connection-created measurement boundary is preserved
- elapsed duration is now stable across wall-clock changes and clamps non-forward intervals to zero

## Validation
- full Java 11 test suite: 1,689 tests, 0 failures/errors, 5 skipped
- Java 21 NullAway/Error Prone verify with tests skipped
- targeted HTTP/1, HTTP/2 construction, settings, flow-control, and connection metric tests