### PR TITLE
Claim async request bodies before dispatch

### DIFF
--- a/src/main/java/io/muserver/AsyncHandle.java
+++ b/src/main/java/io/muserver/AsyncHandle.java
@@ -20,6 +20,7 @@ public interface AsyncHandle {
      * <p>Sets a listener that will be notified when chunks of request data become available.</p>
      * <p>If this is not set, then the usual (blocking) request reading methods on the request object can be used.</p>
      * @param readListener The listener.
+     * @throws IllegalStateException if request-body access has already been claimed
      */
     void setReadListener(RequestBodyListener readListener);
 

--- a/src/main/java/io/muserver/Mu3AsyncHandleImpl.java
+++ b/src/main/java/io/muserver/Mu3AsyncHandleImpl.java
@@ -57,17 +57,24 @@ class Mu3AsyncHandleImpl implements AsyncHandle {
 
     @Override
     public void setReadListener(RequestBodyListener readListener) {
-        new AsyncBodyReader(readListener).scheduleNextRead();
+        Objects.requireNonNull(readListener, "readListener");
+        // Claim body ownership before asynchronous dispatch so a blocking read
+        // or second listener cannot race the first reader task.
+        new AsyncBodyReader(readListener, request.body()).scheduleNextRead();
     }
 
     private final class AsyncBodyReader {
         private final RequestBodyListener readListener;
         private final byte[] buffer = new byte[8192];
         private final AtomicBoolean finished = new AtomicBoolean();
-        private @Nullable InputStream clientIn;
+        private final InputStream clientIn;
 
-        private AsyncBodyReader(RequestBodyListener readListener) {
+        private AsyncBodyReader(
+            RequestBodyListener readListener,
+            InputStream clientIn
+        ) {
             this.readListener = readListener;
+            this.clientIn = clientIn;
         }
 
         private void scheduleNextRead() {
@@ -85,20 +92,9 @@ class Mu3AsyncHandleImpl implements AsyncHandle {
             if (finished.get()) {
                 return;
             }
-            InputStream input = clientIn;
-            if (input == null) {
-                try {
-                    input = request.body();
-                    clientIn = input;
-                } catch (Throwable t) {
-                    fail(t, false);
-                    return;
-                }
-            }
-
             final int read;
             try {
-                read = input.read(buffer);
+                read = clientIn.read(buffer);
             } catch (Throwable t) {
                 fail(t, true);
                 return;

--- a/src/main/java/io/muserver/Mu3Request.java
+++ b/src/main/java/io/muserver/Mu3Request.java
@@ -31,8 +31,12 @@ class Mu3Request implements MuRequest {
     private String contextPath = "";
     private String relativePath;
     @Nullable private List<Cookie> cookies;
-    private boolean bodyClaimed;
-    private boolean inputStreamAccessed;
+    private enum BodyAccess {
+        UNCLAIMED,
+        INPUT_STREAM,
+        EXCLUSIVE
+    }
+    private BodyAccess bodyAccess = BodyAccess.UNCLAIMED;
     @Nullable private volatile Mu3AsyncHandleImpl asyncHandle;
     private boolean clientCancelled;
     private volatile boolean rateLimitRejected;
@@ -64,11 +68,18 @@ class Mu3Request implements MuRequest {
         return mu3Headers.get("content-type");
     }
 
-    private void claimbody() {
-        if (bodyClaimed || inputStreamAccessed) {
+    private synchronized void claimBody() {
+        if (bodyAccess != BodyAccess.UNCLAIMED) {
             throw new IllegalStateException("The body of the request message cannot be read twice. This can happen when calling any 2 of inputStream(), readBodyAsString(), or form() methods.");
         }
-        bodyClaimed = true;
+        bodyAccess = BodyAccess.EXCLUSIVE;
+    }
+
+    private synchronized void claimInputStream() {
+        if (bodyAccess == BodyAccess.EXCLUSIVE) {
+            throw new IllegalStateException("The body of the request message cannot be read twice. This can happen when calling any 2 of inputStream(), readBodyAsString(), or form() methods.");
+        }
+        bodyAccess = BodyAccess.INPUT_STREAM;
     }
 
     @Override
@@ -113,7 +124,7 @@ class Mu3Request implements MuRequest {
         if (BodySize.NONE.equals(bodySize)) {
             return Optional.empty();
         }
-        inputStreamAccessed = true;
+        claimInputStream();
         return Optional.of(body);
     }
 
@@ -135,7 +146,7 @@ class Mu3Request implements MuRequest {
 
     @Override
     public InputStream body() {
-        claimbody();
+        claimBody();
         return body;
     }
 
@@ -146,7 +157,7 @@ class Mu3Request implements MuRequest {
 
     @Override
     public String readBodyAsString() throws IOException {
-        claimbody();
+        claimBody();
         Long size = bodySize.size();
         if (size == null || size > 4096) {
             return streamBodyToString(Headtils.bodyCharset(mu3Headers, true));
@@ -183,7 +194,7 @@ class Mu3Request implements MuRequest {
     @Override
     public MuForm form() throws IOException {
         if (this.form == null) {
-            claimbody();
+            claimBody();
             MediaType bodyType = mu3Headers.contentType();
             if (bodyType == null) {
                 this.form = EmptyForm.VALUE;

--- a/src/test/java/io/muserver/ExecutionDomainsTest.java
+++ b/src/test/java/io/muserver/ExecutionDomainsTest.java
@@ -1035,6 +1035,64 @@ class ExecutionDomainsTest {
     }
 
     @Test
+    void asyncReadListenerClaimsBodyBeforeDispatch() throws Exception {
+        var asyncExecutor = track(Executors.newSingleThreadExecutor(namedThreads("async-")));
+        var blockerStarted = new CountDownLatch(1);
+        var releaseBlocker = new CountDownLatch(1);
+        Future<?> blocker = asyncExecutor.submit(() -> {
+            blockerStarted.countDown();
+            releaseBlocker.await();
+            return null;
+        });
+        assertThat(blockerStarted.await(5, TimeUnit.SECONDS), is(true));
+
+        var competingReadFailure = new CompletableFuture<Throwable>();
+        server = httpServer()
+            .withAsyncExecutor(asyncExecutor)
+            .addHandler(Method.POST, "/", (request, response, pathParams) -> {
+                AsyncHandle handle = request.handleAsync();
+                handle.setReadListener(new RequestBodyListener() {
+                    @Override
+                    public void onDataReceived(
+                        ByteBuffer data,
+                        DoneCallback doneCallback
+                    ) throws Exception {
+                        doneCallback.onComplete(null);
+                    }
+
+                    @Override
+                    public void onComplete() {
+                    }
+
+                    @Override
+                    public void onError(Throwable t) {
+                    }
+                });
+                try {
+                    request.readBodyAsString();
+                    competingReadFailure.complete(null);
+                } catch (Throwable failure) {
+                    competingReadFailure.complete(failure);
+                }
+                handle.complete();
+            })
+            .start();
+
+        try (Response response = call(
+            request(server.uri()).post(RequestBody.create("body", null))
+        )) {
+            assertThat(response.code(), is(200));
+            assertThat(
+                competingReadFailure.get(5, TimeUnit.SECONDS),
+                instanceOf(IllegalStateException.class)
+            );
+        } finally {
+            releaseBlocker.countDown();
+            blocker.get(5, TimeUnit.SECONDS);
+        }
+    }
+
+    @Test
     void asyncBodyListenerFailuresAreReportedOnTheAsyncExecutor() throws Exception {
         var asyncExecutor = track(Executors.newSingleThreadExecutor(namedThreads("async-")));
         var dataThread = new CompletableFuture<String>();

--- a/src/test/java/io/muserver/RequestBodyReaderInputStreamAdapterTest.java
+++ b/src/test/java/io/muserver/RequestBodyReaderInputStreamAdapterTest.java
@@ -185,6 +185,25 @@ public class RequestBodyReaderInputStreamAdapterTest {
     }
 
     @Test
+    void bodyClaimsTheInputStream() {
+        var request = new Mu3Request(
+            null,
+            Method.POST,
+            URI.create("/"),
+            URI.create("https://localhost/"),
+            HttpVersion.HTTP_1_1,
+            new FieldBlock(),
+            new BodySize(BodyType.FIXED_SIZE, 7L),
+            new ByteArrayInputStream("a=1&b=2".getBytes(StandardCharsets.UTF_8))
+        );
+
+        request.body();
+
+        var ex = assertThrows(IllegalStateException.class, request::inputStream);
+        assertThat(ex.getMessage(), containsString("cannot be read twice"));
+    }
+
+    @Test
     public void chunkedRequestBodiesCanBeRead() throws Exception {
         server = httpServer()
             .addHandler((request, response) -> {


### PR DESCRIPTION
## Summary
- replace competing request-body booleans with one synchronized ownership state
- claim the body synchronously when an async read listener is installed, before its worker can race another access mode
- preserve repeated `inputStream()` retrieval while preventing it from bypassing an exclusive `body()` claim
- document the immediate `IllegalStateException` contract

## Concurrency model
Request-body access has one short ownership transition. The async executor performs I/O only after ownership has already been published; it no longer decides ownership opportunistically when its queued task happens to start.

## Validation
- `mise exec java@temurin-11 maven@3.9.16 -- mvn -q -Dtest=AsyncTest,ExecutionDomainsTest,RequestBodyReaderInputStreamAdapterTest,RequestBodyReaderListenerAdapterTest test`
- `mise exec java@temurin-21 maven@3.9.16 -- mvn -q -DskipTests compile`
- `git diff --check`