### PR TITLE
Apply HTTP/2 field section size accounting

### DIFF
--- a/src/main/java/io/muserver/FieldBlockDecoder.java
+++ b/src/main/java/io/muserver/FieldBlockDecoder.java
@@ -31,8 +31,8 @@ class FieldBlockDecoder {
     private FieldBlock decodeCompleteBlock(ByteBuffer buffer)
         throws HttpException, Http2Exception {
         var fb = new FieldBlock();
-        int totalLen = 0;
-        int uriLen = 0;
+        long totalLen = 0;
+        long uriLen = 0;
         boolean canChangeTableSize = true;
 
         while (buffer.hasRemaining()) {
@@ -46,7 +46,7 @@ class FieldBlockDecoder {
                 if (HeaderNames.PSEUDO_PATH.equals(line.name())) {
                     uriLen += line.value().length();
                 }
-                totalLen += line.length();
+                totalLen += line.hpackSize();
                 if (totalLen <= maxHeadersSize) {
                     fb.add(line);
                 }
@@ -88,9 +88,8 @@ class FieldBlockDecoder {
                         uriLen += value.length();
                     }
 
-                    totalLen += name.length() + value.length();
-
                     var line = new FieldLine(name, value, litNever);
+                    totalLen += line.hpackSize();
                     if (totalLen <= maxHeadersSize) {
                         fb.add(line);
                     }

--- a/src/main/java/io/muserver/FieldLine.java
+++ b/src/main/java/io/muserver/FieldLine.java
@@ -21,8 +21,10 @@ class FieldLine implements Map.Entry<String,String> {
         this.neverIndexed = neverIndexed;
     }
 
-    int length() {
-        return name.length() + value.length();
+    int hpackSize() {
+        // RFC 7541 section 4.1 and RFC 9113 section 6.5.2 use the same
+        // accounting: name octets + value octets + 32 octets of overhead.
+        return name.length() + value.length() + 32;
     }
 
     public HeaderString name() {

--- a/src/main/java/io/muserver/HpackTable.java
+++ b/src/main/java/io/muserver/HpackTable.java
@@ -169,7 +169,7 @@ class HpackTable {
     public int dynamicTableSizeInBytes() {
         int size = 0;
         for (FieldLine line : dynamicQueue) {
-            size += line.length() + 32;
+            size += line.hpackSize();
         }
         return size;
     }

--- a/src/test/java/io/muserver/FieldBlockDecoderTest.java
+++ b/src/test/java/io/muserver/FieldBlockDecoderTest.java
@@ -283,6 +283,26 @@ class FieldBlockDecoderTest {
     }
 
     @Test
+    void maxHeaderSizeIncludesThePerFieldOverhead() throws Exception {
+        var indexedAcceptEncoding = ByteBuffer.wrap(new byte[] {(byte) 0x90});
+        var table = new HpackTable(4096);
+        int fieldSize = table.getValue(16).hpackSize();
+
+        var exactLimit = new FieldBlockDecoder(table, 8192, fieldSize);
+        assertThat(
+            exactLimit.decodeFrom(indexedAcceptEncoding.duplicate()).get("accept-encoding"),
+            equalTo("gzip, deflate")
+        );
+
+        var belowLimit = new FieldBlockDecoder(new HpackTable(4096), 8192, fieldSize - 1);
+        var ex = assertThrows(
+            HttpException.class,
+            () -> belowLimit.decodeFrom(indexedAcceptEncoding.duplicate())
+        );
+        assertThat(ex.status(), equalTo(HttpStatus.REQUEST_HEADER_FIELDS_TOO_LARGE_431));
+    }
+
+    @Test
     void indexedHpackPathFieldsCountTowardMaxUrlSize() {
         byte[] indexedRootPaths = new byte[20];
         Arrays.fill(indexedRootPaths, (byte) 0x84); // static index 4: :path: /

--- a/src/test/java/io/muserver/RFC9113_6_2_HeadersTest.java
+++ b/src/test/java/io/muserver/RFC9113_6_2_HeadersTest.java
@@ -406,6 +406,24 @@ class RFC9113_6_2_HeadersTest {
     }
 
     @Test
+    void maxHeaderListSizeIncludesPerFieldOverhead() throws Exception {
+        server = httpsServer()
+            .withMaxHeadersSize(150)
+            .withHttp2Config(Http2ConfigBuilder.http2Enabled())
+            .start();
+
+        try (var client = new H2Client();
+             var con = client.connect(server)) {
+            con.handshake()
+                .writeFrame(new Http2HeadersFrame(1, true, getHelloHeaders(getPort())))
+                .flush();
+
+            var responseHeaders = con.readLogicalFrame(Http2HeadersFrame.class);
+            assertThat(responseHeaders.headers().get(":status"), equalTo("431"));
+        }
+    }
+
+    @Test
     void rejectedInitialHeadersDiscardTheRemainingRequestBody() throws Exception {
         server = httpsServer()
             .withMaxHeadersSize(512)


### PR DESCRIPTION
## Summary
- count the RFC-defined 32-octet overhead for every decoded HTTP/2 field line
- share the same accounting helper with HPACK dynamic-table sizing
- use overflow-safe aggregate counters and cover the exact decoder boundary plus a live HTTP/2 rejection

## Specification
RFC 9113 section 6.5.2 defines SETTINGS_MAX_FIELD_SECTION_SIZE as the uncompressed name length plus value length plus 32 octets per field line. RFC 7541 section 4.1 uses the same formula for dynamic-table entries.

## Validation
- `mise exec java@temurin-11 maven@3.9.16 -- mvn -q -Dtest=FieldBlockDecoderTest,RFC9113_6_2_HeadersTest test`
- `mise exec java@temurin-21 maven@3.9.16 -- mvn -q -DskipTests compile`
- `git diff --check`