### PR TITLE
Encode ':' in request path so segments are not treated as schemes

### DIFF
--- a/src/main/java/io/muserver/rest/RequestMatcher.java
+++ b/src/main/java/io/muserver/rest/RequestMatcher.java
@@ -48,7 +48,9 @@ class RequestMatcher {
     }
 
     Set<MatchedMethod> getMatchedMethodsForPath(String path, Function<MatchedMethod, ResourceClass> subResourceLocator) throws NotMatchedException {
-        StepOneOutput stepOneOutput = stepOneIdentifyASetOfCandidateRootResourceClassesMatchingTheRequest(path);
+        // Encode colon so it doesn't cause a path segment to be interpreted as scheme
+        String uriSafePath = path.replace(":", "%3A");
+        StepOneOutput stepOneOutput = stepOneIdentifyASetOfCandidateRootResourceClassesMatchingTheRequest(uriSafePath);
         @Nullable URI methodURI = stepOneOutput.unmatchedGroup == null ? null : URI.create(UriPattern.trimSlashes(stepOneOutput.unmatchedGroup));
         return stepTwoObtainASetOfCandidateResourceMethodsForTheRequest(methodURI, stepOneOutput.candidates, subResourceLocator);
     }

--- a/src/main/java/io/muserver/rest/RequestMatcher.java
+++ b/src/main/java/io/muserver/rest/RequestMatcher.java
@@ -11,7 +11,6 @@ import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.PathSegment;
 import org.jspecify.annotations.Nullable;
 
-import java.net.URI;
 import java.util.*;
 import java.util.function.Function;
 
@@ -48,11 +47,11 @@ class RequestMatcher {
     }
 
     Set<MatchedMethod> getMatchedMethodsForPath(String path, Function<MatchedMethod, ResourceClass> subResourceLocator) throws NotMatchedException {
-        // Encode colon so it doesn't cause a path segment to be interpreted as scheme
-        String uriSafePath = path.replace(":", "%3A");
-        StepOneOutput stepOneOutput = stepOneIdentifyASetOfCandidateRootResourceClassesMatchingTheRequest(uriSafePath);
-        @Nullable URI methodURI = stepOneOutput.unmatchedGroup == null ? null : URI.create(UriPattern.trimSlashes(stepOneOutput.unmatchedGroup));
-        return stepTwoObtainASetOfCandidateResourceMethodsForTheRequest(methodURI, stepOneOutput.candidates, subResourceLocator);
+        StepOneOutput stepOneOutput = stepOneIdentifyASetOfCandidateRootResourceClassesMatchingTheRequest(path);
+        // This is an unmatched path, not a URI reference. Parsing values such as "foo:bar" as a URI would treat
+        // "foo" as a scheme, even though ':' is valid data in an absolute-path segment.
+        @Nullable String methodPath = stepOneOutput.unmatchedGroup == null ? null : UriPattern.trimSlashes(stepOneOutput.unmatchedGroup);
+        return stepTwoObtainASetOfCandidateResourceMethodsForTheRequest(methodPath, stepOneOutput.candidates, subResourceLocator);
     }
 
     StepOneOutput stepOneIdentifyASetOfCandidateRootResourceClassesMatchingTheRequest(String uri) throws NotMatchedException {
@@ -95,8 +94,8 @@ class RequestMatcher {
         return new StepOneOutput(u, c0);
     }
 
-    private Set<MatchedMethod> stepTwoObtainASetOfCandidateResourceMethodsForTheRequest(@Nullable URI relativeUri, List<MatchedClass> candidateClasses, Function<MatchedMethod, ResourceClass> subResourceLocator) throws NotMatchedException {
-        if (relativeUri == null) {
+    private Set<MatchedMethod> stepTwoObtainASetOfCandidateResourceMethodsForTheRequest(@Nullable String relativePath, List<MatchedClass> candidateClasses, Function<MatchedMethod, ResourceClass> subResourceLocator) throws NotMatchedException {
+        if (relativePath == null) {
             // handle section 3.7.2 - 2(a)
             Set<MatchedMethod> candidates = getNonLocatorMethods(candidateClasses, false);
             if (!candidates.isEmpty()) {
@@ -109,8 +108,8 @@ class RequestMatcher {
         for (MatchedClass candidateClass : candidateClasses) {
             for (ResourceMethod resourceMethod : candidateClass.resourceClass.resourceMethods) {
                 if (resourceMethod.isSubResource() || resourceMethod.isSubResourceLocator()) {
-                    if (relativeUri != null) {
-                        PathMatch matcher = resourceMethod.requiredPathPattern().matcher(relativeUri);
+                    if (relativePath != null) {
+                        PathMatch matcher = resourceMethod.requiredPathPattern().matcher(relativePath);
                         // 2(c) add and 2(d) filter out
                         if (matcher.fullyMatches() || (resourceMethod.isSubResourceLocator() && matcher.prefixMatches())) {
                             Map<String, PathSegment> combinedParams = new HashMap<>(candidateClass.pathMatch.segments());
@@ -178,7 +177,7 @@ class RequestMatcher {
             //Set U to be the value of the final capturing group of R(TL) when matched against U, and set C0 to be the
             //singleton set containing only the class that defines L.
             return stepTwoObtainASetOfCandidateResourceMethodsForTheRequest(
-                remainingUrl == null ? null : URI.create(remainingUrl), Collections.singletonList(mc), subResourceLocator
+                remainingUrl, Collections.singletonList(mc), subResourceLocator
             );
         }
 

--- a/src/test/java/io/muserver/rest/MuUriInfoTest.java
+++ b/src/test/java/io/muserver/rest/MuUriInfoTest.java
@@ -209,6 +209,35 @@ public class MuUriInfoTest {
     }
 
     @Test
+    public void rawColonsArePreservedInMatchedUris() {
+        AtomicReference<UriInfo> uriRef = new AtomicReference<>();
+
+        @Path("api")
+        class ApiResource {
+            @GET
+            @Path("{segment}")
+            public void get(@PathParam("segment") String segment, @Context UriInfo uriInfo) {
+                assertThat(segment, equalTo("foo:bar"));
+                uriRef.set(uriInfo);
+            }
+        }
+
+        server = httpsServerForTest()
+            .addHandler(restHandler(new ApiResource()))
+            .start();
+
+        call(request(server.uri().resolve("/api/foo:bar"))).close();
+
+        UriInfo uriInfo = uriRef.get();
+        assertThat(uriInfo, not(nullValue()));
+        assertThat(uriInfo.getPath(true), equalTo("api/foo:bar"));
+        assertThat(uriInfo.getPath(false), equalTo("api/foo:bar"));
+        assertThat(uriInfo.getMatchedURIs(true), contains("api/foo:bar", "api"));
+        assertThat(uriInfo.getMatchedURIs(false), contains("api/foo:bar", "api"));
+        assertThat(uriInfo.getRequestUri(), equalTo(server.uri().resolve("/api/foo:bar")));
+    }
+
+    @Test
     public void preMatchFiltersHaveMostUriInfo() {
 
         AtomicReference<UriInfo> uriRef = new AtomicReference<>();

--- a/src/test/java/io/muserver/rest/RequestMatcherTest.java
+++ b/src/test/java/io/muserver/rest/RequestMatcherTest.java
@@ -8,6 +8,7 @@ import io.netty.handler.codec.http.HttpHeaderNames;
 import jakarta.ws.rs.*;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.ext.ParamConverterProvider;
+import org.jspecify.annotations.Nullable;
 import org.junit.Assert;
 import org.junit.Test;
 import scaffolding.NotImplementedMuRequest;
@@ -182,6 +183,23 @@ public class RequestMatcherTest {
         RequestMatcher.MatchedMethod mm = findResourceMethod(rm, Method.GET, "api/fruits/orange", emptyList(), null);
         assertThat(mm.resourceMethod.methodHandle().getName(), equalTo("get"));
         assertThat(mm.pathParams.get("name").getPath(), equalTo("orange"));
+    }
+
+    @Test
+    public void pathSegmentsCanContainColons() throws NotMatchedException {
+        @Path("api")
+        class ApiResource {
+            @GET
+            @Path("{segment}")
+            public String get(@PathParam("segment") String segment) {
+                return segment;
+            }
+        }
+
+        RequestMatcher rm = new RequestMatcher(singletonList(ResourceClass.fromObject(new ApiResource(), paramConverterProviders, customizer)));
+        RequestMatcher.MatchedMethod mm = findResourceMethod(rm, Method.GET, "api/foo:bar", emptyList(), null);
+        assertThat(mm.resourceMethod.methodHandle().getName(), equalTo("get"));
+        assertThat(mm.pathParams.get("segment").getPath(), equalTo("foo:bar"));
     }
 
     @Test
@@ -421,11 +439,11 @@ public class RequestMatcherTest {
         assertThat(findResourceMethod(rm, Method.POST, "pictures", emptyList(), null).resourceMethod.methodHandle().getName(), equalTo("concreteAndWildcard"));
     }
 
-    private static String nameOf(RequestMatcher rm, List<MediaType> acceptHeaders, String requestBodyContentType) throws NotMatchedException {
+    private static String nameOf(RequestMatcher rm, List<MediaType> acceptHeaders, @Nullable String requestBodyContentType) throws NotMatchedException {
         return findResourceMethod(rm, Method.GET, "pictures", acceptHeaders, requestBodyContentType).resourceMethod.methodHandle().getName();
     }
 
-    private static void assertNotAcceptable(RequestMatcher rm, List<MediaType> acceptHeaders, String requestBodyContentType) {
+    private static void assertNotAcceptable(RequestMatcher rm, List<MediaType> acceptHeaders, @Nullable String requestBodyContentType) {
         try {
             RequestMatcher.MatchedMethod found = findResourceMethod(rm, Method.GET, "pictures", acceptHeaders, requestBodyContentType);
             Assert.fail("Should have thrown exception but instead got " + found);
@@ -436,11 +454,11 @@ public class RequestMatcherTest {
         }
     }
 
-    private static RequestMatcher.MatchedMethod findResourceMethod(RequestMatcher rm, Method method, String path, List<MediaType> acceptHeaders, String contentBodyType) throws NotMatchedException {
+    private static RequestMatcher.MatchedMethod findResourceMethod(RequestMatcher rm, Method method, String path, List<MediaType> acceptHeaders, @Nullable String contentBodyType) throws NotMatchedException {
         return findResourceMethod(rm, method, path, acceptHeaders, contentBodyType, contentBodyType != null);
     }
 
-    private static RequestMatcher.MatchedMethod findResourceMethod(RequestMatcher rm, Method method, String path, List<MediaType> acceptHeaders, String contentBodyType, boolean requestHasEntity) throws NotMatchedException {
+    private static RequestMatcher.MatchedMethod findResourceMethod(RequestMatcher rm, Method method, String path, List<MediaType> acceptHeaders, @Nullable String contentBodyType, boolean requestHasEntity) throws NotMatchedException {
         NotImplementedMuRequest request = new NotImplementedMuRequest() {
             @Override
             public URI uri() {

--- a/src/test/java/io/muserver/rest/RequestMatcherTest.java
+++ b/src/test/java/io/muserver/rest/RequestMatcherTest.java
@@ -7,6 +7,7 @@ import io.muserver.Method;
 import io.netty.handler.codec.http.HttpHeaderNames;
 import jakarta.ws.rs.*;
 import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.PathSegment;
 import jakarta.ws.rs.ext.ParamConverterProvider;
 import org.jspecify.annotations.Nullable;
 import org.junit.Assert;
@@ -200,6 +201,128 @@ public class RequestMatcherTest {
         RequestMatcher.MatchedMethod mm = findResourceMethod(rm, Method.GET, "api/foo:bar", emptyList(), null);
         assertThat(mm.resourceMethod.methodHandle().getName(), equalTo("get"));
         assertThat(mm.pathParams.get("segment").getPath(), equalTo("foo:bar"));
+    }
+
+    @Test
+    public void schemeLikePathSegmentsAreTreatedAsPathData() throws NotMatchedException {
+        @Path("api")
+        class ApiResource {
+            @GET
+            @Path("{segment}")
+            public String get(@PathParam("segment") String segment) {
+                return segment;
+            }
+        }
+
+        RequestMatcher rm = new RequestMatcher(singletonList(ResourceClass.fromObject(new ApiResource(), paramConverterProviders, customizer)));
+        for (String segment : asList("a:b", "sha256:1234", "urn:example:item", "a+b:value", "a.b:value", "a-b:value")) {
+            RequestMatcher.MatchedMethod mm = findResourceMethod(rm, Method.GET, "api/" + segment, emptyList(), null);
+            assertThat(mm.pathParams.get("segment").getPath(), equalTo(segment));
+        }
+    }
+
+    @Test
+    public void percentEncodedColonsContinueToWork() throws NotMatchedException {
+        @Path("api")
+        class ApiResource {
+            @GET
+            @Path("{segment}")
+            public String get(@PathParam("segment") String segment) {
+                return segment;
+            }
+        }
+
+        RequestMatcher rm = new RequestMatcher(singletonList(ResourceClass.fromObject(new ApiResource(), paramConverterProviders, customizer)));
+        RequestMatcher.MatchedMethod mm = rm.getMatchedMethodsForPath("api/foo%3Abar", ignored -> {
+            throw new AssertionError("No sub-resource locator should be invoked");
+        }).iterator().next();
+        assertThat(mm.pathParams.get("segment").getPath(), equalTo("foo:bar"));
+        assertThat(mm.pathMatch.regexMatcher().group(), equalTo("foo%3Abar"));
+    }
+
+    @Test
+    public void rawColonsRemainVisibleToMethodPathRegexes() throws NotMatchedException {
+        @Path("api")
+        class ApiResource {
+            @GET
+            @Path("{segment:[a-z]+:[a-z]+}")
+            public String get(@PathParam("segment") String segment) {
+                return segment;
+            }
+        }
+
+        RequestMatcher rm = new RequestMatcher(singletonList(ResourceClass.fromObject(new ApiResource(), paramConverterProviders, customizer)));
+        RequestMatcher.MatchedMethod mm = findResourceMethod(rm, Method.GET, "api/foo:bar", emptyList(), null);
+        assertThat(mm.pathParams.get("segment").getPath(), equalTo("foo:bar"));
+        assertThat(mm.pathMatch.regexMatcher().group(), equalTo("foo:bar"));
+    }
+
+    @Test
+    public void rawColonsRemainVisibleToRootResourcePathRegexes() throws NotMatchedException {
+        @Path("{segment:[a-z]+:[a-z]+}")
+        class ColonResource {
+            @GET
+            public String get(@PathParam("segment") String segment) {
+                return segment;
+            }
+        }
+
+        RequestMatcher rm = new RequestMatcher(singletonList(ResourceClass.fromObject(new ColonResource(), paramConverterProviders, customizer)));
+        RequestMatcher.MatchedMethod mm = rm.getMatchedMethodsForPath("foo:bar", ignored -> {
+            throw new AssertionError("No sub-resource locator should be invoked");
+        }).iterator().next();
+        assertThat(mm.pathParams.get("segment").getPath(), equalTo("foo:bar"));
+        assertThat(mm.matchedClass.pathMatch.regexMatcher().group(), equalTo("foo:bar"));
+    }
+
+    @Test
+    public void colonsInLaterRemainingSegmentsContinueToWork() throws NotMatchedException {
+        @Path("api")
+        class ApiResource {
+            @GET
+            @Path("prefix/{segment}")
+            public String get(@PathParam("segment") String segment) {
+                return segment;
+            }
+        }
+
+        RequestMatcher rm = new RequestMatcher(singletonList(ResourceClass.fromObject(new ApiResource(), paramConverterProviders, customizer)));
+        RequestMatcher.MatchedMethod mm = findResourceMethod(rm, Method.GET, "api/prefix/foo:bar", emptyList(), null);
+        assertThat(mm.pathParams.get("segment").getPath(), equalTo("foo:bar"));
+    }
+
+    @Test
+    public void slashTrimmingBehaviorIsPreservedForColonSegments() throws NotMatchedException {
+        @Path("api")
+        class ApiResource {
+            @GET
+            @Path("{segment}")
+            public String get(@PathParam("segment") String segment) {
+                return segment;
+            }
+        }
+
+        RequestMatcher rm = new RequestMatcher(singletonList(ResourceClass.fromObject(new ApiResource(), paramConverterProviders, customizer)));
+        RequestMatcher.MatchedMethod mm = findResourceMethod(rm, Method.GET, "api//foo:bar/", emptyList(), null);
+        assertThat(mm.pathParams.get("segment").getPath(), equalTo("foo:bar"));
+    }
+
+    @Test
+    public void colonSegmentsCanHaveMatrixParameters() throws NotMatchedException {
+        @Path("api")
+        class ApiResource {
+            @GET
+            @Path("{segment}")
+            public String get(@PathParam("segment") PathSegment segment) {
+                return segment.getPath();
+            }
+        }
+
+        RequestMatcher rm = new RequestMatcher(singletonList(ResourceClass.fromObject(new ApiResource(), paramConverterProviders, customizer)));
+        RequestMatcher.MatchedMethod mm = findResourceMethod(rm, Method.GET, "api/foo:bar;color=blue", emptyList(), null);
+        PathSegment segment = mm.pathParams.get("segment");
+        assertThat(segment.getPath(), equalTo("foo:bar"));
+        assertThat(segment.getMatrixParameters().getFirst("color"), equalTo("blue"));
     }
 
     @Test

--- a/src/test/java/io/muserver/rest/SubResourceLocatorTest.java
+++ b/src/test/java/io/muserver/rest/SubResourceLocatorTest.java
@@ -65,6 +65,40 @@ public class SubResourceLocatorTest {
     }
 
     @Test
+    public void colonSegmentsWorkThroughSubResourceLocators() throws Exception {
+        class WidgetResource {
+            private final String id;
+
+            WidgetResource(String id) {
+                this.id = id;
+            }
+
+            @GET
+            @Path("details/{detail:[a-z]+:[a-z]+}")
+            public String getDetails(@PathParam("detail") String detail) {
+                return id + "/" + detail;
+            }
+        }
+
+        @Path("widgets")
+        class WidgetsResource {
+            @Path("{id}")
+            public WidgetResource findWidget(@PathParam("id") String id) {
+                return new WidgetResource(id);
+            }
+        }
+
+        server = httpsServerForTest()
+            .addHandler(restHandler(new WidgetsResource()))
+            .start();
+
+        try (Response resp = call(request(server.uri().resolve("/widgets/sha256:parent/details/urn:child")))) {
+            assertThat(resp.code(), is(200));
+            assertThat(resp.body().string(), is("sha256:parent/urn:child"));
+        }
+    }
+
+    @Test
     public void subResourceMethodsInASubResourceWork() throws Exception {
         class WidgetResource {
             private final String id;


### PR DESCRIPTION
RequestMatcher.getMatchedMethodsForPath trims '/'s from the remaining path once the resource-matching segments are removed, then creates a URI from that path. If the first segment contains a ':' it is then seen as a scheme.

This is one possible fix, another would be to not `trimSlashes` but trim only a trailing '/' and add a leading '/' if there isn't one.