### PR TITLE
Add WebJar resource handlers

### DIFF
--- a/src/main/java/io/muserver/handlers/ResourceHandlerBuilder.java
+++ b/src/main/java/io/muserver/handlers/ResourceHandlerBuilder.java
@@ -280,6 +280,8 @@ public class ResourceHandlerBuilder implements MuHandlerBuilder<ResourceHandler>
      *     .addHandler(ContextHandlerBuilder.context("/api-docs")
      *         .addHandler(ResourceHandlerBuilder.webjarHandler("swagger-ui")))
      *     .start();
+     *
+     * // The Swagger UI home page is now available at /api-docs/index.html
      * </code></pre>
      *
      * @param artifactId The WebJar Maven artifact ID.

--- a/src/main/java/io/muserver/handlers/ResourceHandlerBuilder.java
+++ b/src/main/java/io/muserver/handlers/ResourceHandlerBuilder.java
@@ -248,7 +248,9 @@ public class ResourceHandlerBuilder implements MuHandlerBuilder<ResourceHandler>
 
     /**
      * Creates a handler that serves files from a specific WebJar version.
-     * <p>For example, the Swagger UI WebJar can be served at {@code /api-docs/} like this:</p>
+     * <p>In this example, {@code swagger-ui} is the WebJar's Maven artifact ID and {@code 5.17.14} is its
+     * version. The {@code /api-docs} context path is chosen by the application and can be replaced with any
+     * desired path:</p>
      * <pre><code>
      * MuServer server = MuServerBuilder.httpServer()
      *     .addHandler(ContextHandlerBuilder.context("/api-docs")
@@ -274,7 +276,8 @@ public class ResourceHandlerBuilder implements MuHandlerBuilder<ResourceHandler>
      * <p>This supports WebJars in the {@code org.webjars} and {@code org.webjars.npm} Maven groups that include
      * their standard {@code META-INF/maven/.../pom.properties} file. Use
      * {@link #webjarHandler(String, String)} for WebJars without that metadata.</p>
-     * <p>For example, the Swagger UI WebJar can be served at {@code /api-docs/} like this:</p>
+     * <p>In this example, {@code swagger-ui} is the WebJar's Maven artifact ID. The {@code /api-docs} context
+     * path is chosen by the application and can be replaced with any desired path:</p>
      * <pre><code>
      * MuServer server = MuServerBuilder.httpServer()
      *     .addHandler(ContextHandlerBuilder.context("/api-docs")

--- a/src/main/java/io/muserver/handlers/ResourceHandlerBuilder.java
+++ b/src/main/java/io/muserver/handlers/ResourceHandlerBuilder.java
@@ -273,9 +273,6 @@ public class ResourceHandlerBuilder implements MuHandlerBuilder<ResourceHandler>
 
     /**
      * Creates a handler that serves files from an official WebJar, with its version read from Maven metadata.
-     * <p>This supports WebJars in the {@code org.webjars} and {@code org.webjars.npm} Maven groups that include
-     * their standard {@code META-INF/maven/.../pom.properties} file. Use
-     * {@link #webjarHandler(String, String)} for WebJars without that metadata.</p>
      * <p>In this example, {@code swagger-ui} is the WebJar's Maven artifact ID. The {@code /api-docs} context
      * path is chosen by the application and can be replaced with any desired path:</p>
      * <pre><code>
@@ -287,8 +284,9 @@ public class ResourceHandlerBuilder implements MuHandlerBuilder<ResourceHandler>
      *
      * @param artifactId The WebJar Maven artifact ID.
      * @return A new builder.
-     * @throws IllegalArgumentException If the artifact ID is invalid, its Maven metadata cannot be found, or
-     *                                  multiple versions are present.
+     * @throws IllegalArgumentException If the artifact ID is invalid, its version cannot be determined, or
+     *                                  multiple versions are present. The exception message explains how to
+     *                                  specify a version explicitly.
      */
     public static ResourceHandlerBuilder webjarHandler(String artifactId) {
         String version = findWebJarVersion(artifactId, ResourceHandlerBuilder.class.getClassLoader());
@@ -322,12 +320,12 @@ public class ResourceHandlerBuilder implements MuHandlerBuilder<ResourceHandler>
         }
 
         if (versions.isEmpty()) {
-            throw new IllegalArgumentException("Could not find Maven metadata for WebJar '" + artifactId
-                + "'. Use webjarHandler(artifactId, version) for WebJars without pom.properties.");
+            throw new IllegalArgumentException("Could not determine the version of WebJar '" + artifactId
+                + "'. Use webjarHandler(\"" + artifactId + "\", \"<version>\") to specify it explicitly.");
         }
         if (versions.size() > 1) {
             throw new IllegalArgumentException("Multiple versions found for WebJar '" + artifactId + "': " + versions
-                + ". Use webjarHandler(artifactId, version) to select one.");
+                + ". Use webjarHandler(\"" + artifactId + "\", \"<version>\") to select one explicitly.");
         }
         return versions.iterator().next();
     }

--- a/src/main/java/io/muserver/handlers/ResourceHandlerBuilder.java
+++ b/src/main/java/io/muserver/handlers/ResourceHandlerBuilder.java
@@ -5,7 +5,9 @@ import io.muserver.rest.RestHandlerBuilder;
 import org.jspecify.annotations.Nullable;
 
 import java.io.File;
+import java.io.IOException;
 import java.io.InputStream;
+import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -13,9 +15,13 @@ import java.nio.file.Paths;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.Collections;
+import java.util.Enumeration;
+import java.util.LinkedHashSet;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Properties;
 import java.util.Scanner;
+import java.util.Set;
 
 import static io.muserver.handlers.ResourceType.DEFAULT_EXTENSION_MAPPINGS;
 import static java.util.Objects.requireNonNull;
@@ -26,6 +32,8 @@ import static java.util.Objects.requireNonNull;
  * {@link #fileOrClasspath(String, String)}</p>
  */
 public class ResourceHandlerBuilder implements MuHandlerBuilder<ResourceHandler> {
+
+    private static final String[] WEBJAR_GROUP_IDS = {"org.webjars.npm", "org.webjars"};
 
     private @Nullable DateTimeFormatter directoryListingDateFormatter;
     private Map<String, ResourceType> extensionToResourceType = DEFAULT_EXTENSION_MAPPINGS;
@@ -236,6 +244,98 @@ public class ResourceHandlerBuilder implements MuHandlerBuilder<ResourceHandler>
      */
     public static ResourceHandlerBuilder classpathHandler(String classpathRoot) {
         return new ResourceHandlerBuilder().withResourceProviderFactory(ResourceProviderFactory.classpathBased(classpathRoot));
+    }
+
+    /**
+     * Creates a handler that serves files from a specific WebJar version.
+     * <p>For example, the Swagger UI WebJar can be served at {@code /api-docs/} like this:</p>
+     * <pre><code>
+     * MuServer server = MuServerBuilder.httpServer()
+     *     .addHandler(ContextHandlerBuilder.context("/api-docs")
+     *         .addHandler(ResourceHandlerBuilder.webjarHandler("swagger-ui", "5.17.14")))
+     *     .start();
+     *
+     * // The Swagger UI home page is now available at /api-docs/index.html
+     * </code></pre>
+     *
+     * @param artifactId The WebJar Maven artifact ID.
+     * @param version The WebJar version.
+     * @return A new builder.
+     * @throws IllegalArgumentException If either argument is blank or is not a single path segment.
+     */
+    public static ResourceHandlerBuilder webjarHandler(String artifactId, String version) {
+        validateWebJarPathSegment("artifactId", artifactId);
+        validateWebJarPathSegment("version", version);
+        return classpathHandler("/META-INF/resources/webjars/" + artifactId + "/" + version);
+    }
+
+    /**
+     * Creates a handler that serves files from an official WebJar, with its version read from Maven metadata.
+     * <p>This supports WebJars in the {@code org.webjars} and {@code org.webjars.npm} Maven groups that include
+     * their standard {@code META-INF/maven/.../pom.properties} file. Use
+     * {@link #webjarHandler(String, String)} for WebJars without that metadata.</p>
+     * <p>For example, the Swagger UI WebJar can be served at {@code /api-docs/} like this:</p>
+     * <pre><code>
+     * MuServer server = MuServerBuilder.httpServer()
+     *     .addHandler(ContextHandlerBuilder.context("/api-docs")
+     *         .addHandler(ResourceHandlerBuilder.webjarHandler("swagger-ui")))
+     *     .start();
+     * </code></pre>
+     *
+     * @param artifactId The WebJar Maven artifact ID.
+     * @return A new builder.
+     * @throws IllegalArgumentException If the artifact ID is invalid, its Maven metadata cannot be found, or
+     *                                  multiple versions are present.
+     */
+    public static ResourceHandlerBuilder webjarHandler(String artifactId) {
+        String version = findWebJarVersion(artifactId, ResourceHandlerBuilder.class.getClassLoader());
+        return webjarHandler(artifactId, version);
+    }
+
+    static String findWebJarVersion(String artifactId, ClassLoader classLoader) {
+        validateWebJarPathSegment("artifactId", artifactId);
+        requireNonNull(classLoader, "classLoader");
+
+        Set<String> versions = new LinkedHashSet<>();
+        try {
+            for (String groupId : WEBJAR_GROUP_IDS) {
+                String metadataPath = "META-INF/maven/" + groupId + "/" + artifactId + "/pom.properties";
+                Enumeration<URL> resources = classLoader.getResources(metadataPath);
+                while (resources.hasMoreElements()) {
+                    URL resource = resources.nextElement();
+                    Properties properties = new Properties();
+                    try (InputStream input = resource.openStream()) {
+                        properties.load(input);
+                    }
+                    String version = properties.getProperty("version");
+                    if (version == null || version.trim().isEmpty()) {
+                        throw new IllegalArgumentException("WebJar metadata at " + resource + " does not contain a version");
+                    }
+                    versions.add(version);
+                }
+            }
+        } catch (IOException e) {
+            throw new IllegalArgumentException("Could not read Maven metadata for WebJar '" + artifactId + "'", e);
+        }
+
+        if (versions.isEmpty()) {
+            throw new IllegalArgumentException("Could not find Maven metadata for WebJar '" + artifactId
+                + "'. Use webjarHandler(artifactId, version) for WebJars without pom.properties.");
+        }
+        if (versions.size() > 1) {
+            throw new IllegalArgumentException("Multiple versions found for WebJar '" + artifactId + "': " + versions
+                + ". Use webjarHandler(artifactId, version) to select one.");
+        }
+        return versions.iterator().next();
+    }
+
+    private static void validateWebJarPathSegment(String name, String value) {
+        if (value == null || value.trim().isEmpty()) {
+            throw new IllegalArgumentException(name + " cannot be null or blank");
+        }
+        if (value.indexOf('/') >= 0 || value.indexOf('\\') >= 0 || value.equals(".") || value.equals("..")) {
+            throw new IllegalArgumentException(name + " must be a single path segment");
+        }
     }
 
     /**

--- a/src/test/java/io/muserver/handlers/ResourceHandlerTest.java
+++ b/src/test/java/io/muserver/handlers/ResourceHandlerTest.java
@@ -521,8 +521,8 @@ public class ResourceHandlerTest {
         IllegalArgumentException error = assertThrows(IllegalArgumentException.class,
             () -> webjarHandler("definitely-not-a-real-webjar"));
 
-        assertThat(error.getMessage(), containsString("Could not find Maven metadata"));
-        assertThat(error.getMessage(), containsString("webjarHandler(artifactId, version)"));
+        assertThat(error.getMessage(), containsString("Could not determine the version"));
+        assertThat(error.getMessage(), containsString("webjarHandler(\"definitely-not-a-real-webjar\", \"<version>\")"));
     }
 
     @Test
@@ -537,6 +537,7 @@ public class ResourceHandlerTest {
             assertThat(error.getMessage(), containsString("Multiple versions found"));
             assertThat(error.getMessage(), containsString("1.0.0"));
             assertThat(error.getMessage(), containsString("2.0.0"));
+            assertThat(error.getMessage(), containsString("webjarHandler(\"duplicate-webjar\", \"<version>\")"));
         } finally {
             Files.deleteIfExists(first);
             Files.deleteIfExists(second);

--- a/src/test/java/io/muserver/handlers/ResourceHandlerTest.java
+++ b/src/test/java/io/muserver/handlers/ResourceHandlerTest.java
@@ -12,9 +12,15 @@ import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
+import java.util.jar.JarEntry;
+import java.util.jar.JarOutputStream;
 
 import static io.muserver.ContextHandlerBuilder.context;
 import static io.muserver.Mutils.urlDecode;
@@ -25,6 +31,7 @@ import static io.muserver.handlers.ResourceType.gzippableMimeTypes;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.assertThrows;
 import static scaffolding.ClientUtils.call;
 import static scaffolding.ClientUtils.request;
 import static scaffolding.FileUtils.readResource;
@@ -467,6 +474,91 @@ public class ResourceHandlerTest {
             assertThat(resp.header("Content-Type"), is("application/javascript"));
             assertThat(resp.body().string(), is(readResource("/META-INF/resources/webjars/jquery-ui/1.13.2/jquery-ui.min.js")));
         }
+    }
+
+    @Test
+    public void canServeAWebJarWithAnExplicitVersion() throws IOException {
+        server = ServerUtils.httpsServerForTest()
+            .withGzipEnabled(false)
+            .addHandler(context("/jquery")
+                .addHandler(webjarHandler("jquery", "3.7.1")))
+            .start();
+
+        try (Response resp = call(request(server.uri().resolve("/jquery/jquery.min.js")))) {
+            assertThat(resp.code(), is(200));
+            assertThat(resp.header("Content-Type"), is("application/javascript"));
+            assertThat(resp.body().string(), is(readResource("/META-INF/resources/webjars/jquery/3.7.1/jquery.min.js")));
+        }
+    }
+
+    @Test
+    public void canServeAWebJarWithTheVersionFromMavenMetadata() throws IOException {
+        server = ServerUtils.httpsServerForTest()
+            .withGzipEnabled(false)
+            .addHandler(context("/jquery")
+                .addHandler(webjarHandler("jquery")))
+            .start();
+
+        try (Response resp = call(request(server.uri().resolve("/jquery/jquery.min.js")))) {
+            assertThat(resp.code(), is(200));
+            assertThat(resp.header("Content-Type"), is("application/javascript"));
+            assertThat(resp.body().string(), is(readResource("/META-INF/resources/webjars/jquery/3.7.1/jquery.min.js")));
+        }
+    }
+
+    @Test
+    public void versionDetectionDoesNotRequireJarDirectoryEntriesOrAManifest() throws Exception {
+        Path jar = createWebJarMetadataJar("org.webjars.npm", "metadata-only", "1.2.3");
+        try (URLClassLoader classLoader = new URLClassLoader(new URL[]{jar.toUri().toURL()}, null)) {
+            assertThat(ResourceHandlerBuilder.findWebJarVersion("metadata-only", classLoader), is("1.2.3"));
+        } finally {
+            Files.deleteIfExists(jar);
+        }
+    }
+
+    @Test
+    public void versionDetectionRejectsMissingMetadata() {
+        IllegalArgumentException error = assertThrows(IllegalArgumentException.class,
+            () -> webjarHandler("definitely-not-a-real-webjar"));
+
+        assertThat(error.getMessage(), containsString("Could not find Maven metadata"));
+        assertThat(error.getMessage(), containsString("webjarHandler(artifactId, version)"));
+    }
+
+    @Test
+    public void versionDetectionRejectsMultipleVersions() throws Exception {
+        Path first = createWebJarMetadataJar("org.webjars", "duplicate-webjar", "1.0.0");
+        Path second = createWebJarMetadataJar("org.webjars", "duplicate-webjar", "2.0.0");
+        try (URLClassLoader classLoader = new URLClassLoader(
+            new URL[]{first.toUri().toURL(), second.toUri().toURL()}, null)) {
+            IllegalArgumentException error = assertThrows(IllegalArgumentException.class,
+                () -> ResourceHandlerBuilder.findWebJarVersion("duplicate-webjar", classLoader));
+
+            assertThat(error.getMessage(), containsString("Multiple versions found"));
+            assertThat(error.getMessage(), containsString("1.0.0"));
+            assertThat(error.getMessage(), containsString("2.0.0"));
+        } finally {
+            Files.deleteIfExists(first);
+            Files.deleteIfExists(second);
+        }
+    }
+
+    @Test
+    public void webJarCoordinatesMustBeSinglePathSegments() {
+        assertThrows(IllegalArgumentException.class, () -> webjarHandler("../jquery", "3.7.1"));
+        assertThrows(IllegalArgumentException.class, () -> webjarHandler("jquery", "../3.7.1"));
+    }
+
+    private static Path createWebJarMetadataJar(String groupId, String artifactId, String version) throws IOException {
+        Path jar = Files.createTempFile("webjar-metadata-", ".jar");
+        try (JarOutputStream output = new JarOutputStream(Files.newOutputStream(jar))) {
+            String metadataPath = "META-INF/maven/" + groupId + "/" + artifactId + "/pom.properties";
+            output.putNextEntry(new JarEntry(metadataPath));
+            output.write(("artifactId=" + artifactId + "\nversion=" + version + "\n")
+                .getBytes(StandardCharsets.ISO_8859_1));
+            output.closeEntry();
+        }
+        return jar;
     }
 
     @After


### PR DESCRIPTION
## Summary

- add `webjarHandler(artifactId, version)` for explicitly versioned WebJars
- add `webjarHandler(artifactId)` with version lookup from standard Maven `pom.properties` metadata
- support official `org.webjars` and `org.webjars.npm` artifacts without scanning the classpath
- document how to mount a WebJar beneath a context handler
- reject missing metadata, ambiguous versions, and non-segment coordinates with actionable errors

## Why

This is the narrower replacement for #202. Versionless WebJar setup is useful because applications do not need to repeat a dependency version in source code, but generic classpath enumeration introduced precedence, packaging, performance, and ZIP filesystem ownership problems.

This implementation asks the existing classloader only for the two exact metadata paths used by official WebJars. It does not enumerate classpath roots, inspect manifests, mount unrelated JARs, merge resource roots, or change existing `classpathHandler` behavior. The explicit-version overload remains available for custom or unusually packaged WebJars.

## Compatibility and impact

- the public API change is additive
- existing classpath resource behavior is unchanged
- no runtime dependency is added
- no wire-level behavior changes for existing handlers

## Validation

- `mise exec java@temurin-11 -- mvn -q -Dtest=ResourceHandlerTest test`
- `mise exec java@temurin-11 -- mvn -q -Pnullaway -DskipTests compile`
- `mise exec java@temurin-11 -- mvn -q test` — 1,072 tests, 0 failures/errors
- `mise exec java@temurin-11 -- mvn -q -DskipTests javadoc:javadoc`
- `git diff --check`