### PR TITLE
Reject oversized HPACK integers

### DIFF
--- a/src/main/java/io/muserver/FieldBlockDecoder.java
+++ b/src/main/java/io/muserver/FieldBlockDecoder.java
@@ -128,7 +128,8 @@ class FieldBlockDecoder {
             return I;
         }
 
-        var M = 0;
+        int shift = 0;
+        long value = I;
 
         // repeat
         int B;
@@ -143,15 +144,23 @@ class FieldBlockDecoder {
             B = buffer.get() & 0xFF;
 
             // I = I + (B & 127) * 2^M
-            I = I + ((B & 127) * (1 << M));
-            if (I < 0) {
+            value += (long) (B & 127) << shift;
+            if (value > Integer.MAX_VALUE) {
                 throw new Http2Exception(Http2ErrorCode.COMPRESSION_ERROR, "hpack integer overflow");
             }
 
-            M = M + 7;
-            if (M > 80) throw new Http2Exception(Http2ErrorCode.COMPRESSION_ERROR, "hpack integer too long");
+            shift += 7;
+            if (shift >= 35 && (B & 128) == 128) {
+                // Five continuation octets can represent every non-negative
+                // Java int. RFC 7541 Section 5.1 requires encodings beyond an
+                // implementation's value or octet-length limit to fail.
+                throw new Http2Exception(
+                    Http2ErrorCode.COMPRESSION_ERROR,
+                    "hpack integer too long"
+                );
+            }
         } while ((B & 128) == 128);
-        return I;
+        return (int) value;
     }
 
     private static HeaderString readHeaderString(ByteBuffer buffer, HeaderString.Type type) throws Http2Exception {

--- a/src/test/java/io/muserver/FieldBlockDecoderTest.java
+++ b/src/test/java/io/muserver/FieldBlockDecoderTest.java
@@ -117,6 +117,29 @@ class FieldBlockDecoderTest {
     }
 
     @Test
+    void shiftsBeyondAnIntegerDoNotWrapIntoAnAcceptedValue() {
+        var ex = assertThrows(
+            Http2Exception.class,
+            () -> readHpackInt(
+                7,
+                (byte) 0x7f,
+                buffed(
+                    (byte) 0x80,
+                    (byte) 0x80,
+                    (byte) 0x80,
+                    (byte) 0x80,
+                    (byte) 0x80,
+                    (byte) 0x01
+                )
+            )
+        );
+
+        assertThat(ex.errorType(), equalTo(Http2Level.CONNECTION));
+        assertThat(ex.errorCode(), equalTo(Http2ErrorCode.COMPRESSION_ERROR));
+        assertThat(ex.getMessage(), equalTo("hpack integer too long"));
+    }
+
+    @Test
     public void rfc7541_c_3_Request_Examples_without_Huffman_Coding() throws Exception {
         /*
            C.3.1.  First Request


### PR DESCRIPTION
## Summary
- decode HPACK integer continuations with non-wrapping `long` arithmetic
- reject values above `Integer.MAX_VALUE` and encodings longer than the five continuation octets needed for any accepted value
- cover the previous Java shift-wrap case directly

RFC 7541 Section 5.1 says integer encodings that exceed implementation limits in value or octet length MUST be treated as decoding errors.

Stacked on #186.

## Validation
- focused Java 11 HPACK suite: `mise exec java@temurin-11 maven@3.9.16 -- mvn -q -Dtest=FieldBlockDecoderTest,RFC7541_5_1_IntegerRepresentationTest,RFC7541_6_1_IndexedHeaderFieldRepresentationTest,RFC7541_6_2_1_LiteralHeaderFieldWithIncrementalIndexingTest,RFC7541_6_2_2_LiteralHeaderFieldWithoutIndexingTest,RFC7541_6_2_3_LiteralHeaderFieldNeverIndexedTest,RFC7541_6_3_DynamicTableSizeUpdateTest test`
- Java 21 strict compile: `mise exec java@temurin-21 maven@3.9.16 -- mvn -q -DskipTests compile`
- `git diff --check`