### PR TITLE
Use monotonic rate-limit windows

### DIFF
--- a/src/main/java/io/muserver/RateLimit.java
+++ b/src/main/java/io/muserver/RateLimit.java
@@ -30,7 +30,7 @@ public class RateLimit {
         return new RateLimitBuilder();
     }
 
-    long expiryMillis() {
-        return this.perUnit.toMillis(this.per);
+    long expiryNanos() {
+        return this.perUnit.toNanos(this.per);
     }
 }

--- a/src/main/java/io/muserver/RateLimiterImpl.java
+++ b/src/main/java/io/muserver/RateLimiterImpl.java
@@ -4,40 +4,41 @@ import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.time.Instant;
 import java.util.*;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.LongSupplier;
 
 class RateLimiterImpl implements RateLimiter {
     private final Logger log = LoggerFactory.getLogger(RateLimiterImpl.class);
 
     private final Lock lock = new ReentrantLock();
     private final RateLimitSelector selector;
-    private final Map<String, Queue<Instant>> map = new HashMap<>();
+    private final LongSupplier nanoTime;
+    private final Map<String, Queue<Long>> map = new HashMap<>();
 
     RateLimiterImpl(RateLimitSelector selector) {
-        this.selector = selector;
+        this(selector, System::nanoTime);
     }
 
-    private void removeExpired(String bucket, @Nullable Queue<Instant> queue) {
+    RateLimiterImpl(RateLimitSelector selector, LongSupplier nanoTime) {
+        this.selector = selector;
+        this.nanoTime = nanoTime;
+    }
+
+    private static void removeExpired(
+        @Nullable Queue<Long> queue,
+        long nowNanos
+    ) {
         if (queue == null) {
             return;
         }
-        var cutoff = Instant.now();
         var head = queue.peek();
-        while (head != null) {
-            if (head.isBefore(cutoff)) {
-                queue.poll();
-                if (queue.isEmpty()) {
-                    map.remove(bucket);
-                    head = null;
-                } else {
-                    head = queue.peek();
-                }
-            } else {
-                break;
-            }
+        while (head != null
+            && MonotonicTime.nanosUntil(head, nowNanos) <= 0L) {
+            queue.poll();
+            head = queue.peek();
         }
     }
 
@@ -48,27 +49,47 @@ class RateLimiterImpl implements RateLimiter {
         }
         String name = rateLimit.bucket;
         RateLimitRejectionAction action = null;
-        Instant nextExpiry = null;
+        Long nextExpiryNanos = null;
         lock.lock();
         try {
-            removeExpired(name, map.get(name));
-            var queue = map.computeIfAbsent(name, s -> new LinkedList<>());
+            long nowNanos = nanoTime.getAsLong();
+            Queue<Long> existing = map.get(name);
+            removeExpired(existing, nowNanos);
+            if (existing != null && existing.isEmpty()) {
+                map.remove(name);
+            }
+            var queue = map.computeIfAbsent(name, s -> new ArrayDeque<>());
             long curVal = queue.size();
             if (curVal >= rateLimit.allowed) {
                 action = rateLimit.action;
                 if (action == RateLimitRejectionAction.SEND_429) {
-                    nextExpiry = queue.peek();
+                    nextExpiryNanos = queue.peek();
                 }
             } else {
-                queue.add(Instant.now().plusMillis(rateLimit.expiryMillis()));
+                queue.add(
+                    MonotonicTime.deadlineAfter(
+                        nowNanos,
+                        rateLimit.expiryNanos()
+                    )
+                );
             }
         } finally {
             lock.unlock();
         }
         if (action != null) {
             log.info("Rate limit for {} exceeded. Action: {}", rateLimit.bucket, rateLimit.action);
-            if (action == RateLimitRejectionAction.SEND_429 && request != null && nextExpiry != null) {
-                long secondsToNext = (nextExpiry.toEpochMilli() - System.currentTimeMillis()) / 1000L;
+            if (action == RateLimitRejectionAction.SEND_429
+                && request != null
+                && nextExpiryNanos != null) {
+                long remainingNanos = Math.max(
+                    0L,
+                    MonotonicTime.nanosUntil(
+                        nextExpiryNanos,
+                        nanoTime.getAsLong()
+                    )
+                );
+                long secondsToNext =
+                    TimeUnit.NANOSECONDS.toSeconds(remainingNanos);
                 long fuzz = (long) (Math.random() * 20.0);
                 request.headers().set(HeaderNames.RETRY_AFTER, secondsToNext + fuzz);
             }
@@ -81,11 +102,19 @@ class RateLimiterImpl implements RateLimiter {
         HashMap<String, Long> copy = new HashMap<>();
         lock.lock();
         try {
-            for (Map.Entry<String, Queue<Instant>> entry : map.entrySet()) {
+            long nowNanos = nanoTime.getAsLong();
+            Iterator<Map.Entry<String, Queue<Long>>> iterator =
+                map.entrySet().iterator();
+            while (iterator.hasNext()) {
+                Map.Entry<String, Queue<Long>> entry = iterator.next();
                 String bucket = entry.getKey();
-                Queue<Instant> expiries = entry.getValue();
-                removeExpired(bucket, expiries);
-                copy.put(bucket, (long) expiries.size());
+                Queue<Long> expiries = entry.getValue();
+                removeExpired(expiries, nowNanos);
+                if (expiries.isEmpty()) {
+                    iterator.remove();
+                } else {
+                    copy.put(bucket, (long) expiries.size());
+                }
             }
         } finally {
             lock.unlock();
@@ -100,8 +129,13 @@ class RateLimiterImpl implements RateLimiter {
 
     @Override
     public String toString() {
-        return "RateLimiterImpl{" +
-            "buckets=" + map +
-            '}';
+        lock.lock();
+        try {
+            return "RateLimiterImpl{" +
+                "buckets=" + map +
+                '}';
+        } finally {
+            lock.unlock();
+        }
     }
 }

--- a/src/test/java/io/muserver/RateLimiterTest.java
+++ b/src/test/java/io/muserver/RateLimiterTest.java
@@ -5,8 +5,14 @@ import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 import scaffolding.ServerUtils;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static io.muserver.RateLimitBuilder.rateLimit;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -19,19 +25,104 @@ public class RateLimiterTest {
 
 
     @Test
-    public void returnsActionIfLimitExceeded() throws InterruptedException {
+    public void returnsActionIfLimitExceeded() {
+        var nowNanos = new AtomicLong(100L);
         RateLimiterImpl limiter = new RateLimiterImpl(
             request -> rateLimit().withBucket("blah")
                 .withRate(3)
                 .withRejectionAction(RateLimitRejectionAction.SEND_429)
-                .withWindow(100, TimeUnit.MILLISECONDS).build());
+                .withWindow(100, TimeUnit.MILLISECONDS).build(),
+            nowNanos::get
+        );
         assertThat(limiter.record(null), nullValue());
         assertThat(limiter.record(null), nullValue());
         assertThat(limiter.record(null), nullValue());
         assertThat(limiter.record(null), equalTo(RateLimitRejectionAction.SEND_429));
-        Thread.sleep(250);
+        nowNanos.addAndGet(TimeUnit.MILLISECONDS.toNanos(101L));
         assertThat(limiter.record(null), nullValue());
-        assertEventually(() -> limiter.currentBuckets().keySet(), is(empty()));
+        nowNanos.addAndGet(TimeUnit.MILLISECONDS.toNanos(101L));
+        assertThat(limiter.currentBuckets().keySet(), is(empty()));
+    }
+
+    @Test
+    void windowsExpireAcrossSignedNanoTimeWraparound() {
+        var nowNanos = new AtomicLong(Long.MAX_VALUE - 50_000_000L);
+        RateLimiterImpl limiter = new RateLimiterImpl(
+            request -> rateLimit().withBucket("wrap")
+                .withRate(1)
+                .withWindow(100, TimeUnit.MILLISECONDS)
+                .build(),
+            nowNanos::get
+        );
+
+        assertThat(limiter.record(null), nullValue());
+        nowNanos.addAndGet(TimeUnit.MILLISECONDS.toNanos(99L));
+        assertThat(
+            limiter.record(null),
+            is(RateLimitRejectionAction.SEND_429)
+        );
+        nowNanos.addAndGet(TimeUnit.MILLISECONDS.toNanos(2L));
+        assertThat(limiter.record(null), nullValue());
+    }
+
+    @Test
+    void currentBucketsRemovesMultipleExpiredBucketsInOneSnapshot() {
+        var nowNanos = new AtomicLong(1L);
+        var bucket = new AtomicReference<>("first");
+        RateLimiterImpl limiter = new RateLimiterImpl(
+            request -> rateLimit().withBucket(bucket.get())
+                .withRate(1)
+                .withWindow(1, TimeUnit.MILLISECONDS)
+                .build(),
+            nowNanos::get
+        );
+        limiter.record(null);
+        bucket.set("second");
+        limiter.record(null);
+
+        nowNanos.addAndGet(TimeUnit.MILLISECONDS.toNanos(2L));
+
+        assertThat(limiter.currentBuckets(), anEmptyMap());
+    }
+
+    @Test
+    void concurrentDecisionsRemainAtomic() throws Exception {
+        var start = new CountDownLatch(1);
+        RateLimiterImpl limiter = new RateLimiterImpl(
+            request -> rateLimit().withBucket("shared")
+                .withRate(1)
+                .withWindow(1, TimeUnit.MINUTES)
+                .build(),
+            () -> 1L
+        );
+        var executor = Executors.newFixedThreadPool(8);
+        try {
+            var decisions =
+                new ArrayList<Future<RateLimitRejectionAction>>();
+            for (int i = 0; i < 16; i++) {
+                decisions.add(executor.submit(() -> {
+                    start.await();
+                    return limiter.record(null);
+                }));
+            }
+
+            start.countDown();
+
+            long allowed = 0L;
+            long rejected = 0L;
+            for (var decision : decisions) {
+                if (decision.get() == null) {
+                    allowed++;
+                } else {
+                    rejected++;
+                }
+            }
+            assertThat(allowed, is(1L));
+            assertThat(rejected, is(15L));
+            assertThat(limiter.currentBuckets().get("shared"), is(1L));
+        } finally {
+            executor.shutdownNow();
+        }
     }
 
     @Test


### PR DESCRIPTION
Stacked on #180.

## Summary
- store rate-limit expiries as monotonic deadlines rather than Instants
- sample one monotonic time inside the existing decision lock and use one consistent time for currentBuckets snapshots
- preserve the global lock as the clear atomic owner of bucket counts and bring toString under it
- remove expired buckets through the map iterator, avoiding mutation-during-iteration and empty buckets in snapshots
- honor sub-millisecond TimeUnit windows rather than truncating them to zero milliseconds

Retry-After remains a non-negative decimal delay in seconds as defined by RFC 9110 section 10.2.3, with the existing random fuzz preserved: https://www.rfc-editor.org/rfc/rfc9110.html#section-10.2.3

## Compatibility
- no public signature or dependency changes
- rejection actions, Retry-After wire form, fuzz, and bucket count semantics are preserved
- windows no longer depend on wall-clock adjustments

## Validation
- full Java 11 test suite: 1,692 tests, 0 failures/errors, 5 skipped
- Java 21 NullAway/Error Prone verify with tests skipped
- deterministic tests for signed nanoTime wrap, multi-bucket expiry snapshots, and 16 simultaneous decisions admitting exactly one request