### PR TITLE
Implement Jakarta REST Providers and ContextResolver

### DIFF
--- a/src/main/java/io/muserver/rest/ApplicationRegistrar.java
+++ b/src/main/java/io/muserver/rest/ApplicationRegistrar.java
@@ -12,6 +12,7 @@ import jakarta.ws.rs.container.ContainerResponseFilter;
 import jakarta.ws.rs.container.PreMatching;
 import jakarta.ws.rs.container.ResourceInfo;
 import jakarta.ws.rs.core.Application;
+import jakarta.ws.rs.ext.ContextResolver;
 import jakarta.ws.rs.ext.ExceptionMapper;
 import jakarta.ws.rs.ext.MessageBodyReader;
 import jakarta.ws.rs.ext.MessageBodyWriter;
@@ -154,6 +155,16 @@ final class ApplicationRegistrar {
             builder.addExceptionMapper((Class<? extends Throwable>) exceptionType, (ExceptionMapper) component);
             registered = true;
         }
+        if (component instanceof ContextResolver) {
+            Type contextType = GenericTypeResolver.resolveTypeArgument(component.getClass(), ContextResolver.class, 0);
+            Class<?> contextClass = GenericTypeResolver.rawClass(contextType);
+            if (contextClass == null) {
+                throw new IllegalArgumentException("Could not infer the context type supplied by "
+                    + component.getClass().getName());
+            }
+            builder.addContextResolver((Class) contextClass, (ContextResolver) component);
+            registered = true;
+        }
         if (component instanceof SchemaObjectCustomizer) {
             builder.addSchemaObjectCustomizer((SchemaObjectCustomizer) component);
             registered = true;
@@ -255,6 +266,7 @@ final class ApplicationRegistrar {
             || MessageBodyWriter.class.isAssignableFrom(componentClass)
             || ParamConverterProvider.class.isAssignableFrom(componentClass)
             || ExceptionMapper.class.isAssignableFrom(componentClass)
+            || ContextResolver.class.isAssignableFrom(componentClass)
             || ContainerRequestFilter.class.isAssignableFrom(componentClass)
             || ContainerResponseFilter.class.isAssignableFrom(componentClass)
             || ReaderInterceptor.class.isAssignableFrom(componentClass)

--- a/src/main/java/io/muserver/rest/CustomExceptionMapper.java
+++ b/src/main/java/io/muserver/rest/CustomExceptionMapper.java
@@ -3,12 +3,11 @@ package io.muserver.rest;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.ext.ExceptionMapper;
+import jakarta.ws.rs.ext.Providers;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.lang.reflect.InvocationTargetException;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.UUID;
 
 import org.jspecify.annotations.Nullable;
@@ -16,10 +15,10 @@ import org.jspecify.annotations.Nullable;
 class CustomExceptionMapper {
     private static final Logger log = LoggerFactory.getLogger(CustomExceptionMapper.class);
 
-    private final Map<Class<? extends Throwable>, ExceptionMapper<? extends Throwable>> mappers;
+    private final Providers providers;
 
-    CustomExceptionMapper(Map<Class<? extends Throwable>, ExceptionMapper<? extends Throwable>> mappers) {
-        this.mappers = new HashMap<>(mappers);
+    CustomExceptionMapper(Providers providers) {
+        this.providers = providers;
     }
 
     @SuppressWarnings("unchecked")
@@ -31,8 +30,7 @@ class CustomExceptionMapper {
 
         Class<? extends Throwable> exClass = ex.getClass();
 
-        int maxDepth = Integer.MAX_VALUE;
-        ExceptionMapper exceptionMapper = findBestMatchingExceptionMapper(exClass, maxDepth);
+        ExceptionMapper exceptionMapper = providers.getExceptionMapper(exClass);
 
         if (exceptionMapper == null) {
             return null;
@@ -52,30 +50,6 @@ class CustomExceptionMapper {
                 .entity("<h1>500 Internal Server Error</h1><p>ErrorID=" + errorID + "</p>")
                 .build();
         }
-    }
-
-    @SuppressWarnings("unchecked")
-    private @Nullable ExceptionMapper findBestMatchingExceptionMapper(Class<? extends Throwable> exClass, int maxDepth) {
-        ExceptionMapper exceptionMapper = null;
-        for (Map.Entry<Class<? extends Throwable>, ExceptionMapper<? extends Throwable>> entry : mappers.entrySet()) {
-            Class mapperClass = entry.getKey();
-            if (mapperClass.isAssignableFrom(exClass)) {
-                int depth = 0;
-                Class yo = exClass;
-                while (yo != null) {
-                    if (mapperClass.equals(yo)) {
-                        if (depth < maxDepth) {
-                            maxDepth = depth;
-                            exceptionMapper = entry.getValue();
-                        }
-                        break;
-                    }
-                    depth++;
-                    yo = yo.getSuperclass();
-                }
-            }
-        }
-        return exceptionMapper;
     }
 
 }

--- a/src/main/java/io/muserver/rest/EntityProviders.java
+++ b/src/main/java/io/muserver/rest/EntityProviders.java
@@ -1,10 +1,9 @@
 package io.muserver.rest;
 
-import jakarta.ws.rs.InternalServerErrorException;
-import jakarta.ws.rs.NotSupportedException;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.ext.MessageBodyReader;
 import jakarta.ws.rs.ext.MessageBodyWriter;
+import org.jspecify.annotations.Nullable;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
@@ -13,8 +12,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
-import java.util.Optional;
-import java.util.stream.Collectors;
 
 class EntityProviders {
 
@@ -22,11 +19,24 @@ class EntityProviders {
     final List<ProviderWrapper<MessageBodyWriter<?>>> writers;
 
     public EntityProviders(List<MessageBodyReader> readers, List<MessageBodyWriter> writers) {
-        this.readers = readers.stream().map(ProviderWrapper::reader).sorted().collect(Collectors.toList());
-        this.writers = writers.stream().map(ProviderWrapper::writer).sorted().collect(Collectors.toList());
+        this(new ArrayList<>(), readers, new ArrayList<>(), writers);
     }
-    public MessageBodyReader<?> selectReader(Class<?> type, Type genericType, Annotation[] annotations, MediaType requestBodyMediaType) {
-        Optional<ProviderWrapper<MessageBodyReader<?>>> best = readers.stream()
+
+    public EntityProviders(List<MessageBodyReader> builtInReaders, List<MessageBodyReader> customReaders,
+                           List<MessageBodyWriter> builtInWriters, List<MessageBodyWriter> customWriters) {
+        this.readers = new ArrayList<>();
+        builtInReaders.stream().map(reader -> ProviderWrapper.reader(reader, true)).forEach(this.readers::add);
+        customReaders.stream().map(reader -> ProviderWrapper.reader(reader, false)).forEach(this.readers::add);
+        this.readers.sort(ProviderWrapper::compareTo);
+
+        this.writers = new ArrayList<>();
+        builtInWriters.stream().map(writer -> ProviderWrapper.writer(writer, true)).forEach(this.writers::add);
+        customWriters.stream().map(writer -> ProviderWrapper.writer(writer, false)).forEach(this.writers::add);
+        this.writers.sort(ProviderWrapper::compareTo);
+    }
+
+    public @Nullable MessageBodyReader<?> findReader(Class<?> type, Type genericType, Annotation[] annotations, MediaType requestBodyMediaType) {
+        return readers.stream()
             .filter(reader -> reader.supports(requestBodyMediaType))
             .filter(reader -> !(reader.genericType instanceof Class) || ((Class<?>) reader.genericType).isAssignableFrom(box(type)))
             .sorted((first, second) -> {
@@ -39,11 +49,9 @@ class EntityProviders {
                 return first.compareTo(second);
             })
             .filter(reader -> reader.provider.isReadable(type, genericType, annotations, requestBodyMediaType))
-            .findFirst();
-        if (best.isPresent()) {
-            return best.get().provider;
-        }
-        throw new NotSupportedException("Could not find a suitable entity provider to read " + type);
+            .map(reader -> reader.provider)
+            .findFirst()
+            .orElse(null);
     }
 
     private static int mediaTypeSpecificity(ProviderWrapper<?> provider, MediaType requestedType) {
@@ -74,11 +82,11 @@ class EntityProviders {
         if (type == double.class) return Double.class;
         return type;
     }
-    public MessageBodyWriter<?> selectWriter(Class<?> type, Type genericType, Annotation[] annotations, MediaType responseMediaType) {
+    public @Nullable MessageBodyWriter<?> findWriter(Class<?> type, Type genericType, Annotation[] annotations, MediaType responseMediaType) {
         // From 4.2.2
 
         // 3. SelectthesetofMessageBodyWriterprovidersthatsupport(seeSection4.2.3)theobjectandmedia type of the message entity body.
-        Optional<ProviderWrapper<MessageBodyWriter<?>>> best = writers.stream().filter(w -> w.supports(responseMediaType))
+        return writers.stream().filter(w -> w.supports(responseMediaType))
             .sorted((o1, o2) -> {
                 // Application-provided providers take precedence over built-in providers.
                 int providerCompare = o1.compareTo(o2);
@@ -105,12 +113,9 @@ class EntityProviders {
                 return 0;
             })
             .filter(w -> w.provider.isWriteable(type, genericType, annotations, responseMediaType))
-            .findFirst();
-
-        if (best.isPresent()) {
-            return best.get().provider;
-        }
-        throw new InternalServerErrorException("Could not find a suitable entity provider to write " + type);
+            .map(writer -> writer.provider)
+            .findFirst()
+            .orElse(null);
     }
 
     boolean isBuiltInWriter(MessageBodyWriter<?> writer) {

--- a/src/main/java/io/muserver/rest/JaxRSProviders.java
+++ b/src/main/java/io/muserver/rest/JaxRSProviders.java
@@ -102,7 +102,7 @@ final class JaxRSProviders implements Providers {
     public <T> @Nullable ContextResolver<T> getContextResolver(Class<T> contextType, MediaType mediaType) {
         List<ContextResolverRegistration<?>> matches = new ArrayList<>();
         for (ContextResolverRegistration<?> registration : requiredState().contextResolvers) {
-            if (contextType.isAssignableFrom(registration.contextType) && registration.supports(mediaType)) {
+            if (contextType.equals(registration.contextType) && registration.supports(mediaType)) {
                 matches.add(registration);
             }
         }

--- a/src/main/java/io/muserver/rest/JaxRSProviders.java
+++ b/src/main/java/io/muserver/rest/JaxRSProviders.java
@@ -1,0 +1,197 @@
+package io.muserver.rest;
+
+import jakarta.ws.rs.InternalServerErrorException;
+import jakarta.ws.rs.NotSupportedException;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.ext.ContextResolver;
+import jakarta.ws.rs.ext.ExceptionMapper;
+import jakarta.ws.rs.ext.MessageBodyReader;
+import jakarta.ws.rs.ext.MessageBodyWriter;
+import jakarta.ws.rs.ext.Providers;
+import org.jspecify.annotations.Nullable;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * The providers registered for a single {@link RestHandler}.
+ *
+ * <p>This is initialized in two phases so that reader and writer factories can retain the final
+ * {@link Providers} instance while the provider list is being assembled. Lookups are only valid after initialization.</p>
+ */
+final class JaxRSProviders implements Providers {
+
+    private volatile @Nullable State state;
+
+    synchronized void initialize(EntityProviders entityProviders,
+                                 Map<Class<? extends Throwable>, ExceptionMapper<? extends Throwable>> exceptionMappers,
+                                 List<ContextResolverRegistration<?>> contextResolvers) {
+        if (state != null) {
+            throw new IllegalStateException("Providers have already been initialized");
+        }
+        state = new State(entityProviders, exceptionMappers, contextResolvers);
+    }
+
+    static JaxRSProviders builtInReadersOnly() {
+        JaxRSProviders providers = new JaxRSProviders();
+        providers.initialize(new EntityProviders(
+                EntityProviders.builtInReaders(), Collections.emptyList(),
+                Collections.emptyList(), Collections.emptyList()),
+            Collections.emptyMap(), Collections.emptyList());
+        return providers;
+    }
+
+    private State requiredState() {
+        State current = state;
+        if (current == null) {
+            throw new IllegalStateException("Providers cannot be queried until RestHandlerBuilder.build() has completed");
+        }
+        return current;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <T> @Nullable MessageBodyReader<T> getMessageBodyReader(Class<T> type, Type genericType,
+                                                                   Annotation[] annotations, MediaType mediaType) {
+        return (MessageBodyReader<T>) requiredState().entityProviders.findReader(type, genericType, annotations, mediaType);
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <T> @Nullable MessageBodyWriter<T> getMessageBodyWriter(Class<T> type, Type genericType,
+                                                                   Annotation[] annotations, MediaType mediaType) {
+        return (MessageBodyWriter<T>) requiredState().entityProviders.findWriter(type, genericType, annotations, mediaType);
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <T extends Throwable> @Nullable ExceptionMapper<T> getExceptionMapper(Class<T> type) {
+        ExceptionMapper<?> best = null;
+        int bestDepth = Integer.MAX_VALUE;
+        for (Map.Entry<Class<? extends Throwable>, ExceptionMapper<? extends Throwable>> entry
+            : requiredState().exceptionMappers.entrySet()) {
+            Class<? extends Throwable> mappedType = entry.getKey();
+            if (!mappedType.isAssignableFrom(type)) {
+                continue;
+            }
+            int depth = 0;
+            Class<?> candidate = type;
+            while (candidate != null) {
+                if (candidate.equals(mappedType)) {
+                    if (depth < bestDepth) {
+                        best = entry.getValue();
+                        bestDepth = depth;
+                    }
+                    break;
+                }
+                candidate = candidate.getSuperclass();
+                depth++;
+            }
+        }
+        return (ExceptionMapper<T>) best;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <T> @Nullable ContextResolver<T> getContextResolver(Class<T> contextType, MediaType mediaType) {
+        List<ContextResolverRegistration<?>> matches = new ArrayList<>();
+        for (ContextResolverRegistration<?> registration : requiredState().contextResolvers) {
+            if (contextType.isAssignableFrom(registration.contextType) && registration.supports(mediaType)) {
+                matches.add(registration);
+            }
+        }
+        matches.sort(Comparator.comparingInt(registration -> registration.mediaTypeSpecificity(mediaType)));
+        if (matches.isEmpty()) {
+            return null;
+        }
+        if (matches.size() == 1) {
+            return (ContextResolver<T>) matches.get(0).resolver;
+        }
+        return type -> {
+            for (ContextResolverRegistration<?> registration : matches) {
+                Object context = registration.resolver.getContext(type);
+                if (context != null) {
+                    return (T) context;
+                }
+            }
+            return null;
+        };
+    }
+
+    List<ProviderWrapper<MessageBodyWriter<?>>> writers() {
+        return requiredState().entityProviders.writers;
+    }
+
+    boolean isBuiltInWriter(MessageBodyWriter<?> writer) {
+        return requiredState().entityProviders.isBuiltInWriter(writer);
+    }
+
+    static <T> MessageBodyReader<T> requireMessageBodyReader(Providers providers, Class<T> type, Type genericType,
+                                                              Annotation[] annotations, MediaType mediaType) {
+        MessageBodyReader<T> reader = providers.getMessageBodyReader(type, genericType, annotations, mediaType);
+        if (reader == null) {
+            throw new NotSupportedException("Could not find a suitable entity provider to read " + type);
+        }
+        return reader;
+    }
+
+    static <T> MessageBodyWriter<T> requireMessageBodyWriter(Providers providers, Class<T> type, Type genericType,
+                                                              Annotation[] annotations, MediaType mediaType) {
+        MessageBodyWriter<T> writer = providers.getMessageBodyWriter(type, genericType, annotations, mediaType);
+        if (writer == null) {
+            throw new InternalServerErrorException("Could not find a suitable entity provider to write " + type);
+        }
+        return writer;
+    }
+
+    static final class ContextResolverRegistration<T> {
+        final Class<T> contextType;
+        final ContextResolver<T> resolver;
+        private final List<MediaType> mediaTypes;
+
+        ContextResolverRegistration(Class<T> contextType, ContextResolver<T> resolver) {
+            this.contextType = contextType;
+            this.resolver = resolver;
+            this.mediaTypes = MediaTypeDeterminer.supportedProducesTypes(resolver.getClass());
+        }
+
+        private boolean supports(MediaType mediaType) {
+            return mediaTypes.isEmpty()
+                || mediaTypes.stream().anyMatch(candidate -> MediaTypeHeaderDelegate.isCompatible(candidate, mediaType));
+        }
+
+        private int mediaTypeSpecificity(MediaType requestedType) {
+            return mediaTypes.stream()
+                .filter(candidate -> MediaTypeHeaderDelegate.isCompatible(candidate, requestedType))
+                .mapToInt(JaxRSProviders::mediaTypeSpecificity)
+                .min()
+                .orElse(2);
+        }
+    }
+
+    private static int mediaTypeSpecificity(MediaType mediaType) {
+        return mediaType.isWildcardType()
+            ? 2
+            : MediaTypeHeaderDelegate.isWildcardSubtype(mediaType.getSubtype()) ? 1 : 0;
+    }
+
+    private static final class State {
+        private final EntityProviders entityProviders;
+        private final Map<Class<? extends Throwable>, ExceptionMapper<? extends Throwable>> exceptionMappers;
+        private final List<ContextResolverRegistration<?>> contextResolvers;
+
+        private State(EntityProviders entityProviders,
+                      Map<Class<? extends Throwable>, ExceptionMapper<? extends Throwable>> exceptionMappers,
+                      List<ContextResolverRegistration<?>> contextResolvers) {
+            this.entityProviders = entityProviders;
+            this.exceptionMappers = Collections.unmodifiableMap(new HashMap<>(exceptionMappers));
+            this.contextResolvers = Collections.unmodifiableList(new ArrayList<>(contextResolvers));
+        }
+    }
+}

--- a/src/main/java/io/muserver/rest/JaxRSRequest.java
+++ b/src/main/java/io/muserver/rest/JaxRSRequest.java
@@ -9,6 +9,7 @@ import jakarta.ws.rs.container.ResourceInfo;
 import jakarta.ws.rs.core.*;
 import jakarta.ws.rs.core.Cookie;
 import jakarta.ws.rs.ext.MessageBodyReader;
+import jakarta.ws.rs.ext.Providers;
 import jakarta.ws.rs.ext.ReaderInterceptor;
 import jakarta.ws.rs.ext.ReaderInterceptorContext;
 import org.jspecify.annotations.Nullable;
@@ -35,14 +36,14 @@ class JaxRSRequest implements Request, ContainerRequestContext, ReaderIntercepto
     private @Nullable Type genericType;
     private int nextReader;
     private final List<ReaderInterceptor> readerInterceptors;
-    private final EntityProviders entityProviders;
+    private final Providers providers;
     private String httpMethod;
     private @Nullable Response abortResponse;
     private boolean requestFilterChainRunning;
     private boolean responseFilterChainStarted;
     private boolean exceptionMapperUsed;
 
-    JaxRSRequest(MuRequest muRequest, MuResponse muResponse, InputStream inputStream, String relativePath, SecurityContext securityContext, List<ReaderInterceptor> readerInterceptors, EntityProviders entityProviders) {
+    JaxRSRequest(MuRequest muRequest, MuResponse muResponse, InputStream inputStream, String relativePath, SecurityContext securityContext, List<ReaderInterceptor> readerInterceptors, Providers providers) {
         this.muRequest = muRequest;
         this.httpMethod = muRequest.method().name();
         this.muResponse = muResponse;
@@ -50,7 +51,7 @@ class JaxRSRequest implements Request, ContainerRequestContext, ReaderIntercepto
         this.relativePath = relativePath;
         this.securityContext = securityContext;
         this.readerInterceptors = readerInterceptors;
-        this.entityProviders = entityProviders;
+        this.providers = providers;
         String basePath = muRequest.contextPath();
         if (!basePath.endsWith("/")) {
             basePath += "/";
@@ -374,7 +375,8 @@ class JaxRSRequest implements Request, ContainerRequestContext, ReaderIntercepto
         Annotation[] annotations = getAnnotations();
 
         // 3 & 4: Select a reader that supports the media type of the request and isReadable
-        MessageBodyReader messageBodyReader = entityProviders.selectReader(type, genericType, annotations, requestBodyMediaType);
+        MessageBodyReader messageBodyReader = JaxRSProviders.requireMessageBodyReader(
+            providers, type, genericType, annotations, requestBodyMediaType);
         try {
             return messageBodyReader.readFrom(type, genericType, annotations, requestBodyMediaType, getHeaders(), getInputStream());
         } catch (NoContentException nce) {

--- a/src/main/java/io/muserver/rest/JaxRSResponse.java
+++ b/src/main/java/io/muserver/rest/JaxRSResponse.java
@@ -8,6 +8,7 @@ import jakarta.ws.rs.container.ContainerResponseContext;
 import jakarta.ws.rs.core.*;
 import jakarta.ws.rs.core.Cookie;
 import jakarta.ws.rs.ext.MessageBodyReader;
+import jakarta.ws.rs.ext.Providers;
 import jakarta.ws.rs.ext.RuntimeDelegate;
 import jakarta.ws.rs.ext.WriterInterceptor;
 import jakarta.ws.rs.ext.WriterInterceptorContext;
@@ -205,8 +206,8 @@ class JaxRSResponse extends Response implements ContainerResponseContext, Writer
         InputStream toRead = inputStreamBuffer != null ? inputStreamBuffer : (InputStream) entity;
         Type typeToRead = genericType == null ? entityType : genericType;
         MediaType mediaType = getMediaType() == null ? MediaType.APPLICATION_OCTET_STREAM_TYPE : getMediaType();
-        EntityProviders ep = new EntityProviders(EntityProviders.builtInReaders(), emptyList());
-        MessageBodyReader<T> reader = (MessageBodyReader<T>) ep.selectReader(entityType, typeToRead, annotations, mediaType);
+        Providers providers = JaxRSProviders.builtInReadersOnly();
+        MessageBodyReader<T> reader = providers.getMessageBodyReader(entityType, typeToRead, annotations, mediaType);
         if (reader == null) {
             throw new ProcessingException("Cannot read this entity type");
         }

--- a/src/main/java/io/muserver/rest/JaxSseEventSinkImpl.java
+++ b/src/main/java/io/muserver/rest/JaxSseEventSinkImpl.java
@@ -6,6 +6,7 @@ import io.muserver.MuResponse;
 import io.muserver.ResponseCompleteListener;
 import jakarta.ws.rs.ServerErrorException;
 import jakarta.ws.rs.ext.MessageBodyWriter;
+import jakarta.ws.rs.ext.Providers;
 import jakarta.ws.rs.sse.OutboundSseEvent;
 import jakarta.ws.rs.sse.SseEventSink;
 import org.jspecify.annotations.Nullable;
@@ -29,13 +30,13 @@ class JaxSseEventSinkImpl implements SseEventSink {
 
     private final @Nullable AsyncSsePublisher ssePublisher;
     private final @Nullable MuResponse response;
-    private final @Nullable EntityProviders entityProviders;
+    private final @Nullable Providers providers;
     private final List<ResponseCompleteListener> responseCompleteListeners = new CopyOnWriteArrayList<>();
 
-    public JaxSseEventSinkImpl(@Nullable AsyncSsePublisher ssePublisher, @Nullable MuResponse response, @Nullable EntityProviders entityProviders) {
+    public JaxSseEventSinkImpl(@Nullable AsyncSsePublisher ssePublisher, @Nullable MuResponse response, @Nullable Providers providers) {
         this.ssePublisher = ssePublisher;
         this.response = response;
-        this.entityProviders = entityProviders;
+        this.providers = providers;
         if (ssePublisher != null) {
             ssePublisher.setResponseCompleteHandler(info -> {
                 for (ResponseCompleteListener listener : responseCompleteListeners) {
@@ -65,7 +66,7 @@ class JaxSseEventSinkImpl implements SseEventSink {
         Objects.requireNonNull(event, "event");
         AsyncSsePublisher publisher = Objects.requireNonNull(ssePublisher, "ssePublisher");
         MuResponse muResponse = Objects.requireNonNull(response, "response");
-        EntityProviders providers = Objects.requireNonNull(entityProviders, "entityProviders");
+        Providers providers = Objects.requireNonNull(this.providers, "providers");
         if (isClosed()) {
             throw new IllegalStateException("The SSE stream was already closed");
         }
@@ -86,8 +87,8 @@ class JaxSseEventSinkImpl implements SseEventSink {
                 if (genericDataType == null) {
                     genericDataType = dataType;
                 }
-                MessageBodyWriter messageBodyWriter = providers.selectWriter(dataType, genericDataType,
-                    JaxRSResponse.Builder.EMPTY_ANNOTATIONS, event.getMediaType());
+                MessageBodyWriter messageBodyWriter = JaxRSProviders.requireMessageBodyWriter(
+                    providers, dataType, genericDataType, JaxRSResponse.Builder.EMPTY_ANNOTATIONS, event.getMediaType());
                 try (ByteArrayOutputStream out = new ByteArrayOutputStream()) {
                     messageBodyWriter.writeTo(dataObject, dataType, genericDataType, JaxRSResponse.Builder.EMPTY_ANNOTATIONS,
                         event.getMediaType(), muHeadersToJaxObj(muResponse.headers()), out);

--- a/src/main/java/io/muserver/rest/ProviderWrapper.java
+++ b/src/main/java/io/muserver/rest/ProviderWrapper.java
@@ -15,20 +15,29 @@ class ProviderWrapper<T> implements Comparable<ProviderWrapper<T>> {
     public final List<MediaType> mediaTypes;
     public final Type genericType;
 
-    private ProviderWrapper(T provider, List<MediaType> mediaTypes, Type genericType) {
+    private ProviderWrapper(T provider, List<MediaType> mediaTypes, Type genericType, boolean isBuiltIn) {
         this.provider = provider;
-        this.isBuiltIn = provider.getClass().getPackage().getName().equals(ProviderWrapper.class.getPackage().getName());
+        this.isBuiltIn = isBuiltIn;
         this.mediaTypes = mediaTypes;
         this.genericType = genericType;
     }
 
     public static ProviderWrapper<MessageBodyReader<?>> reader(MessageBodyReader<?> provider) {
-        List<MediaType> mediaTypes = MediaTypeDeterminer.supportedConsumesTypes(provider.getClass());
-        return new ProviderWrapper<>(provider, mediaTypes, genericTypeOf(provider, MessageBodyReader.class));
+        return reader(provider, false);
     }
+
+    public static ProviderWrapper<MessageBodyReader<?>> reader(MessageBodyReader<?> provider, boolean isBuiltIn) {
+        List<MediaType> mediaTypes = MediaTypeDeterminer.supportedConsumesTypes(provider.getClass());
+        return new ProviderWrapper<>(provider, mediaTypes, genericTypeOf(provider, MessageBodyReader.class), isBuiltIn);
+    }
+
     public static ProviderWrapper<MessageBodyWriter<?>> writer(MessageBodyWriter<?> provider) {
+        return writer(provider, false);
+    }
+
+    public static ProviderWrapper<MessageBodyWriter<?>> writer(MessageBodyWriter<?> provider, boolean isBuiltIn) {
         List<MediaType> mediaTypes = MediaTypeDeterminer.supportedProducesTypes(provider.getClass());
-        return new ProviderWrapper<>(provider, mediaTypes, genericTypeOf(provider, MessageBodyWriter.class));
+        return new ProviderWrapper<>(provider, mediaTypes, genericTypeOf(provider, MessageBodyWriter.class), isBuiltIn);
     }
 
     public static Type genericTypeOf(Object instance, Class implementedInterface) {

--- a/src/main/java/io/muserver/rest/README.md
+++ b/src/main/java/io/muserver/rest/README.md
@@ -14,7 +14,7 @@ returned by `Application.getClasses()` are instantiated once with a public no-ar
 components must be safe to use concurrently.
 
 Resource classes returned by `Application.getClasses()` are rejected because their default lifecycle is per-request,
-which Mu Server does not support. Application properties, features, dynamic features, context resolvers, and classpath
+which Mu Server does not support. Application properties, features, dynamic features, and classpath
 scanning are also not supported. `@ApplicationPath` is honored when starting an application with `SeBootstrap`; a
 handler created directly with `RestHandlerBuilder.fromApplication` can instead be mounted in a Mu context. All
 supported components can alternatively be registered programmatically using `RestHandlerBuilder`.
@@ -216,11 +216,13 @@ No plan to implement as it would add another dependency.
 
 ### 4.3 Context Providers 
 
-- [ ] Not implemented.
+- [x] Context resolvers can be registered explicitly with `RestHandlerBuilder.addContextResolver`, or supplied as
+  singleton instances or provider classes from an `Application`.
 
 #### 4.3.1 Declaring Media Type Capabilities 
 
-- [ ] Not implemented.
+- [x] `@Produces` is used to filter and order context resolvers. When multiple resolvers match, they are called in
+  order until one returns a non-null context.
 
 ### 4.4 Exception Mapping Providers 
 
@@ -400,7 +402,11 @@ N/A. Will not implement, as there is no support for `Application`.
 
 #### 10.2.6 Providers 
 
-Will not implement.
+- [x] Implemented for resource method parameters using `@Context Providers`.
+
+Mu Server does not inject fields or bean properties on provider instances. Readers and writers that need access to
+the handler's providers can instead be registered with a factory, for example
+`addCustomWriter(providers -> new JsonWriter(providers))`.
 
 #### 10.2.7 Resource Context 
 

--- a/src/main/java/io/muserver/rest/RestHandler.java
+++ b/src/main/java/io/muserver/rest/RestHandler.java
@@ -9,6 +9,7 @@ import jakarta.ws.rs.container.ContainerRequestContext;
 import jakarta.ws.rs.core.*;
 import jakarta.ws.rs.ext.MessageBodyWriter;
 import jakarta.ws.rs.ext.ParamConverterProvider;
+import jakarta.ws.rs.ext.Providers;
 import jakarta.ws.rs.ext.ReaderInterceptor;
 import jakarta.ws.rs.ext.WriterInterceptor;
 import jakarta.ws.rs.sse.Sse;
@@ -37,7 +38,7 @@ public class RestHandler implements MuHandler {
     private static final Logger log = LoggerFactory.getLogger(RestHandler.class);
 
     private final RequestMatcher requestMatcher;
-    private final EntityProviders entityProviders;
+    private final JaxRSProviders providers;
     private final @Nullable MuHandler documentor;
     private final CustomExceptionMapper customExceptionMapper;
     private final FilterManagerThing filterManagerThing;
@@ -49,9 +50,9 @@ public class RestHandler implements MuHandler {
     private final List<WriterInterceptor> writerInterceptors;
     private final CollectionParameterStrategy collectionParameterStrategy;
 
-    RestHandler(EntityProviders entityProviders, List<ResourceClass> roots, @Nullable MuHandler documentor, CustomExceptionMapper customExceptionMapper, FilterManagerThing filterManagerThing, CORSConfig corsConfig, List<ParamConverterProvider> paramConverterProviders, SchemaObjectCustomizer schemaObjectCustomizer, List<ReaderInterceptor> readerInterceptors, List<WriterInterceptor> writerInterceptors, CollectionParameterStrategy collectionParameterStrategy) {
+    RestHandler(JaxRSProviders providers, List<ResourceClass> roots, @Nullable MuHandler documentor, CustomExceptionMapper customExceptionMapper, FilterManagerThing filterManagerThing, CORSConfig corsConfig, List<ParamConverterProvider> paramConverterProviders, SchemaObjectCustomizer schemaObjectCustomizer, List<ReaderInterceptor> readerInterceptors, List<WriterInterceptor> writerInterceptors, CollectionParameterStrategy collectionParameterStrategy) {
         this.requestMatcher = new RequestMatcher(roots);
-        this.entityProviders = entityProviders;
+        this.providers = providers;
         this.documentor = documentor;
         this.customExceptionMapper = customExceptionMapper;
         this.filterManagerThing = filterManagerThing;
@@ -74,7 +75,7 @@ public class RestHandler implements MuHandler {
         List<MediaType> directlyProducesRef = null;
         SecurityContext securityContext = muRequest.uri().getScheme().equals("https") ? MuSecurityContext.notLoggedInHttpsContext : MuSecurityContext.notLoggedInHttpContext;
 
-        JaxRSRequest requestContext = new JaxRSRequest(muRequest, muResponse, new LazyAccessInputStream(muRequest), Mutils.trim(muRequest.relativePath(), "/"), securityContext, readerInterceptors, entityProviders);
+        JaxRSRequest requestContext = new JaxRSRequest(muRequest, muResponse, new LazyAccessInputStream(muRequest), Mutils.trim(muRequest.relativePath(), "/"), securityContext, readerInterceptors, providers);
         try {
             final List<MediaType> acceptHeaders;
             try {
@@ -96,7 +97,7 @@ public class RestHandler implements MuHandler {
                 ResourceMethod rm = matchedMethod.resourceMethod;
                 try {
                     Object instance = Objects.requireNonNull(
-                        invokeResourceMethod(requestContext, muResponse, matchedMethod, onSuspended, entityProviders, collectionParameterStrategy),
+                        invokeResourceMethod(requestContext, muResponse, matchedMethod, onSuspended, providers, collectionParameterStrategy),
                         "Sub-resource locator returned null");
                     return ResourceClass.forSubResourceLocator(rm, instance.getClass(), instance, schemaObjectCustomizer, paramConverterProviders);
                 } catch (WebApplicationException wae) {
@@ -146,7 +147,7 @@ public class RestHandler implements MuHandler {
             };
 
 
-            @Nullable Object result = invokeResourceMethod(requestContext, muResponse, mm, suspendedParamCallback, entityProviders, collectionParameterStrategy);
+            @Nullable Object result = invokeResourceMethod(requestContext, muResponse, mm, suspendedParamCallback, providers, collectionParameterStrategy);
 
             if (!muRequest.isAsync()) {
                 if (result instanceof CompletionStage) {
@@ -183,7 +184,7 @@ public class RestHandler implements MuHandler {
         return GenericTypeResolver.resolveTypeArgument(returnType, CompletionStage.class, 0);
     }
 
-    static @Nullable Object invokeResourceMethod(JaxRSRequest requestContext, MuResponse muResponse, RequestMatcher.MatchedMethod mm, Function<ResourceMethod, @Nullable Object> suspendedParamCallback, EntityProviders entityProviders, CollectionParameterStrategy collectionParameterStrategy) throws Exception {
+    static @Nullable Object invokeResourceMethod(JaxRSRequest requestContext, MuResponse muResponse, RequestMatcher.MatchedMethod mm, Function<ResourceMethod, @Nullable Object> suspendedParamCallback, JaxRSProviders providers, CollectionParameterStrategy collectionParameterStrategy) throws Exception {
         ResourceMethod rm = mm.resourceMethod;
         @Nullable Object[] params = new Object[rm.methodHandle().getParameterCount()];
         for (ResourceMethodParam param : rm.params) {
@@ -191,7 +192,7 @@ public class RestHandler implements MuHandler {
             if (param.source() == ResourceMethodParam.ValueSource.MESSAGE_BODY) {
                 paramValue = readRequestEntity(requestContext, param);
             } else if (param.source() == ResourceMethodParam.ValueSource.CONTEXT) {
-                paramValue = getContextParam(requestContext, muResponse, mm, param, entityProviders);
+                paramValue = getContextParam(requestContext, muResponse, mm, param, providers);
             } else if (param.source() == ResourceMethodParam.ValueSource.SUSPENDED) {
                 paramValue = suspendedParamCallback.apply(rm);
             } else {
@@ -278,7 +279,7 @@ public class RestHandler implements MuHandler {
                     jaxRSResponse.setAnnotations(writerAnnontations);
 
                     if (obj.entity != null) {
-                        MediaType responseMediaType = MediaTypeDeterminer.determine(obj, produces, directlyProduces, entityProviders.writers, acceptHeaders, writerAnnontations);
+                        MediaType responseMediaType = MediaTypeDeterminer.determine(obj, produces, directlyProduces, providers.writers(), acceptHeaders, writerAnnontations);
                         jaxRSResponse.setMediaType(responseMediaType);
                     }
 
@@ -324,9 +325,10 @@ public class RestHandler implements MuHandler {
                             "A response entity must have a raw type");
                         Type entityGenericType = Objects.requireNonNull(jaxRSResponse.getEntityType(),
                             "A response entity must have a generic type");
-                        MessageBodyWriter messageBodyWriter = entityProviders.selectWriter(entityType, entityGenericType, writerAnnontations, responseMediaType);
+                        MessageBodyWriter messageBodyWriter = JaxRSProviders.requireMessageBodyWriter(
+                            providers, entityType, entityGenericType, writerAnnontations, responseMediaType);
 
-                        if (!entityStreamReplaced && !muResponse.hasStartedSendingData() && entityProviders.isBuiltInWriter(messageBodyWriter)) {
+                        if (!entityStreamReplaced && !muResponse.hasStartedSendingData() && providers.isBuiltInWriter(messageBodyWriter)) {
                             long size = messageBodyWriter.getSize(jaxRSResponse.getEntity(), entityType, entityGenericType, writerAnnontations, responseMediaType);
                             if (size >= 0) {
                                 jaxRSResponse.getHeaders().putSingle("content-length", Long.toString(size));
@@ -395,7 +397,7 @@ public class RestHandler implements MuHandler {
         }
     }
 
-    private static @Nullable Object getContextParam(JaxRSRequest requestContext, MuResponse muResponse, RequestMatcher.MatchedMethod mm, ResourceMethodParam param, EntityProviders providers) {
+    private static @Nullable Object getContextParam(JaxRSRequest requestContext, MuResponse muResponse, RequestMatcher.MatchedMethod mm, ResourceMethodParam param, JaxRSProviders providers) {
         MuRequest request = requestContext.muRequest;
         Object paramValue;
         Class<?> type = param.type();
@@ -407,6 +409,8 @@ public class RestHandler implements MuHandler {
             paramValue = request;
         } else if (type.equals(HttpHeaders.class)) {
             paramValue = new JaxRsHttpHeadersAdapter(request.headers(), request.cookies());
+        } else if (type.equals(Providers.class)) {
+            paramValue = providers;
         } else if (SecurityContext.class.isAssignableFrom(type)) {
             SecurityContext sc = requestContext.getSecurityContext();
             if (sc != null && !type.isAssignableFrom(sc.getClass())) {

--- a/src/main/java/io/muserver/rest/RestHandlerBuilder.java
+++ b/src/main/java/io/muserver/rest/RestHandlerBuilder.java
@@ -21,6 +21,7 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 import java.nio.charset.StandardCharsets;
 import java.util.*;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import static io.muserver.openapi.PathsObjectBuilder.pathsObject;
@@ -38,8 +39,10 @@ public class RestHandlerBuilder implements MuHandlerBuilder<RestHandler> {
 
     private final List<Object> resources = new ArrayList<>();
     private final List<MessageBodyWriter> customWriters = new ArrayList<>();
+    private final List<Function<Providers, MessageBodyWriter<?>>> customWriterRegistrations = new ArrayList<>();
     private final List<WriterInterceptor> writerInterceptors = new ArrayList<>();
     private final List<MessageBodyReader> customReaders = new ArrayList<>();
+    private final List<Function<Providers, MessageBodyReader<?>>> customReaderRegistrations = new ArrayList<>();
     private final List<ReaderInterceptor> readerInterceptors = new ArrayList<>();
     private final List<ParamConverterProvider> customParamConverterProviders = new ArrayList<>();
     private final List<SchemaReference> customSchemas = new ArrayList<>();
@@ -48,6 +51,7 @@ public class RestHandlerBuilder implements MuHandlerBuilder<RestHandler> {
     private @Nullable OpenAPIObjectBuilder openAPIObject;
     private @Nullable String openApiHtmlCss;
     private final Map<Class<? extends Throwable>, ExceptionMapper<? extends Throwable>> exceptionMappers = new HashMap<>();
+    private final List<JaxRSProviders.ContextResolverRegistration<?>> contextResolvers = new ArrayList<>();
     private final List<ContainerRequestFilter> preMatchRequestFilters = new ArrayList<>();
     private final List<ContainerRequestFilter> requestFilters = new ArrayList<>();
     private final List<ContainerResponseFilter> responseFilters = new ArrayList<>();
@@ -80,7 +84,25 @@ public class RestHandlerBuilder implements MuHandlerBuilder<RestHandler> {
      * @return This builder
      */
     public <T> RestHandlerBuilder addCustomWriter(MessageBodyWriter<T> writer) {
+        Objects.requireNonNull(writer, "writer");
         customWriters.add(writer);
+        customWriterRegistrations.add(providers -> writer);
+        return this;
+    }
+
+    /**
+     * Registers a factory for a custom response body writer that needs access to the providers registered for this
+     * REST handler. The factory is invoked once each time {@link #build()} is called. The supplied {@link Providers}
+     * instance may be retained by the writer, but it cannot be queried until the build has completed.
+     *
+     * @param writerFactory Creates a response body writer for a single REST handler
+     * @param <T> The type of object that the writer can serialise
+     * @return This builder
+     */
+    public <T> RestHandlerBuilder addCustomWriter(
+        Function<Providers, ? extends MessageBodyWriter<T>> writerFactory) {
+        Objects.requireNonNull(writerFactory, "writerFactory");
+        customWriterRegistrations.add(providers -> writerFactory.apply(providers));
         return this;
     }
 
@@ -94,7 +116,41 @@ public class RestHandlerBuilder implements MuHandlerBuilder<RestHandler> {
      * @return This builder
      */
     public <T> RestHandlerBuilder addCustomReader(MessageBodyReader<T> reader) {
+        Objects.requireNonNull(reader, "reader");
         customReaders.add(reader);
+        customReaderRegistrations.add(providers -> reader);
+        return this;
+    }
+
+    /**
+     * Registers a factory for a custom request body reader that needs access to the providers registered for this
+     * REST handler. The factory is invoked once each time {@link #build()} is called. The supplied {@link Providers}
+     * instance may be retained by the reader, but it cannot be queried until the build has completed.
+     *
+     * @param readerFactory Creates a request body reader for a single REST handler
+     * @param <T> The type of object that the reader can deserialise
+     * @return This builder
+     */
+    public <T> RestHandlerBuilder addCustomReader(
+        Function<Providers, ? extends MessageBodyReader<T>> readerFactory) {
+        Objects.requireNonNull(readerFactory, "readerFactory");
+        customReaderRegistrations.add(providers -> readerFactory.apply(providers));
+        return this;
+    }
+
+    /**
+     * Registers a context resolver for a given context type. More than one resolver can be registered for the same
+     * type; {@link jakarta.ws.rs.Produces} annotations on the resolver classes are used to select and order matches.
+     *
+     * @param contextType The type of context supplied by the resolver
+     * @param resolver The context resolver
+     * @param <T> The context type
+     * @return This builder
+     */
+    public <T> RestHandlerBuilder addContextResolver(Class<T> contextType, ContextResolver<T> resolver) {
+        contextResolvers.add(new JaxRSProviders.ContextResolverRegistration<>(
+            Objects.requireNonNull(contextType, "contextType"),
+            Objects.requireNonNull(resolver, "resolver")));
         return this;
     }
 
@@ -300,7 +356,7 @@ public class RestHandlerBuilder implements MuHandlerBuilder<RestHandler> {
      * <p>Mu Server supports resource instances returned by {@link Application#getSingletons()}, but not resource
      * classes returned by {@link Application#getClasses()} because those have a per-request lifecycle by default.
      * Singleton resources must therefore be safe to use concurrently. Provider classes are instantiated once using a
-     * public no-argument constructor. Application properties, features, dynamic features, context resolvers, automatic
+     * public no-argument constructor. Application properties, features, dynamic features, automatic
      * discovery, and {@link jakarta.ws.rs.ApplicationPath} mounting are not supported.</p>
      *
      * @param application The application configuration to adapt.
@@ -592,11 +648,25 @@ public class RestHandlerBuilder implements MuHandlerBuilder<RestHandler> {
      */
     @Override
     public RestHandler build() {
-        List<MessageBodyReader> readers = EntityProviders.builtInReaders();
-        readers.addAll(customReaders);
-        List<MessageBodyWriter> writers = EntityProviders.builtInWriters();
-        writers.addAll(customWriters);
-        EntityProviders entityProviders = new EntityProviders(readers, writers);
+        JaxRSProviders providers = new JaxRSProviders();
+        List<MessageBodyReader> readers = new ArrayList<>();
+        for (Function<Providers, MessageBodyReader<?>> registration : customReaderRegistrations) {
+            MessageBodyReader<?> reader = registration.apply(providers);
+            if (reader == null) {
+                throw new IllegalStateException("A custom message body reader factory returned null");
+            }
+            readers.add(reader);
+        }
+        List<MessageBodyWriter> writers = new ArrayList<>();
+        for (Function<Providers, MessageBodyWriter<?>> registration : customWriterRegistrations) {
+            MessageBodyWriter<?> writer = registration.apply(providers);
+            if (writer == null) {
+                throw new IllegalStateException("A custom message body writer factory returned null");
+            }
+            writers.add(writer);
+        }
+        EntityProviders entityProviders = new EntityProviders(
+            EntityProviders.builtInReaders(), readers, EntityProviders.builtInWriters(), writers);
         List<ParamConverterProvider> paramConverterProviders = new ArrayList<>(customParamConverterProviders);
         paramConverterProviders.add(new BuiltInParamConverterProvider());
 
@@ -628,7 +698,7 @@ public class RestHandlerBuilder implements MuHandlerBuilder<RestHandler> {
             documentor = new OpenApiDocumentor(roots, openApiJsonUrl, openApiHtmlUrl, openAPIObjectToUse.build(), openApiHtmlCss, corsConfig, new ArrayList<>(customSchemas), schemaObjectCustomizer, paramConverterProviders);
         }
 
-        CustomExceptionMapper customExceptionMapper = new CustomExceptionMapper(exceptionMappers);
+        CustomExceptionMapper customExceptionMapper = new CustomExceptionMapper(providers);
 
         FilterManagerThing filterManagerThing = new FilterManagerThing(preMatchRequestFilters, requestFilters, responseFilters);
 
@@ -637,6 +707,9 @@ public class RestHandlerBuilder implements MuHandlerBuilder<RestHandler> {
             cps = CollectionParameterStrategy.NO_TRANSFORM;
         }
 
-        return new RestHandler(entityProviders, roots, documentor, customExceptionMapper, filterManagerThing, corsConfig, paramConverterProviders, schemaObjectCustomizer, readerInterceptors, writerInterceptors, cps);
+        RestHandler handler = new RestHandler(providers, roots, documentor, customExceptionMapper, filterManagerThing,
+            corsConfig, paramConverterProviders, schemaObjectCustomizer, readerInterceptors, writerInterceptors, cps);
+        providers.initialize(entityProviders, exceptionMappers, contextResolvers);
+        return handler;
     }
 }

--- a/src/test/java/io/muserver/rest/ApplicationTest.java
+++ b/src/test/java/io/muserver/rest/ApplicationTest.java
@@ -18,13 +18,16 @@ import jakarta.ws.rs.container.ContainerRequestFilter;
 import jakarta.ws.rs.container.ContainerResponseContext;
 import jakarta.ws.rs.container.ContainerResponseFilter;
 import jakarta.ws.rs.core.Application;
+import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.ext.ContextResolver;
 import jakarta.ws.rs.ext.ExceptionMapper;
 import jakarta.ws.rs.ext.MessageBodyReader;
 import jakarta.ws.rs.ext.MessageBodyWriter;
 import jakarta.ws.rs.ext.ParamConverter;
 import jakarta.ws.rs.ext.ParamConverterProvider;
+import jakarta.ws.rs.ext.Providers;
 import jakarta.ws.rs.ext.ReaderInterceptor;
 import jakarta.ws.rs.ext.ReaderInterceptorContext;
 import jakarta.ws.rs.ext.WriterInterceptor;
@@ -229,6 +232,29 @@ public class ApplicationTest {
     }
 
     @Test
+    public void contextResolverClassesAreRegistered() throws IOException {
+        Application application = new Application() {
+            @Override
+            public Set<Class<?>> getClasses() {
+                return Set.of(ApplicationContextResolver.class);
+            }
+
+            @Override
+            public Set<Object> getSingletons() {
+                return Set.of(new ContextResource());
+            }
+        };
+        server = ServerUtils.httpsServerForTest()
+            .addHandler(RestHandlerBuilder.fromApplication(application))
+            .start();
+
+        try (Response response = call(request(server.uri().resolve("/application-context")))) {
+            assertThat(response.code(), is(200));
+            assertThat(response.body().string(), is("application-context"));
+        }
+    }
+
+    @Test
     public void nameBindingOnApplicationMakesMatchingProviderGlobal() throws IOException {
         BoundResponseFilter filter = new BoundResponseFilter();
         server = ServerUtils.httpsServerForTest()
@@ -417,6 +443,30 @@ public class ApplicationTest {
     }
 
     public static class SampleException extends RuntimeException {
+    }
+
+    private static class ApplicationContext {
+        private final String value;
+
+        private ApplicationContext(String value) {
+            this.value = value;
+        }
+    }
+
+    public static class ApplicationContextResolver implements ContextResolver<ApplicationContext> {
+        @Override
+        public ApplicationContext getContext(Class<?> type) {
+            return new ApplicationContext("application-context");
+        }
+    }
+
+    @Path("application-context")
+    private static class ContextResource {
+        @GET
+        public String context(@Context Providers providers) {
+            return providers.getContextResolver(ApplicationContext.class, MediaType.TEXT_PLAIN_TYPE)
+                .getContext(ContextResource.class).value;
+        }
     }
 
     private static class Converted {

--- a/src/test/java/io/muserver/rest/CustomExceptionMapperTest.java
+++ b/src/test/java/io/muserver/rest/CustomExceptionMapperTest.java
@@ -8,6 +8,8 @@ import org.junit.Test;
 import java.util.HashMap;
 import java.util.Map;
 
+import static java.util.Collections.emptyList;
+
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
@@ -31,7 +33,9 @@ public class CustomExceptionMapperTest {
         mappers.put(ConcurrentException.class, exception -> Response.status(409).build());
         mappers.put(NoContentException.class, exception -> null);
         mappers.put(ServerException.class, exception -> { throw new RuntimeException("oops");});
-        mapper = new CustomExceptionMapper(mappers);
+        JaxRSProviders providers = new JaxRSProviders();
+        providers.initialize(new EntityProviders(emptyList(), emptyList()), mappers, emptyList());
+        mapper = new CustomExceptionMapper(providers);
     }
 
     @Test

--- a/src/test/java/io/muserver/rest/EntityProvidersTest.java
+++ b/src/test/java/io/muserver/rest/EntityProvidersTest.java
@@ -415,10 +415,11 @@ public class EntityProvidersTest {
     public void broadApplicationReaderOverridesMoreSpecificBuiltInReader() {
         ObjectReader applicationReader = new ObjectReader();
         EntityProviders providers = new EntityProviders(
-            asList(applicationReader, StringEntityProviders.stringEntityReaders.get(0)),
-            Collections.emptyList());
+            Collections.singletonList(StringEntityProviders.stringEntityReaders.get(0)),
+            Collections.singletonList(applicationReader),
+            Collections.emptyList(), Collections.emptyList());
 
-        assertThat(providers.selectReader(
+        assertThat(providers.findReader(
             String.class,
             String.class,
             new Annotation[0],
@@ -879,14 +880,14 @@ public class EntityProvidersTest {
 
         EntityProviders firstReadable = new EntityProviders(
             asList(new WildcardReader(), new ExactReader(true)), Collections.emptyList());
-        assertThat(firstReadable.selectReader(String.class, String.class, new Annotation[0], mediaType),
+        assertThat(firstReadable.findReader(String.class, String.class, new Annotation[0], mediaType),
             Matchers.instanceOf(ExactReader.class));
         assertThat(calls, Matchers.contains("exact"));
 
         calls.clear();
         EntityProviders fallback = new EntityProviders(
             asList(new WildcardReader(), new ExactReader(false)), Collections.emptyList());
-        assertThat(fallback.selectReader(String.class, String.class, new Annotation[0], mediaType),
+        assertThat(fallback.findReader(String.class, String.class, new Annotation[0], mediaType),
             Matchers.instanceOf(WildcardReader.class));
         assertThat(calls, Matchers.contains("exact", "wildcard"));
     }

--- a/src/test/java/io/muserver/rest/ProvidersTest.java
+++ b/src/test/java/io/muserver/rest/ProvidersTest.java
@@ -1,0 +1,325 @@
+package io.muserver.rest;
+
+import io.muserver.MuServer;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.ext.ContextResolver;
+import jakarta.ws.rs.ext.ExceptionMapper;
+import jakarta.ws.rs.ext.MessageBodyReader;
+import jakarta.ws.rs.ext.MessageBodyWriter;
+import jakarta.ws.rs.ext.Providers;
+import okhttp3.RequestBody;
+import okhttp3.Response;
+import org.junit.After;
+import org.junit.Test;
+import scaffolding.ServerUtils;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static io.muserver.rest.RestHandlerBuilder.restHandler;
+import static java.util.Collections.emptyList;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.sameInstance;
+import static org.junit.Assert.assertThrows;
+import static scaffolding.ClientUtils.call;
+import static scaffolding.ClientUtils.request;
+import static scaffolding.MuAssert.stopAndCheck;
+
+public class ProvidersTest {
+
+    private MuServer server;
+
+    @After
+    public void stop() {
+        stopAndCheck(server);
+    }
+
+    @Test
+    public void entityProviderLookupsReturnMatchesOrNull() {
+        PayloadReader reader = new PayloadReader(null);
+        PayloadWriter writer = new PayloadWriter(null);
+        JaxRSProviders providers = initializedProviders(
+            Collections.singletonList(reader), Collections.singletonList(writer),
+            Collections.emptyMap(), Collections.emptyList());
+
+        assertThat(providers.getMessageBodyReader(Payload.class, Payload.class, new Annotation[0], MediaType.TEXT_PLAIN_TYPE),
+            sameInstance(reader));
+        assertThat(providers.getMessageBodyWriter(Payload.class, Payload.class, new Annotation[0], MediaType.TEXT_PLAIN_TYPE),
+            sameInstance(writer));
+        assertThat(providers.getMessageBodyReader(Payload.class, Payload.class, new Annotation[0], MediaType.APPLICATION_JSON_TYPE),
+            nullValue());
+        assertThat(providers.getMessageBodyWriter(Payload.class, Payload.class, new Annotation[0], MediaType.APPLICATION_JSON_TYPE),
+            nullValue());
+    }
+
+    @Test
+    public void exceptionMapperLookupUsesTheNearestRegisteredSuperclass() {
+        ExceptionMapper<Exception> broad = exception -> jakarta.ws.rs.core.Response.serverError().build();
+        ExceptionMapper<IllegalArgumentException> exact = exception -> jakarta.ws.rs.core.Response.status(400).build();
+        Map<Class<? extends Throwable>, ExceptionMapper<? extends Throwable>> mappers = new HashMap<>();
+        mappers.put(Exception.class, broad);
+        mappers.put(IllegalArgumentException.class, exact);
+        JaxRSProviders providers = initializedProviders(emptyList(), emptyList(), mappers, emptyList());
+
+        assertThat(providers.getExceptionMapper(IllegalArgumentException.class), sameInstance(exact));
+        assertThat(providers.getExceptionMapper(NumberFormatException.class), sameInstance(exact));
+        assertThat(providers.getExceptionMapper(IOException.class), sameInstance(broad));
+        assertThat(providers.getExceptionMapper(Error.class), nullValue());
+    }
+
+    @Test
+    public void contextResolversAreFilteredAndComposedInMediaTypeOrder() {
+        List<String> calls = new ArrayList<>();
+        ContextResolver<Prefix> wildcard = new WildcardPrefixResolver(calls);
+        ContextResolver<Prefix> json = new JsonPrefixResolver(calls);
+        List<JaxRSProviders.ContextResolverRegistration<?>> registrations = new ArrayList<>();
+        registrations.add(new JaxRSProviders.ContextResolverRegistration<>(Prefix.class, wildcard));
+        registrations.add(new JaxRSProviders.ContextResolverRegistration<>(Prefix.class, json));
+        JaxRSProviders providers = initializedProviders(emptyList(), emptyList(), Collections.emptyMap(), registrations);
+
+        ContextResolver<Prefix> resolver = providers.getContextResolver(Prefix.class, MediaType.APPLICATION_JSON_TYPE);
+        assertThat(resolver.getContext(Payload.class).value, equalTo("wildcard"));
+        assertThat(calls, contains("json", "wildcard"));
+
+        calls.clear();
+        assertThat(resolver.getContext(String.class).value, equalTo("json"));
+        assertThat(calls, contains("json"));
+        assertThat(providers.getContextResolver(Prefix.class, MediaType.TEXT_XML_TYPE), sameInstance(wildcard));
+    }
+
+    @Test
+    public void contextResolverLookupReturnsNullWhenTypeOrMediaTypeDoesNotMatch() {
+        ContextResolver<Prefix> json = new JsonPrefixResolver(new ArrayList<>());
+        List<JaxRSProviders.ContextResolverRegistration<?>> registrations = Collections.singletonList(
+            new JaxRSProviders.ContextResolverRegistration<>(Prefix.class, json));
+        JaxRSProviders providers = initializedProviders(emptyList(), emptyList(), Collections.emptyMap(), registrations);
+
+        assertThat(providers.getContextResolver(Prefix.class, MediaType.TEXT_PLAIN_TYPE), nullValue());
+        assertThat(providers.getContextResolver(CharSequence.class, MediaType.APPLICATION_JSON_TYPE), nullValue());
+    }
+
+    @Test
+    public void factoriesReceiveTheSameProvidersThatResourcesReceive() throws Exception {
+        AtomicReference<Providers> writerProviders = new AtomicReference<>();
+        AtomicReference<Providers> readerProviders = new AtomicReference<>();
+
+        @Path("providers")
+        class Resource {
+            @POST
+            @Consumes(MediaType.TEXT_PLAIN)
+            @Produces(MediaType.TEXT_PLAIN)
+            public Payload echo(Payload payload) {
+                return payload;
+            }
+
+            @GET
+            @Path("same")
+            @Produces(MediaType.TEXT_PLAIN)
+            public String same(@Context Providers providers) {
+                return Boolean.toString(providers == readerProviders.get() && providers == writerProviders.get());
+            }
+        }
+
+        server = ServerUtils.httpsServerForTest().addHandler(
+            restHandler(new Resource())
+                .addContextResolver(Prefix.class, new PlainTextPrefixResolver())
+                .addCustomReader(providers -> {
+                    readerProviders.set(providers);
+                    return new PayloadReader(providers);
+                })
+                .addCustomWriter(providers -> {
+                    writerProviders.set(providers);
+                    return new PayloadWriter(providers);
+                })
+                .build()).start();
+
+        try (Response response = call(request()
+            .url(server.uri().resolve("/providers").toString())
+            .post(RequestBody.create("hello", okhttp3.MediaType.parse("text/plain"))))) {
+            assertThat(response.code(), is(200));
+            assertThat(response.body().string(), equalTo("context:context:hello"));
+        }
+        try (Response response = call(request(server.uri().resolve("/providers/same")))) {
+            assertThat(response.body().string(), equalTo("true"));
+        }
+    }
+
+    @Test
+    public void providersCannotBeQueriedFromInsideAFactory() {
+        AtomicReference<IllegalStateException> error = new AtomicReference<>();
+        RestHandlerBuilder builder = new RestHandlerBuilder().addCustomWriter(providers -> {
+            error.set(assertThrows(IllegalStateException.class, () -> providers.getExceptionMapper(Exception.class)));
+            return new PayloadWriter(providers);
+        });
+
+        builder.build();
+
+        assertThat(error.get().getMessage(), equalTo(
+            "Providers cannot be queried until RestHandlerBuilder.build() has completed"));
+    }
+
+    @Test
+    public void factoriesAreInvokedOncePerBuildWithAnIsolatedRegistry() {
+        AtomicInteger calls = new AtomicInteger();
+        List<Providers> providerInstances = new ArrayList<>();
+        RestHandlerBuilder builder = new RestHandlerBuilder().addCustomWriter(providers -> {
+            calls.incrementAndGet();
+            providerInstances.add(providers);
+            return new PayloadWriter(providers);
+        });
+
+        builder.build();
+        builder.build();
+
+        assertThat(calls.get(), is(2));
+        assertThat(providerInstances.get(0), not(sameInstance(providerInstances.get(1))));
+    }
+
+    @Test
+    public void nullFactoryResultsFailTheBuild() {
+        RestHandlerBuilder builder = new RestHandlerBuilder()
+            .addCustomWriter(providers -> (MessageBodyWriter<Payload>) null);
+
+        IllegalStateException error = assertThrows(IllegalStateException.class, builder::build);
+
+        assertThat(error.getMessage(), equalTo("A custom message body writer factory returned null"));
+    }
+
+    private static JaxRSProviders initializedProviders(
+        List<MessageBodyReader> readers,
+        List<MessageBodyWriter> writers,
+        Map<Class<? extends Throwable>, ExceptionMapper<? extends Throwable>> exceptionMappers,
+        List<JaxRSProviders.ContextResolverRegistration<?>> contextResolvers) {
+        JaxRSProviders providers = new JaxRSProviders();
+        providers.initialize(new EntityProviders(readers, writers), exceptionMappers, contextResolvers);
+        return providers;
+    }
+
+    private static class Payload {
+        private final String value;
+
+        private Payload(String value) {
+            this.value = value;
+        }
+    }
+
+    private static class Prefix {
+        private final String value;
+
+        private Prefix(String value) {
+            this.value = value;
+        }
+    }
+
+    @Consumes(MediaType.TEXT_PLAIN)
+    private static class PayloadReader implements MessageBodyReader<Payload> {
+        private final Providers providers;
+
+        private PayloadReader(Providers providers) {
+            this.providers = providers;
+        }
+
+        @Override
+        public boolean isReadable(Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType) {
+            return type.equals(Payload.class);
+        }
+
+        @Override
+        public Payload readFrom(Class<Payload> type, Type genericType, Annotation[] annotations, MediaType mediaType,
+                                MultivaluedMap<String, String> httpHeaders, InputStream entityStream) throws IOException {
+            String value = new String(entityStream.readAllBytes(), StandardCharsets.UTF_8);
+            if (providers == null) {
+                return new Payload(value);
+            }
+            ContextResolver<Prefix> resolver = providers.getContextResolver(Prefix.class, mediaType);
+            return new Payload(resolver.getContext(type).value + value);
+        }
+    }
+
+    @Produces(MediaType.TEXT_PLAIN)
+    private static class PayloadWriter implements MessageBodyWriter<Payload> {
+        private final Providers providers;
+
+        private PayloadWriter(Providers providers) {
+            this.providers = providers;
+        }
+
+        @Override
+        public boolean isWriteable(Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType) {
+            return type.equals(Payload.class);
+        }
+
+        @Override
+        public void writeTo(Payload payload, Class<?> type, Type genericType, Annotation[] annotations,
+                            MediaType mediaType, MultivaluedMap<String, Object> httpHeaders,
+                            OutputStream entityStream) throws IOException {
+            String prefix = "";
+            if (providers != null) {
+                ContextResolver<Prefix> resolver = providers.getContextResolver(Prefix.class, mediaType);
+                prefix = resolver.getContext(type).value;
+            }
+            entityStream.write((prefix + payload.value).getBytes(StandardCharsets.UTF_8));
+        }
+    }
+
+    @Produces(MediaType.WILDCARD)
+    private static class WildcardPrefixResolver implements ContextResolver<Prefix> {
+        private final List<String> calls;
+
+        private WildcardPrefixResolver(List<String> calls) {
+            this.calls = calls;
+        }
+
+        @Override
+        public Prefix getContext(Class<?> type) {
+            calls.add("wildcard");
+            return new Prefix("wildcard");
+        }
+    }
+
+    @Produces(MediaType.APPLICATION_JSON)
+    private static class JsonPrefixResolver implements ContextResolver<Prefix> {
+        private final List<String> calls;
+
+        private JsonPrefixResolver(List<String> calls) {
+            this.calls = calls;
+        }
+
+        @Override
+        public Prefix getContext(Class<?> type) {
+            calls.add("json");
+            return type.equals(Payload.class) ? null : new Prefix("json");
+        }
+    }
+
+    @Produces(MediaType.TEXT_PLAIN)
+    private static class PlainTextPrefixResolver implements ContextResolver<Prefix> {
+        @Override
+        public Prefix getContext(Class<?> type) {
+            return type.equals(Payload.class) ? new Prefix("context:") : null;
+        }
+    }
+}

--- a/src/test/java/io/muserver/rest/ProvidersTest.java
+++ b/src/test/java/io/muserver/rest/ProvidersTest.java
@@ -119,6 +119,7 @@ public class ProvidersTest {
 
         assertThat(providers.getContextResolver(Prefix.class, MediaType.TEXT_PLAIN_TYPE), nullValue());
         assertThat(providers.getContextResolver(CharSequence.class, MediaType.APPLICATION_JSON_TYPE), nullValue());
+        assertThat(providers.getContextResolver(Object.class, MediaType.APPLICATION_JSON_TYPE), nullValue());
     }
 
     @Test

--- a/src/test/java/io/muserver/rest/SseEventSinkTest.java
+++ b/src/test/java/io/muserver/rest/SseEventSinkTest.java
@@ -6,7 +6,9 @@ import jakarta.ws.rs.*;
 import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.ext.ContextResolver;
 import jakarta.ws.rs.ext.MessageBodyWriter;
+import jakarta.ws.rs.ext.Providers;
 import jakarta.ws.rs.sse.Sse;
 import jakarta.ws.rs.sse.SseEventSink;
 import org.junit.After;
@@ -78,7 +80,26 @@ public class SseEventSinkTest {
                 this.name = name;
             }
         }
+        class DogFormat {
+            final String prefix;
+
+            DogFormat(String prefix) {
+                this.prefix = prefix;
+            }
+        }
+        @Produces(MediaType.WILDCARD)
+        class DogFormatResolver implements ContextResolver<DogFormat> {
+            @Override
+            public DogFormat getContext(Class<?> type) {
+                return type.equals(Dog.class) ? new DogFormat("Dog ") : null;
+            }
+        }
         class DogWriter implements MessageBodyWriter<Dog> {
+            private final Providers providers;
+
+            DogWriter(Providers providers) {
+                this.providers = providers;
+            }
 
             @Override
             public boolean isWriteable(Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType) {
@@ -87,7 +108,8 @@ public class SseEventSinkTest {
 
             @Override
             public void writeTo(Dog dog, Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType, MultivaluedMap<String, Object> httpHeaders, OutputStream entityStream) throws IOException, WebApplicationException {
-                entityStream.write(("Dog " + dog.name + " has tail? " + dog.hasTail).getBytes(UTF_8));
+                DogFormat format = providers.getContextResolver(DogFormat.class, mediaType).getContext(type);
+                entityStream.write((format.prefix + dog.name + " has tail? " + dog.hasTail).getBytes(UTF_8));
             }
         }
 
@@ -116,7 +138,8 @@ public class SseEventSinkTest {
 
         server = ServerUtils.httpsServerForTest().addHandler(
             restHandler(new Streamer())
-                .addCustomWriter(new DogWriter())
+                .addContextResolver(DogFormat.class, new DogFormatResolver())
+                .addCustomWriter(providers -> new DogWriter(providers))
         ).start();
 
         try (SseClient.ServerSentEvent ignored = sseClient.newServerSentEvent(request().url(server.uri().resolve("/streamer/eventStream").toString()).build(), listener)) {

--- a/v3-release-notes.md
+++ b/v3-release-notes.md
@@ -4,3 +4,9 @@ Breaking changes
 
 * Minimum Java version is now 11
 * Deleted unused `io.muserver.Toggles` class
+
+New features
+============
+
+* Implemented Jakarta REST `Providers`, including explicit `ContextResolver` registration and provider-aware
+  message body reader and writer factories.


### PR DESCRIPTION
## Summary

- implement a handler-scoped Jakarta REST Providers registry with all four lookup methods
- support ContextResolver registration through RestHandlerBuilder and Application, including Produces-based aggregation
- add provider-aware message body reader and writer factories
- use the shared registry for request bodies, responses, exception mapping, and SSE
- track built-in providers explicitly and update compliance/release documentation

## Testing

- Full Maven test suite on Java 11: 1,091 tests passed
- Focused provider, application, and SSE tests after the final initialization-order adjustment: 26 tests passed