### PR TITLE
Matrix-parameter: segment-local injection, UriBuilder segment semantics, and OpenAPI matrix-as-path support

### DIFF
--- a/src/main/java/io/muserver/rest/MuUriBuilder.java
+++ b/src/main/java/io/muserver/rest/MuUriBuilder.java
@@ -189,7 +189,7 @@ class MuUriBuilder extends UriBuilder {
         Mutils.notNull("segments", segments);
         for (String segment : segments) {
             Mutils.notNull("segment", segment);
-            this.pathSegments.addAll(MuUriInfo.pathStringToSegments(Objects.requireNonNull(decode(segment)), true).collect(toList()));
+            this.pathSegments.add(new MuPathSegment(Objects.requireNonNull(decode(segment)), new MultivaluedHashMap<>()));
         }
         this.hasTrailingSlash = false;
         return this;

--- a/src/main/java/io/muserver/rest/OpenApiDocumentor.java
+++ b/src/main/java/io/muserver/rest/OpenApiDocumentor.java
@@ -9,6 +9,8 @@ import java.io.OutputStreamWriter;
 import java.lang.reflect.Type;
 import java.nio.charset.StandardCharsets;
 import java.util.*;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import org.jspecify.annotations.Nullable;
@@ -24,6 +26,7 @@ import static java.util.Collections.emptySet;
 import static java.util.Collections.singletonList;
 
 class OpenApiDocumentor implements MuHandler {
+    private static final Pattern PATH_TEMPLATE_PATTERN = Pattern.compile("\\{([^{}]+)}");
     private final List<ResourceClass> roots;
     private final @Nullable String openApiJsonUrl;
     private final OpenAPIObject openAPIObject;
@@ -59,7 +62,7 @@ class OpenApiDocumentor implements MuHandler {
 
         Map<String, PathItemObjectBuilder> pathItemBuilders = new LinkedHashMap<>();
         for (ResourceClass root : roots) {
-            addResourceClass(0, "", tags, pathItemBuilders, root);
+            addResourceClass(0, Collections.emptyList(), tags, pathItemBuilders, root);
         }
         Map<String, PathItemObject> pathItems = pathItemBuilders.entrySet().stream().collect(Collectors.toMap(Map.Entry::getKey, v -> v.getValue().build()));
 
@@ -119,7 +122,7 @@ class OpenApiDocumentor implements MuHandler {
         return true;
     }
 
-    private void addResourceClass(int recursiveLevel, String parentResourcePath, List<TagObject> tags, Map<String, PathItemObjectBuilder> pathItems, ResourceClass root) {
+    private void addResourceClass(int recursiveLevel, List<PathPart> parentPathParts, List<TagObject> tags, Map<String, PathItemObjectBuilder> pathItems, ResourceClass root) {
         if (recursiveLevel == 5) {
             return;
         }
@@ -130,12 +133,14 @@ class OpenApiDocumentor implements MuHandler {
         for (ResourceMethod method : root.resourceMethods) {
             if (method.isSubResourceLocator()) {
                 ResourceClass rc = ResourceClass.forSubResourceLocator(method, method.methodHandle().getReturnType(), null, schemaObjectCustomizer, paramConverterProviders);
-                String newParentResourcePath = Mutils.join(parentResourcePath, "/", method.resourceClass.pathPattern.pathWithoutRegex);
-                addResourceClass(recursiveLevel + 1, newParentResourcePath, tags, pathItems, rc);
+                List<PathPart> newParentPathParts = new ArrayList<>(parentPathParts);
+                newParentPathParts.add(resourcePathPart(root));
+                addResourceClass(recursiveLevel + 1, newParentPathParts, tags, pathItems, rc);
                 continue;
             }
 
-            String path = getPathWithoutRegex(root, method, parentResourcePath);
+            DocumentedPath documentedPath = documentedPath(parentPathParts, root, method);
+            String path = documentedPath.path;
 
             Map<String, OperationObject> operations;
             if (pathItems.containsKey(path)) {
@@ -152,9 +157,17 @@ class OpenApiDocumentor implements MuHandler {
                 pathItems.put(path, pathItem);
             }
             List<ParameterObject> parameters = method.paramsIncludingLocators().stream()
-                .filter(p -> (p.source().openAPIIn != null || p.source() == ResourceMethodParam.ValueSource.MATRIX_PARAM) && p instanceof ResourceMethodParam.RequestBasedParam)
+                .filter(p -> p instanceof ResourceMethodParam.RequestBasedParam)
                 .map(ResourceMethodParam.RequestBasedParam.class::cast)
-                .map(p -> p.createDocumentationBuilder().build())
+                .filter(p -> p.source().openAPIIn != null || documentedPath.matrixParams.containsKey(p))
+                .map(p -> {
+                    MatrixParamDocumentation matrixParam = documentedPath.matrixParams.get(p);
+                    ParameterObjectBuilder builder = p.createDocumentationBuilder(matrixParam == null ? p.key() : matrixParam.parameterName);
+                    if (matrixParam != null && matrixParam.nativeMatrixStyle) {
+                        builder.withStyle("matrix").withExplode(true);
+                    }
+                    return builder.build();
+                })
                 .reduce(new ArrayList<>(), (parameterObjects, parameterObject) -> {
                     if (parameterObjects.stream().noneMatch(existing -> existing.name().equals(parameterObject.name()) && existing.in().equals(parameterObject.in())))
                     parameterObjects.add(parameterObject);
@@ -164,7 +177,7 @@ class OpenApiDocumentor implements MuHandler {
                     return list1;
                 });
 
-            String opIdPath = getPathWithoutRegex(root, method, parentResourcePath).replace("{", "_").replace("}", "_");
+            String opIdPath = path.replace("{", "_").replace("}", "_");
             String opPath = Mutils.trim(opIdPath, "/").replace("/", "_");
             String opKey = method.requiredHttpMethod().name().toLowerCase(Locale.ROOT);
             OperationObject existing = operations.get(opKey);
@@ -213,51 +226,153 @@ class OpenApiDocumentor implements MuHandler {
         }
     }
 
-    static String getPathWithoutRegex(ResourceClass rc, ResourceMethod rm, String parentResourcePath) {
-        String resourcePath = rc.pathPattern == null ? null : rc.pathPattern.pathWithoutRegex;
-        if (resourcePath != null) {
-            resourcePath = appendMatrixTemplates(resourcePath,
-                rc.locatorMethod == null ? Collections.emptyList() : matrixParamNames(rc.locatorMethod.params));
-        }
-        @Nullable String methodPath = rm.pathPattern() == null ? null : rm.pathPattern().pathWithoutRegex;
-        List<String> methodMatrixParams = matrixParamNames(rm.params);
-        if (!methodMatrixParams.isEmpty()) {
-            if (methodPath == null) {
-                resourcePath = appendMatrixTemplates(resourcePath, methodMatrixParams);
-            } else {
-                methodPath = appendMatrixTemplates(methodPath, methodMatrixParams);
+    private static DocumentedPath documentedPath(List<PathPart> parentPathParts, ResourceClass resourceClass, ResourceMethod resourceMethod) {
+        List<PathPart> parts = new ArrayList<>(parentPathParts);
+        parts.add(resourcePathPart(resourceClass));
+        parts.add(new PathPart(resourceMethod.pathPattern() == null ? null : resourceMethod.pathPattern().pathWithoutRegex,
+            matrixParams(resourceMethod.params)));
+
+        Map<String, Integer> matrixParamSiteCounts = new HashMap<>();
+        for (PathPart part : parts) {
+            for (String wireName : paramsByWireName(part.matrixParams).keySet()) {
+                matrixParamSiteCounts.merge(wireName, 1, Integer::sum);
             }
         }
-        return "/" + Mutils.trim(Mutils.join(parentResourcePath, "/",
-            Mutils.join(resourcePath,
-                "/", methodPath)), "/");
+
+        Set<String> usedPathParameterNames = resourceMethod.paramsIncludingLocators().stream()
+            .filter(p -> p.source() == ResourceMethodParam.ValueSource.PATH_PARAM)
+            .map(ResourceMethodParam.RequestBasedParam.class::cast)
+            .map(ResourceMethodParam.RequestBasedParam::key)
+            .collect(Collectors.toCollection(LinkedHashSet::new));
+        for (PathPart part : parts) {
+            if (part.path != null) {
+                Matcher matcher = PATH_TEMPLATE_PATTERN.matcher(part.path);
+                while (matcher.find()) {
+                    usedPathParameterNames.add(matcher.group(1));
+                }
+            }
+        }
+        IdentityHashMap<ResourceMethodParam.RequestBasedParam, MatrixParamDocumentation> documentedMatrixParams = new IdentityHashMap<>();
+
+        String plainPath = "";
+        String decoratedPath = "";
+        for (PathPart part : parts) {
+            plainPath = Mutils.join(plainPath, "/", part.path);
+            decoratedPath = Mutils.join(decoratedPath, "/", part.path);
+            for (Map.Entry<String, List<ResourceMethodParam.RequestBasedParam>> entry : paramsByWireName(part.matrixParams).entrySet()) {
+                String wireName = entry.getKey();
+                List<ResourceMethodParam.RequestBasedParam> params = entry.getValue();
+                boolean multiValued = params.stream().anyMatch(ResourceMethodParam.RequestBasedParam::isMultiValued);
+                boolean needsAlias = matrixParamSiteCounts.get(wireName) > 1 || usedPathParameterNames.contains(wireName);
+
+                // Matrix-style arrays use the OpenAPI parameter name as their wire name. If that name
+                // needs an alias, OpenAPI cannot express the repeated values without changing the wire URI.
+                if (multiValued && needsAlias) {
+                    continue;
+                }
+
+                String parameterName = needsAlias
+                    ? uniqueParameterName(matrixAliasBase(plainPath, wireName), usedPathParameterNames)
+                    : wireName;
+                usedPathParameterNames.add(parameterName);
+                ResourceMethodParam.RequestBasedParam representative = params.stream()
+                    .filter(ResourceMethodParam.RequestBasedParam::isMultiValued)
+                    .findFirst()
+                    .orElse(params.get(0));
+                MatrixParamDocumentation documentation = new MatrixParamDocumentation(parameterName, multiValued);
+                documentedMatrixParams.put(representative, documentation);
+
+                if (multiValued) {
+                    String template = "{" + parameterName + "}";
+                    if (!decoratedPath.endsWith(template)) {
+                        decoratedPath += template;
+                    }
+                } else {
+                    String template = ";" + wireName + "={" + parameterName + "}";
+                    if (!decoratedPath.contains(template)) {
+                        decoratedPath += template;
+                    }
+                }
+            }
+        }
+        return new DocumentedPath("/" + Mutils.trim(decoratedPath, "/"), documentedMatrixParams);
     }
 
-    private static List<String> matrixParamNames(List<ResourceMethodParam> params) {
+    private static PathPart resourcePathPart(ResourceClass resourceClass) {
+        return new PathPart(resourceClass.pathPattern.pathWithoutRegex,
+            resourceClass.locatorMethod == null ? Collections.emptyList() : matrixParams(resourceClass.locatorMethod.params));
+    }
+
+    private static List<ResourceMethodParam.RequestBasedParam> matrixParams(List<ResourceMethodParam> params) {
         return params.stream()
             .filter(p -> p.source() == ResourceMethodParam.ValueSource.MATRIX_PARAM)
             .map(ResourceMethodParam.RequestBasedParam.class::cast)
-            .map(ResourceMethodParam.RequestBasedParam::key)
-            .distinct()
             .collect(Collectors.toList());
     }
 
-    private static @Nullable String appendMatrixTemplates(@Nullable String path, List<String> matrixParams) {
-        for (String matrixParam : matrixParams) {
-            path = appendMatrixTemplateToLastSegment(path, matrixParam);
+    private static Map<String, List<ResourceMethodParam.RequestBasedParam>> paramsByWireName(List<ResourceMethodParam.RequestBasedParam> params) {
+        Map<String, List<ResourceMethodParam.RequestBasedParam>> byName = new LinkedHashMap<>();
+        for (ResourceMethodParam.RequestBasedParam param : params) {
+            byName.computeIfAbsent(param.key(), ignored -> new ArrayList<>()).add(param);
         }
-        return path;
+        return byName;
     }
 
-    private static String appendMatrixTemplateToLastSegment(@Nullable String path, String matrixParam) {
-        String template = ";" + matrixParam + "={" + matrixParam + "}";
-        if (path == null) {
-            return template;
+    private static String matrixAliasBase(String path, String wireName) {
+        String lastSegment = path.substring(path.lastIndexOf('/') + 1);
+        Matcher matcher = PATH_TEMPLATE_PATTERN.matcher(lastSegment);
+        @Nullable String segmentName = null;
+        while (matcher.find()) {
+            segmentName = matcher.group(1);
         }
-        if (path.contains(template)) {
-            return path;
+        if (segmentName == null) {
+            segmentName = lastSegment;
         }
-        return path + template;
+        String safeSegmentName = safeParameterName(segmentName);
+        return (safeSegmentName.isEmpty() ? "matrix" : safeSegmentName) + "_" + safeParameterName(wireName);
+    }
+
+    private static String safeParameterName(String name) {
+        String safeName = name.replaceAll("[^A-Za-z0-9_]", "_");
+        return !safeName.isEmpty() && Character.isDigit(safeName.charAt(0)) ? "_" + safeName : safeName;
+    }
+
+    private static String uniqueParameterName(String base, Set<String> usedNames) {
+        String candidate = base;
+        for (int suffix = 2; usedNames.contains(candidate); suffix++) {
+            candidate = base + "_" + suffix;
+        }
+        return candidate;
+    }
+
+    private static final class PathPart {
+        private final @Nullable String path;
+        private final List<ResourceMethodParam.RequestBasedParam> matrixParams;
+
+        private PathPart(@Nullable String path, List<ResourceMethodParam.RequestBasedParam> matrixParams) {
+            this.path = path;
+            this.matrixParams = matrixParams;
+        }
+    }
+
+    private static final class MatrixParamDocumentation {
+        private final String parameterName;
+        private final boolean nativeMatrixStyle;
+
+        private MatrixParamDocumentation(String parameterName, boolean nativeMatrixStyle) {
+            this.parameterName = parameterName;
+            this.nativeMatrixStyle = nativeMatrixStyle;
+        }
+    }
+
+    private static final class DocumentedPath {
+        private final String path;
+        private final IdentityHashMap<ResourceMethodParam.RequestBasedParam, MatrixParamDocumentation> matrixParams;
+
+        private DocumentedPath(String path, IdentityHashMap<ResourceMethodParam.RequestBasedParam, MatrixParamDocumentation> matrixParams) {
+            this.path = path;
+            this.matrixParams = matrixParams;
+        }
     }
 
 }

--- a/src/main/java/io/muserver/rest/OpenApiDocumentor.java
+++ b/src/main/java/io/muserver/rest/OpenApiDocumentor.java
@@ -152,7 +152,7 @@ class OpenApiDocumentor implements MuHandler {
                 pathItems.put(path, pathItem);
             }
             List<ParameterObject> parameters = method.paramsIncludingLocators().stream()
-                .filter(p -> p.source().openAPIIn != null && p instanceof ResourceMethodParam.RequestBasedParam)
+                .filter(p -> (p.source().openAPIIn != null || p.source() == ResourceMethodParam.ValueSource.MATRIX_PARAM) && p instanceof ResourceMethodParam.RequestBasedParam)
                 .map(ResourceMethodParam.RequestBasedParam.class::cast)
                 .map(p -> p.createDocumentationBuilder().build())
                 .reduce(new ArrayList<>(), (parameterObjects, parameterObject) -> {
@@ -214,9 +214,29 @@ class OpenApiDocumentor implements MuHandler {
     }
 
     static String getPathWithoutRegex(ResourceClass rc, ResourceMethod rm, String parentResourcePath) {
+        String resourcePath = rc.pathPattern == null ? null : rc.pathPattern.pathWithoutRegex;
+        if (resourcePath != null) {
+            List<String> matrixParams = rm.paramsIncludingLocators().stream()
+                .filter(p -> p.source() == ResourceMethodParam.ValueSource.MATRIX_PARAM)
+                .map(ResourceMethodParam.RequestBasedParam.class::cast)
+                .map(ResourceMethodParam.RequestBasedParam::key)
+                .distinct()
+                .collect(Collectors.toList());
+            for (String matrixParam : matrixParams) {
+                resourcePath = appendMatrixTemplateToLastSegment(resourcePath, matrixParam);
+            }
+        }
         return "/" + Mutils.trim(Mutils.join(parentResourcePath, "/",
-            Mutils.join(rc.pathPattern == null ? null : rc.pathPattern.pathWithoutRegex,
+            Mutils.join(resourcePath,
                 "/", rm.pathPattern() == null ? null : rm.pathPattern().pathWithoutRegex)), "/");
+    }
+
+    private static String appendMatrixTemplateToLastSegment(String path, String matrixParam) {
+        String template = ";" + matrixParam + "={" + matrixParam + "}";
+        if (path.contains(template)) {
+            return path;
+        }
+        return path + template;
     }
 
 }

--- a/src/main/java/io/muserver/rest/OpenApiDocumentor.java
+++ b/src/main/java/io/muserver/rest/OpenApiDocumentor.java
@@ -216,23 +216,44 @@ class OpenApiDocumentor implements MuHandler {
     static String getPathWithoutRegex(ResourceClass rc, ResourceMethod rm, String parentResourcePath) {
         String resourcePath = rc.pathPattern == null ? null : rc.pathPattern.pathWithoutRegex;
         if (resourcePath != null) {
-            List<String> matrixParams = rm.paramsIncludingLocators().stream()
-                .filter(p -> p.source() == ResourceMethodParam.ValueSource.MATRIX_PARAM)
-                .map(ResourceMethodParam.RequestBasedParam.class::cast)
-                .map(ResourceMethodParam.RequestBasedParam::key)
-                .distinct()
-                .collect(Collectors.toList());
-            for (String matrixParam : matrixParams) {
-                resourcePath = appendMatrixTemplateToLastSegment(resourcePath, matrixParam);
+            resourcePath = appendMatrixTemplates(resourcePath,
+                rc.locatorMethod == null ? Collections.emptyList() : matrixParamNames(rc.locatorMethod.params));
+        }
+        @Nullable String methodPath = rm.pathPattern() == null ? null : rm.pathPattern().pathWithoutRegex;
+        List<String> methodMatrixParams = matrixParamNames(rm.params);
+        if (!methodMatrixParams.isEmpty()) {
+            if (methodPath == null) {
+                resourcePath = appendMatrixTemplates(resourcePath, methodMatrixParams);
+            } else {
+                methodPath = appendMatrixTemplates(methodPath, methodMatrixParams);
             }
         }
         return "/" + Mutils.trim(Mutils.join(parentResourcePath, "/",
             Mutils.join(resourcePath,
-                "/", rm.pathPattern() == null ? null : rm.pathPattern().pathWithoutRegex)), "/");
+                "/", methodPath)), "/");
     }
 
-    private static String appendMatrixTemplateToLastSegment(String path, String matrixParam) {
+    private static List<String> matrixParamNames(List<ResourceMethodParam> params) {
+        return params.stream()
+            .filter(p -> p.source() == ResourceMethodParam.ValueSource.MATRIX_PARAM)
+            .map(ResourceMethodParam.RequestBasedParam.class::cast)
+            .map(ResourceMethodParam.RequestBasedParam::key)
+            .distinct()
+            .collect(Collectors.toList());
+    }
+
+    private static @Nullable String appendMatrixTemplates(@Nullable String path, List<String> matrixParams) {
+        for (String matrixParam : matrixParams) {
+            path = appendMatrixTemplateToLastSegment(path, matrixParam);
+        }
+        return path;
+    }
+
+    private static String appendMatrixTemplateToLastSegment(@Nullable String path, String matrixParam) {
         String template = ";" + matrixParam + "={" + matrixParam + "}";
+        if (path == null) {
+            return template;
+        }
         if (path.contains(template)) {
             return path;
         }

--- a/src/main/java/io/muserver/rest/OpenApiDocumentor.java
+++ b/src/main/java/io/muserver/rest/OpenApiDocumentor.java
@@ -263,7 +263,7 @@ class OpenApiDocumentor implements MuHandler {
                 String wireName = entry.getKey();
                 List<ResourceMethodParam.RequestBasedParam> params = entry.getValue();
                 boolean multiValued = params.stream().anyMatch(ResourceMethodParam.RequestBasedParam::isMultiValued);
-                boolean needsAlias = matrixParamSiteCounts.get(wireName) > 1 || usedPathParameterNames.contains(wireName);
+                boolean needsAlias = Objects.requireNonNull(matrixParamSiteCounts.get(wireName)) > 1 || usedPathParameterNames.contains(wireName);
 
                 // Matrix-style arrays use the OpenAPI parameter name as their wire name. If that name
                 // needs an alias, OpenAPI cannot express the repeated values without changing the wire URI.

--- a/src/main/java/io/muserver/rest/OpenApiDocumentor.java
+++ b/src/main/java/io/muserver/rest/OpenApiDocumentor.java
@@ -61,8 +61,9 @@ class OpenApiDocumentor implements MuHandler {
         List<TagObject> tags = new ArrayList<>();
 
         Map<String, PathItemObjectBuilder> pathItemBuilders = new LinkedHashMap<>();
+        Set<String> operationIds = new HashSet<>();
         for (ResourceClass root : roots) {
-            addResourceClass(0, Collections.emptyList(), tags, pathItemBuilders, root);
+            addResourceClass(0, Collections.emptyList(), tags, pathItemBuilders, operationIds, root);
         }
         Map<String, PathItemObject> pathItems = pathItemBuilders.entrySet().stream().collect(Collectors.toMap(Map.Entry::getKey, v -> v.getValue().build()));
 
@@ -122,7 +123,9 @@ class OpenApiDocumentor implements MuHandler {
         return true;
     }
 
-    private void addResourceClass(int recursiveLevel, List<PathPart> parentPathParts, List<TagObject> tags, Map<String, PathItemObjectBuilder> pathItems, ResourceClass root) {
+    private void addResourceClass(int recursiveLevel, List<PathPart> parentPathParts, List<TagObject> tags,
+                                  Map<String, PathItemObjectBuilder> pathItems, Set<String> operationIds,
+                                  ResourceClass root) {
         if (recursiveLevel == 5) {
             return;
         }
@@ -135,7 +138,7 @@ class OpenApiDocumentor implements MuHandler {
                 ResourceClass rc = ResourceClass.forSubResourceLocator(method, method.methodHandle().getReturnType(), null, schemaObjectCustomizer, paramConverterProviders);
                 List<PathPart> newParentPathParts = new ArrayList<>(parentPathParts);
                 newParentPathParts.add(resourcePathPart(root));
-                addResourceClass(recursiveLevel + 1, newParentPathParts, tags, pathItems, rc);
+                addResourceClass(recursiveLevel + 1, newParentPathParts, tags, pathItems, operationIds, rc);
                 continue;
             }
 
@@ -177,13 +180,15 @@ class OpenApiDocumentor implements MuHandler {
                     return list1;
                 });
 
-            String opIdPath = path.replace("{", "_").replace("}", "_");
+            String opIdPath = documentedPath.plainPath.replace("{", "_").replace("}", "_");
             String opPath = Mutils.trim(opIdPath, "/").replace("/", "_");
             String opKey = method.requiredHttpMethod().name().toLowerCase(Locale.ROOT);
             OperationObject existing = operations.get(opKey);
             if (existing == null) {
+                String operationId = uniqueName(method.requiredHttpMethod().name() + "_" + opPath, operationIds);
+                operationIds.add(operationId);
                 existing = method.createOperationBuilder(customSchemas)
-                    .withOperationId(method.requiredHttpMethod().name() + "_" + opPath)
+                    .withOperationId(operationId)
                     .withTags(singletonList(root.tag.name()))
                     .withParameters(parameters)
                     .build();
@@ -257,8 +262,10 @@ class OpenApiDocumentor implements MuHandler {
         String plainPath = "";
         String decoratedPath = "";
         for (PathPart part : parts) {
-            plainPath = Mutils.join(plainPath, "/", part.path);
-            decoratedPath = Mutils.join(decoratedPath, "/", part.path);
+            if (part.path != null && !part.path.equals("/")) {
+                plainPath = Mutils.join(plainPath, "/", part.path);
+                decoratedPath = Mutils.join(decoratedPath, "/", part.path);
+            }
             for (Map.Entry<String, List<ResourceMethodParam.RequestBasedParam>> entry : paramsByWireName(part.matrixParams).entrySet()) {
                 String wireName = entry.getKey();
                 List<ResourceMethodParam.RequestBasedParam> params = entry.getValue();
@@ -272,7 +279,7 @@ class OpenApiDocumentor implements MuHandler {
                 }
 
                 String parameterName = needsAlias
-                    ? uniqueParameterName(matrixAliasBase(plainPath, wireName), usedPathParameterNames)
+                    ? uniqueName(matrixAliasBase(plainPath, wireName), usedPathParameterNames)
                     : wireName;
                 usedPathParameterNames.add(parameterName);
                 ResourceMethodParam.RequestBasedParam representative = params.stream()
@@ -295,7 +302,10 @@ class OpenApiDocumentor implements MuHandler {
                 }
             }
         }
-        return new DocumentedPath("/" + Mutils.trim(decoratedPath, "/"), documentedMatrixParams);
+        return new DocumentedPath(
+            "/" + Mutils.trim(decoratedPath, "/"),
+            "/" + Mutils.trim(plainPath, "/"),
+            documentedMatrixParams);
     }
 
     private static PathPart resourcePathPart(ResourceClass resourceClass) {
@@ -337,7 +347,7 @@ class OpenApiDocumentor implements MuHandler {
         return !safeName.isEmpty() && Character.isDigit(safeName.charAt(0)) ? "_" + safeName : safeName;
     }
 
-    private static String uniqueParameterName(String base, Set<String> usedNames) {
+    private static String uniqueName(String base, Set<String> usedNames) {
         String candidate = base;
         for (int suffix = 2; usedNames.contains(candidate); suffix++) {
             candidate = base + "_" + suffix;
@@ -367,10 +377,13 @@ class OpenApiDocumentor implements MuHandler {
 
     private static final class DocumentedPath {
         private final String path;
+        private final String plainPath;
         private final IdentityHashMap<ResourceMethodParam.RequestBasedParam, MatrixParamDocumentation> matrixParams;
 
-        private DocumentedPath(String path, IdentityHashMap<ResourceMethodParam.RequestBasedParam, MatrixParamDocumentation> matrixParams) {
+        private DocumentedPath(String path, String plainPath,
+                               IdentityHashMap<ResourceMethodParam.RequestBasedParam, MatrixParamDocumentation> matrixParams) {
             this.path = path;
+            this.plainPath = plainPath;
             this.matrixParams = matrixParams;
         }
     }

--- a/src/main/java/io/muserver/rest/PathMatch.java
+++ b/src/main/java/io/muserver/rest/PathMatch.java
@@ -77,6 +77,18 @@ public class PathMatch {
         return allParams;
     }
 
+    @Nullable PathSegment lastMatchedSegment() {
+        String remainder = lastGroup();
+        String matchedPath = matcher.group();
+        if (remainder != null && matchedPath.endsWith(remainder)) {
+            matchedPath = matchedPath.substring(0, matchedPath.length() - remainder.length());
+        }
+        while (matchedPath.endsWith("/")) {
+            matchedPath = matchedPath.substring(0, matchedPath.length() - 1);
+        }
+        return MuUriInfo.pathStringToSegments(matchedPath, false, true).reduce((first, second) -> second).orElse(null);
+    }
+
     PathMatch withParams(Map<String, PathSegment> combinedParams, Map<String, List<PathSegment>> combinedAllParams) {
         return new PathMatch(matches, combinedParams, combinedAllParams, matcher);
     }

--- a/src/main/java/io/muserver/rest/ResourceMethodParam.java
+++ b/src/main/java/io/muserver/rest/ResourceMethodParam.java
@@ -262,7 +262,7 @@ abstract class ResourceMethodParam {
             @Nullable Pattern pattern = pattern();
             @Nullable Pattern patternIfNotDefault = pattern == null || UriPattern.DEFAULT_CAPTURING_GROUP_PATTERN.equals(pattern.pattern()) ? null : pattern;
             return builder.withSchema(
-                schemaObjectFrom(type(), genericType(), isRequired())
+                schemaObjectFrom(type(), genericType(), source() == ValueSource.MATRIX_PARAM || isRequired())
                     .withDefaultValue(documentationDefaultValue())
                     .withExternalDocs(externalDoc)
                     .withPattern(patternIfNotDefault)

--- a/src/main/java/io/muserver/rest/ResourceMethodParam.java
+++ b/src/main/java/io/muserver/rest/ResourceMethodParam.java
@@ -245,20 +245,33 @@ abstract class ResourceMethodParam {
             return introspection().pattern;
         }
 
+        boolean isMultiValued() {
+            return array || createCollection(type()) != null;
+        }
+
         ParameterObjectBuilder createDocumentationBuilder() {
+            return createDocumentationBuilder(key());
+        }
+
+        ParameterObjectBuilder createDocumentationBuilder(String documentationName) {
             ParameterObjectBuilder builder = parameterObject()
                 .withIn(source() == ValueSource.MATRIX_PARAM ? "path" : requireNonNull(source().openAPIIn, "Parameter source is not represented as an OpenAPI parameter"))
                 .withRequired(source() == ValueSource.MATRIX_PARAM || isRequired())
                 .withDeprecated(deprecated() ? true : null)
-                .withName(key());
+                .withName(documentationName);
+            @Nullable String description = null;
             @Nullable ExternalDocumentationObject externalDoc = null;
             if (descriptionData != null) {
                 String desc = descriptionData.summaryAndDescription();
-                builder
-                    .withDescription(key().equals(desc) ? null : desc)
-                    .withExample(descriptionData.example);
+                description = key().equals(desc) ? null : desc;
+                builder.withExample(descriptionData.example);
                 externalDoc = descriptionData.externalDocumentation;
             }
+            if (source() == ValueSource.MATRIX_PARAM && !documentationName.equals(key())) {
+                String matrixDescription = "Matrix parameter \"" + key() + "\".";
+                description = description == null ? matrixDescription : matrixDescription + " " + description;
+            }
+            builder.withDescription(description);
             @Nullable Pattern pattern = pattern();
             @Nullable Pattern patternIfNotDefault = pattern == null || UriPattern.DEFAULT_CAPTURING_GROUP_PATTERN.equals(pattern.pattern()) ? null : pattern;
             return builder.withSchema(

--- a/src/main/java/io/muserver/rest/ResourceMethodParam.java
+++ b/src/main/java/io/muserver/rest/ResourceMethodParam.java
@@ -247,8 +247,8 @@ abstract class ResourceMethodParam {
 
         ParameterObjectBuilder createDocumentationBuilder() {
             ParameterObjectBuilder builder = parameterObject()
-                .withIn(requireNonNull(source().openAPIIn, "Parameter source is not represented as an OpenAPI parameter"))
-                .withRequired(isRequired())
+                .withIn(source() == ValueSource.MATRIX_PARAM ? "path" : requireNonNull(source().openAPIIn, "Parameter source is not represented as an OpenAPI parameter"))
+                .withRequired(source() == ValueSource.MATRIX_PARAM || isRequired())
                 .withDeprecated(deprecated() ? true : null)
                 .withName(key());
             @Nullable ExternalDocumentationObject externalDoc = null;
@@ -382,7 +382,7 @@ abstract class ResourceMethodParam {
                     : source() == ValueSource.HEADER_PARAM ? getParamValues(jaxRequest.getHeaders(), key(), cps, collection != null || array)
                     : source() == ValueSource.FORM_PARAM ? muRequest.form().getAll(key())
                     : source() == ValueSource.COOKIE_PARAM ? cookieValue(muRequest, key())
-                    : source() == ValueSource.MATRIX_PARAM ? matrixParamValue(key(), jaxRequest.relativePath())
+                    : source() == ValueSource.MATRIX_PARAM ? matrixParamValue(key(), matchedMethod.pathMatch)
                     : emptyList();
             boolean isSpecified = specifiedValue != null && !specifiedValue.isEmpty();
             if (encodedRequested() && isSpecified) {
@@ -461,11 +461,13 @@ abstract class ResourceMethodParam {
             return cookie.map(Collections::singletonList).orElse(emptyList());
         }
 
-        private List<String> matrixParamValue(String key, String path) {
-            MuPathSegment last = MuUriInfo.pathStringToSegments(path, false).reduce((first, second) -> second).orElse(null);
+        private List<String> matrixParamValue(String key, PathMatch pathMatch) {
+            // Jakarta REST defines @MatrixParam against the last matched path segment.
+            // Resolve from the current PathMatch rather than the request URI's final segment, so
+            // sub-resource locators and methods with the same matrix name remain segment-local.
+            PathSegment last = pathMatch.lastMatchedSegment();
             if (last != null && last.getMatrixParameters().containsKey(key)) {
                 return last.getMatrixParameters().get(key).stream()
-                    .map(Jaxutils::leniantUrlDecode)
                     .collect(Collectors.toList());
             }
             return emptyList();

--- a/src/test/java/io/muserver/rest/MatrixParamTest.java
+++ b/src/test/java/io/muserver/rest/MatrixParamTest.java
@@ -13,6 +13,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import static java.util.Arrays.asList;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static scaffolding.ClientUtils.call;
@@ -62,6 +63,110 @@ public class MatrixParamTest {
             .start();
         try (Response resp = call(request(server.uri().resolve("/cars/mercedes;country=Germany/e55;colour=black;colour=blue;year=2021")))) {
             assertThat(resp.body().string(), is("2021: black, blue"));
+        }
+    }
+
+    @Test
+    public void matrixParamsOnResourceMethodAreSegmentLocalAndSupportConversionDefaultsAndPathSegmentAccess() throws IOException {
+        @Path("/items/{id}")
+        class ItemResource {
+            @GET
+            public String get(@PathParam("id") String id,
+                              @PathParam("id") PathSegment segment,
+                              @MatrixParam("idType") String idType,
+                              @MatrixParam("missing") @DefaultValue("17") int missing,
+                              @MatrixParam("tag") List<String> tags) {
+                return id + "|" + segment.getPath() + "|" + segment.getMatrixParameters().getFirst("idType") + "|" + idType + "|" + missing + "|" + String.join(",", tags);
+            }
+        }
+
+        server = ServerUtils.httpsServerForTest()
+            .addHandler(RestHandlerBuilder.restHandler(new ItemResource()).build())
+            .start();
+        try (Response resp = call(request(server.uri().resolve("/items/123;idType=legacy;tag=one;tag=two")))) {
+            assertThat(resp.body().string(), is("123|123|legacy|legacy|17|one,two"));
+        }
+        try (Response resp = call(request(server.uri().resolve("/items/123;missing=nope")))) {
+            assertThat(resp.code(), is(400));
+        }
+    }
+
+    @Test
+    public void subResourceLocatorReceivesMatrixParamsFromItsOwnMatchedSegment() throws IOException {
+        class ChildResource {
+            private final String result;
+            ChildResource(String result) { this.result = result; }
+            @GET
+            @Path("children")
+            public String child() { return result + "|child"; }
+        }
+        @Path("/resources")
+        class RootResource {
+            @Path("/{id}")
+            public ChildResource locate(@PathParam("id") String id, @MatrixParam("idType") String idType) {
+                return new ChildResource(id + "|" + idType);
+            }
+        }
+
+        server = ServerUtils.httpsServerForTest()
+            .addHandler(RestHandlerBuilder.restHandler(new RootResource()).build())
+            .start();
+        try (Response resp = call(request(server.uri().resolve("/resources/123;idType=legacy/children")))) {
+            assertThat(resp.body().string(), is("123|legacy|child"));
+        }
+    }
+
+    @Test
+    public void sameMatrixParamNameOnMultipleSegmentsResolvesAgainstCurrentMatchedSegment() throws IOException {
+        class ChildResource {
+            private final String outer;
+            ChildResource(String outer) { this.outer = outer; }
+            @GET
+            @Path("children/ordinary/{childId}")
+            public String child(@PathParam("childId") String childId, @MatrixParam("idType") String inner) {
+                return outer + "|" + childId + ":" + inner;
+            }
+        }
+        @Path("/resources")
+        class RootResource {
+            @Path("/{id}")
+            public ChildResource locate(@PathParam("id") String id, @MatrixParam("idType") String idType) {
+                return new ChildResource(id + ":" + idType);
+            }
+        }
+
+        server = ServerUtils.httpsServerForTest()
+            .addHandler(RestHandlerBuilder.restHandler(new RootResource()).build())
+            .start();
+        for (String[] uriAndExpected : asList(
+            new String[]{"/resources/123;idType=legacy/children/ordinary/456;idType=external", "123:legacy|456:external"},
+            new String[]{"/resources/123;idType=legacy/children/ordinary/456", "123:legacy|456:null"},
+            new String[]{"/resources/123/children/ordinary/456;idType=external", "123:null|456:external"})) {
+            try (Response resp = call(request(server.uri().resolve(uriAndExpected[0])))) {
+                assertThat(resp.body().string(), is(uriAndExpected[1]));
+            }
+        }
+    }
+
+    @Test
+    public void encodedAndEdgeCaseMatrixValuesUsePathSegmentSemantics() throws IOException {
+        @Path("/edge/{id}")
+        class EdgeResource {
+            @GET
+            public String get(@PathParam("id") String id,
+                              @PathParam("id") PathSegment segment,
+                              @MatrixParam("idType") String idType,
+                              @MatrixParam("empty") String empty,
+                              @MatrixParam("IDTYPE") String upper) {
+                return id + "|" + segment.getPath() + "|" + idType + "|" + segment.getMatrixParameters().getFirst("kind") + "|" + empty + "|" + upper;
+            }
+        }
+
+        server = ServerUtils.httpsServerForTest()
+            .addHandler(RestHandlerBuilder.restHandler(new EdgeResource()).build())
+            .start();
+        try (Response resp = call(request(server.uri().resolve("/edge/a%3Bb;idType=leg%20acy;kind=primary;empty;IDTYPE=upper?x=1")))) {
+            assertThat(resp.body().string(), is("a;b|a;b|leg acy|primary||upper"));
         }
     }
 

--- a/src/test/java/io/muserver/rest/MuUriBuilderTest.java
+++ b/src/test/java/io/muserver/rest/MuUriBuilderTest.java
@@ -348,6 +348,39 @@ public class MuUriBuilderTest {
     }
 
     @Test
+    public void matrixParamsAttachToCurrentFinalSegmentAndSurviveLaterPathOperations() {
+        URI uri = UriBuilder.fromPath("/resources/{id}")
+            .resolveTemplate("id", "123")
+            .matrixParam("idType", "legacy")
+            .path("children")
+            .segment("456;opaque")
+            .matrixParam("idType", "external", "canonical")
+            .build();
+
+        assertThat(uri.toString(), equalTo("/resources/123;idType=legacy/children/456%3Bopaque;idType=external;idType=canonical"));
+    }
+
+    @Test
+    public void matrixParamsWorkWithBuildBuildFromMapCloneAndLiteralPathSyntax() {
+        UriBuilder builder = UriBuilder.fromPath("/resources/{id};literal={literal}/children")
+            .matrixParam("idType", "{idType}");
+
+        assertThat(builder.build("a b", "kept", "legacy").toString(),
+            equalTo("/resources/a%20b;literal=kept/children;idType=legacy"));
+        assertThat(builder.buildFromMap(new HashMap<String, Object>() {{
+            put("id", "a/b");
+            put("literal", "x=y");
+            put("idType", "leg;acy");
+        }}).toString(), equalTo("/resources/a%2Fb;literal=x%3Dy/children;idType=leg%3Bacy"));
+
+        UriBuilder clone = builder.clone().replaceMatrixParam("idType", "external");
+        assertThat(clone.buildFromMap(new HashMap<String, Object>() {{
+            put("id", "123");
+            put("literal", "kept");
+        }}).toString(), equalTo("/resources/123;literal=kept/children;idType=external"));
+    }
+
+    @Test
     public void replaceQueryWithNullValueClearsParams() {
         URI uri = MuUriBuilder.fromUri(u("http://example.org/blah?hah=ba"))
             .queryParam("a", "b")

--- a/src/test/java/io/muserver/rest/OpenApiDocumentorTest.java
+++ b/src/test/java/io/muserver/rest/OpenApiDocumentorTest.java
@@ -923,6 +923,8 @@ public class OpenApiDocumentorTest {
             assertThat(parameters.toString(), not(containsString("\"style\":\"matrix\"")));
             assertThat(parameters.toString(), containsString("\"legacy\""));
             assertThat(parameters.toString(), containsString("\"external\""));
+            assertThat(parameters.toString(), not(containsString("\"nullable\":true")));
+            assertThat(parameters.toString(), not(containsString("null")));
         }
     }
 

--- a/src/test/java/io/muserver/rest/OpenApiDocumentorTest.java
+++ b/src/test/java/io/muserver/rest/OpenApiDocumentorTest.java
@@ -43,6 +43,16 @@ public class OpenApiDocumentorTest {
     private MuServer server;
     enum MatrixOpenApiIdType { legacy, external }
 
+    private static JSONObject parameterNamed(JSONArray parameters, String name) {
+        for (int i = 0; i < parameters.length(); i++) {
+            JSONObject parameter = parameters.getJSONObject(i);
+            if (name.equals(parameter.getString("name"))) {
+                return parameter;
+            }
+        }
+        throw new AssertionError("No parameter named " + name + " in " + parameters);
+    }
+
     private static MuServer serverWithPetStore() {
         return httpsServerForTest()
             .addHandler(restHandler(
@@ -952,6 +962,169 @@ public class OpenApiDocumentorTest {
             JSONObject paths = doc.getJSONObject("paths");
             assertThat(paths.has("/resources/{id};idType={idType}/children/{childId};childType={childType}"), is(true));
             assertThat(paths.has("/resources/{id};idType={idType};childType={childType}/children/{childId}"), is(false));
+        }
+    }
+
+    @Test
+    public void openApiAliasesTheSameMatrixNameOnDifferentSegments() throws Exception {
+        class ChildResource {
+            @GET
+            @Path("children/{childId}")
+            public void children(@PathParam("childId") String childId,
+                                 @MatrixParam("type") @Description(value = "Component type", example = "x") String type) { }
+        }
+        @Path("resources")
+        class ResourceRoot {
+            @Path("{id}")
+            public ChildResource locate(@PathParam("id") String id,
+                                        @MatrixParam("type") @Description(value = "Product type", example = "legacy") String type) {
+                return new ChildResource();
+            }
+        }
+
+        server = httpsServerForTest()
+            .addHandler(restHandler(new ResourceRoot()).withOpenApiJsonUrl("/openapi.json"))
+            .start();
+
+        try (okhttp3.Response resp = call(request(server.uri().resolve("/openapi.json")))) {
+            JSONObject doc = new JSONObject(resp.body().string());
+            JSONObject get = doc.getJSONObject("paths")
+                .getJSONObject("/resources/{id};type={id_type}/children/{childId};type={childId_type}")
+                .getJSONObject("get");
+            JSONArray parameters = get.getJSONArray("parameters");
+            assertThat(parameters.length(), is(4));
+
+            JSONObject productType = parameterNamed(parameters, "id_type");
+            assertThat(productType.getString("in"), is("path"));
+            assertThat(productType.getBoolean("required"), is(true));
+            assertThat(productType.getString("description"), is("Matrix parameter \"type\". Product type"));
+            assertThat(productType.getString("example"), is("legacy"));
+
+            JSONObject componentType = parameterNamed(parameters, "childId_type");
+            assertThat(componentType.getString("description"), is("Matrix parameter \"type\". Component type"));
+            assertThat(componentType.getString("example"), is("x"));
+        }
+    }
+
+    @Test
+    public void openApiAliasesMatrixNamesThatCollideWithPathParameterNames() throws Exception {
+        @Path("resources")
+        class ResourceRoot {
+            @GET
+            @Path("{type}")
+            public void get(@PathParam("type") String type, @MatrixParam("type") String matrixType) { }
+        }
+
+        server = httpsServerForTest()
+            .addHandler(restHandler(new ResourceRoot()).withOpenApiJsonUrl("/openapi.json"))
+            .start();
+
+        try (okhttp3.Response resp = call(request(server.uri().resolve("/openapi.json")))) {
+            JSONObject doc = new JSONObject(resp.body().string());
+            JSONArray parameters = doc.getJSONObject("paths")
+                .getJSONObject("/resources/{type};type={type_type}")
+                .getJSONObject("get")
+                .getJSONArray("parameters");
+            assertThat(parameters.length(), is(2));
+            assertThat(parameterNamed(parameters, "type").getString("in"), is("path"));
+            assertThat(parameterNamed(parameters, "type_type").getString("description"), is("Matrix parameter \"type\"."));
+        }
+    }
+
+    @Test
+    public void openApiKeepsMatrixParamsFromNestedSubResourceLocators() throws Exception {
+        class LeafResource {
+            @GET
+            @Path("leaves/{leafId}")
+            public void leaf(@PathParam("leafId") String leafId, @MatrixParam("type") String leafType) { }
+        }
+        class ChildResource {
+            @Path("children/{childId}")
+            public LeafResource child(@PathParam("childId") String childId, @MatrixParam("type") String childType) {
+                return new LeafResource();
+            }
+        }
+        @Path("roots")
+        class RootResource {
+            @Path("{rootId}")
+            public ChildResource root(@PathParam("rootId") String rootId, @MatrixParam("type") String rootType) {
+                return new ChildResource();
+            }
+        }
+
+        server = httpsServerForTest()
+            .addHandler(restHandler(new RootResource()).withOpenApiJsonUrl("/openapi.json"))
+            .start();
+
+        try (okhttp3.Response resp = call(request(server.uri().resolve("/openapi.json")))) {
+            JSONObject doc = new JSONObject(resp.body().string());
+            JSONObject get = doc.getJSONObject("paths")
+                .getJSONObject("/roots/{rootId};type={rootId_type}/children/{childId};type={childId_type}/leaves/{leafId};type={leafId_type}")
+                .getJSONObject("get");
+            JSONArray parameters = get.getJSONArray("parameters");
+            assertThat(parameters.length(), is(6));
+            assertThat(parameterNamed(parameters, "rootId_type").getString("description"), is("Matrix parameter \"type\"."));
+            assertThat(parameterNamed(parameters, "childId_type").getString("description"), is("Matrix parameter \"type\"."));
+            assertThat(parameterNamed(parameters, "leafId_type").getString("description"), is("Matrix parameter \"type\"."));
+        }
+    }
+
+    @Test
+    public void openApiUsesNativeMatrixStyleForCollectionValues() throws Exception {
+        @Path("resources")
+        class ResourceRoot {
+            @GET
+            @Path("{id}")
+            public void get(@PathParam("id") String id, @MatrixParam("tag") List<String> tags) { }
+        }
+
+        server = httpsServerForTest()
+            .addHandler(restHandler(new ResourceRoot()).withOpenApiJsonUrl("/openapi.json"))
+            .start();
+
+        try (okhttp3.Response resp = call(request(server.uri().resolve("/openapi.json")))) {
+            JSONObject doc = new JSONObject(resp.body().string());
+            JSONArray parameters = doc.getJSONObject("paths")
+                .getJSONObject("/resources/{id}{tag}")
+                .getJSONObject("get")
+                .getJSONArray("parameters");
+            JSONObject tags = parameterNamed(parameters, "tag");
+            assertThat(tags.getString("in"), is("path"));
+            assertThat(tags.getString("style"), is("matrix"));
+            assertThat(tags.getBoolean("explode"), is(true));
+            assertThat(tags.getJSONObject("schema").getString("type"), is("array"));
+        }
+    }
+
+    @Test
+    public void openApiOmitsCollectionMatrixParamsWhenTheirWireNameWouldNeedAnAlias() throws Exception {
+        class ChildResource {
+            @GET
+            @Path("children/{childId}")
+            public void children(@PathParam("childId") String childId, @MatrixParam("tag") List<String> tags) { }
+        }
+        @Path("resources")
+        class ResourceRoot {
+            @Path("{id}")
+            public ChildResource locate(@PathParam("id") String id, @MatrixParam("tag") List<String> tags) {
+                return new ChildResource();
+            }
+        }
+
+        server = httpsServerForTest()
+            .addHandler(restHandler(new ResourceRoot()).withOpenApiJsonUrl("/openapi.json"))
+            .start();
+
+        try (okhttp3.Response resp = call(request(server.uri().resolve("/openapi.json")))) {
+            JSONObject doc = new JSONObject(resp.body().string());
+            JSONObject get = doc.getJSONObject("paths")
+                .getJSONObject("/resources/{id}/children/{childId}")
+                .getJSONObject("get");
+            JSONArray parameters = get.getJSONArray("parameters");
+            assertThat(parameters.length(), is(2));
+            assertThat(parameterNamed(parameters, "id").getString("in"), is("path"));
+            assertThat(parameterNamed(parameters, "childId").getString("in"), is("path"));
+            assertThat(parameters.toString(), not(containsString("\"name\":\"tag\"")));
         }
     }
 

--- a/src/test/java/io/muserver/rest/OpenApiDocumentorTest.java
+++ b/src/test/java/io/muserver/rest/OpenApiDocumentorTest.java
@@ -895,7 +895,7 @@ public class OpenApiDocumentorTest {
         class ChildResource {
             @GET
             @Path("children")
-            public void children(@PathParam("id") String id, @MatrixParam("idType") MatrixOpenApiIdType idType) { }
+            public void children(@PathParam("id") String id) { }
         }
         @Path("resources")
         class ResourceRoot {
@@ -925,6 +925,33 @@ public class OpenApiDocumentorTest {
             assertThat(parameters.toString(), containsString("\"external\""));
             assertThat(parameters.toString(), not(containsString("\"nullable\":true")));
             assertThat(parameters.toString(), not(containsString("null")));
+        }
+    }
+
+    @Test
+    public void openApiPlacesMatrixParamsOnTheSegmentMatchedByTheDeclaringMethodOrLocator() throws Exception {
+        class ChildResource {
+            @GET
+            @Path("children/{childId}")
+            public void children(@PathParam("childId") String childId, @MatrixParam("childType") String childType) { }
+        }
+        @Path("resources")
+        class ResourceRoot {
+            @Path("{id}")
+            public ChildResource locate(@PathParam("id") String id, @MatrixParam("idType") String idType) {
+                return new ChildResource();
+            }
+        }
+
+        server = httpsServerForTest()
+            .addHandler(restHandler(new ResourceRoot()).withOpenApiJsonUrl("/openapi.json"))
+            .start();
+
+        try (okhttp3.Response resp = call(request(server.uri().resolve("/openapi.json")))) {
+            JSONObject doc = new JSONObject(resp.body().string());
+            JSONObject paths = doc.getJSONObject("paths");
+            assertThat(paths.has("/resources/{id};idType={idType}/children/{childId};childType={childType}"), is(true));
+            assertThat(paths.has("/resources/{id};idType={idType};childType={childType}/children/{childId}"), is(false));
         }
     }
 

--- a/src/test/java/io/muserver/rest/OpenApiDocumentorTest.java
+++ b/src/test/java/io/muserver/rest/OpenApiDocumentorTest.java
@@ -41,6 +41,7 @@ import static scaffolding.ServerUtils.httpsServerForTest;
 public class OpenApiDocumentorTest {
 
     private MuServer server;
+    enum MatrixOpenApiIdType { legacy, external }
 
     private static MuServer serverWithPetStore() {
         return httpsServerForTest()
@@ -886,6 +887,42 @@ public class OpenApiDocumentorTest {
             assertThat(doc.query("/paths/~1widgets~1{id}~1category~1{cat}/get/tags/0"), equalTo("WidgetsResource"));
             assertThat(doc.query("/paths/~1widgets~1{id}~1recursive~1{anotherId}~1category~1{cat}/get/tags/0"), equalTo("WidgetsResource"));
             assertThat(doc.query("/paths/~1widgets~1{id}~1recursive~1{anotherId}~1recursive~1{anotherId}~1category~1{cat}/get/tags/0"), equalTo("WidgetsResource"));
+        }
+    }
+
+    @Test
+    public void openApiRepresentsMatrixParamsAsPathTemplateParametersForUsableSubstitution() throws Exception {
+        class ChildResource {
+            @GET
+            @Path("children")
+            public void children(@PathParam("id") String id, @MatrixParam("idType") MatrixOpenApiIdType idType) { }
+        }
+        @Path("resources")
+        class ResourceRoot {
+            @Path("{id}")
+            public ChildResource locate(@PathParam("id") String id, @MatrixParam("idType") MatrixOpenApiIdType idType) {
+                return new ChildResource();
+            }
+        }
+
+        server = httpsServerForTest()
+            .addHandler(restHandler(new ResourceRoot()).withOpenApiJsonUrl("/openapi.json"))
+            .start();
+
+        try (okhttp3.Response resp = call(request(server.uri().resolve("/openapi.json")))) {
+            JSONObject doc = new JSONObject(resp.body().string());
+            JSONObject get = doc.getJSONObject("paths")
+                .getJSONObject("/resources/{id};idType={idType}/children")
+                .getJSONObject("get");
+            JSONArray parameters = get.getJSONArray("parameters");
+            assertThat(parameters.length(), is(2));
+            assertThat(parameters.toString(), containsString("\"name\":\"id\""));
+            assertThat(parameters.toString(), containsString("\"name\":\"idType\""));
+            assertThat(parameters.toString(), containsString("\"in\":\"path\""));
+            assertThat(parameters.toString(), not(containsString("\"in\":\"query\"")));
+            assertThat(parameters.toString(), not(containsString("\"style\":\"matrix\"")));
+            assertThat(parameters.toString(), containsString("\"legacy\""));
+            assertThat(parameters.toString(), containsString("\"external\""));
         }
     }
 

--- a/src/test/java/io/muserver/rest/OpenApiDocumentorTest.java
+++ b/src/test/java/io/muserver/rest/OpenApiDocumentorTest.java
@@ -991,6 +991,7 @@ public class OpenApiDocumentorTest {
             JSONObject get = doc.getJSONObject("paths")
                 .getJSONObject("/resources/{id};type={id_type}/children/{childId};type={childId_type}")
                 .getJSONObject("get");
+            assertThat(get.getString("operationId"), is("GET_resources__id__children__childId_"));
             JSONArray parameters = get.getJSONArray("parameters");
             assertThat(parameters.length(), is(4));
 
@@ -1003,6 +1004,41 @@ public class OpenApiDocumentorTest {
             JSONObject componentType = parameterNamed(parameters, "childId_type");
             assertThat(componentType.getString("description"), is("Matrix parameter \"type\". Component type"));
             assertThat(componentType.getString("example"), is("x"));
+        }
+    }
+
+    @Test
+    public void openApiOperationIdsIgnoreMatrixDecorationsAndRemainUnique() throws Exception {
+        @Path("resources/{id}")
+        class ResourceRoot {
+            @GET
+            @Produces("application/json")
+            public String asJson(@PathParam("id") String id, @MatrixParam("view") String view) {
+                return "{}";
+            }
+
+            @GET
+            @Produces("text/plain")
+            public String asText(@PathParam("id") String id, @MatrixParam("format") String format) {
+                return "text";
+            }
+        }
+
+        server = httpsServerForTest()
+            .addHandler(restHandler(new ResourceRoot()).withOpenApiJsonUrl("/openapi.json"))
+            .start();
+
+        try (okhttp3.Response resp = call(request(server.uri().resolve("/openapi.json")))) {
+            JSONObject paths = new JSONObject(resp.body().string()).getJSONObject("paths");
+            String viewOperationId = paths.getJSONObject("/resources/{id};view={view}")
+                .getJSONObject("get")
+                .getString("operationId");
+            String formatOperationId = paths.getJSONObject("/resources/{id};format={format}")
+                .getJSONObject("get")
+                .getString("operationId");
+
+            assertThat(List.of(viewOperationId, formatOperationId),
+                containsInAnyOrder("GET_resources__id_", "GET_resources__id__2"));
         }
     }
 


### PR DESCRIPTION
### Motivation

Jakarta REST matrix parameters are associated with a particular matched path segment. The previous Mu implementation instead read `@MatrixParam` values from the final segment of the complete request URI. For a request such as:

```text
/api/v1/products/123;type=legacy/sub-components/234;type=x
```

a matrix parameter declared by the product sub-resource locator should receive `legacy`, while one declared by the sub-component method should receive `x`.

This PR also makes matrix parameters usable from generated OpenAPI documents and corrects `UriBuilder.segment(...)` so segment values remain opaque data.

### Runtime and URI-building changes

- Resolve `@MatrixParam` from the last path segment matched by the resource method or sub-resource locator that declares it, rather than the request URI's final segment.
- Add `PathMatch.lastMatchedSegment()` to expose that segment while preserving the existing `PathSegment` decoding and matrix parsing behavior.
- Treat values passed to `UriBuilder.segment(...)` as a single opaque segment. A semicolon in segment data is therefore percent-encoded; callers can use `matrixParam(...)` to add matrix syntax.

These changes follow the Jakarta REST contracts: `@MatrixParam` refers to the last matched segment of the `@Path`-annotated structure that injects it, and matrix parameters are tied to individual URI path segments.

### OpenAPI behavior

- Preserve matrix parameters declared by root resources, resource methods, and nested sub-resource locators on their corresponding path segments.
- Represent scalar matrix parameters as literal matrix syntax plus ordinary path-template values, for example `/resources/{id};idType={idType}`. This works with Swagger UI's path substitution.
- Alias scalar OpenAPI parameter names when the same wire name is used on multiple segments, for example `/products/{id};type={id_type}/components/{componentId};type={componentId_type}`. The parameter description retains the actual matrix wire name.
- Preserve enum schemas, so Swagger UI renders enum matrix values as dropdowns.
- Use native OpenAPI `style: matrix` with `explode: true` for collection-valued matrix parameters when their OpenAPI name can remain the wire name.
- Omit collection-valued matrix parameters when their wire name would require an alias. OpenAPI matrix serialization uses the Parameter Object name as the wire name, so aliasing would generate the wrong URI.
- Generate `operationId` from the undecorated JAX-RS path. Matrix parameters do not participate in Jakarta REST resource-method selection and therefore do not define operation identity. If separately documented operations otherwise produce the same ID, add a numeric suffix to retain OpenAPI's uniqueness requirement.
- Attach method matrix parameters to the preceding matched segment when the resource method has no method-level `@Path`, rather than creating an artificial trailing empty segment.

OpenAPI requires every `in: path` parameter to be marked as required, even though Jakarta REST matrix parameters may be absent at runtime. This is an OpenAPI modeling limitation of the Swagger-compatible representation used here.

### Compatibility

- No public Java API or dependency changes.
- Applications that accidentally relied on locator matrix parameters leaking from a later request segment will observe the corrected, segment-local value.
- `UriBuilder.segment("a;b")` now produces an encoded semicolon as required for opaque segment data; use `matrixParam(...)` when `;b` is intended as matrix syntax.
- Generated OpenAPI paths now include documented matrix parameters. Generated operation IDs remain based on the underlying JAX-RS route rather than those documentation decorations.

### Validation

- Focused `MatrixParamTest`, `MuUriBuilderTest`, and `OpenApiDocumentorTest`: 72 tests passed.
- Full Java 11 Maven suite: 1,055 tests passed.
- Clean Java 21 compilation with the `netty-4.1,nullaway` profiles passed.
- Focused Jakarta REST 3.1 matrix-parameter TCK run: 51 passed, 18 existing known-unsupported field-injection cases, and no unexpected results.
- Manually verified the generated document in Swagger UI, including separate enum dropdowns and a request where locator and sub-resource matrix parameters share the same wire name.
