### PR TITLE
Bound HTTP/2 field block accumulation

### DIFF
--- a/src/main/java/io/muserver/Http2Connection.java
+++ b/src/main/java/io/muserver/Http2Connection.java
@@ -699,7 +699,11 @@ class Http2Connection extends BaseHttpConnection implements Http2Peer {
             // started, so no ACK can race this registration.
             registerInitialSettingsAck();
 
-            var fieldBlockDecoder = new FieldBlockDecoder(new HpackTable(serverSettings.headerTableSize), server.maxUrlSize(), server.maxRequestHeadersSize());
+            var fieldBlockDecoder = new FieldBlockDecoder(
+                new HpackTable(serverSettings.headerTableSize),
+                server.maxUrlSize(),
+                serverSettings.maxHeaderListSize
+            );
             writeEndedFuture = startWriteLoop(clientOut);
 
             // and now just read frames
@@ -1014,7 +1018,7 @@ class Http2Connection extends BaseHttpConnection implements Http2Peer {
                 buffer,
                 clientIn,
                 Math.max(
-                    server.maxRequestHeadersSize(),
+                    serverSettings.maxHeaderListSize,
                     serverSettings.maxFrameSize
                 )
             );

--- a/src/main/java/io/muserver/Http2Connection.java
+++ b/src/main/java/io/muserver/Http2Connection.java
@@ -1008,7 +1008,16 @@ class Http2Connection extends BaseHttpConnection implements Http2Peer {
             throw Http2Exception.connection(Http2ErrorCode.PROTOCOL_ERROR, "Invalid stream ID " + fh.streamId());
         }
         try {
-            var headerFragment = Http2HeadersFrame.readLogicalFrame(fh, fieldBlockDecoder, buffer, clientIn);
+            var headerFragment = Http2HeadersFrame.readLogicalFrame(
+                fh,
+                fieldBlockDecoder,
+                buffer,
+                clientIn,
+                Math.max(
+                    server.maxRequestHeadersSize(),
+                    serverSettings.maxFrameSize
+                )
+            );
             log.info("Got headers " + headerFragment);
             Http2StreamRegistry.Lookup registered =
                 streamRegistry.lookup(headerFragment.streamId());

--- a/src/main/java/io/muserver/Http2HeadersFrame.java
+++ b/src/main/java/io/muserver/Http2HeadersFrame.java
@@ -34,6 +34,27 @@ class Http2HeadersFrame implements LogicalHttp2Frame {
      * @throws IOException if there is an error reading from the client input during processing
      */
     static Http2HeadersFrame readLogicalFrame(Http2FrameHeader frameHeader, FieldBlockDecoder fieldBlockDecoder, ByteBuffer buffer, InputStream clientIn) throws HttpException, Http2Exception, IOException {
+        return readLogicalFrame(
+            frameHeader,
+            fieldBlockDecoder,
+            buffer,
+            clientIn,
+            Integer.MAX_VALUE
+        );
+    }
+
+    static Http2HeadersFrame readLogicalFrame(
+        Http2FrameHeader frameHeader,
+        FieldBlockDecoder fieldBlockDecoder,
+        ByteBuffer buffer,
+        InputStream clientIn,
+        int maxBufferedFieldBlockSize
+    ) throws HttpException, Http2Exception, IOException {
+        if (maxBufferedFieldBlockSize < 1) {
+            throw new IllegalArgumentException(
+                "The maximum buffered field block size must be positive"
+            );
+        }
         // figure out the fields
         var priority = (frameHeader.flags() & 0b00100000) > 0;
         var padded = (frameHeader.flags() & 0b00001000) > 0;
@@ -94,7 +115,17 @@ class Http2HeadersFrame implements LogicalHttp2Frame {
                 headers = new FieldBlock();
             }
         } else {
-            baos = new NiceByteArrayOutputStream(Math.max(32, hpackLength * 2));
+            requireFieldBlockCapacity(
+                0,
+                hpackLength,
+                maxBufferedFieldBlockSize
+            );
+            baos = new NiceByteArrayOutputStream(
+                Math.min(
+                    maxBufferedFieldBlockSize,
+                    Math.max(32, hpackLength)
+                )
+            );
             if (hpackLength > 0) {
                 if (buffer.hasArray()) {
                     baos.write(buffer.array(), buffer.arrayOffset() + buffer.position(), hpackLength);
@@ -119,13 +150,26 @@ class Http2HeadersFrame implements LogicalHttp2Frame {
                 if (hf.frameType() != Http2FrameType.CONTINUATION) {
                     throw new Http2Exception(Http2ErrorCode.PROTOCOL_ERROR, "invalid frame type: expected CONTINUATION");
                 }
-                Mutils.readAtLeast(buffer, clientIn, hf.length());
-                var cf = Http2ContinuationFrame.readFrom(hf, buffer);
-                if (cf.streamId() != frameHeader.streamId()) {
+                if (hf.streamId() != frameHeader.streamId()) {
                     throw new Http2Exception(Http2ErrorCode.PROTOCOL_ERROR, "stream id mismatch");
                 }
-                baos.write(cf.fragment());
-                ended = cf.endHeaders();
+                requireFieldBlockCapacity(
+                    baos.size(),
+                    hf.length(),
+                    maxBufferedFieldBlockSize
+                );
+                Mutils.readAtLeast(buffer, clientIn, hf.length());
+                if (buffer.hasArray()) {
+                    baos.write(
+                        buffer.array(),
+                        buffer.arrayOffset() + buffer.position(),
+                        hf.length()
+                    );
+                    buffer.position(buffer.position() + hf.length());
+                } else {
+                    throw new IllegalStateException("Not supported");
+                }
+                ended = (hf.flags() & 0b00000100) > 0;
             }
             try {
                 headers = fieldBlockDecoder.decodeFrom(baos.toByteBuffer());
@@ -143,6 +187,22 @@ class Http2HeadersFrame implements LogicalHttp2Frame {
         }
 
         return new Http2HeadersFrame(frameHeader.streamId(), endStream, java.util.Objects.requireNonNull(headers));
+    }
+
+    private static void requireFieldBlockCapacity(
+        int currentSize,
+        int fragmentSize,
+        int maximumSize
+    ) throws Http2Exception {
+        if (fragmentSize > maximumSize - currentSize) {
+            // RFC 9113 Sections 4.3 and 10.5.1 require either processing the
+            // complete field block or closing the connection. Closing bounds
+            // memory without leaving the shared HPACK context inconsistent.
+            throw Http2Exception.connection(
+                Http2ErrorCode.COMPRESSION_ERROR,
+                "Encoded field block exceeds the configured buffering limit"
+            );
+        }
     }
 
     @Override

--- a/src/test/java/io/muserver/Http2HeaderFragmentTest.java
+++ b/src/test/java/io/muserver/Http2HeaderFragmentTest.java
@@ -12,6 +12,7 @@ import java.nio.ByteBuffer;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class Http2HeaderFragmentTest {
 
@@ -65,6 +66,42 @@ public class Http2HeaderFragmentTest {
         assertThat(headers.endStream(), equalTo(true));
         assertThat(headers.headers().get(":method"), equalTo("GET"));
         assertThat(headers.headers().get(":path"), equalTo("/hello"));
+    }
+
+    @Test
+    void continuationAccumulationIsBoundedBeforeTheNextFragmentIsRetained() {
+        var frameHeader = new Http2FrameHeader(
+            5,
+            Http2FrameType.HEADERS,
+            0b00000001,
+            1
+        );
+        ByteBuffer firstFragment = ByteBuffer.allocate(32);
+        firstFragment.put(
+            new byte[]{(byte) 0x82, (byte) 0x87, (byte) 0x84, (byte) 0x81, (byte) 0x90}
+        );
+        firstFragment.flip();
+        var continuation = new ByteArrayInputStream(
+            RFCTestUtils.continuationFrame(
+                1,
+                true,
+                new byte[]{(byte) 0x90, (byte) 0x90}
+            )
+        );
+
+        var failure = assertThrows(
+            Http2Exception.class,
+            () -> Http2HeadersFrame.readLogicalFrame(
+                frameHeader,
+                getFieldBlockDecoder(),
+                firstFragment,
+                continuation,
+                6
+            )
+        );
+
+        assertThat(failure.errorType(), equalTo(Http2Level.CONNECTION));
+        assertThat(failure.errorCode(), equalTo(Http2ErrorCode.COMPRESSION_ERROR));
     }
 
     @Test

--- a/src/test/java/io/muserver/RFC9113_6_10_ContinuationTest.java
+++ b/src/test/java/io/muserver/RFC9113_6_10_ContinuationTest.java
@@ -86,6 +86,29 @@ class RFC9113_6_10_ContinuationTest {
         }
     }
 
+    @Test
+    void aContinuationSequenceCannotGrowTheFieldBlockWithoutBound() throws Exception {
+        server = httpsServer()
+            .withHttp2Config(Http2ConfigBuilder.http2Enabled())
+            .start();
+        try (var client = new H2Client();
+             var con = client.connect(server)) {
+            byte[] fullFrame = new byte[16384];
+            Arrays.fill(fullFrame, (byte) 0x82);
+
+            con.handshake()
+                .writeRaw(headersFrame(1, true, false, fullFrame))
+                .writeRaw(continuationFrame(1, true, new byte[]{(byte) 0x82}))
+                .flush();
+
+            assertThat(
+                con.readLogicalFrame(),
+                equalTo(goAway(0, Http2ErrorCode.COMPRESSION_ERROR))
+            );
+            assertThrows(IOException.class, con::readFrameHeader);
+        }
+    }
+
     private byte[] priorityFrame(int streamId) {
         return new byte[] {
             0, 0, 5,

--- a/src/test/java/io/muserver/RFC9113_6_10_ContinuationTest.java
+++ b/src/test/java/io/muserver/RFC9113_6_10_ContinuationTest.java
@@ -89,7 +89,10 @@ class RFC9113_6_10_ContinuationTest {
     @Test
     void aContinuationSequenceCannotGrowTheFieldBlockWithoutBound() throws Exception {
         server = httpsServer()
-            .withHttp2Config(Http2ConfigBuilder.http2Enabled())
+            .withMaxHeadersSize(65536)
+            .withHttp2Config(
+                Http2ConfigBuilder.http2Enabled().withMaxHeaderListSize(512)
+            )
             .start();
         try (var client = new H2Client();
              var con = client.connect(server)) {
@@ -106,6 +109,34 @@ class RFC9113_6_10_ContinuationTest {
                 equalTo(goAway(0, Http2ErrorCode.COMPRESSION_ERROR))
             );
             assertThrows(IOException.class, con::readFrameHeader);
+        }
+    }
+
+    @Test
+    void http2HeaderLimitCanExceedTheServerWideLimit() throws Exception {
+        server = httpsServer()
+            .withMaxHeadersSize(128)
+            .withHttp2Config(
+                Http2ConfigBuilder.http2Enabled().withMaxHeaderListSize(512)
+            )
+            .addHandler(
+                Method.GET,
+                "/hello",
+                (request, response, pathParams) -> response.status(202)
+            )
+            .start();
+        try (var client = new H2Client();
+             var con = client.connect(server)) {
+            var headers = getHelloHeaders(getPort());
+            headers.add("x-large-for-http1", "x".repeat(200));
+
+            con.handshake()
+                .writeFrame(new Http2HeadersFrame(1, true, headers))
+                .flush();
+
+            var response = con.readLogicalFrame(Http2HeadersFrame.class);
+            assertThat(response.streamId(), equalTo(1));
+            assertThat(response.headers().get(":status"), equalTo("202"));
         }
     }
 


### PR DESCRIPTION
## Summary
- cap reassembled HTTP/2 field blocks at the larger of one accepted frame and the configured request-header budget
- close with `COMPRESSION_ERROR` before retaining a fragment that would exceed the cap, preserving HPACK consistency by ending the connection
- copy CONTINUATION fragments directly from the fixed connection buffer instead of allocating a temporary array per frame
- cover the bound both at the parser boundary and over a live HTTP/2 connection

RFC 9113 Sections 4.3 and 10.5.1 require a field block to be fully decompressed to keep shared compression state consistent unless the connection is closed. This uses that permitted close path to prevent unbounded CONTINUATION accumulation.

Stacked on #184.

## Validation
- full Java 11 test suite: `mise exec java@temurin-11 maven@3.9.16 -- mvn -q test`
- focused Java 11 parser/RFC tests: `mise exec java@temurin-11 maven@3.9.16 -- mvn -q -Dtest=Http2HeaderFragmentTest,RFC9113_6_10_ContinuationTest,RFC9113_6_2_HeadersTest test`
- Java 21 strict compile: `mise exec java@temurin-21 maven@3.9.16 -- mvn -q -DskipTests compile`
- `git diff --check`