### PR TITLE
Return flow-control credit for padding-only DATA

### DIFF
--- a/src/main/java/io/muserver/Http2BodyInputStream.java
+++ b/src/main/java/io/muserver/Http2BodyInputStream.java
@@ -165,7 +165,18 @@ class Http2BodyInputStream extends InputStream implements RequestTrailersAccesso
                 if (dataFrame.endStream()) {
                     requestBodyComplete = true;
                 }
-            } else if (dataFrame.payloadLength() > 0 || dataFrame.endStream()) {
+            } else if (dataFrame.payloadLength() == 0) {
+                // RFC 9113 Section 6.9.1 counts the complete DATA payload,
+                // including the Pad Length field and padding, against flow
+                // control. There are no application bytes to retain in this
+                // case, so all of that capacity is reusable immediately.
+                discardedCredit = flowControlSize;
+                if (dataFrame.endStream()) {
+                    requestBodyComplete = true;
+                    frames.add(END_OF_STREAM);
+                    hasData.signal();
+                }
+            } else {
                 frames.add(new PendingDataFrame(dataFrame, flowControlSize));
                 if (dataFrame.endStream()) {
                     requestBodyComplete = true;

--- a/src/test/java/io/muserver/Http2BodyInputStreamTest.java
+++ b/src/test/java/io/muserver/Http2BodyInputStreamTest.java
@@ -156,6 +156,31 @@ class Http2BodyInputStreamTest {
         }
     }
 
+    @Test
+    void paddingOnlyDataReturnsFlowControlCreditImmediately() throws Exception {
+        var callbackValue = new AtomicLong();
+
+        try (var stream = new Http2BodyInputStream(10000, callbackValue::addAndGet, credit -> {})) {
+            stream.onData(data("", false), 8);
+
+            assertThat(callbackValue.get(), equalTo(8L));
+            assertThat(stream.isRequestBodyComplete(), equalTo(false));
+        }
+    }
+
+    @Test
+    void paddingOnlyEndStreamReturnsCreditAndPublishesEof() throws Exception {
+        var callbackValue = new AtomicLong();
+
+        try (var stream = new Http2BodyInputStream(10000, callbackValue::addAndGet, credit -> {})) {
+            stream.onData(data("", true), 8);
+
+            assertThat(callbackValue.get(), equalTo(8L));
+            assertThat(stream.read(), equalTo(-1));
+            assertThat(stream.isRequestBodyComplete(), equalTo(true));
+        }
+    }
+
     @ParameterizedTest
     @ValueSource(ints = {1, 2, 4})
     void unreadQueuedDataIsRefundedOnCancel(int firstReadSize) throws Exception {

--- a/src/test/java/io/muserver/RFC9113_6_1_DataFrameTest.java
+++ b/src/test/java/io/muserver/RFC9113_6_1_DataFrameTest.java
@@ -219,6 +219,42 @@ class RFC9113_6_1_DataFrameTest {
     }
 
     @Test
+    void paddingOnlyDataReturnsCreditBeforeApplicationDataArrives() throws Exception {
+        server = httpsServer()
+            .withHttp2Config(Http2ConfigBuilder.http2Enabled().withInitialWindowSize(8))
+            .addHandler(Method.POST, "/hello", (request, response, pathParams) -> {
+                response.write(request.readBodyAsString());
+            })
+            .start();
+
+        try (var client = new H2Client();
+             var con = client.connect(server)) {
+
+            con.handshake()
+                .writeFrame(new Http2HeadersFrame(1, false, postHelloHeaders(getPort())))
+                .writeRaw(RFCTestUtils.paddedDataFrame(1, false, new byte[0], 7))
+                .flush();
+
+            assertThat(con.readLogicalFrame(), equalTo(new Http2WindowUpdate(1, 8)));
+
+            con.writeFrame(new Http2DataFrame(
+                    1,
+                    true,
+                    "Goodbye!".getBytes(StandardCharsets.UTF_8),
+                    0,
+                    8
+                ))
+                .flush();
+
+            var headers = readIgnoringWindowUpdates(con, Http2HeadersFrame.class);
+            assertThat(headers.streamId(), equalTo(1));
+            assertThat(headers.headers().get(":status"), equalTo("200"));
+            assertThat(readIgnoringWindowUpdates(con, Http2DataFrame.class).toUTF8(), equalTo("Goodbye!"));
+            assertThat(readIgnoringWindowUpdates(con, Http2DataFrame.class).endStream(), equalTo(true));
+        }
+    }
+
+    @Test
     void invalidPaddingOnALiveConnectionIsAConnectionError() throws Exception {
         server = httpsServer()
             .withHttp2Config(Http2ConfigBuilder.http2Enabled())


### PR DESCRIPTION
## Summary
- return flow-control credit immediately when a DATA frame contains padding but no application bytes
- publish EOF for a padding-only END_STREAM without retaining a synthetic data frame
- prove stream progress after padding exhausts the advertised receive window

RFC 9113 Section 6.1 says the entire DATA payload, including Pad Length and padding, is included in flow control. Padding has no application semantic value, so its receive capacity is reusable as soon as the frame is parsed.

Stacked on #183.

## Validation
- `mise exec java@temurin-11 maven@3.9.16 -- mvn -q -Dtest=Http2BodyInputStreamTest,RFC9113_6_1_DataFrameTest test`
- `mise exec java@temurin-21 maven@3.9.16 -- mvn -q -DskipTests compile`
- `git diff --check`