### PR TITLE
Enforce WebSocket control frame limits

### DIFF
--- a/src/main/java/io/muserver/MuWebSocketSession.java
+++ b/src/main/java/io/muserver/MuWebSocketSession.java
@@ -177,6 +177,7 @@ public interface MuWebSocketSession {
      * Sends a ping message to the client, which is used for keeping sockets alive.
      * @param payload The message to send.
      * @throws IOException If the ping cannot be written to the client.
+     * @throws IllegalArgumentException if the payload exceeds 125 bytes
      */
     void sendPing(ByteBuffer payload) throws IOException;
 
@@ -207,6 +208,7 @@ public interface MuWebSocketSession {
      * Sends a pong message to the client, generally in response to receiving a ping via {@link MuWebSocket#onPing(ByteBuffer)}
      * @param payload The payload to send back to the client.
      * @throws IOException If the pong cannot be written to the client.
+     * @throws IllegalArgumentException if the payload exceeds 125 bytes
      */
     void sendPong(ByteBuffer payload) throws IOException;
 
@@ -244,6 +246,7 @@ public interface MuWebSocketSession {
      * @param statusCode The status code to send, such as <code>1000</code>. See <a href="https://tools.ietf.org/html/rfc6455#section-7.4">https://tools.ietf.org/html/rfc6455#section-7.4</a>
      * @param reason An optional reason for closing.
      * @throws IOException Thrown if there is an error writing to the client, for example if the user has closed their browser.
+     * @throws IllegalArgumentException if the UTF-8-encoded reason exceeds 123 bytes
      */
     void close(int statusCode, @Nullable String reason) throws IOException;
 

--- a/src/main/java/io/muserver/WebsocketConnection.java
+++ b/src/main/java/io/muserver/WebsocketConnection.java
@@ -590,12 +590,14 @@ class WebsocketConnection implements MuWebSocketSession {
 
     @Override
     public void sendPing(ByteBuffer payload) throws IOException {
+        requireControlPayloadSize(payload.remaining());
         payload = arrayBuffer(payload);
         writeFragment((byte)0b10001001, payload.array(), payload.arrayOffset() + payload.position(), payload.remaining(), null, null);
     }
 
     @Override
     public void sendPong(ByteBuffer payload) throws IOException {
+        requireControlPayloadSize(payload.remaining());
         payload = arrayBuffer(payload);
         writeFragment((byte)0b10001010, payload.array(), payload.arrayOffset() + payload.position(), payload.remaining(), null, null);
     }
@@ -619,27 +621,32 @@ class WebsocketConnection implements MuWebSocketSession {
         if (statusCode < 1000 || statusCode > 4999) {
             throw new IllegalArgumentException("Websocket closure codes must be between 1000 and 4999 (inclusive)");
         }
+        byte[] reasonBytes = reason == null || reason.isEmpty()
+            ? new byte[0]
+            : reason.getBytes(StandardCharsets.UTF_8);
+        requireControlPayloadSize(reasonBytes.length + 2);
+        var payload = new byte[reasonBytes.length + 2];
+        payload[0] = (byte) ((statusCode >> 8) & 0xFF);
+        payload[1] = (byte) (statusCode & 0xFF);
+        System.arraycopy(reasonBytes, 0, payload, 2, reasonBytes.length);
+
         writeLock.lock();
         try {
             lifecycle.onServerCloseStarted();
-            if (reason == null || reason.isEmpty()) {
-                byte[] closeCodeBytes = new byte[2];
-                closeCodeBytes[0] = (byte) ((statusCode >> 8) & 0xFF);
-                closeCodeBytes[1] = (byte) (statusCode & 0xFF);
-                writeFragment((byte)0b10001000, closeCodeBytes, 0, 2, null, null);
-            } else {
-                var reasonBytes = reason.getBytes(StandardCharsets.UTF_8);
-                var payload = new byte[reasonBytes.length + 2];
-                payload[0] = (byte) ((statusCode >> 8) & 0xFF);
-                payload[1] = (byte) (statusCode & 0xFF);
-                System.arraycopy(reasonBytes, 0, payload, 2, reasonBytes.length);
-                writeFragment((byte)0b10001000, payload, 0, payload.length, null, null);
-            }
+            writeFragment((byte)0b10001000, payload, 0, payload.length, null, null);
             if (!closeSent) {
                 closeSent = true;
             }
         } finally {
             writeLock.unlock();
+        }
+    }
+
+    private static void requireControlPayloadSize(int payloadLength) {
+        if (payloadLength > 125) {
+            throw new IllegalArgumentException(
+                "WebSocket control frame payload cannot exceed 125 bytes"
+            );
         }
     }
 
@@ -653,6 +660,9 @@ class WebsocketConnection implements MuWebSocketSession {
     }
 
     private void writeFragment(byte firstByte, byte@Nullable[] payload, int payloadOffset, int payloadLen, @Nullable MessageWritingState expectedState, @Nullable MessageWritingState endState) throws IOException {
+        if ((firstByte & 0x08) != 0) {
+            requireControlPayloadSize(payloadLen);
+        }
         var header = header(firstByte, payloadLen);
         OutputStream output = java.util.Objects.requireNonNull(outputStream);
         IOException failure = null;

--- a/src/test/java/io/muserver/WebSocketsTest.java
+++ b/src/test/java/io/muserver/WebSocketsTest.java
@@ -41,6 +41,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static scaffolding.ClientUtils.*;
 import static scaffolding.MuAssert.assertEventually;
@@ -1019,6 +1020,49 @@ public class WebSocketsTest {
 
         clientSocket.close(1000, "Finished");
         assertNotTimedOut("Closing", serverSocket.closedLatch);
+    }
+
+    @Test
+    void outgoingControlFramesCannotExceed125Bytes() throws Exception {
+        server = ServerUtils.httpsServerForTest()
+            .addHandler(webSocketHandler((request, responseHeaders) -> serverSocket).withPath("/ws"))
+            .start();
+
+        ClientListener listener = new ClientListener();
+        WebSocket clientSocket = client.newWebSocket(
+            webSocketRequest(server.uri().resolve("/ws")),
+            listener
+        );
+        assertNotTimedOut("Connecting", serverSocket.connectedLatch);
+
+        var tooLarge = ByteBuffer.allocate(126);
+        assertAll(
+            () -> assertThrows(
+                IllegalArgumentException.class,
+                () -> serverSocket.session().sendPing(tooLarge.duplicate())
+            ),
+            () -> assertThrows(
+                IllegalArgumentException.class,
+                () -> serverSocket.session().sendPong(tooLarge.duplicate())
+            ),
+            () -> assertThrows(
+                IllegalArgumentException.class,
+                () -> serverSocket.session().close(1000, "x".repeat(124))
+            )
+        );
+        assertThat(serverSocket.state(), equalTo(WebsocketSessionState.OPEN));
+
+        assertDoesNotThrow(() ->
+            serverSocket.session().sendPing(ByteBuffer.allocate(125))
+        );
+        assertNotTimedOut("Pong wait", serverSocket.pongLatch);
+        assertDoesNotThrow(() ->
+            serverSocket.session().sendPong(ByteBuffer.allocate(125))
+        );
+        assertDoesNotThrow(() ->
+            serverSocket.session().close(1000, "x".repeat(123))
+        );
+        assertNotTimedOut("Closing", listener.closedLatch);
     }
 
     @Test


### PR DESCRIPTION
## Summary
- reject outgoing Ping, Pong, and Close payloads over 125 bytes before any wire or lifecycle mutation
- retain a defensive control-frame check at the common writer boundary
- document the public argument limits and cover both the 125-byte accepted boundary and 126-byte rejection

## Specification
RFC 6455 section 5.5 requires every control-frame payload to be at most 125 bytes. A Close payload includes its two-byte status code, leaving at most 123 UTF-8 bytes for the reason.

## Validation
- `mise exec java@temurin-11 maven@3.9.16 -- mvn -q -Dtest=WebSocketsTest,WebsocketLifecycleTest test`
- `mise exec java@temurin-21 maven@3.9.16 -- mvn -q -DskipTests compile`
- `git diff --check`