### PR TITLE
Classify HTTP/1 transport failures

### DIFF
--- a/src/main/java/io/muserver/BaseHttpConnection.java
+++ b/src/main/java/io/muserver/BaseHttpConnection.java
@@ -248,6 +248,15 @@ abstract class BaseHttpConnection implements HttpConnection {
         server.getStatsImpl().onBytesSent(sent);
     }
 
+    void onTransportInputEnd() {
+    }
+
+    void onTransportInputFailure(IOException failure) {
+    }
+
+    void onTransportOutputFailure(IOException failure) {
+    }
+
     private void onIO() {
         MonotonicTime.publishLatest(lastIONanos, System.nanoTime());
     }

--- a/src/main/java/io/muserver/Http1Connection.java
+++ b/src/main/java/io/muserver/Http1Connection.java
@@ -464,14 +464,41 @@ class Http1Connection extends BaseHttpConnection {
         ResponseState terminalState,
         Exception error
     ) {
+        markActiveResponse(terminalState);
         var cur = activeExchange.get();
         if (cur != null && cur.request != null) {
-            java.util.Objects.requireNonNull(cur.response).setState(terminalState);
             Mu3AsyncHandleImpl asyncHandle = cur.request.getAsyncHandle();
             if (asyncHandle != null) {
                 asyncHandle.complete(error);
             }
         }
+    }
+
+    private void markActiveResponse(ResponseState terminalState) {
+        var cur = activeExchange.get();
+        if (cur != null && cur.response != null) {
+            cur.response.setState(terminalState);
+        }
+    }
+
+    @Override
+    void onTransportInputEnd() {
+        markActiveResponse(ResponseState.CLIENT_DISCONNECTED);
+    }
+
+    @Override
+    void onTransportInputFailure(IOException failure) {
+        // The HTTP/1 request deadline is implemented as a socket read timeout.
+        // Leave that non-terminal so the parser can turn it into a 408 response;
+        // connection-idle timeout is published by abortWithTimeout().
+        if (!(failure instanceof java.net.SocketTimeoutException)) {
+            markActiveResponse(ResponseState.CLIENT_DISCONNECTED);
+        }
+    }
+
+    @Override
+    void onTransportOutputFailure(IOException failure) {
+        markActiveResponse(ResponseState.CLIENT_DISCONNECTED);
     }
 
     private void notifyWebsocketTimeout() {

--- a/src/main/java/io/muserver/HttpConnectionInputStream.java
+++ b/src/main/java/io/muserver/HttpConnectionInputStream.java
@@ -15,9 +15,17 @@ class HttpConnectionInputStream extends FilterInputStream {
     @Override
     public int read() throws IOException {
         if (httpConnection.isClosed()) throw new IOException("The connection is closed");
-        int read = in.read();
+        int read;
+        try {
+            read = in.read();
+        } catch (IOException failure) {
+            httpConnection.onTransportInputFailure(failure);
+            throw failure;
+        }
         if (read != -1) {
             httpConnection.onBytesRead(1);
+        } else {
+            httpConnection.onTransportInputEnd();
         }
         return read;
     }
@@ -30,9 +38,17 @@ class HttpConnectionInputStream extends FilterInputStream {
     @Override
     public int read(byte[] b, int off, int len) throws IOException {
         if (httpConnection.isClosed()) throw new IOException("The connection is closed");
-        int read = in.read(b, off, len);
+        int read;
+        try {
+            read = in.read(b, off, len);
+        } catch (IOException failure) {
+            httpConnection.onTransportInputFailure(failure);
+            throw failure;
+        }
         if (read > 0) {
             httpConnection.onBytesRead(read);
+        } else if (read == -1) {
+            httpConnection.onTransportInputEnd();
         }
         return read;
     }

--- a/src/main/java/io/muserver/HttpConnectionOutputStream.java
+++ b/src/main/java/io/muserver/HttpConnectionOutputStream.java
@@ -20,7 +20,12 @@ class HttpConnectionOutputStream extends FilterOutputStream {
 
     @Override
     public void write(int b) throws IOException {
-        out.write(b);
+        try {
+            out.write(b);
+        } catch (IOException failure) {
+            httpConnection.onTransportOutputFailure(failure);
+            throw failure;
+        }
         httpConnection.onBytesSent(1);
     }
 
@@ -31,9 +36,24 @@ class HttpConnectionOutputStream extends FilterOutputStream {
 
     @Override
     public void write(byte[] b, int off, int len) throws IOException {
-        out.write(b, off, len);
+        try {
+            out.write(b, off, len);
+        } catch (IOException failure) {
+            httpConnection.onTransportOutputFailure(failure);
+            throw failure;
+        }
         if (len > 0) {
             httpConnection.onBytesSent(len);
+        }
+    }
+
+    @Override
+    public void flush() throws IOException {
+        try {
+            out.flush();
+        } catch (IOException failure) {
+            httpConnection.onTransportOutputFailure(failure);
+            throw failure;
         }
     }
 }

--- a/src/test/java/io/muserver/Http1ConnectionTerminationTest.java
+++ b/src/test/java/io/muserver/Http1ConnectionTerminationTest.java
@@ -1,0 +1,102 @@
+package io.muserver;
+
+import org.jspecify.annotations.Nullable;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import scaffolding.Http1Client;
+import scaffolding.MuAssert;
+
+import java.io.IOException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static io.muserver.MuServerBuilder.httpServer;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+class Http1ConnectionTerminationTest {
+
+    private @Nullable MuServer server;
+
+    @Test
+    void abortedUploadPublishesClientDisconnectBeforeTheReadFails()
+        throws Exception {
+        var reading = new CountDownLatch(1);
+        var stateAtFailure = new CompletableFuture<ResponseState>();
+        var completed = new CompletableFuture<ResponseInfo>();
+        server = httpServer()
+            .addResponseCompleteListener(completed::complete)
+            .addHandler(Method.POST, "/", (request, response, pathParams) -> {
+                reading.countDown();
+                try {
+                    request.readBodyAsString();
+                } catch (IOException failure) {
+                    stateAtFailure.complete(response.responseState());
+                    throw failure;
+                }
+            })
+            .start();
+
+        try (var client = Http1Client.connect(server)) {
+            client.writeRequestLine(Method.POST, "/")
+                .writeHeader(HeaderNames.CONTENT_LENGTH.toString(), 10)
+                .endHeaders()
+                .writeAscii("x")
+                .flush();
+            assertThat(reading.await(5, TimeUnit.SECONDS), equalTo(true));
+
+            client.abort();
+
+            assertThat(
+                stateAtFailure.get(5, TimeUnit.SECONDS),
+                equalTo(ResponseState.CLIENT_DISCONNECTED)
+            );
+            assertThat(
+                completed.get(5, TimeUnit.SECONDS).response().responseState(),
+                equalTo(ResponseState.CLIENT_DISCONNECTED)
+            );
+        }
+    }
+
+    @Test
+    void abortedResponseWriteCompletesAsClientDisconnected() throws Exception {
+        var handlerStarted = new CountDownLatch(1);
+        var writeResponse = new CountDownLatch(1);
+        var completed = new CompletableFuture<ResponseInfo>();
+        server = httpServer()
+            .addResponseCompleteListener(completed::complete)
+            .addHandler(Method.GET, "/", (request, response, pathParams) -> {
+                handlerStarted.countDown();
+                assertThat(
+                    writeResponse.await(5, TimeUnit.SECONDS),
+                    equalTo(true)
+                );
+                response.write("too late");
+            })
+            .start();
+
+        try (var client = Http1Client.connect(server)) {
+            client.writeRequestLine(Method.GET, "/").endHeaders().flush();
+            assertThat(
+                handlerStarted.await(5, TimeUnit.SECONDS),
+                equalTo(true)
+            );
+
+            client.abort();
+            writeResponse.countDown();
+
+            assertThat(
+                completed.get(5, TimeUnit.SECONDS).response().responseState(),
+                equalTo(ResponseState.CLIENT_DISCONNECTED)
+            );
+        } finally {
+            writeResponse.countDown();
+        }
+    }
+
+    @AfterEach
+    void stopServer() {
+        MuAssert.stopAndCheck(server);
+    }
+}


### PR DESCRIPTION
## Summary
- publish transport EOF and non-timeout I/O failure events at the connection stream boundary
- classify active HTTP/1 exchanges as client-disconnected before read/write failures reach application cleanup
- preserve socket read deadlines as request-level events so valid 408 responses remain possible
- prove classification for aborted uploads and aborted response writes

## Validation
- `mise exec java@temurin-11 maven@3.9.16 -- mvn -q -Dtest=Http1ConnectionTerminationTest,AsyncTest,MuServerTest,RequestBodyReaderStringTest test`
- `mise exec java@temurin-21 maven@3.9.16 -- mvn -q -DskipTests compile`