### PR TITLE
Reject truncated HPACK field blocks

### DIFF
--- a/src/main/java/io/muserver/FieldBlockDecoder.java
+++ b/src/main/java/io/muserver/FieldBlockDecoder.java
@@ -1,5 +1,6 @@
 package io.muserver;
 
+import java.nio.BufferUnderflowException;
 import java.nio.ByteBuffer;
 
 class FieldBlockDecoder {
@@ -17,6 +18,18 @@ class FieldBlockDecoder {
     }
 
     FieldBlock decodeFrom(ByteBuffer buffer) throws HttpException, Http2Exception {
+        try {
+            return decodeCompleteBlock(buffer);
+        } catch (BufferUnderflowException truncated) {
+            throw new Http2Exception(
+                Http2ErrorCode.COMPRESSION_ERROR,
+                "truncated HPACK field block"
+            );
+        }
+    }
+
+    private FieldBlock decodeCompleteBlock(ByteBuffer buffer)
+        throws HttpException, Http2Exception {
         var fb = new FieldBlock();
         int totalLen = 0;
         int uriLen = 0;
@@ -121,6 +134,12 @@ class FieldBlockDecoder {
         int B;
         do {
             // B = next octet
+            if (!buffer.hasRemaining()) {
+                throw new Http2Exception(
+                    Http2ErrorCode.COMPRESSION_ERROR,
+                    "truncated HPACK integer"
+                );
+            }
             B = buffer.get() & 0xFF;
 
             // I = I + (B & 127) * 2^M
@@ -136,8 +155,20 @@ class FieldBlockDecoder {
     }
 
     private static HeaderString readHeaderString(ByteBuffer buffer, HeaderString.Type type) throws Http2Exception {
+        if (!buffer.hasRemaining()) {
+            throw new Http2Exception(
+                Http2ErrorCode.COMPRESSION_ERROR,
+                "missing HPACK string length"
+            );
+        }
         byte decl = buffer.get();
         int codeLen = readHpackInt(7, decl, buffer);
+        if (codeLen > buffer.remaining()) {
+            throw new Http2Exception(
+                Http2ErrorCode.COMPRESSION_ERROR,
+                "HPACK string exceeds the field block"
+            );
+        }
         if ((decl & 0b10000000) > 0) {
             return HuffmanDecoder.decodeFrom(buffer, codeLen, type);
         } else {

--- a/src/main/java/io/muserver/HuffmanDecoder.java
+++ b/src/main/java/io/muserver/HuffmanDecoder.java
@@ -7,6 +7,12 @@ import java.nio.ByteBuffer;
 class HuffmanDecoder {
 
     static HeaderString decodeFrom(ByteBuffer bb, int len, HeaderString.Type type) throws Http2Exception {
+        if (len < 0 || len > bb.remaining()) {
+            throw new Http2Exception(
+                Http2ErrorCode.COMPRESSION_ERROR,
+                "Huffman string exceeds the field block"
+            );
+        }
         var sb = new StringBuilder();
         var node = root;
         int bitsSinceLastSymbol = 0;

--- a/src/test/java/io/muserver/FieldBlockDecoderTest.java
+++ b/src/test/java/io/muserver/FieldBlockDecoderTest.java
@@ -77,6 +77,36 @@ class FieldBlockDecoderTest {
     }
 
     @Test
+    void truncatedHpackIntegersAreCompressionErrors() {
+        var ex = assertThrows(
+            Http2Exception.class,
+            () -> readHpackInt(7, (byte) 0xff, ByteBuffer.allocate(0))
+        );
+
+        assertThat(ex.errorType(), equalTo(Http2Level.CONNECTION));
+        assertThat(ex.errorCode(), equalTo(Http2ErrorCode.COMPRESSION_ERROR));
+    }
+
+    @Test
+    void truncatedLiteralFieldsAreCompressionErrors() {
+        byte[][] malformedBlocks = {
+            {0x00},
+            {0x00, 0x05, 'a'},
+            {0x01},
+            {0x01, (byte) 0x85, 'a'}
+        };
+
+        for (byte[] malformedBlock : malformedBlocks) {
+            var ex = assertThrows(
+                Http2Exception.class,
+                () -> decoder.decodeFrom(ByteBuffer.wrap(malformedBlock))
+            );
+            assertThat(ex.errorType(), equalTo(Http2Level.CONNECTION));
+            assertThat(ex.errorCode(), equalTo(Http2ErrorCode.COMPRESSION_ERROR));
+        }
+    }
+
+    @Test
     public void integerMaxValueIsMaxValue() throws Http2Exception {
         assertThat(readHpackInt(5, (byte) 31, buffed((byte) 224, (byte) 255, (byte) 255, (byte) 255, (byte) 7)), equalTo(Integer.MAX_VALUE));
 

--- a/src/test/java/io/muserver/RFC9113_7_ErrorCodesTest.java
+++ b/src/test/java/io/muserver/RFC9113_7_ErrorCodesTest.java
@@ -153,6 +153,27 @@ class RFC9113_7_ErrorCodesTest {
         }
     }
 
+    @Test
+    void truncatedCompressionBlocksBecomeConnectionErrors() throws Exception {
+        server = httpsServer()
+            .withHttp2Config(Http2ConfigBuilder.http2Enabled())
+            .start();
+
+        try (var client = new H2Client();
+             var con = client.connect(server)) {
+
+            con.handshake()
+                .writeRaw(headersFrame(1, true, true, new byte[]{0x00}))
+                .flush();
+
+            assertThat(
+                con.readLogicalFrame(),
+                equalTo(goAway(0, Http2ErrorCode.COMPRESSION_ERROR))
+            );
+            assertThrows(IOException.class, con::readFrameHeader);
+        }
+    }
+
     private int getPort() {
         return server.uri().getPort();
     }
@@ -162,7 +183,6 @@ class RFC9113_7_ErrorCodesTest {
         if (server != null) server.stop();
     }
 }
-
 
 
 


### PR DESCRIPTION
## Summary
- translate truncated HPACK integers and strings into connection-level `COMPRESSION_ERROR` results
- validate declared string lengths before allocation or Huffman decoding
- retain a defensive decoder-boundary translation for malformed buffer exhaustion
- prove a live HTTP/2 connection emits GOAWAY rather than losing its reader task to `BufferUnderflowException`

RFC 9113 Section 4.3 requires field-block decoding errors to be treated as connection errors of type `COMPRESSION_ERROR`.

Stacked on #185.

## Validation
- `mise exec java@temurin-11 maven@3.9.16 -- mvn -q -Dtest=FieldBlockDecoderTest,RFC7541_5_1_IntegerRepresentationTest,RFC7541_5_2_StringLiteralRepresentationTest,RFC9113_7_ErrorCodesTest test`
- `mise exec java@temurin-21 maven@3.9.16 -- mvn -q -DskipTests compile`
- `git diff --check`

The parent #185 ran the full Java 11 suite before this isolated decoder increment.