### PR TITLE
Serialize WebSocket close lifecycle

### DIFF
--- a/src/main/java/io/muserver/BaseWebSocket.java
+++ b/src/main/java/io/muserver/BaseWebSocket.java
@@ -62,7 +62,9 @@ public abstract class BaseWebSocket implements MuWebSocket {
     @Override
     public void onClientClosed(int statusCode, @Nullable String reason) throws Exception {
         MuWebSocketSession sesh = session();
-        if (!sesh.closeSent()) {
+        // A peer can respond before the server's close write has returned.
+        if (sesh.state() != WebsocketSessionState.SERVER_CLOSING
+            && !sesh.closeSent()) {
             if (statusCode == 1005) {
                 // the client didn't send a code so we won't either
                 sesh.close();

--- a/src/main/java/io/muserver/SimpleWebSocket.java
+++ b/src/main/java/io/muserver/SimpleWebSocket.java
@@ -67,7 +67,9 @@ public abstract class SimpleWebSocket implements MuWebSocket {
     @Override
     public void onClientClosed(int statusCode, @Nullable String reason) throws Exception {
         MuWebSocketSession sesh = session();
-        if (!sesh.closeSent()) {
+        // A peer can respond before the server's close write has returned.
+        if (sesh.state() != WebsocketSessionState.SERVER_CLOSING
+            && !sesh.closeSent()) {
             if (statusCode == 1005) {
                 // the client didn't send a code so we won't either
                 sesh.close();

--- a/src/main/java/io/muserver/WebsocketConnection.java
+++ b/src/main/java/io/muserver/WebsocketConnection.java
@@ -32,7 +32,7 @@ class WebsocketConnection implements MuWebSocketSession {
     private @Nullable OutputStream outputStream;
     final WebSocketHandlerBuilder.Settings settings;
 
-    private volatile WebsocketSessionState state = WebsocketSessionState.NOT_STARTED;
+    private final WebsocketLifecycle lifecycle = new WebsocketLifecycle();
     private final Http1Connection httpConnection;
     private final Mu3ServerImpl server;
     private final MuWebSocket webSocket;
@@ -41,8 +41,8 @@ class WebsocketConnection implements MuWebSocketSession {
     private final AtomicBoolean applicationEventRunnerScheduled = new AtomicBoolean();
     private final AtomicBoolean errorEventQueued = new AtomicBoolean();
     private final AtomicBoolean serverShutdownRequested = new AtomicBoolean();
-    private boolean closeReceived = false;
-    private boolean closeSent = false;
+    private volatile boolean closeReceived = false;
+    private volatile boolean closeSent = false;
     private final Lock writeLock = new ReentrantLock();
     private final @Nullable WebsocketPingTracker pingTracker;
     private ReadState readState = ReadState.NONE;
@@ -97,14 +97,14 @@ class WebsocketConnection implements MuWebSocketSession {
         pingFuture = httpConnection.serverImpl().scheduleConnectionTask(() -> {
             writeLock.lock();
             try {
-                if (state == WebsocketSessionState.OPEN) {
+                if (lifecycle.state() == WebsocketSessionState.OPEN) {
                     sendPing(java.util.Objects.requireNonNull(pingTracker).newPingPayload());
                 }
-                if (state == WebsocketSessionState.OPEN) {
+                if (lifecycle.state() == WebsocketSessionState.OPEN) {
                     startPinging();
                 }
             } catch (IOException e) {
-                if (state == WebsocketSessionState.OPEN) {
+                if (lifecycle.state() == WebsocketSessionState.OPEN) {
                     // force an IO exception on the read operation in runAndBlockUntilDone()
                     Mutils.closeSilently(inputStream);
                 }
@@ -122,7 +122,7 @@ class WebsocketConnection implements MuWebSocketSession {
         connectionTaskThread = Thread.currentThread();
 
         try {
-            state = WebsocketSessionState.OPEN;
+            lifecycle.onConnected();
             invokeApplicationEvent(() -> webSocket.onConnect(this));
 
             if (settings.pingIntervalMillis > 0) {
@@ -233,9 +233,7 @@ class WebsocketConnection implements MuWebSocketSession {
                     if (payloadLen == 1) {
                         throw frameError(1002, "Close frame payload of 1 byte is invalid");
                     }
-                    if (state == WebsocketSessionState.OPEN) {
-                        state = WebsocketSessionState.CLIENT_CLOSING;
-                    }
+                    lifecycle.onClientCloseStarted();
                     closeReceived = true;
                     // close frame
                     short closeCode;
@@ -251,13 +249,7 @@ class WebsocketConnection implements MuWebSocketSession {
                     log.info("Client close: " + closeCode + " " + reason);
                     String closeReason = reason;
                     invokeApplicationEvent(() -> webSocket.onClientClosed(closeCode, closeReason));
-                    if (closeSent) {
-                        if (state == WebsocketSessionState.CLIENT_CLOSING) {
-                            state = WebsocketSessionState.CLIENT_CLOSED;
-                        } else if (state == WebsocketSessionState.SERVER_CLOSING) {
-                            state = WebsocketSessionState.SERVER_CLOSED;
-                        }
-                    }
+                    completeCloseHandshakeIfCloseSent();
                 } else if (opcode == 0x9) {
                     invokeApplicationEvent(() -> webSocket.onPing(slice));
                 } else if (opcode == 0xA) {
@@ -273,7 +265,7 @@ class WebsocketConnection implements MuWebSocketSession {
         } catch (Throwable e) {
             if (!serverShutdownRequested.get()
                 && !errorEventQueued.get()
-                && state != WebsocketSessionState.TIMED_OUT) {
+                && lifecycle.state() != WebsocketSessionState.TIMED_OUT) {
                 WebsocketSessionState errorState =
                     e instanceof TimeoutException || e instanceof SocketTimeoutException
                         ? WebsocketSessionState.TIMED_OUT
@@ -350,6 +342,19 @@ class WebsocketConnection implements MuWebSocketSession {
         return new ProtocolException(reason);
     }
 
+    private void completeCloseHandshakeIfCloseSent() {
+        // Synchronize with the close-frame writer before publishing that both
+        // sides of the closing handshake have completed.
+        writeLock.lock();
+        try {
+            if (closeSent) {
+                lifecycle.onCloseHandshakeCompleted();
+            }
+        } finally {
+            writeLock.unlock();
+        }
+    }
+
     @Override
     public boolean closeReceived() {
         return closeReceived;
@@ -369,7 +374,7 @@ class WebsocketConnection implements MuWebSocketSession {
             // The connection-level timeout closes the transport immediately after this
             // method returns. Publish the terminal state before the callback so default
             // implementations do not try to write a close frame to that closed transport.
-            state = WebsocketSessionState.TIMED_OUT;
+            lifecycle.terminateWith(WebsocketSessionState.TIMED_OUT);
             enqueueApplicationEvent(() ->
                 webSocket.onError(new TimeoutException("Connection idle timeout"))
             );
@@ -448,7 +453,7 @@ class WebsocketConnection implements MuWebSocketSession {
             try {
                 webSocket.onError(cause);
             } finally {
-                state = errorState;
+                lifecycle.terminateWith(errorState);
             }
         };
     }
@@ -599,11 +604,9 @@ class WebsocketConnection implements MuWebSocketSession {
     public void close() throws IOException {
         writeLock.lock();
         try {
+            lifecycle.onServerCloseStarted();
             writeFragment((byte)0b10001000, null, 0, 0, null, null);
             if (!closeSent) {
-                if (state == WebsocketSessionState.OPEN) {
-                    state = WebsocketSessionState.SERVER_CLOSING;
-                }
                 closeSent = true;
             }
         } finally {
@@ -618,9 +621,7 @@ class WebsocketConnection implements MuWebSocketSession {
         }
         writeLock.lock();
         try {
-            if (state == WebsocketSessionState.OPEN) {
-                state = WebsocketSessionState.SERVER_CLOSING;
-            }
+            lifecycle.onServerCloseStarted();
             if (reason == null || reason.isEmpty()) {
                 byte[] closeCodeBytes = new byte[2];
                 closeCodeBytes[0] = (byte) ((statusCode >> 8) & 0xFF);
@@ -729,7 +730,7 @@ class WebsocketConnection implements MuWebSocketSession {
 
     @Override
     public WebsocketSessionState state() {
-        return state;
+        return lifecycle.state();
     }
 
     @Override
@@ -742,7 +743,7 @@ class WebsocketConnection implements MuWebSocketSession {
     @Override
     public String toString() {
         return "WebsocketConnection{" +
-            "state=" + state +
+            "state=" + lifecycle.state() +
             ", remote=" + remoteAddress() +
             '}';
     }

--- a/src/main/java/io/muserver/WebsocketLifecycle.java
+++ b/src/main/java/io/muserver/WebsocketLifecycle.java
@@ -1,0 +1,77 @@
+package io.muserver;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Linearizes lifecycle transitions originating from the connection reader,
+ * application writers, and timer or error callbacks. Terminal states are
+ * monotonic so a delayed callback cannot overwrite an already completed
+ * close handshake.
+ */
+final class WebsocketLifecycle {
+    private final AtomicReference<WebsocketSessionState> state =
+        new AtomicReference<>(WebsocketSessionState.NOT_STARTED);
+
+    WebsocketSessionState state() {
+        return state.get();
+    }
+
+    void onConnected() {
+        if (!state.compareAndSet(
+            WebsocketSessionState.NOT_STARTED,
+            WebsocketSessionState.OPEN
+        )) {
+            throw new IllegalStateException(
+                "Cannot connect a WebSocket in state " + state.get()
+            );
+        }
+    }
+
+    void onClientCloseStarted() {
+        state.compareAndSet(
+            WebsocketSessionState.OPEN,
+            WebsocketSessionState.CLIENT_CLOSING
+        );
+    }
+
+    void onServerCloseStarted() {
+        state.compareAndSet(
+            WebsocketSessionState.OPEN,
+            WebsocketSessionState.SERVER_CLOSING
+        );
+    }
+
+    void onCloseHandshakeCompleted() {
+        while (true) {
+            WebsocketSessionState current = state.get();
+            WebsocketSessionState completed;
+            if (current == WebsocketSessionState.CLIENT_CLOSING) {
+                completed = WebsocketSessionState.CLIENT_CLOSED;
+            } else if (current == WebsocketSessionState.SERVER_CLOSING) {
+                completed = WebsocketSessionState.SERVER_CLOSED;
+            } else {
+                return;
+            }
+            if (state.compareAndSet(current, completed)) {
+                return;
+            }
+        }
+    }
+
+    void terminateWith(WebsocketSessionState terminalState) {
+        if (!terminalState.endState()) {
+            throw new IllegalArgumentException(
+                terminalState + " is not a terminal WebSocket state"
+            );
+        }
+        while (true) {
+            WebsocketSessionState current = state.get();
+            if (current.endState()) {
+                return;
+            }
+            if (state.compareAndSet(current, terminalState)) {
+                return;
+            }
+        }
+    }
+}

--- a/src/test/java/io/muserver/WebsocketLifecycleTest.java
+++ b/src/test/java/io/muserver/WebsocketLifecycleTest.java
@@ -1,0 +1,170 @@
+package io.muserver;
+
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Proxy;
+import java.nio.ByteBuffer;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class WebsocketLifecycleTest {
+
+    @Test
+    void serverInitiatedHandshakeCompletesCleanly() {
+        WebsocketLifecycle lifecycle = connectedLifecycle();
+
+        lifecycle.onServerCloseStarted();
+        lifecycle.onClientCloseStarted();
+        lifecycle.onCloseHandshakeCompleted();
+
+        assertThat(
+            lifecycle.state(),
+            is(WebsocketSessionState.SERVER_CLOSED)
+        );
+    }
+
+    @Test
+    void clientInitiatedHandshakeCompletesCleanly() {
+        WebsocketLifecycle lifecycle = connectedLifecycle();
+
+        lifecycle.onClientCloseStarted();
+        lifecycle.onServerCloseStarted();
+        lifecycle.onCloseHandshakeCompleted();
+
+        assertThat(
+            lifecycle.state(),
+            is(WebsocketSessionState.CLIENT_CLOSED)
+        );
+    }
+
+    @Test
+    void delayedFailureCannotOverwriteCleanClose() {
+        WebsocketLifecycle lifecycle = connectedLifecycle();
+        lifecycle.onServerCloseStarted();
+        lifecycle.onCloseHandshakeCompleted();
+
+        lifecycle.terminateWith(WebsocketSessionState.ERRORED);
+
+        assertThat(
+            lifecycle.state(),
+            is(WebsocketSessionState.SERVER_CLOSED)
+        );
+    }
+
+    @Test
+    void firstTerminalFailureWins() {
+        WebsocketLifecycle lifecycle = connectedLifecycle();
+
+        lifecycle.terminateWith(WebsocketSessionState.TIMED_OUT);
+        lifecycle.terminateWith(WebsocketSessionState.ERRORED);
+
+        assertThat(
+            lifecycle.state(),
+            is(WebsocketSessionState.TIMED_OUT)
+        );
+    }
+
+    @Test
+    void nonTerminalFailureStateIsRejected() {
+        WebsocketLifecycle lifecycle = connectedLifecycle();
+
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> lifecycle.terminateWith(WebsocketSessionState.OPEN)
+        );
+    }
+
+    @Test
+    void baseImplementationsDoNotReplyAgainWhileServerCloseIsInFlight()
+        throws Exception {
+        assertCloseReplyCount(emptySimpleWebSocket(), 0);
+        assertCloseReplyCount(emptyBaseWebSocket(), 0);
+    }
+
+    @Test
+    void baseImplementationsReplyToClientInitiatedClose() throws Exception {
+        assertCloseReplyCount(
+            emptySimpleWebSocket(),
+            WebsocketSessionState.CLIENT_CLOSING,
+            1
+        );
+        assertCloseReplyCount(
+            emptyBaseWebSocket(),
+            WebsocketSessionState.CLIENT_CLOSING,
+            1
+        );
+    }
+
+    private static WebsocketLifecycle connectedLifecycle() {
+        WebsocketLifecycle lifecycle = new WebsocketLifecycle();
+        lifecycle.onConnected();
+        return lifecycle;
+    }
+
+    private static MuWebSocket emptySimpleWebSocket() {
+        return new SimpleWebSocket() {
+            @Override
+            public void onText(String message) {
+            }
+
+            @Override
+            public void onBinary(ByteBuffer payload) {
+            }
+        };
+    }
+
+    private static MuWebSocket emptyBaseWebSocket() {
+        return new BaseWebSocket() {
+            @Override
+            public void onText(String message) {
+            }
+
+            @Override
+            public void onBinary(ByteBuffer payload) {
+            }
+        };
+    }
+
+    private static void assertCloseReplyCount(
+        MuWebSocket webSocket,
+        int expectedReplies
+    ) throws Exception {
+        assertCloseReplyCount(
+            webSocket,
+            WebsocketSessionState.SERVER_CLOSING,
+            expectedReplies
+        );
+    }
+
+    private static void assertCloseReplyCount(
+        MuWebSocket webSocket,
+        WebsocketSessionState state,
+        int expectedReplies
+    ) throws Exception {
+        AtomicInteger replies = new AtomicInteger();
+        MuWebSocketSession session = (MuWebSocketSession) Proxy.newProxyInstance(
+            WebsocketLifecycleTest.class.getClassLoader(),
+            new Class<?>[]{MuWebSocketSession.class},
+            (proxy, method, args) -> {
+                if (method.getName().equals("state")) {
+                    return state;
+                }
+                if (method.getName().equals("closeSent")) {
+                    return false;
+                }
+                if (method.getName().equals("close")) {
+                    replies.incrementAndGet();
+                }
+                return null;
+            }
+        );
+        webSocket.onConnect(session);
+
+        webSocket.onClientClosed(1001, "closing");
+
+        assertThat(replies.get(), is(expectedReplies));
+    }
+}


### PR DESCRIPTION
Stacked on #182.

The Java 11 job on #181 exposed a real shutdown race: the server parsed the peer close frame, but the session later ended as ERRORED rather than SERVER_CLOSED. The close-sent flags and lifecycle state were being read and written by the connection reader, application writers, and callback workers without one transition owner.

This adds a small atomic WebSocket lifecycle owner. Closing-handshake transitions are linearized, terminal states are monotonic, and public close-sent/received observations are safely published. The frame write remains serialized by the existing write lock. Default WebSocket adapters now distinguish an in-flight server close from a client-initiated close, so a fast peer response cannot cause a duplicate close write.

This follows RFC 6455 sections 7.1.2 through 7.1.4: either close frame starts CLOSING, and receiving the peer close after our close completes the clean closing handshake.

Tests cover both close initiators, delayed errors after clean closure, terminal-state monotonicity, and adapter behavior while the server close is still in flight. Both server-close integration tests passed 25 fresh-connection repetitions each.

Validation:
- Java 11 full suite: 1,705 tests, 0 failures/errors, 5 skipped
- Java 21 NullAway/Error Prone compile
- focused WebSocket and execution-domain suites
- 50 fresh-connection server-close stress cases
- git diff --check