### PR TITLE
Complete async exchanges on HTTP/2 termination

### DIFF
--- a/src/main/java/io/muserver/BaseResponse.java
+++ b/src/main/java/io/muserver/BaseResponse.java
@@ -34,8 +34,16 @@ abstract class BaseResponse implements MuResponse {
         this.headers = headers;
     }
 
-    void setState(ResponseState newState) {
+    /**
+     * Publishes a state transition. The first terminal state wins so that
+     * concurrent cleanup cannot turn a failed exchange into a successful one.
+     */
+    synchronized boolean setState(ResponseState newState) {
+        if (state.endState()) {
+            return false;
+        }
         state = newState;
+        return true;
     }
 
     @Nullable

--- a/src/main/java/io/muserver/Http1Response.java
+++ b/src/main/java/io/muserver/Http1Response.java
@@ -103,9 +103,7 @@ class Http1Response extends BaseResponse implements MuResponse, ResponseInfo {
                 out.close();
             }
         }
-        if (!responseState().endState()) {
-            setState(ResponseState.FINISHED);
-        }
+        setState(ResponseState.FINISHED);
     }
 
     @Override

--- a/src/main/java/io/muserver/Http1Response.java
+++ b/src/main/java/io/muserver/Http1Response.java
@@ -109,11 +109,14 @@ class Http1Response extends BaseResponse implements MuResponse, ResponseInfo {
     }
 
     @Override
-    void setState(ResponseState newState) {
-        super.setState(newState);
+    synchronized boolean setState(ResponseState newState) {
+        if (responseState().endState()) {
+            return false;
+        }
         if (newState.endState()) {
             endNanos = System.nanoTime();
         }
+        return super.setState(newState);
     }
 
     @Override

--- a/src/main/java/io/muserver/Http2Connection.java
+++ b/src/main/java/io/muserver/Http2Connection.java
@@ -485,7 +485,7 @@ class Http2Connection extends BaseHttpConnection implements Http2Peer {
             stateLock.unlock();
         }
         for (Http2Stream stream : streamRegistry.applicationStreams()) {
-            stream.cancel(reason, false);
+            stream.onConnectionTerminated(reason);
         }
         signalWriteLoop();
     }
@@ -830,14 +830,14 @@ class Http2Connection extends BaseHttpConnection implements Http2Peer {
                     // work triggered by cancellation is then rejected behind this command.
                     failConnection(writeTask, connectionError);
                     for (var stream : streamRegistry.applicationStreams()) {
-                        stream.cancel(connectionError, false);
+                        stream.onConnectionTerminated(connectionError);
                     }
                     writeTask.await(30, TimeUnit.SECONDS);
                     setReadStateAndSignal(HState.ERRORED);
                     writeEndedFuture.get(1, TimeUnit.MINUTES);
                 } else {
                     for (var stream : streamRegistry.applicationStreams()) {
-                        stream.cancel(connectionError, false);
+                        stream.onConnectionTerminated(connectionError);
                     }
                     goAway.writeTo(this, clientOut);
                     clientOut.flush();
@@ -1493,8 +1493,10 @@ class Http2Connection extends BaseHttpConnection implements Http2Peer {
 
     @Override
     public void abortWithTimeout() {
-        // TODO do something with this
-        abort();
+        forceShutdown(new IOException(
+            "HTTP/2 connection idle timeout exceeded",
+            new TimeoutException("Idle timeout exceeded")
+        ));
     }
 
     @Override
@@ -1509,6 +1511,10 @@ class Http2Connection extends BaseHttpConnection implements Http2Peer {
 
     @Override
     void forceShutdown() {
+        forceShutdown(new IOException("HTTP/2 connection was shut down"));
+    }
+
+    private void forceShutdown(IOException reason) {
         stateLock.lock();
         try {
             if (writeState.canSendFrames) {
@@ -1516,6 +1522,9 @@ class Http2Connection extends BaseHttpConnection implements Http2Peer {
             }
         } finally {
             stateLock.unlock();
+        }
+        for (Http2Stream stream : streamRegistry.applicationStreams()) {
+            stream.onConnectionTerminated(reason);
         }
         signalWriteLoop();
         closeSocketQuietly();

--- a/src/main/java/io/muserver/Http2Connection.java
+++ b/src/main/java/io/muserver/Http2Connection.java
@@ -683,7 +683,7 @@ class Http2Connection extends BaseHttpConnection implements Http2Peer {
             stateLock.unlock();
         }
         for (Http2Stream stream : streamRegistry.applicationStreams()) {
-            stream.cancel(reason, false);
+            stream.onConnectionTerminated(reason, ResponseState.ERRORED);
         }
         return new Http2GoAway(acceptedLastStreamId, error.errorCode().code(), null);
     }
@@ -789,22 +789,22 @@ class Http2Connection extends BaseHttpConnection implements Http2Peer {
                         stream.cancel(new IOException("Stream error", h2e));
                     }
                 } catch (EOFException e) {
-                    boolean noActiveStreams = noProtocolStreamsAreActive();
-                    if (readingFrameHeader && noActiveStreams) {
+                    boolean noActiveWork = noConnectionWorkIsActive();
+                    if (readingFrameHeader && noActiveWork) {
                         log.info("Client closed HTTP/2 connection while waiting for the next frame");
                         setReadStateIfActiveAndSignal(HState.COMPLETED);
                     } else {
                         String frameDetails = readingFrameHeader ? "frame header" : "frame payload for " + currentFrameHeader;
                         log.warn("EOF while reading {} at read state {} writeState={}", frameDetails, readState, writeState, e);
-                        if (noActiveStreams) {
+                        if (noActiveWork) {
                             setReadStateIfActiveAndSignal(HState.COMPLETED);
                         } else {
                             failAfterUnexpectedInputEnd(new IOException("Client closed an active HTTP/2 connection", e));
                         }
                     }
                 } catch (SocketException e) {
-                    boolean noActiveStreams = noProtocolStreamsAreActive();
-                    if (noActiveStreams) {
+                    boolean noActiveWork = noConnectionWorkIsActive();
+                    if (noActiveWork) {
                         log.info("Socket closed while reading HTTP/2 frames at read state {} writeState={}: {}", readState, writeState, e.getMessage());
                         setReadStateIfActiveAndSignal(HState.COMPLETED);
                     } else {
@@ -1003,8 +1003,8 @@ class Http2Connection extends BaseHttpConnection implements Http2Peer {
         }
     }
 
-    private boolean noProtocolStreamsAreActive() {
-        return !streamRegistry.hasActiveProtocolStreams();
+    private boolean noConnectionWorkIsActive() {
+        return !streamRegistry.hasActiveConnectionWork();
     }
 
     private void readHeaders(InputStream clientIn, Http2FrameHeader fh, FieldBlockDecoder fieldBlockDecoder) throws Http2Exception, IOException {

--- a/src/main/java/io/muserver/Http2Connection.java
+++ b/src/main/java/io/muserver/Http2Connection.java
@@ -1347,8 +1347,8 @@ class Http2Connection extends BaseHttpConnection implements Http2Peer {
         log.warn("Aborting accepted HTTP/2 stream because its application executors rejected completion", dispatchFailure);
         try {
             BaseResponse response = stream.response();
-            if (!stream.resetWasInitiated() && !response.responseState().endState()) {
-                response.setState(ResponseState.ERRORED);
+            if (!stream.resetWasInitiated()
+                && response.setState(ResponseState.ERRORED)) {
                 write(new Http2ResetStreamFrame(stream.id, Http2ErrorCode.INTERNAL_ERROR.code()));
                 stream.cancel(
                     new IOException("Application executors rejected HTTP/2 stream completion", dispatchFailure)
@@ -1395,8 +1395,7 @@ class Http2Connection extends BaseHttpConnection implements Http2Peer {
             log.info("Unhandled stream exception", e);
             if (stream.response().hasStartedSendingData()
                 && !stream.resetWasInitiated()
-                && !stream.response().responseState().endState()) {
-                stream.response().setState(ResponseState.ERRORED);
+                && stream.response().setState(ResponseState.ERRORED)) {
                 Http2ErrorCode errorCode =
                     e instanceof HttpException
                         && ((HttpException) e).status().sameCode(HttpStatus.REQUEST_TIMEOUT_408)

--- a/src/main/java/io/muserver/Http2Connection.java
+++ b/src/main/java/io/muserver/Http2Connection.java
@@ -485,7 +485,7 @@ class Http2Connection extends BaseHttpConnection implements Http2Peer {
             stateLock.unlock();
         }
         for (Http2Stream stream : streamRegistry.applicationStreams()) {
-            stream.onConnectionTerminated(reason);
+            stream.onConnectionTerminated(reason, ResponseState.CLIENT_DISCONNECTED);
         }
         signalWriteLoop();
     }
@@ -830,14 +830,14 @@ class Http2Connection extends BaseHttpConnection implements Http2Peer {
                     // work triggered by cancellation is then rejected behind this command.
                     failConnection(writeTask, connectionError);
                     for (var stream : streamRegistry.applicationStreams()) {
-                        stream.onConnectionTerminated(connectionError);
+                        stream.onConnectionTerminated(connectionError, ResponseState.ERRORED);
                     }
                     writeTask.await(30, TimeUnit.SECONDS);
                     setReadStateAndSignal(HState.ERRORED);
                     writeEndedFuture.get(1, TimeUnit.MINUTES);
                 } else {
                     for (var stream : streamRegistry.applicationStreams()) {
-                        stream.onConnectionTerminated(connectionError);
+                        stream.onConnectionTerminated(connectionError, ResponseState.ERRORED);
                     }
                     goAway.writeTo(this, clientOut);
                     clientOut.flush();
@@ -1496,7 +1496,7 @@ class Http2Connection extends BaseHttpConnection implements Http2Peer {
         forceShutdown(new IOException(
             "HTTP/2 connection idle timeout exceeded",
             new TimeoutException("Idle timeout exceeded")
-        ));
+        ), ResponseState.TIMED_OUT);
     }
 
     @Override
@@ -1511,10 +1511,13 @@ class Http2Connection extends BaseHttpConnection implements Http2Peer {
 
     @Override
     void forceShutdown() {
-        forceShutdown(new IOException("HTTP/2 connection was shut down"));
+        forceShutdown(
+            new IOException("HTTP/2 connection was shut down"),
+            ResponseState.ERRORED
+        );
     }
 
-    private void forceShutdown(IOException reason) {
+    private void forceShutdown(IOException reason, ResponseState terminalState) {
         stateLock.lock();
         try {
             if (writeState.canSendFrames) {
@@ -1524,7 +1527,7 @@ class Http2Connection extends BaseHttpConnection implements Http2Peer {
             stateLock.unlock();
         }
         for (Http2Stream stream : streamRegistry.applicationStreams()) {
-            stream.onConnectionTerminated(reason);
+            stream.onConnectionTerminated(reason, terminalState);
         }
         signalWriteLoop();
         closeSocketQuietly();

--- a/src/main/java/io/muserver/Http2Response.java
+++ b/src/main/java/io/muserver/Http2Response.java
@@ -31,9 +31,7 @@ class Http2Response extends BaseResponse {
         } else {
             closeWriter();
         }
-        if (!responseState().endState()) {
-            setState(ResponseState.FINISHED);
-        }
+        setState(ResponseState.FINISHED);
     }
 
     private void writeStatusAndHeaders(boolean endOfStream) throws InterruptedException, IOException {

--- a/src/main/java/io/muserver/Http2Stream.java
+++ b/src/main/java/io/muserver/Http2Stream.java
@@ -153,6 +153,17 @@ class Http2Stream implements ResponseInfo {
         }
     }
 
+    void onConnectionTerminated(IOException reason) {
+        cancel(reason, false);
+        Http2Response currentResponse = requiredResponse();
+        if (!currentResponse.responseState().endState()) {
+            currentResponse.setState(ResponseState.CLIENT_CANCELLED);
+        }
+        // Complete the private async-exchange future. Its continuation is
+        // dispatched to the handler executor before application cleanup runs.
+        request.onClientCancelled();
+    }
+
     boolean canReceiveData() {
         return !remoteEndStreamRead && !resetInitiated;
     }

--- a/src/main/java/io/muserver/Http2Stream.java
+++ b/src/main/java/io/muserver/Http2Stream.java
@@ -131,9 +131,7 @@ class Http2Stream implements ResponseInfo {
     void applyPeerReset(Http2ResetStreamFrame rstStream) {
         onProtocolResetApplied();
         Http2Response currentResponse = requiredResponse();
-        if (!currentResponse.responseState().endState()) {
-            currentResponse.setState(ResponseState.CLIENT_CANCELLED);
-        }
+        currentResponse.setState(ResponseState.CLIENT_CANCELLED);
         if (bodyInputStream instanceof Http2BodyInputStream) {
             ((Http2BodyInputStream) bodyInputStream).onStreamReset(rstStream);
         }
@@ -156,9 +154,7 @@ class Http2Stream implements ResponseInfo {
     void onConnectionTerminated(IOException reason, ResponseState terminalState) {
         cancel(reason, false);
         Http2Response currentResponse = requiredResponse();
-        if (!currentResponse.responseState().endState()) {
-            currentResponse.setState(terminalState);
-        }
+        currentResponse.setState(terminalState);
         // Complete the private async-exchange future. Its continuation is
         // dispatched to the handler executor before application cleanup runs.
         request.onClientCancelled();

--- a/src/main/java/io/muserver/Http2Stream.java
+++ b/src/main/java/io/muserver/Http2Stream.java
@@ -153,11 +153,11 @@ class Http2Stream implements ResponseInfo {
         }
     }
 
-    void onConnectionTerminated(IOException reason) {
+    void onConnectionTerminated(IOException reason, ResponseState terminalState) {
         cancel(reason, false);
         Http2Response currentResponse = requiredResponse();
         if (!currentResponse.responseState().endState()) {
-            currentResponse.setState(ResponseState.CLIENT_CANCELLED);
+            currentResponse.setState(terminalState);
         }
         // Complete the private async-exchange future. Its continuation is
         // dispatched to the handler executor before application cleanup runs.

--- a/src/main/java/io/muserver/Http2Stream.java
+++ b/src/main/java/io/muserver/Http2Stream.java
@@ -101,6 +101,11 @@ class Http2Stream implements ResponseInfo {
         return applicationExchangeEnded;
     }
 
+    boolean applicationExchangeNeedsTermination() {
+        return !applicationExchangeEnded
+            && request.asyncCompletionIsPending();
+    }
+
     void onProtocolStateClosed() {
         protocolStateClosed = true;
     }

--- a/src/main/java/io/muserver/Http2StreamRegistry.java
+++ b/src/main/java/io/muserver/Http2StreamRegistry.java
@@ -183,8 +183,21 @@ final class Http2StreamRegistry {
         }
     }
 
-    boolean hasActiveProtocolStreams() {
-        return concurrentStreamCount() != 0;
+    boolean hasActiveConnectionWork() {
+        lock.lock();
+        try {
+            for (Lookup entry : entries.values()) {
+                Http2Stream stream = entry.applicationStream();
+                if (stream == null
+                    || stream.countsTowardsMaxConcurrentStreams()
+                    || !stream.applicationExchangeEnded()) {
+                    return true;
+                }
+            }
+            return false;
+        } finally {
+            lock.unlock();
+        }
     }
 
     boolean isEmpty() {

--- a/src/main/java/io/muserver/Http2StreamRegistry.java
+++ b/src/main/java/io/muserver/Http2StreamRegistry.java
@@ -190,7 +190,7 @@ final class Http2StreamRegistry {
                 Http2Stream stream = entry.applicationStream();
                 if (stream == null
                     || stream.countsTowardsMaxConcurrentStreams()
-                    || !stream.applicationExchangeEnded()) {
+                    || stream.applicationExchangeNeedsTermination()) {
                     return true;
                 }
             }

--- a/src/main/java/io/muserver/Mu3AsyncHandleImpl.java
+++ b/src/main/java/io/muserver/Mu3AsyncHandleImpl.java
@@ -55,6 +55,15 @@ class Mu3AsyncHandleImpl implements AsyncHandle {
         return exchangeCompletion;
     }
 
+    boolean completionIsPending() {
+        lock.lock();
+        try {
+            return !completionRequested;
+        } finally {
+            lock.unlock();
+        }
+    }
+
     @Override
     public void setReadListener(RequestBodyListener readListener) {
         new AsyncBodyReader(readListener).scheduleNextRead();

--- a/src/main/java/io/muserver/Mu3Request.java
+++ b/src/main/java/io/muserver/Mu3Request.java
@@ -290,6 +290,11 @@ class Mu3Request implements MuRequest {
         return asyncHandle != null;
     }
 
+    boolean asyncCompletionIsPending() {
+        Mu3AsyncHandleImpl current = asyncHandle;
+        return current != null && current.completionIsPending();
+    }
+
     @Override
     public HttpVersion httpVersion() {
         return httpVersion;

--- a/src/test/java/io/muserver/RFC9113_5_4_3_ConnectionTerminationTest.java
+++ b/src/test/java/io/muserver/RFC9113_5_4_3_ConnectionTerminationTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
@@ -41,6 +42,71 @@ class RFC9113_5_4_3_ConnectionTerminationTest {
 
             assertThat(con.readLogicalFrame(Http2GoAway.class), equalTo(goAway(0, Http2ErrorCode.NO_ERROR)));
             assertThrows(IOException.class, con::readFrameHeader);
+        }
+    }
+
+    @Test
+    void abruptClientDisconnectCompletesAnAsyncExchange() throws Exception {
+        var asyncStarted = new CountDownLatch(1);
+        var completed = new CompletableFuture<ResponseInfo>();
+        server = httpsServer()
+            .withHttp2Config(Http2ConfigBuilder.http2Enabled())
+            .addResponseCompleteListener(completed::complete)
+            .addHandler(Method.GET, "/hello", (request, response, pathParams) -> {
+                request.handleAsync();
+                asyncStarted.countDown();
+            })
+            .start();
+
+        try (var client = new H2Client()) {
+            var con = client.connect(server);
+            con.handshake()
+                .writeFrame(new Http2HeadersFrame(
+                    1,
+                    true,
+                    getHelloHeaders(server.uri().getPort())
+                ))
+                .flush();
+            assertThat(asyncStarted.await(5, TimeUnit.SECONDS), equalTo(true));
+
+            con.close();
+
+            ResponseInfo responseInfo = completed.get(5, TimeUnit.SECONDS);
+            assertThat(responseInfo.completedSuccessfully(), equalTo(false));
+            assertThat(server.stats().activeRequests().isEmpty(), equalTo(true));
+        }
+    }
+
+    @Test
+    void idleTimeoutCompletesAnAsyncExchange() throws Exception {
+        var asyncStarted = new CountDownLatch(1);
+        var completed = new CompletableFuture<ResponseInfo>();
+        server = httpsServer()
+            .withHttp2Config(Http2ConfigBuilder.http2Enabled())
+            .addResponseCompleteListener(completed::complete)
+            .addHandler(Method.GET, "/hello", (request, response, pathParams) -> {
+                request.handleAsync();
+                asyncStarted.countDown();
+            })
+            .start();
+
+        try (var client = new H2Client();
+             var con = client.connect(server)) {
+            con.handshake()
+                .writeFrame(new Http2HeadersFrame(
+                    1,
+                    true,
+                    getHelloHeaders(server.uri().getPort())
+                ))
+                .flush();
+            assertThat(asyncStarted.await(5, TimeUnit.SECONDS), equalTo(true));
+
+            ((BaseHttpConnection) server.activeConnections().iterator().next())
+                .abortWithTimeout();
+
+            ResponseInfo responseInfo = completed.get(5, TimeUnit.SECONDS);
+            assertThat(responseInfo.completedSuccessfully(), equalTo(false));
+            assertThat(server.stats().activeRequests().isEmpty(), equalTo(true));
         }
     }
 
@@ -191,5 +257,3 @@ class RFC9113_5_4_3_ConnectionTerminationTest {
     }
 
 }
-
-

--- a/src/test/java/io/muserver/RFC9113_5_4_3_ConnectionTerminationTest.java
+++ b/src/test/java/io/muserver/RFC9113_5_4_3_ConnectionTerminationTest.java
@@ -79,6 +79,95 @@ class RFC9113_5_4_3_ConnectionTerminationTest {
     }
 
     @Test
+    void disconnectCompletesAnAsyncExchangeAfterItsWireStreamClosed()
+        throws Exception {
+        var responsePublished = new CountDownLatch(1);
+        var completed = new CompletableFuture<ResponseInfo>();
+        server = httpsServer()
+            .withHttp2Config(Http2ConfigBuilder.http2Enabled())
+            .addResponseCompleteListener(completed::complete)
+            .addHandler(Method.GET, "/hello", (request, response, pathParams) -> {
+                request.handleAsync();
+                response.write("done");
+                responsePublished.countDown();
+            })
+            .start();
+
+        try (var client = new H2Client()) {
+            var con = client.connect(server);
+            con.handshake()
+                .writeFrame(new Http2HeadersFrame(
+                    1,
+                    true,
+                    getHelloHeaders(server.uri().getPort())
+                ))
+                .flush();
+            assertThat(
+                responsePublished.await(5, TimeUnit.SECONDS),
+                equalTo(true)
+            );
+            assertThat(server.stats().activeRequests().size(), equalTo(1));
+
+            con.close();
+
+            ResponseInfo responseInfo = completed.get(5, TimeUnit.SECONDS);
+            assertThat(responseInfo.completedSuccessfully(), equalTo(true));
+            assertThat(
+                responseInfo.response().responseState(),
+                equalTo(ResponseState.FULL_SENT)
+            );
+            assertThat(server.stats().activeRequests().isEmpty(), equalTo(true));
+        }
+    }
+
+    @Test
+    void coordinatorConnectionErrorsCompleteAsyncExchangesAsErrored()
+        throws Exception {
+        var asyncStarted = new CountDownLatch(1);
+        var completed = new CompletableFuture<ResponseInfo>();
+        server = httpsServer()
+            .withHttp2Config(Http2ConfigBuilder.http2Enabled())
+            .addResponseCompleteListener(completed::complete)
+            .addHandler(Method.GET, "/hello", (request, response, pathParams) -> {
+                request.handleAsync();
+                asyncStarted.countDown();
+            })
+            .start();
+
+        try (var client = new H2Client();
+             var con = client.connect(server)) {
+            con.handshake()
+                .writeFrame(new Http2HeadersFrame(
+                    1,
+                    true,
+                    getHelloHeaders(server.uri().getPort())
+                ))
+                .flush();
+            assertThat(
+                asyncStarted.await(5, TimeUnit.SECONDS),
+                equalTo(true)
+            );
+
+            con.writeFrame(
+                new Http2WindowUpdate(0, Integer.MAX_VALUE)
+            ).flush();
+
+            Http2GoAway goAway = con.readLogicalFrame(Http2GoAway.class);
+            assertThat(
+                goAway.errorCodeEnum(),
+                equalTo(Http2ErrorCode.FLOW_CONTROL_ERROR)
+            );
+            ResponseInfo responseInfo = completed.get(5, TimeUnit.SECONDS);
+            assertThat(responseInfo.completedSuccessfully(), equalTo(false));
+            assertThat(
+                responseInfo.response().responseState(),
+                equalTo(ResponseState.ERRORED)
+            );
+            assertThat(server.stats().activeRequests().isEmpty(), equalTo(true));
+        }
+    }
+
+    @Test
     void idleTimeoutCompletesAnAsyncExchange() throws Exception {
         var asyncStarted = new CountDownLatch(1);
         var completed = new CompletableFuture<ResponseInfo>();

--- a/src/test/java/io/muserver/RFC9113_5_4_3_ConnectionTerminationTest.java
+++ b/src/test/java/io/muserver/RFC9113_5_4_3_ConnectionTerminationTest.java
@@ -73,6 +73,7 @@ class RFC9113_5_4_3_ConnectionTerminationTest {
 
             ResponseInfo responseInfo = completed.get(5, TimeUnit.SECONDS);
             assertThat(responseInfo.completedSuccessfully(), equalTo(false));
+            assertThat(responseInfo.response().responseState(), equalTo(ResponseState.CLIENT_DISCONNECTED));
             assertThat(server.stats().activeRequests().isEmpty(), equalTo(true));
         }
     }
@@ -106,6 +107,7 @@ class RFC9113_5_4_3_ConnectionTerminationTest {
 
             ResponseInfo responseInfo = completed.get(5, TimeUnit.SECONDS);
             assertThat(responseInfo.completedSuccessfully(), equalTo(false));
+            assertThat(responseInfo.response().responseState(), equalTo(ResponseState.TIMED_OUT));
             assertThat(server.stats().activeRequests().isEmpty(), equalTo(true));
         }
     }

--- a/src/test/java/io/muserver/ResponseStateTest.java
+++ b/src/test/java/io/muserver/ResponseStateTest.java
@@ -1,0 +1,22 @@
+package io.muserver;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+class ResponseStateTest {
+
+    @Test
+    void lateSuccessfulCleanupCannotOverwriteAConnectionFailure() {
+        var response = new Http1Response(null, new ByteArrayOutputStream());
+
+        assertThat(response.setState(ResponseState.WRITING_HEADERS), equalTo(true));
+        assertThat(response.setState(ResponseState.CLIENT_DISCONNECTED), equalTo(true));
+
+        assertThat(response.setState(ResponseState.FINISHED), equalTo(false));
+        assertThat(response.responseState(), equalTo(ResponseState.CLIENT_DISCONNECTED));
+    }
+}

--- a/src/test/java/io/muserver/ResponseStateTest.java
+++ b/src/test/java/io/muserver/ResponseStateTest.java
@@ -19,4 +19,16 @@ class ResponseStateTest {
         assertThat(response.setState(ResponseState.FINISHED), equalTo(false));
         assertThat(response.responseState(), equalTo(ResponseState.CLIENT_DISCONNECTED));
     }
+
+    @Test
+    void firstTerminalCauseWins() {
+        var response = new Http1Response(null, new ByteArrayOutputStream());
+
+        assertThat(response.setState(ResponseState.TIMED_OUT), equalTo(true));
+        assertThat(
+            response.setState(ResponseState.CLIENT_DISCONNECTED),
+            equalTo(false)
+        );
+        assertThat(response.responseState(), equalTo(ResponseState.TIMED_OUT));
+    }
 }


### PR DESCRIPTION
## Summary
- give HTTP/2 streams one connection-termination transition that closes response admission, wakes body waiters, and completes suspended async exchanges
- apply it to peer disconnects, protocol connection errors, forced shutdown, and idle timeout
- verify both abrupt peer disconnect and deterministic idle-timeout abort retire the async request as unsuccessful

## Concurrency model
The reader or maintenance thread only completes the private exchange future. Existing async completion dispatch then returns application cleanup and response-completion callbacks to the handler/application executors.

## Validation
- `mise exec java@temurin-11 maven@3.9.16 -- mvn -q -Dtest=RFC9113_5_4_3_ConnectionTerminationTest,AsyncTest test`
- `mise exec java@temurin-21 maven@3.9.16 -- mvn -q -DskipTests compile`
- the full Java 11 suite passed on parent #189 after the propagated #185 review fix
- `git diff --check`