### PR TITLE
Apply rate limits consistently across HTTP versions

### DIFF
--- a/src/main/java/io/muserver/BaseHttpConnection.java
+++ b/src/main/java/io/muserver/BaseHttpConnection.java
@@ -110,14 +110,15 @@ abstract class BaseHttpConnection implements HttpConnection {
         Mu3Request request,
         BaseResponse response
     ) {
-        RateLimitRejectionAction first = null;
+        RateLimiterImpl.Decision first = null;
         for (RateLimiterImpl rateLimiter : server.rateLimiters) {
-            RateLimitRejectionAction action = rateLimiter.record(request);
-            if (action != null && first == null) {
-                first = action;
+            RateLimiterImpl.Decision decision = rateLimiter.record(request);
+            if (decision != null && first == null) {
+                first = decision;
             }
         }
-        if (first != RateLimitRejectionAction.SEND_429) {
+        if (first == null
+            || first.action() != RateLimitRejectionAction.SEND_429) {
             return false;
         }
 
@@ -126,7 +127,7 @@ abstract class BaseHttpConnection implements HttpConnection {
         onInvalidRequest(rejection);
         request.onRateLimitRejected();
         response.status(rejection.status());
-        String retryAfter = request.headers().get(HeaderNames.RETRY_AFTER);
+        String retryAfter = first.retryAfter();
         if (retryAfter != null) {
             response.headers().set(HeaderNames.RETRY_AFTER, retryAfter);
         }

--- a/src/main/java/io/muserver/BaseHttpConnection.java
+++ b/src/main/java/io/muserver/BaseHttpConnection.java
@@ -71,8 +71,22 @@ abstract class BaseHttpConnection implements HttpConnection {
         server.onRequestStarted(req);
     }
 
+    protected RejectedRequest rateLimitRejection(Mu3Request request) {
+        String reason = HttpStatus.TOO_MANY_REQUESTS_429.toString();
+        return new RejectedRequestImpl(
+            HttpStatus.TOO_MANY_REQUESTS_429.code(),
+            reason,
+            request.method().name(),
+            request.uri().toString(),
+            this
+        );
+    }
+
     protected @Nullable CompletableFuture<@Nullable Void> handleExchange(Mu3Request muRequest, BaseResponse muResponse) throws Throwable {
         try {
+            if (applyRateLimits(muRequest, muResponse)) {
+                return null;
+            }
             var handled = false;
             for (var handler : server.handlers()) {
                 if (handler.handle(muRequest, muResponse)) {
@@ -90,6 +104,34 @@ abstract class BaseHttpConnection implements HttpConnection {
             handleExchangeException(muRequest, muResponse, e);
         }
         return null;
+    }
+
+    private boolean applyRateLimits(
+        Mu3Request request,
+        BaseResponse response
+    ) {
+        RateLimitRejectionAction first = null;
+        for (RateLimiterImpl rateLimiter : server.rateLimiters) {
+            RateLimitRejectionAction action = rateLimiter.record(request);
+            if (action != null && first == null) {
+                first = action;
+            }
+        }
+        if (first != RateLimitRejectionAction.SEND_429) {
+            return false;
+        }
+
+        HttpException rejection =
+            new HttpException(HttpStatus.TOO_MANY_REQUESTS_429);
+        onInvalidRequest(rejection);
+        request.onRateLimitRejected();
+        response.status(rejection.status());
+        String retryAfter = request.headers().get(HeaderNames.RETRY_AFTER);
+        if (retryAfter != null) {
+            response.headers().set(HeaderNames.RETRY_AFTER, retryAfter);
+        }
+        response.write(java.util.Objects.requireNonNull(rejection.getMessage()));
+        return true;
     }
 
     protected void handleExchangeException(Mu3Request muRequest, BaseResponse muResponse, Exception failure) throws Throwable {

--- a/src/main/java/io/muserver/Http1Connection.java
+++ b/src/main/java/io/muserver/Http1Connection.java
@@ -135,22 +135,6 @@ class Http1Connection extends BaseHttpConnection {
                 muRequest.setResponse(muResponse);
                 closeConnection = muRequest.headers().closeConnectionRequested(httpVersion);
 
-                if (rejectException == null) {
-                    RateLimitRejectionAction first = null;
-                    for (RateLimiterImpl rateLimiter : server.rateLimiters) {
-                        var action = rateLimiter.record(muRequest);
-                        if (action != null && first == null) {
-                            first = action;
-                        }
-                    }
-                    if (first != null) {
-                        if (first == RateLimitRejectionAction.SEND_429) {
-                            rejectException = new HttpException(HttpStatus.TOO_MANY_REQUESTS_429);
-                            rejectException.responseHeaders().setAll(request.headers());
-                        }
-                    }
-                }
-
                 if (rejectException != null) {
                     onInvalidRequest(rejectException);
                     String rejectedMethod = method.name();
@@ -196,7 +180,10 @@ class Http1Connection extends BaseHttpConnection {
                         log.warn("Unrecoverable error for " + muRequest, e);
                         muResponse.setState(ResponseState.ERRORED);
                     } finally {
-                        if (!rejectedByHandlerExecutor) {
+                        if (muRequest.wasRateLimitRejected()) {
+                            onApplicationRequestRejected(muRequest);
+                            server.onRequestRejected(rateLimitRejection(muRequest));
+                        } else if (!rejectedByHandlerExecutor) {
                             onExchangeEndedOnHandler(muResponse);
                         }
                         clientSocket.setSoTimeout(0);
@@ -299,10 +286,7 @@ class Http1Connection extends BaseHttpConnection {
     private boolean rejectRequestDueToHandlerOverload(Mu3Request request, OutputStream outputStream) throws IOException {
         rejectedDueToOverload.incrementAndGet();
         server.getStatsImpl().onRejectedDueToOverload();
-        server.onRequestSubmissionRejected(request);
-        activeExchange.updateAndGet(cur ->
-            cur != null && isSameRequest(cur.request, request) ? null : cur
-        );
+        onApplicationRequestRejected(request);
 
         String rejectionReason = "503 Service Unavailable";
         outputStream.write(ConnectionAcceptor.serverUnavailableResponse);
@@ -315,6 +299,13 @@ class Http1Connection extends BaseHttpConnection {
             this
         ));
         return true;
+    }
+
+    private void onApplicationRequestRejected(Mu3Request request) {
+        server.onRequestSubmissionRejected(request);
+        activeExchange.updateAndGet(cur ->
+            cur != null && isSameRequest(cur.request, request) ? null : cur
+        );
     }
 
     private boolean cleanUpNicely(Boolean closeConnection, Http1Response muResponse, Mu3Request muRequest) {

--- a/src/main/java/io/muserver/Http2Connection.java
+++ b/src/main/java/io/muserver/Http2Connection.java
@@ -1295,6 +1295,10 @@ class Http2Connection extends BaseHttpConnection implements Http2Peer {
     private void startHandledStream(Http2Stream stream) {
         try {
             CompletableFuture<@Nullable Void> asyncCompletion = handleExchange(stream.request, stream.response());
+            if (stream.request.wasRateLimitRejected()) {
+                finishRateLimitedStream(stream, null);
+                return;
+            }
             if (asyncCompletion == null) {
                 finishHandledStream(stream, null, false);
             } else {
@@ -1303,7 +1307,11 @@ class Http2Connection extends BaseHttpConnection implements Http2Peer {
                 );
             }
         } catch (Throwable failure) {
-            finishHandledStream(stream, failure, false);
+            if (stream.request.wasRateLimitRejected()) {
+                finishRateLimitedStream(stream, failure);
+            } else {
+                finishHandledStream(stream, failure, false);
+            }
         }
     }
 
@@ -1341,6 +1349,23 @@ class Http2Connection extends BaseHttpConnection implements Http2Peer {
 
     private void finishHandledStream(Http2Stream stream, @Nullable Throwable failure,
                                      boolean handleAsyncFailure) {
+        finishApplicationStream(stream, failure, handleAsyncFailure, true);
+    }
+
+    private void finishRateLimitedStream(
+        Http2Stream stream,
+        @Nullable Throwable failure
+    ) {
+        finishApplicationStream(stream, failure, false, false);
+        server.onRequestRejected(rateLimitRejection(stream.request));
+    }
+
+    private void finishApplicationStream(
+        Http2Stream stream,
+        @Nullable Throwable failure,
+        boolean handleAsyncFailure,
+        boolean completedApplicationExchange
+    ) {
         try {
             if (failure != null) {
                 if (handleAsyncFailure && failure instanceof Exception) {
@@ -1368,7 +1393,11 @@ class Http2Connection extends BaseHttpConnection implements Http2Peer {
                 stream.cancel(new IOException("Unhandled stream exception", e));
             }
         } finally {
-            onExchangeEnded(stream);
+            if (completedApplicationExchange) {
+                onExchangeEnded(stream);
+            } else {
+                onRejectedApplicationExchangeEnded(stream);
+            }
         }
     }
 
@@ -1513,6 +1542,13 @@ class Http2Connection extends BaseHttpConnection implements Http2Peer {
         signalWriteLoop();
         recordExchangeEnded(stream);
         server.executeResponseCompletionTask(() -> notifyExchangeEnded(stream));
+    }
+
+    private void onRejectedApplicationExchangeEnded(Http2Stream stream) {
+        server.onRequestSubmissionRejected(stream.request);
+        stream.onApplicationExchangeEnded();
+        applicationExchangeEndedForWrites(stream.id);
+        signalWriteLoop();
     }
 
     void removeProtocolStream(Http2Stream stream) {

--- a/src/main/java/io/muserver/Mu3Request.java
+++ b/src/main/java/io/muserver/Mu3Request.java
@@ -35,6 +35,7 @@ class Mu3Request implements MuRequest {
     private boolean inputStreamAccessed;
     @Nullable private volatile Mu3AsyncHandleImpl asyncHandle;
     private boolean clientCancelled;
+    private volatile boolean rateLimitRejected;
 
     Mu3Request(HttpConnection connection,
                Method method,
@@ -73,6 +74,14 @@ class Mu3Request implements MuRequest {
     @Override
     public long startTime() {
         return startTime;
+    }
+
+    void onRateLimitRejected() {
+        rateLimitRejected = true;
+    }
+
+    boolean wasRateLimitRejected() {
+        return rateLimitRejected;
     }
 
     long startNanos() {

--- a/src/main/java/io/muserver/RateLimiterImpl.java
+++ b/src/main/java/io/muserver/RateLimiterImpl.java
@@ -11,6 +11,27 @@ import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.LongSupplier;
 
 class RateLimiterImpl implements RateLimiter {
+    static final class Decision {
+        private final RateLimitRejectionAction action;
+        private final @Nullable String retryAfter;
+
+        private Decision(
+            RateLimitRejectionAction action,
+            @Nullable String retryAfter
+        ) {
+            this.action = action;
+            this.retryAfter = retryAfter;
+        }
+
+        RateLimitRejectionAction action() {
+            return action;
+        }
+
+        @Nullable String retryAfter() {
+            return retryAfter;
+        }
+    }
+
     private final Logger log = LoggerFactory.getLogger(RateLimiterImpl.class);
 
     private final Lock lock = new ReentrantLock();
@@ -42,7 +63,7 @@ class RateLimiterImpl implements RateLimiter {
         }
     }
 
-    @Nullable RateLimitRejectionAction record(MuRequest request) {
+    @Nullable Decision record(MuRequest request) {
         RateLimit rateLimit = selector.select(request);
         if (rateLimit == null || rateLimit.bucket == null) {
             return null;
@@ -76,25 +97,30 @@ class RateLimiterImpl implements RateLimiter {
         } finally {
             lock.unlock();
         }
-        if (action != null) {
-            log.info("Rate limit for {} exceeded. Action: {}", rateLimit.bucket, rateLimit.action);
-            if (action == RateLimitRejectionAction.SEND_429
-                && request != null
-                && nextExpiryNanos != null) {
-                long remainingNanos = Math.max(
-                    0L,
-                    MonotonicTime.nanosUntil(
-                        nextExpiryNanos,
-                        nanoTime.getAsLong()
-                    )
-                );
-                long secondsToNext =
-                    TimeUnit.NANOSECONDS.toSeconds(remainingNanos);
-                long fuzz = (long) (Math.random() * 20.0);
-                request.headers().set(HeaderNames.RETRY_AFTER, secondsToNext + fuzz);
-            }
+        if (action == null) {
+            return null;
         }
-        return action;
+        log.info(
+            "Rate limit for {} exceeded. Action: {}",
+            rateLimit.bucket,
+            rateLimit.action
+        );
+        String retryAfter = null;
+        if (action == RateLimitRejectionAction.SEND_429
+            && nextExpiryNanos != null) {
+            long remainingNanos = Math.max(
+                0L,
+                MonotonicTime.nanosUntil(
+                    nextExpiryNanos,
+                    nanoTime.getAsLong()
+                )
+            );
+            long secondsToNext =
+                TimeUnit.NANOSECONDS.toSeconds(remainingNanos);
+            long fuzz = (long) (Math.random() * 20.0);
+            retryAfter = Long.toString(secondsToNext + fuzz);
+        }
+        return new Decision(action, retryAfter);
     }
 
     @Override

--- a/src/test/java/io/muserver/RateLimiterTest.java
+++ b/src/test/java/io/muserver/RateLimiterTest.java
@@ -3,14 +3,19 @@ package io.muserver;
 import okhttp3.Response;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import scaffolding.ServerUtils;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -122,6 +127,196 @@ public class RateLimiterTest {
             assertThat(limiter.currentBuckets().get("shared"), is(1L));
         } finally {
             executor.shutdownNow();
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"http", "h2"})
+    void rateLimitsHaveTheSameObservableBehaviorAcrossHttpVersions(
+        String protocol
+    ) throws Exception {
+        var handlerCalls = new AtomicInteger();
+        var rejected = new CompletableFuture<RejectedRequest>();
+        try (MuServer limitedServer = ServerUtils.httpsServerForTest(protocol)
+            .withRateLimiter(request -> rateLimit()
+                .withBucket("shared")
+                .withRate(1)
+                .withWindow(1, TimeUnit.MINUTES)
+                .build())
+            .addRequestRejectListener(rejected::complete)
+            .addHandler(Method.GET, "/", (request, response, pathParams) -> {
+                handlerCalls.incrementAndGet();
+                response.write("allowed");
+            })
+            .start()) {
+            try (Response allowed = call(request(limitedServer.uri()))) {
+                assertThat(allowed.code(), is(200));
+                assertThat(allowed.body().string(), is("allowed"));
+            }
+            try (Response denied = call(request(limitedServer.uri())
+                .header("x-client-only", "secret"))) {
+                assertThat(denied.code(), is(429));
+                assertThat(
+                    denied.body().string(),
+                    is("429 Too Many Requests")
+                );
+                assertThat(
+                    denied.header("retry-after"),
+                    matchesPattern("\\d+")
+                );
+                assertThat(denied.header("x-client-only"), nullValue());
+            }
+
+            RejectedRequest rejection = rejected.get(2, TimeUnit.SECONDS);
+            assertThat(rejection.status(), is(429));
+            assertThat(rejection.method().orElseThrow(), is("GET"));
+            assertThat(handlerCalls.get(), is(1));
+            assertEventually(
+                () -> limitedServer.stats().completedRequests(),
+                is(1L)
+            );
+            assertThat(limitedServer.stats().rejectedDueToOverload(), is(1L));
+            assertThat(limitedServer.stats().activeRequests(), empty());
+        }
+    }
+
+    @Test
+    void rateLimitedHttp2StreamDiscardsItsRemainingRequestBody() throws Exception {
+        try (MuServer limitedServer = ServerUtils.httpsServerForTest("h2")
+            .withRateLimiter(request -> rateLimit()
+                .withBucket("shared")
+                .withRate(1)
+                .withWindow(1, TimeUnit.MINUTES)
+                .build())
+            .addHandler((request, response) -> {
+                response.write("allowed");
+                return true;
+            })
+            .start();
+             H2Client client = new H2Client();
+             H2ClientConnection connection = client.connect(limitedServer)) {
+            int port = limitedServer.uri().getPort();
+            connection.handshake()
+                .writeFrame(new Http2HeadersFrame(
+                    1,
+                    true,
+                    RFCTestUtils.getHelloHeaders(port)
+                ))
+                .flush();
+
+            assertThat(
+                RFCTestUtils.readIgnoringWindowUpdates(
+                    connection,
+                    Http2HeadersFrame.class
+                ).headers().get(":status"),
+                is("200")
+            );
+            assertThat(
+                RFCTestUtils.readIgnoringWindowUpdates(
+                    connection,
+                    Http2DataFrame.class
+                ).toUTF8(),
+                is("allowed")
+            );
+            assertThat(
+                RFCTestUtils.readIgnoringWindowUpdates(
+                    connection,
+                    Http2DataFrame.class
+                ).endStream(),
+                is(true)
+            );
+
+            connection.writeFrame(new Http2HeadersFrame(
+                    3,
+                    false,
+                    RFCTestUtils.postHeaders(port, "/limited")
+                ))
+                .flush();
+            Http2HeadersFrame rejected =
+                RFCTestUtils.readIgnoringWindowUpdates(
+                    connection,
+                    Http2HeadersFrame.class
+                );
+            assertThat(rejected.streamId(), is(3));
+            assertThat(rejected.headers().get(":status"), is("429"));
+            assertThat(
+                RFCTestUtils.readIgnoringWindowUpdates(
+                    connection,
+                    Http2DataFrame.class
+                ).toUTF8(),
+                is("429 Too Many Requests")
+            );
+            assertThat(
+                RFCTestUtils.readIgnoringWindowUpdates(
+                    connection,
+                    Http2DataFrame.class
+                ).endStream(),
+                is(true)
+            );
+
+            byte[] pingPayload = {0, 1, 2, 3, 4, 5, 6, 7};
+            connection
+                .writeFrame(RFCTestUtils.utf8DataFrame(
+                    3,
+                    true,
+                    "discarded after response"
+                ))
+                .writeFrame(new Http2Ping(false, pingPayload))
+                .flush();
+            assertThat(
+                RFCTestUtils.readIgnoringWindowUpdates(
+                    connection,
+                    Http2Ping.class
+                ),
+                is(new Http2Ping(true, pingPayload))
+            );
+
+            connection.writeFrame(new Http2HeadersFrame(
+                    5,
+                    true,
+                    RFCTestUtils.getHelloHeaders(port)
+                ))
+                .flush();
+            Http2HeadersFrame nextResponse =
+                RFCTestUtils.readIgnoringWindowUpdates(
+                    connection,
+                    Http2HeadersFrame.class
+                );
+            assertThat(nextResponse.streamId(), is(5));
+            assertThat(nextResponse.headers().get(":status"), is("429"));
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"http", "h2"})
+    void selectorsRunOnTheHandlerDomain(String protocol) throws Exception {
+        ExecutorService handlerExecutor = Executors.newSingleThreadExecutor(
+            task -> new Thread(task, "rate-handler")
+        );
+        ExecutorService connectionExecutor = Executors.newSingleThreadExecutor(
+            task -> new Thread(task, "rate-connection")
+        );
+        var selectorThread = new AtomicReference<String>();
+        try (MuServer domainServer = ServerUtils.httpsServerForTest(protocol)
+            .withHandlerExecutor(handlerExecutor)
+            .withConnectionExecutor(connectionExecutor)
+            .withRateLimiter(request -> {
+                selectorThread.set(Thread.currentThread().getName());
+                return rateLimit()
+                    .withBucket("domain")
+                    .withRate(2)
+                    .build();
+            })
+            .addHandler(Method.GET, "/", (request, response, pathParams) ->
+                response.write("okay")
+            )
+            .start();
+             Response ignored = call(request(domainServer.uri()))) {
+            assertThat(ignored.body().string(), is("okay"));
+            assertThat(selectorThread.get(), is("rate-handler"));
+        } finally {
+            handlerExecutor.shutdownNow();
+            connectionExecutor.shutdownNow();
         }
     }
 

--- a/src/test/java/io/muserver/RateLimiterTest.java
+++ b/src/test/java/io/muserver/RateLimiterTest.java
@@ -42,7 +42,10 @@ public class RateLimiterTest {
         assertThat(limiter.record(null), nullValue());
         assertThat(limiter.record(null), nullValue());
         assertThat(limiter.record(null), nullValue());
-        assertThat(limiter.record(null), equalTo(RateLimitRejectionAction.SEND_429));
+        assertThat(
+            limiter.record(null).action(),
+            equalTo(RateLimitRejectionAction.SEND_429)
+        );
         nowNanos.addAndGet(TimeUnit.MILLISECONDS.toNanos(101L));
         assertThat(limiter.record(null), nullValue());
         nowNanos.addAndGet(TimeUnit.MILLISECONDS.toNanos(101L));
@@ -63,7 +66,7 @@ public class RateLimiterTest {
         assertThat(limiter.record(null), nullValue());
         nowNanos.addAndGet(TimeUnit.MILLISECONDS.toNanos(99L));
         assertThat(
-            limiter.record(null),
+            limiter.record(null).action(),
             is(RateLimitRejectionAction.SEND_429)
         );
         nowNanos.addAndGet(TimeUnit.MILLISECONDS.toNanos(2L));
@@ -103,7 +106,7 @@ public class RateLimiterTest {
         var executor = Executors.newFixedThreadPool(8);
         try {
             var decisions =
-                new ArrayList<Future<RateLimitRejectionAction>>();
+                new ArrayList<Future<RateLimiterImpl.Decision>>();
             for (int i = 0; i < 16; i++) {
                 decisions.add(executor.submit(() -> {
                     start.await();
@@ -177,6 +180,39 @@ public class RateLimiterTest {
             );
             assertThat(limitedServer.stats().rejectedDueToOverload(), is(1L));
             assertThat(limitedServer.stats().activeRequests(), empty());
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"http", "h2"})
+    void ignoredDecisionDoesNotExposeLaterRetryMetadataToHandler(
+        String protocol
+    ) throws Exception {
+        try (MuServer limitedServer = ServerUtils.httpsServerForTest(protocol)
+            .withRateLimiter(request -> rateLimit()
+                .withBucket("ignored-first")
+                .withRate(1)
+                .withWindow(1, TimeUnit.MINUTES)
+                .withRejectionAction(RateLimitRejectionAction.IGNORE)
+                .build())
+            .withRateLimiter(request -> rateLimit()
+                .withBucket("send-later")
+                .withRate(1)
+                .withWindow(1, TimeUnit.MINUTES)
+                .build())
+            .addHandler(Method.GET, "/", (request, response, pathParams) -> {
+                String retryAfter =
+                    request.headers().get(HeaderNames.RETRY_AFTER);
+                response.write(retryAfter == null ? "absent" : retryAfter);
+            })
+            .start()) {
+            try (Response first = call(request(limitedServer.uri()))) {
+                assertThat(first.body().string(), is("absent"));
+            }
+            try (Response ignored = call(request(limitedServer.uri()))) {
+                assertThat(ignored.code(), is(200));
+                assertThat(ignored.body().string(), is("absent"));
+            }
         }
     }
 
@@ -336,7 +372,10 @@ public class RateLimiterTest {
             .build());
         assertThat(limiter.record(null), nullValue());
         for (int i = 1; i < 10; i++) {
-            assertThat(limiter.record(null), equalTo(RateLimitRejectionAction.IGNORE));
+            assertThat(
+                limiter.record(null).action(),
+                equalTo(RateLimitRejectionAction.IGNORE)
+            );
         }
         assertEventually(() -> limiter.currentBuckets().keySet(), is(empty()));
     }


### PR DESCRIPTION
Stacked on #181.

This moves rate-limit selection into the shared handler execution path so HTTP/1.1 and HTTP/2 apply the same limits on the handler executor. It keeps protocol-specific response and stream cleanup in each connection implementation.

Rate-limited HTTP/2 streams now send a normal 429 response, discard a request body that may still be arriving, retire application state without counting the request as completed, and leave the connection usable. HTTP/1.1 no longer reflects arbitrary request headers into the 429 response; only the generated Retry-After value is copied.

Tests cover protocol parity, handler-domain ownership, rejection statistics/listeners, header non-reflection, and an HTTP/2 early response followed by remaining request DATA and further connection traffic.

Validation:
- Java 11 full suite: 1,698 tests, 0 failures/errors, 5 skipped
- Java 21 NullAway/Error Prone compile
- git diff --check