### PR TITLE
Keep HPACK sensitivity on field lines

### DIFF
--- a/src/main/java/io/muserver/FieldBlock.java
+++ b/src/main/java/io/muserver/FieldBlock.java
@@ -214,14 +214,14 @@ class FieldBlock implements Headers, Iterable<Map.Entry<String, String>> {
 
     @Override
     public String toString(@Nullable Collection<String> toSuppress) {
-        // TODO keep track of what to suppress based on never-index in the hpack
         var sup = toSuppress == null ? Set.of("authorization", "cookie", "set-cookie") : toSuppress;
         var sb = new StringBuilder("HttpHeaders[");
         var first = true;
         for (var line : lines) {
             if (!first) sb.append(", ");
             var name = line.name().toString();
-            var suppress = sup.stream().anyMatch(v -> v.equalsIgnoreCase(name));
+            var suppress = (toSuppress == null && line.neverIndexed())
+                || sup.stream().anyMatch(v -> v.equalsIgnoreCase(name));
             String value = suppress ? "(hidden)" : line.value().toString();
             sb.append(name).append(": ").append(value);
             first = false;

--- a/src/main/java/io/muserver/FieldBlockDecoder.java
+++ b/src/main/java/io/muserver/FieldBlockDecoder.java
@@ -90,12 +90,9 @@ class FieldBlockDecoder {
 
                     totalLen += name.length() + value.length();
 
-                    var line = new FieldLine(name, value);
+                    var line = new FieldLine(name, value, litNever);
                     if (totalLen <= maxHeadersSize) {
                         fb.add(line);
-                        if (litNever) {
-                            table.neverIndex(line);
-                        }
                     }
                     if (litWith) {
                         table.indexField(line);

--- a/src/main/java/io/muserver/FieldBlockEncoder.java
+++ b/src/main/java/io/muserver/FieldBlockEncoder.java
@@ -16,12 +16,12 @@ class FieldBlockEncoder {
     void encodeTo(FieldBlock block, OutputStream out) throws IOException {
         writePendingTableSizeChanges(out);
         for (FieldLine line : block.lineIterator()) {
-            int lineCode = table.codeFor(line);
+            int lineCode = line.neverIndexed() ? -1 : table.codeFor(line);
             if (lineCode > 0) {
                 // indexed name and value
                 writeHpackInt(7, (byte)0b10000000, out, lineCode);
             } else {
-                int designation = table.isNeverIndex(line) ? 0b00010000 : 0b00000000;
+                int designation = line.neverIndexed() ? 0b00010000 : 0b00000000;
                 int headerCode = table.codeFor(line.name());
                 if (headerCode >= 0) {
                     // indexed name; literal value

--- a/src/main/java/io/muserver/FieldLine.java
+++ b/src/main/java/io/muserver/FieldLine.java
@@ -9,10 +9,16 @@ class FieldLine implements Map.Entry<String,String> {
 
     private final HeaderString name;
     private final HeaderString value;
+    private final boolean neverIndexed;
 
     FieldLine(HeaderString name, HeaderString value) {
+        this(name, value, false);
+    }
+
+    FieldLine(HeaderString name, HeaderString value, boolean neverIndexed) {
         this.name = name;
         this.value = value;
+        this.neverIndexed = neverIndexed;
     }
 
     int length() {
@@ -25,6 +31,10 @@ class FieldLine implements Map.Entry<String,String> {
 
     public HeaderString value() {
         return value;
+    }
+
+    boolean neverIndexed() {
+        return neverIndexed;
     }
 
     @Override
@@ -64,4 +74,3 @@ class FieldLine implements Map.Entry<String,String> {
     }
 
 }
-

--- a/src/main/java/io/muserver/HpackTable.java
+++ b/src/main/java/io/muserver/HpackTable.java
@@ -2,9 +2,7 @@ package io.muserver;
 
 import org.jspecify.annotations.Nullable;
 
-import java.util.HashSet;
 import java.util.LinkedList;
-import java.util.Set;
 
 class HpackTable {
 
@@ -83,8 +81,6 @@ class HpackTable {
      */
     private int maxSize;
 
-    private final Set<FieldLine> neverIndex = new HashSet<>();
-
     HpackTable(int maxSize) {
         this.maxSize = maxSize;
     }
@@ -157,15 +153,6 @@ class HpackTable {
     public void indexField(FieldLine line) {
         dynamicQueue.add(0, line);
         trimSize();
-    }
-
-    void neverIndex(FieldLine line) {
-        System.out.println("Never index " + line);
-        neverIndex.add(line);
-    }
-
-    boolean isNeverIndex(FieldLine line) {
-        return neverIndex.contains(line);
     }
 
     /**

--- a/src/test/java/io/muserver/RFC7541_6_2_3_LiteralHeaderFieldNeverIndexedTest.java
+++ b/src/test/java/io/muserver/RFC7541_6_2_3_LiteralHeaderFieldNeverIndexedTest.java
@@ -5,12 +5,15 @@ import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayOutputStream;
 import java.nio.ByteBuffer;
+import java.util.Collections;
 
 import static io.muserver.FieldBlockEncoderTest.bytesToHex;
 import static io.muserver.FieldBlockEncoderTest.hexToByteArray;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.not;
 
 @DisplayName("RFC 7541 6.2.3 Literal Header Field Never Indexed")
 class RFC7541_6_2_3_LiteralHeaderFieldNeverIndexedTest {
@@ -21,12 +24,20 @@ class RFC7541_6_2_3_LiteralHeaderFieldNeverIndexedTest {
         FieldBlockDecoder decoder = new FieldBlockDecoder(table, 8192, 8192 * 4);
 
         FieldBlock block = decoder.decodeFrom(ByteBuffer.wrap(hexToByteArray("100870617373776f726406736563726574")));
-        FieldLine line = fieldLine("password", "secret");
 
         assertThat(block.entries(), hasSize(1));
         assertThat(block.get("password"), equalTo("secret"));
         assertThat(table.dynamicTableSizeInBytes(), equalTo(0));
-        assertThat(table.isNeverIndex(line), equalTo(true));
+        assertThat(
+            block.lineIterator().iterator().next().neverIndexed(),
+            equalTo(true)
+        );
+        assertThat(block.toString(), not(containsString("secret")));
+        assertThat(block.toString(), containsString("password: (hidden)"));
+        assertThat(
+            block.toString(Collections.emptyList()),
+            containsString("password: secret")
+        );
     }
 
     @Test
@@ -43,8 +54,24 @@ class RFC7541_6_2_3_LiteralHeaderFieldNeverIndexedTest {
         }
     }
 
-    private static FieldLine fieldLine(String name, String value) {
-        return new FieldLine(HeaderString.valueOf(name, HeaderString.Type.HEADER), HeaderString.valueOf(value, HeaderString.Type.VALUE));
+    @Test
+    void anExactStaticTableMatchStillUsesTheNeverIndexedRepresentation()
+        throws Exception {
+        HpackTable table = new HpackTable(4096);
+        FieldBlockDecoder decoder = new FieldBlockDecoder(
+            table,
+            8192,
+            8192 * 4
+        );
+        FieldBlockEncoder encoder = new FieldBlockEncoder(table);
+
+        FieldBlock block = decoder.decodeFrom(
+            ByteBuffer.wrap(hexToByteArray("1f0800"))
+        );
+
+        try (var out = new ByteArrayOutputStream()) {
+            encoder.encodeTo(block, out);
+            assertThat(bytesToHex(out.toByteArray()), equalTo("1f0800"));
+        }
     }
 }
-


### PR DESCRIPTION
## Summary
- store the HPACK never-indexed designation on the decoded field line rather than in a connection-lifetime set
- remove unbounded retention and stdout output for unique sensitive request values
- preserve the designation when a decoded block is re-encoded, even when the name/value exactly matches the static table
- hide never-indexed values from the default header string used by diagnostics while retaining the documented explicit `toString(emptyList())` behavior

RFC 7541 Section 6.2.3 defines never-indexed as a property of the literal field representation. It does not require retaining every value in compression-table state.

Stacked on #187.

## Validation
- `mise exec java@temurin-11 maven@3.9.16 -- mvn -q -Dtest='RFC7541_*Test,FieldBlockDecoderTest,FieldBlockEncoderTest,HpackTableTest,HeadersTest' test`
- `mise exec java@temurin-21 maven@3.9.16 -- mvn -q -DskipTests compile`
- `git diff --check`