### PR TITLE
Upgrade Netty 4.1 to 4.1.137.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <error-prone.version>2.50.0</error-prone.version>
-        <netty.version.4.1>4.1.136.Final</netty.version.4.1>
+        <netty.version.4.1>4.1.137.Final</netty.version.4.1>
         <netty.version.4.2>4.2.16.Final</netty.version.4.2>
         <netty.version>${netty.version.4.1}</netty.version>
         <netty.codec.artifactId>netty-codec</netty.codec.artifactId>


### PR DESCRIPTION
Upgrades the Netty 4.1.x dependency from 4.1.136.Final to 4.1.137.Final. No other dependency versions or code are changed.