### PR TITLE
Fix ':' in request path segments being treated as schemes

### DIFF
--- a/src/main/java/io/muserver/rest/RequestMatcher.java
+++ b/src/main/java/io/muserver/rest/RequestMatcher.java
@@ -11,7 +11,6 @@ import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.PathSegment;
 import org.jspecify.annotations.Nullable;
 
-import java.net.URI;
 import java.util.*;
 import java.util.function.Function;
 
@@ -49,8 +48,8 @@ class RequestMatcher {
 
     Set<MatchedMethod> getMatchedMethodsForPath(String path, Function<MatchedMethod, ResourceClass> subResourceLocator) throws NotMatchedException {
         StepOneOutput stepOneOutput = stepOneIdentifyASetOfCandidateRootResourceClassesMatchingTheRequest(path);
-        @Nullable URI methodURI = stepOneOutput.unmatchedGroup == null ? null : URI.create(UriPattern.trimSlashes(stepOneOutput.unmatchedGroup));
-        return stepTwoObtainASetOfCandidateResourceMethodsForTheRequest(methodURI, stepOneOutput.candidates, subResourceLocator);
+        @Nullable String methodPath = stepOneOutput.unmatchedGroup == null ? null : UriPattern.trimSlashes(stepOneOutput.unmatchedGroup);
+        return stepTwoObtainASetOfCandidateResourceMethodsForTheRequest(methodPath, stepOneOutput.candidates, subResourceLocator);
     }
 
     StepOneOutput stepOneIdentifyASetOfCandidateRootResourceClassesMatchingTheRequest(String uri) throws NotMatchedException {
@@ -93,8 +92,8 @@ class RequestMatcher {
         return new StepOneOutput(u, c0);
     }
 
-    private Set<MatchedMethod> stepTwoObtainASetOfCandidateResourceMethodsForTheRequest(@Nullable URI relativeUri, List<MatchedClass> candidateClasses, Function<MatchedMethod, ResourceClass> subResourceLocator) throws NotMatchedException {
-        if (relativeUri == null) {
+    private Set<MatchedMethod> stepTwoObtainASetOfCandidateResourceMethodsForTheRequest(@Nullable String relativePath, List<MatchedClass> candidateClasses, Function<MatchedMethod, ResourceClass> subResourceLocator) throws NotMatchedException {
+        if (relativePath == null) {
             // handle section 3.7.2 - 2(a)
             Set<MatchedMethod> candidates = getNonLocatorMethods(candidateClasses, false);
             if (!candidates.isEmpty()) {
@@ -107,8 +106,8 @@ class RequestMatcher {
         for (MatchedClass candidateClass : candidateClasses) {
             for (ResourceMethod resourceMethod : candidateClass.resourceClass.resourceMethods) {
                 if (resourceMethod.isSubResource() || resourceMethod.isSubResourceLocator()) {
-                    if (relativeUri != null) {
-                        PathMatch matcher = resourceMethod.requiredPathPattern().matcher(relativeUri);
+                    if (relativePath != null) {
+                        PathMatch matcher = resourceMethod.requiredPathPattern().matcher(relativePath);
                         // 2(c) add and 2(d) filter out
                         if (matcher.fullyMatches() || (resourceMethod.isSubResourceLocator() && matcher.prefixMatches())) {
                             Map<String, PathSegment> combinedParams = new HashMap<>(candidateClass.pathMatch.segments());
@@ -172,11 +171,11 @@ class RequestMatcher {
 
             MatchedClass mc = new MatchedClass(subResourceLocator.apply(mm), mm.pathMatch.withParams(mm.pathParams, mm.pathParamValues));
 
-            String remainingUrl = mm.pathMatch.lastGroup();
+            String remainingPath = mm.pathMatch.lastGroup();
             //Set U to be the value of the final capturing group of R(TL) when matched against U, and set C0 to be the
             //singleton set containing only the class that defines L.
             return stepTwoObtainASetOfCandidateResourceMethodsForTheRequest(
-                remainingUrl == null ? null : URI.create(remainingUrl), Collections.singletonList(mc), subResourceLocator
+                remainingPath, Collections.singletonList(mc), subResourceLocator
             );
         }
 

--- a/src/test/java/io/muserver/rest/RequestMatcherTest.java
+++ b/src/test/java/io/muserver/rest/RequestMatcherTest.java
@@ -8,6 +8,7 @@ import io.netty.handler.codec.http.HttpHeaderNames;
 import jakarta.ws.rs.*;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.ext.ParamConverterProvider;
+import org.jspecify.annotations.Nullable;
 import org.junit.Assert;
 import org.junit.Test;
 import scaffolding.NotImplementedMuRequest;
@@ -182,6 +183,23 @@ public class RequestMatcherTest {
         RequestMatcher.MatchedMethod mm = findResourceMethod(rm, Method.GET, "api/fruits/orange", emptyList(), null);
         assertThat(mm.resourceMethod.methodHandle().getName(), equalTo("get"));
         assertThat(mm.pathParams.get("name").getPath(), equalTo("orange"));
+    }
+
+    @Test
+    public void pathSegmentsCanContainColons() throws NotMatchedException {
+        @Path("api")
+        class ApiResource {
+            @GET
+            @Path("{segment}")
+            public String get(@PathParam("segment") String segment) {
+                return segment;
+            }
+        }
+
+        RequestMatcher rm = new RequestMatcher(singletonList(ResourceClass.fromObject(new ApiResource(), paramConverterProviders, customizer)));
+        RequestMatcher.MatchedMethod mm = findResourceMethod(rm, Method.GET, "api/foo:bar", emptyList(), null);
+        assertThat(mm.resourceMethod.methodHandle().getName(), equalTo("get"));
+        assertThat(mm.pathParams.get("segment").getPath(), equalTo("foo:bar"));
     }
 
     @Test
@@ -421,11 +439,11 @@ public class RequestMatcherTest {
         assertThat(findResourceMethod(rm, Method.POST, "pictures", emptyList(), null).resourceMethod.methodHandle().getName(), equalTo("concreteAndWildcard"));
     }
 
-    private static String nameOf(RequestMatcher rm, List<MediaType> acceptHeaders, String requestBodyContentType) throws NotMatchedException {
+    private static String nameOf(RequestMatcher rm, List<MediaType> acceptHeaders, @Nullable String requestBodyContentType) throws NotMatchedException {
         return findResourceMethod(rm, Method.GET, "pictures", acceptHeaders, requestBodyContentType).resourceMethod.methodHandle().getName();
     }
 
-    private static void assertNotAcceptable(RequestMatcher rm, List<MediaType> acceptHeaders, String requestBodyContentType) {
+    private static void assertNotAcceptable(RequestMatcher rm, List<MediaType> acceptHeaders, @Nullable String requestBodyContentType) {
         try {
             RequestMatcher.MatchedMethod found = findResourceMethod(rm, Method.GET, "pictures", acceptHeaders, requestBodyContentType);
             Assert.fail("Should have thrown exception but instead got " + found);
@@ -436,11 +454,11 @@ public class RequestMatcherTest {
         }
     }
 
-    private static RequestMatcher.MatchedMethod findResourceMethod(RequestMatcher rm, Method method, String path, List<MediaType> acceptHeaders, String contentBodyType) throws NotMatchedException {
+    private static RequestMatcher.MatchedMethod findResourceMethod(RequestMatcher rm, Method method, String path, List<MediaType> acceptHeaders, @Nullable String contentBodyType) throws NotMatchedException {
         return findResourceMethod(rm, method, path, acceptHeaders, contentBodyType, contentBodyType != null);
     }
 
-    private static RequestMatcher.MatchedMethod findResourceMethod(RequestMatcher rm, Method method, String path, List<MediaType> acceptHeaders, String contentBodyType, boolean requestHasEntity) throws NotMatchedException {
+    private static RequestMatcher.MatchedMethod findResourceMethod(RequestMatcher rm, Method method, String path, List<MediaType> acceptHeaders, @Nullable String contentBodyType, boolean requestHasEntity) throws NotMatchedException {
         NotImplementedMuRequest request = new NotImplementedMuRequest() {
             @Override
             public URI uri() {


### PR DESCRIPTION
RequestMatcher.getMatchedMethodsForPath trims '/'s from the remaining path once the resource-matching segments are removed, then creates a URI from that path. If the first segment contains a ':' it is then seen as a scheme.

As the URI is only used when calling `UriPattern.matcher(URI)` which then only uses URI.getRawPath(), the URI seems redundant; *except* for possibly throwing an exception for invalid paths, which would presumably have happened earlier when the MuRequest was created.