### PR TITLE
Preserve raw colons while matching REST paths on 2.x

### DIFF
--- a/src/main/java/io/muserver/rest/RequestMatcher.java
+++ b/src/main/java/io/muserver/rest/RequestMatcher.java
@@ -47,7 +47,9 @@ class RequestMatcher {
     }
 
     Set<MatchedMethod> getMatchedMethodsForPath(String path, Function<MatchedMethod, ResourceClass> subResourceLocator) throws NotMatchedException {
-        StepOneOutput stepOneOutput = stepOneIdentifyASetOfCandidateRootResourceClassesMatchingTheRequest(path);
+        // Encode colon so it doesn't cause a path segment to be interpreted as scheme
+        String uriSafePath = path.replace(":", "%3A");
+        StepOneOutput stepOneOutput = stepOneIdentifyASetOfCandidateRootResourceClassesMatchingTheRequest(uriSafePath);
         URI methodURI = stepOneOutput.unmatchedGroup == null ? null : URI.create(UriPattern.trimSlashes(stepOneOutput.unmatchedGroup));
         return stepTwoObtainASetOfCandidateResourceMethodsForTheRequest(methodURI, stepOneOutput.candidates, subResourceLocator);
     }

--- a/src/main/java/io/muserver/rest/RequestMatcher.java
+++ b/src/main/java/io/muserver/rest/RequestMatcher.java
@@ -10,7 +10,6 @@ import jakarta.ws.rs.ServerErrorException;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.PathSegment;
 
-import java.net.URI;
 import java.util.*;
 import java.util.function.Function;
 
@@ -47,11 +46,11 @@ class RequestMatcher {
     }
 
     Set<MatchedMethod> getMatchedMethodsForPath(String path, Function<MatchedMethod, ResourceClass> subResourceLocator) throws NotMatchedException {
-        // Encode colon so it doesn't cause a path segment to be interpreted as scheme
-        String uriSafePath = path.replace(":", "%3A");
-        StepOneOutput stepOneOutput = stepOneIdentifyASetOfCandidateRootResourceClassesMatchingTheRequest(uriSafePath);
-        URI methodURI = stepOneOutput.unmatchedGroup == null ? null : URI.create(UriPattern.trimSlashes(stepOneOutput.unmatchedGroup));
-        return stepTwoObtainASetOfCandidateResourceMethodsForTheRequest(methodURI, stepOneOutput.candidates, subResourceLocator);
+        StepOneOutput stepOneOutput = stepOneIdentifyASetOfCandidateRootResourceClassesMatchingTheRequest(path);
+        // This is an unmatched path, not a URI reference. Parsing values such as "foo:bar" as a URI would treat
+        // "foo" as a scheme, even though ':' is valid data in an absolute-path segment.
+        String methodPath = stepOneOutput.unmatchedGroup == null ? null : UriPattern.trimSlashes(stepOneOutput.unmatchedGroup);
+        return stepTwoObtainASetOfCandidateResourceMethodsForTheRequest(methodPath, stepOneOutput.candidates, subResourceLocator);
     }
 
     StepOneOutput stepOneIdentifyASetOfCandidateRootResourceClassesMatchingTheRequest(String uri) throws NotMatchedException {
@@ -94,8 +93,8 @@ class RequestMatcher {
         return new StepOneOutput(u, c0);
     }
 
-    private Set<MatchedMethod> stepTwoObtainASetOfCandidateResourceMethodsForTheRequest(URI relativeUri, List<MatchedClass> candidateClasses, Function<MatchedMethod, ResourceClass> subResourceLocator) throws NotMatchedException {
-        if (relativeUri == null) {
+    private Set<MatchedMethod> stepTwoObtainASetOfCandidateResourceMethodsForTheRequest(String relativePath, List<MatchedClass> candidateClasses, Function<MatchedMethod, ResourceClass> subResourceLocator) throws NotMatchedException {
+        if (relativePath == null) {
             // handle section 3.7.2 - 2(a)
             Set<MatchedMethod> candidates = getNonLocatorMethods(candidateClasses, false);
             if (!candidates.isEmpty()) {
@@ -108,8 +107,8 @@ class RequestMatcher {
         for (MatchedClass candidateClass : candidateClasses) {
             for (ResourceMethod resourceMethod : candidateClass.resourceClass.resourceMethods) {
                 if (resourceMethod.isSubResource() || resourceMethod.isSubResourceLocator()) {
-                    if (relativeUri != null) {
-                        PathMatch matcher = resourceMethod.pathPattern.matcher(relativeUri);
+                    if (relativePath != null) {
+                        PathMatch matcher = resourceMethod.pathPattern.matcher(relativePath);
                         // 2(c) add and 2(d) filter out
                         if (matcher.fullyMatches() || (resourceMethod.isSubResourceLocator() && matcher.prefixMatches())) {
                             Map<String, PathSegment> combinedParams = new HashMap<>(candidateClass.pathMatch.segments());
@@ -175,7 +174,7 @@ class RequestMatcher {
             //Set U to be the value of the final capturing group of R(TL) when matched against U, and set C0 to be the
             //singleton set containing only the class that defines L.
             return stepTwoObtainASetOfCandidateResourceMethodsForTheRequest(
-                remainingUrl == null ? null : URI.create(remainingUrl), Collections.singletonList(mc), subResourceLocator
+                remainingUrl, Collections.singletonList(mc), subResourceLocator
             );
         }
 

--- a/src/test/java/io/muserver/MuServerTest.java
+++ b/src/test/java/io/muserver/MuServerTest.java
@@ -274,7 +274,7 @@ public class MuServerTest {
             .addHandler(Method.GET, "/", (req, resp, pp) -> resp.write("Hello there " + req.remoteAddress()))
             .start();
         try (Response resp = call(request().url(server.uri().toString()))) {
-            assertThat(resp.body().string(), containsString("."));
+            assertThat(resp.body().string(), anyOf(containsString("."), containsString(":")));
         }
     }
 

--- a/src/test/java/io/muserver/rest/MuUriInfoTest.java
+++ b/src/test/java/io/muserver/rest/MuUriInfoTest.java
@@ -174,6 +174,35 @@ public class MuUriInfoTest {
     }
 
     @Test
+    public void rawColonsArePreservedInMatchedUris() {
+        AtomicReference<UriInfo> uriRef = new AtomicReference<>();
+
+        @Path("api")
+        class ApiResource {
+            @GET
+            @Path("{segment}")
+            public void get(@PathParam("segment") String segment, @Context UriInfo uriInfo) {
+                assertThat(segment, equalTo("foo:bar"));
+                uriRef.set(uriInfo);
+            }
+        }
+
+        server = httpsServerForTest()
+            .addHandler(restHandler(new ApiResource()))
+            .start();
+
+        call(request(server.uri().resolve("/api/foo:bar"))).close();
+
+        UriInfo uriInfo = uriRef.get();
+        assertThat(uriInfo, not(nullValue()));
+        assertThat(uriInfo.getPath(true), equalTo("api/foo:bar"));
+        assertThat(uriInfo.getPath(false), equalTo("api/foo:bar"));
+        assertThat(uriInfo.getMatchedURIs(true), contains("api/foo:bar", "api"));
+        assertThat(uriInfo.getMatchedURIs(false), contains("api/foo:bar", "api"));
+        assertThat(uriInfo.getRequestUri(), equalTo(server.uri().resolve("/api/foo:bar")));
+    }
+
+    @Test
     public void preMatchFiltersHaveMostUriInfo() {
 
         AtomicReference<UriInfo> uriRef = new AtomicReference<>();

--- a/src/test/java/io/muserver/rest/RequestMatcherTest.java
+++ b/src/test/java/io/muserver/rest/RequestMatcherTest.java
@@ -7,6 +7,7 @@ import io.muserver.Method;
 import io.netty.handler.codec.http.HttpHeaderNames;
 import jakarta.ws.rs.*;
 import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.PathSegment;
 import jakarta.ws.rs.ext.ParamConverterProvider;
 import org.junit.Assert;
 import org.junit.Test;
@@ -199,6 +200,128 @@ public class RequestMatcherTest {
         RequestMatcher.MatchedMethod mm = findResourceMethod(rm, Method.GET, "api/foo:bar", emptyList(), null);
         assertThat(mm.resourceMethod.methodHandle.getName(), equalTo("get"));
         assertThat(mm.pathParams.get("segment").getPath(), equalTo("foo:bar"));
+    }
+
+    @Test
+    public void schemeLikePathSegmentsAreTreatedAsPathData() throws NotMatchedException {
+        @Path("api")
+        class ApiResource {
+            @GET
+            @Path("{segment}")
+            public String get(@PathParam("segment") String segment) {
+                return segment;
+            }
+        }
+
+        RequestMatcher rm = new RequestMatcher(singletonList(ResourceClass.fromObject(new ApiResource(), paramConverterProviders, customizer)));
+        for (String segment : asList("a:b", "sha256:1234", "urn:example:item", "a.b:value", "a-b:value")) {
+            RequestMatcher.MatchedMethod mm = findResourceMethod(rm, Method.GET, "api/" + segment, emptyList(), null);
+            assertThat(mm.pathParams.get("segment").getPath(), equalTo(segment));
+        }
+    }
+
+    @Test
+    public void percentEncodedColonsContinueToWork() throws NotMatchedException {
+        @Path("api")
+        class ApiResource {
+            @GET
+            @Path("{segment}")
+            public String get(@PathParam("segment") String segment) {
+                return segment;
+            }
+        }
+
+        RequestMatcher rm = new RequestMatcher(singletonList(ResourceClass.fromObject(new ApiResource(), paramConverterProviders, customizer)));
+        RequestMatcher.MatchedMethod mm = rm.getMatchedMethodsForPath("api/foo%3Abar", ignored -> {
+            throw new AssertionError("No sub-resource locator should be invoked");
+        }).iterator().next();
+        assertThat(mm.pathParams.get("segment").getPath(), equalTo("foo:bar"));
+        assertThat(mm.pathMatch.regexMatcher().group(), equalTo("foo%3Abar"));
+    }
+
+    @Test
+    public void rawColonsRemainVisibleToMethodPathRegexes() throws NotMatchedException {
+        @Path("api")
+        class ApiResource {
+            @GET
+            @Path("{segment:[a-z]+:[a-z]+}")
+            public String get(@PathParam("segment") String segment) {
+                return segment;
+            }
+        }
+
+        RequestMatcher rm = new RequestMatcher(singletonList(ResourceClass.fromObject(new ApiResource(), paramConverterProviders, customizer)));
+        RequestMatcher.MatchedMethod mm = findResourceMethod(rm, Method.GET, "api/foo:bar", emptyList(), null);
+        assertThat(mm.pathParams.get("segment").getPath(), equalTo("foo:bar"));
+        assertThat(mm.pathMatch.regexMatcher().group(), equalTo("foo:bar"));
+    }
+
+    @Test
+    public void rawColonsRemainVisibleToRootResourcePathRegexes() throws NotMatchedException {
+        @Path("{segment:[a-z]+:[a-z]+}")
+        class ColonResource {
+            @GET
+            public String get(@PathParam("segment") String segment) {
+                return segment;
+            }
+        }
+
+        RequestMatcher rm = new RequestMatcher(singletonList(ResourceClass.fromObject(new ColonResource(), paramConverterProviders, customizer)));
+        RequestMatcher.MatchedMethod mm = rm.getMatchedMethodsForPath("foo:bar", ignored -> {
+            throw new AssertionError("No sub-resource locator should be invoked");
+        }).iterator().next();
+        assertThat(mm.pathParams.get("segment").getPath(), equalTo("foo:bar"));
+        assertThat(mm.matchedClass.pathMatch.regexMatcher().group(), equalTo("foo:bar"));
+    }
+
+    @Test
+    public void colonsInLaterRemainingSegmentsContinueToWork() throws NotMatchedException {
+        @Path("api")
+        class ApiResource {
+            @GET
+            @Path("prefix/{segment}")
+            public String get(@PathParam("segment") String segment) {
+                return segment;
+            }
+        }
+
+        RequestMatcher rm = new RequestMatcher(singletonList(ResourceClass.fromObject(new ApiResource(), paramConverterProviders, customizer)));
+        RequestMatcher.MatchedMethod mm = findResourceMethod(rm, Method.GET, "api/prefix/foo:bar", emptyList(), null);
+        assertThat(mm.pathParams.get("segment").getPath(), equalTo("foo:bar"));
+    }
+
+    @Test
+    public void slashTrimmingBehaviorIsPreservedForColonSegments() throws NotMatchedException {
+        @Path("api")
+        class ApiResource {
+            @GET
+            @Path("{segment}")
+            public String get(@PathParam("segment") String segment) {
+                return segment;
+            }
+        }
+
+        RequestMatcher rm = new RequestMatcher(singletonList(ResourceClass.fromObject(new ApiResource(), paramConverterProviders, customizer)));
+        RequestMatcher.MatchedMethod mm = findResourceMethod(rm, Method.GET, "api//foo:bar/", emptyList(), null);
+        assertThat(mm.pathParams.get("segment").getPath(), equalTo("foo:bar"));
+    }
+
+    @Test
+    public void colonSegmentsCanHaveMatrixParameters() throws NotMatchedException {
+        @Path("api")
+        class ApiResource {
+            @GET
+            @Path("{segment}")
+            public String get(@PathParam("segment") PathSegment segment) {
+                return segment.getPath();
+            }
+        }
+
+        RequestMatcher rm = new RequestMatcher(singletonList(ResourceClass.fromObject(new ApiResource(), paramConverterProviders, customizer)));
+        RequestMatcher.MatchedMethod mm = findResourceMethod(rm, Method.GET, "api/foo:bar;color=blue", emptyList(), null);
+        PathSegment segment = mm.pathParams.get("segment");
+        assertThat(segment.getPath(), equalTo("foo:bar"));
+        assertThat(segment.getMatrixParameters().getFirst("color"), equalTo("blue"));
     }
 
     @Test

--- a/src/test/java/io/muserver/rest/RequestMatcherTest.java
+++ b/src/test/java/io/muserver/rest/RequestMatcherTest.java
@@ -185,6 +185,23 @@ public class RequestMatcherTest {
     }
 
     @Test
+    public void pathSegmentsCanContainColons() throws NotMatchedException {
+        @Path("api")
+        class ApiResource {
+            @GET
+            @Path("{segment}")
+            public String get(@PathParam("segment") String segment) {
+                return segment;
+            }
+        }
+
+        RequestMatcher rm = new RequestMatcher(singletonList(ResourceClass.fromObject(new ApiResource(), paramConverterProviders, customizer)));
+        RequestMatcher.MatchedMethod mm = findResourceMethod(rm, Method.GET, "api/foo:bar", emptyList(), null);
+        assertThat(mm.resourceMethod.methodHandle.getName(), equalTo("get"));
+        assertThat(mm.pathParams.get("segment").getPath(), equalTo("foo:bar"));
+    }
+
+    @Test
     public void pathsOnClassesAreMatchedFirst() throws NotMatchedException {
         // test example taken from https://bill.burkecentral.com/2013/05/29/the-poor-jax-rs-request-dispatching-algorithm/
 

--- a/src/test/java/io/muserver/rest/SubResourceLocatorTest.java
+++ b/src/test/java/io/muserver/rest/SubResourceLocatorTest.java
@@ -59,6 +59,40 @@ public class SubResourceLocatorTest {
     }
 
     @Test
+    public void colonSegmentsWorkThroughSubResourceLocators() throws Exception {
+        class WidgetResource {
+            private final String id;
+
+            WidgetResource(String id) {
+                this.id = id;
+            }
+
+            @GET
+            @Path("details/{detail:[a-z]+:[a-z]+}")
+            public String getDetails(@PathParam("detail") String detail) {
+                return id + "/" + detail;
+            }
+        }
+
+        @Path("widgets")
+        class WidgetsResource {
+            @Path("{id}")
+            public WidgetResource findWidget(@PathParam("id") String id) {
+                return new WidgetResource(id);
+            }
+        }
+
+        server = httpsServerForTest()
+            .addHandler(restHandler(new WidgetsResource()))
+            .start();
+
+        try (Response resp = call(request(server.uri().resolve("/widgets/sha256:parent/details/urn:child")))) {
+            assertThat(resp.code(), is(200));
+            assertThat(resp.body().string(), is("sha256:parent/urn:child"));
+        }
+    }
+
+    @Test
     public void subResourceMethodsInASubResourceWork() throws Exception {
         class WidgetResource {
             private final String id;


### PR DESCRIPTION
Backport of #204 to the 2.x maintenance branch.

This preserves Lee Worrall's original commit and follows it with the corrected implementation and expanded regression coverage. Unmatched REST paths are passed to the existing raw-path string matcher instead of being reinterpreted as URI references or globally encoding colons.

Coverage includes scheme-like colon segments, encoded colons, custom path regexes, matrix parameters, matched URI reporting, slash compatibility, and sub-resource locators.

Validation:
- `mvn -Pnetty-4.1 -Dtest=RequestMatcherTest,MuUriInfoTest,SubResourceLocatorTest test` — 42 tests passed
- `mvn -Pnetty-4.2 -Dtest=RequestMatcherTest,MuUriInfoTest,SubResourceLocatorTest test` — 42 tests passed
- Full Netty 4.1 verification — 837 tests passed with one unrelated fixed-port test excluded because port 8443 was occupied by a local documentation process; all packaging, Javadocs, and dependency analysis passed