### PR TITLE
Honor JAX-RS provider priorities

### DIFF
--- a/src/main/java/io/muserver/rest/ApplicationRegistrar.java
+++ b/src/main/java/io/muserver/rest/ApplicationRegistrar.java
@@ -152,7 +152,7 @@ final class ApplicationRegistrar {
                 throw new IllegalArgumentException("Could not infer the exception type handled by "
                     + component.getClass().getName());
             }
-            builder.addExceptionMapper((Class<? extends Throwable>) exceptionType, (ExceptionMapper) component);
+            builder.addApplicationExceptionMapper((Class<? extends Throwable>) exceptionType, (ExceptionMapper) component);
             registered = true;
         }
         if (component instanceof ContextResolver) {

--- a/src/main/java/io/muserver/rest/EntityProviders.java
+++ b/src/main/java/io/muserver/rest/EntityProviders.java
@@ -40,13 +40,18 @@ class EntityProviders {
             .filter(reader -> reader.supports(requestBodyMediaType))
             .filter(reader -> !(reader.genericType instanceof Class) || ((Class<?>) reader.genericType).isAssignableFrom(box(type)))
             .sorted((first, second) -> {
+                // Application-provided providers always take precedence over built-in providers.
+                int providerCompare = first.compareTo(second);
+                if (providerCompare != 0) {
+                    return providerCompare;
+                }
                 int mediaTypeCompare = Integer.compare(
                     mediaTypeSpecificity(first, requestBodyMediaType),
                     mediaTypeSpecificity(second, requestBodyMediaType));
                 if (mediaTypeCompare != 0) {
                     return mediaTypeCompare;
                 }
-                return first.compareTo(second);
+                return first.comparePriorityTo(second);
             })
             .filter(reader -> reader.provider.isReadable(type, genericType, annotations, requestBodyMediaType))
             .map(reader -> reader.provider)
@@ -110,7 +115,7 @@ class EntityProviders {
                     return mtCompare;
                 }
 
-                return 0;
+                return o1.comparePriorityTo(o2);
             })
             .filter(w -> w.provider.isWriteable(type, genericType, annotations, responseMediaType))
             .map(writer -> writer.provider)

--- a/src/main/java/io/muserver/rest/EntityProviders.java
+++ b/src/main/java/io/muserver/rest/EntityProviders.java
@@ -10,7 +10,6 @@ import java.lang.reflect.Type;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
-import java.util.Comparator;
 import java.util.List;
 
 class EntityProviders {
@@ -108,9 +107,9 @@ class EntityProviders {
                 }
 
                 // and a secondary key of media type
-                Integer min1 = o1.mediaTypes.stream().map(EntityProviders::mediaTypeSpecificity).min(Comparator.naturalOrder()).orElse(2);
-                Integer min2 = o2.mediaTypes.stream().map(EntityProviders::mediaTypeSpecificity).min(Comparator.naturalOrder()).orElse(2);
-                int mtCompare = min1.compareTo(min2);
+                int mtCompare = Integer.compare(
+                    mediaTypeSpecificity(o1, responseMediaType),
+                    mediaTypeSpecificity(o2, responseMediaType));
                 if (mtCompare != 0) {
                     return mtCompare;
                 }

--- a/src/main/java/io/muserver/rest/JaxRSProviders.java
+++ b/src/main/java/io/muserver/rest/JaxRSProviders.java
@@ -15,9 +15,7 @@ import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 /**
  * The providers registered for a single {@link RestHandler}.
@@ -30,7 +28,7 @@ final class JaxRSProviders implements Providers {
     private volatile @Nullable State state;
 
     synchronized void initialize(EntityProviders entityProviders,
-                                 Map<Class<? extends Throwable>, ExceptionMapper<? extends Throwable>> exceptionMappers,
+                                 List<ExceptionMapperRegistration<?>> exceptionMappers,
                                  List<ContextResolverRegistration<?>> contextResolvers) {
         if (state != null) {
             throw new IllegalStateException("Providers have already been initialized");
@@ -43,7 +41,7 @@ final class JaxRSProviders implements Providers {
         providers.initialize(new EntityProviders(
                 EntityProviders.builtInReaders(), Collections.emptyList(),
                 Collections.emptyList(), Collections.emptyList()),
-            Collections.emptyMap(), Collections.emptyList());
+            Collections.emptyList(), Collections.emptyList());
         return providers;
     }
 
@@ -72,11 +70,10 @@ final class JaxRSProviders implements Providers {
     @Override
     @SuppressWarnings("unchecked")
     public <T extends Throwable> @Nullable ExceptionMapper<T> getExceptionMapper(Class<T> type) {
-        ExceptionMapper<?> best = null;
+        ExceptionMapperRegistration<?> best = null;
         int bestDepth = Integer.MAX_VALUE;
-        for (Map.Entry<Class<? extends Throwable>, ExceptionMapper<? extends Throwable>> entry
-            : requiredState().exceptionMappers.entrySet()) {
-            Class<? extends Throwable> mappedType = entry.getKey();
+        for (ExceptionMapperRegistration<?> registration : requiredState().exceptionMappers) {
+            Class<? extends Throwable> mappedType = registration.exceptionType;
             if (!mappedType.isAssignableFrom(type)) {
                 continue;
             }
@@ -84,8 +81,8 @@ final class JaxRSProviders implements Providers {
             Class<?> candidate = type;
             while (candidate != null) {
                 if (candidate.equals(mappedType)) {
-                    if (depth < bestDepth) {
-                        best = entry.getValue();
+                    if (depth < bestDepth || (depth == bestDepth && registration.preferredTo(best))) {
+                        best = registration;
                         bestDepth = depth;
                     }
                     break;
@@ -94,7 +91,7 @@ final class JaxRSProviders implements Providers {
                 depth++;
             }
         }
-        return (ExceptionMapper<T>) best;
+        return best == null ? null : (ExceptionMapper<T>) best.mapper;
     }
 
     @Override
@@ -175,6 +172,30 @@ final class JaxRSProviders implements Providers {
         }
     }
 
+    static final class ExceptionMapperRegistration<T extends Throwable> {
+        final Class<T> exceptionType;
+        final ExceptionMapper<T> mapper;
+        final boolean isBuiltIn;
+        final int priority;
+
+        ExceptionMapperRegistration(Class<T> exceptionType, ExceptionMapper<T> mapper, boolean isBuiltIn) {
+            this.exceptionType = exceptionType;
+            this.mapper = mapper;
+            this.isBuiltIn = isBuiltIn;
+            this.priority = PrioritizedComponent.priorityOf(mapper);
+        }
+
+        boolean preferredTo(@Nullable ExceptionMapperRegistration<?> other) {
+            if (other == null) {
+                return true;
+            }
+            if (isBuiltIn != other.isBuiltIn) {
+                return !isBuiltIn;
+            }
+            return priority < other.priority;
+        }
+    }
+
     private static int mediaTypeSpecificity(MediaType mediaType) {
         return mediaType.isWildcardType()
             ? 2
@@ -183,14 +204,14 @@ final class JaxRSProviders implements Providers {
 
     private static final class State {
         private final EntityProviders entityProviders;
-        private final Map<Class<? extends Throwable>, ExceptionMapper<? extends Throwable>> exceptionMappers;
+        private final List<ExceptionMapperRegistration<?>> exceptionMappers;
         private final List<ContextResolverRegistration<?>> contextResolvers;
 
         private State(EntityProviders entityProviders,
-                      Map<Class<? extends Throwable>, ExceptionMapper<? extends Throwable>> exceptionMappers,
+                      List<ExceptionMapperRegistration<?>> exceptionMappers,
                       List<ContextResolverRegistration<?>> contextResolvers) {
             this.entityProviders = entityProviders;
-            this.exceptionMappers = Collections.unmodifiableMap(new HashMap<>(exceptionMappers));
+            this.exceptionMappers = Collections.unmodifiableList(new ArrayList<>(exceptionMappers));
             this.contextResolvers = Collections.unmodifiableList(new ArrayList<>(contextResolvers));
         }
     }

--- a/src/main/java/io/muserver/rest/ProviderWrapper.java
+++ b/src/main/java/io/muserver/rest/ProviderWrapper.java
@@ -12,12 +12,14 @@ class ProviderWrapper<T> implements Comparable<ProviderWrapper<T>> {
 
     public final T provider;
     public final boolean isBuiltIn;
+    public final int priority;
     public final List<MediaType> mediaTypes;
     public final Type genericType;
 
     private ProviderWrapper(T provider, List<MediaType> mediaTypes, Type genericType, boolean isBuiltIn) {
         this.provider = provider;
         this.isBuiltIn = isBuiltIn;
+        this.priority = PrioritizedComponent.priorityOf(provider);
         this.mediaTypes = mediaTypes;
         this.genericType = genericType;
     }
@@ -86,6 +88,10 @@ class ProviderWrapper<T> implements Comparable<ProviderWrapper<T>> {
         return Boolean.compare(this.isBuiltIn, o.isBuiltIn);
     }
 
+    int comparePriorityTo(ProviderWrapper<?> other) {
+        return Integer.compare(priority, other.priority);
+    }
+
     @SuppressWarnings("unchecked")
     public static int compareTo(ProviderWrapper<MessageBodyWriter<?>> o1, ProviderWrapper<MessageBodyWriter<?>> o2, Type genericType) {
         if (o1.genericType.equals(o2.genericType)) {
@@ -117,6 +123,7 @@ class ProviderWrapper<T> implements Comparable<ProviderWrapper<T>> {
         return "ProviderWrapper{" +
             "provider=" + provider +
             ", isBuiltIn=" + isBuiltIn +
+            ", priority=" + priority +
             ", mediaTypes=" + mediaTypes +
             ", genericType=" + genericType +
             '}';

--- a/src/main/java/io/muserver/rest/README.md
+++ b/src/main/java/io/muserver/rest/README.md
@@ -171,7 +171,9 @@ N/A as Mu will never instantiate user classes.
 
 #### 4.1.4 Priorities
 
-No plan to implement as it would add another dependency.
+- [x] Application-supplied message body readers, message body writers, and exception mappers honor `@Priority`,
+  defaulting to `Priorities.USER`. Application-supplied providers always take precedence over built-in providers.
+- [x] Context resolvers are ordered by `@Produces` media-type specificity as required by `Providers`.
 
 ### 4.2 Entity Providers 
 

--- a/src/main/java/io/muserver/rest/RestHandlerBuilder.java
+++ b/src/main/java/io/muserver/rest/RestHandlerBuilder.java
@@ -50,7 +50,7 @@ public class RestHandlerBuilder implements MuHandlerBuilder<RestHandler> {
     private @Nullable String openApiHtmlUrl;
     private @Nullable OpenAPIObjectBuilder openAPIObject;
     private @Nullable String openApiHtmlCss;
-    private final Map<Class<? extends Throwable>, ExceptionMapper<? extends Throwable>> exceptionMappers = new HashMap<>();
+    private final List<JaxRSProviders.ExceptionMapperRegistration<?>> exceptionMappers = new ArrayList<>();
     private final List<JaxRSProviders.ContextResolverRegistration<?>> contextResolvers = new ArrayList<>();
     private final List<ContainerRequestFilter> preMatchRequestFilters = new ArrayList<>();
     private final List<ContainerRequestFilter> requestFilters = new ArrayList<>();
@@ -59,7 +59,8 @@ public class RestHandlerBuilder implements MuHandlerBuilder<RestHandler> {
     private final List<SchemaObjectCustomizer> schemaObjectCustomizers = new ArrayList<>();
     private @Nullable CollectionParameterStrategy collectionParameterStrategy;
     {
-        exceptionMappers.put(Throwable.class, DEFAULT_EXCEPTION_MAPPER);
+        exceptionMappers.add(new JaxRSProviders.ExceptionMapperRegistration<>(
+            Throwable.class, DEFAULT_EXCEPTION_MAPPER, true));
     }
 
     /**
@@ -306,8 +307,19 @@ public class RestHandlerBuilder implements MuHandlerBuilder<RestHandler> {
         if (exceptionMapper == null) {
             throw new IllegalArgumentException("exceptionMapper cannot be null. Use removeExceptionMapper(" + exceptionClass.getName() + ") to remove a mapper.");
         }
-        this.exceptionMappers.put(exceptionClass, exceptionMapper);
+        removeExceptionMapper(exceptionClass);
+        addExceptionMapper(exceptionClass, exceptionMapper, false);
         return this;
+    }
+
+    <T extends Throwable> void addApplicationExceptionMapper(Class<T> exceptionClass, ExceptionMapper<T> exceptionMapper) {
+        addExceptionMapper(exceptionClass, exceptionMapper, false);
+    }
+
+    private <T extends Throwable> void addExceptionMapper(Class<T> exceptionClass, ExceptionMapper<T> exceptionMapper,
+                                                           boolean isBuiltIn) {
+        exceptionMappers.add(new JaxRSProviders.ExceptionMapperRegistration<>(
+            exceptionClass, exceptionMapper, isBuiltIn));
     }
 
     /**
@@ -321,7 +333,7 @@ public class RestHandlerBuilder implements MuHandlerBuilder<RestHandler> {
         if (exceptionClass == null) {
             throw new IllegalArgumentException("exceptionClass cannot be null");
         }
-        this.exceptionMappers.remove(exceptionClass);
+        this.exceptionMappers.removeIf(registration -> registration.exceptionType.equals(exceptionClass));
         return this;
     }
 
@@ -598,7 +610,16 @@ public class RestHandlerBuilder implements MuHandlerBuilder<RestHandler> {
      * @return The current value of this property
      */
     public Map<Class<? extends Throwable>, ExceptionMapper<? extends Throwable>> exceptionMappers() {
-        return Collections.unmodifiableMap(exceptionMappers);
+        Map<Class<? extends Throwable>, JaxRSProviders.ExceptionMapperRegistration<?>> effective = new LinkedHashMap<>();
+        for (JaxRSProviders.ExceptionMapperRegistration<?> registration : exceptionMappers) {
+            JaxRSProviders.ExceptionMapperRegistration<?> current = effective.get(registration.exceptionType);
+            if (registration.preferredTo(current)) {
+                effective.put(registration.exceptionType, registration);
+            }
+        }
+        Map<Class<? extends Throwable>, ExceptionMapper<? extends Throwable>> result = new LinkedHashMap<>();
+        effective.forEach((type, registration) -> result.put(type, registration.mapper));
+        return Collections.unmodifiableMap(result);
     }
 
     /**

--- a/src/test/java/io/muserver/rest/ApplicationTest.java
+++ b/src/test/java/io/muserver/rest/ApplicationTest.java
@@ -113,6 +113,73 @@ public class ApplicationTest {
     }
 
     @Test
+    public void exceptionMappersForTheSameTypeAreSelectedByPriority() throws IOException {
+        @Path("priority-mapper")
+        class Resource {
+            @GET
+            public String get() throws SampleException {
+                throw new SampleException();
+            }
+        }
+        @Priority(200)
+        class LowerPriorityMapper implements ExceptionMapper<SampleException> {
+            @Override
+            public jakarta.ws.rs.core.Response toResponse(SampleException exception) {
+                return jakarta.ws.rs.core.Response.status(420).build();
+            }
+        }
+        @Priority(100)
+        class HigherPriorityMapper implements ExceptionMapper<SampleException> {
+            @Override
+            public jakarta.ws.rs.core.Response toResponse(SampleException exception) {
+                return jakarta.ws.rs.core.Response.status(421).build();
+            }
+        }
+        Application application = singletonApplication(
+            new Resource(), new LowerPriorityMapper(), new HigherPriorityMapper());
+        server = ServerUtils.httpsServerForTest()
+            .addHandler(RestHandlerBuilder.fromApplication(application))
+            .start();
+
+        try (Response response = call(request(server.uri().resolve("/priority-mapper")))) {
+            assertThat(response.code(), is(421));
+        }
+    }
+
+    @Test
+    public void nearestExceptionMapperTypeWinsBeforePriority() throws IOException {
+        @Path("nearest-priority-mapper")
+        class Resource {
+            @GET
+            public String get() {
+                throw new IllegalArgumentException();
+            }
+        }
+        @Priority(1)
+        class BroadMapper implements ExceptionMapper<Exception> {
+            @Override
+            public jakarta.ws.rs.core.Response toResponse(Exception exception) {
+                return jakarta.ws.rs.core.Response.status(420).build();
+            }
+        }
+        @Priority(5000)
+        class ExactMapper implements ExceptionMapper<IllegalArgumentException> {
+            @Override
+            public jakarta.ws.rs.core.Response toResponse(IllegalArgumentException exception) {
+                return jakarta.ws.rs.core.Response.status(421).build();
+            }
+        }
+        Application application = singletonApplication(new Resource(), new BroadMapper(), new ExactMapper());
+        server = ServerUtils.httpsServerForTest()
+            .addHandler(RestHandlerBuilder.fromApplication(application))
+            .start();
+
+        try (Response response = call(request(server.uri().resolve("/nearest-priority-mapper")))) {
+            assertThat(response.code(), is(421));
+        }
+    }
+
+    @Test
     public void singletonTakesPrecedenceOverClassRegistration() {
         SupportedProvider singleton = new SupportedProvider();
         Application application = new Application() {

--- a/src/test/java/io/muserver/rest/CustomExceptionMapperTest.java
+++ b/src/test/java/io/muserver/rest/CustomExceptionMapperTest.java
@@ -1,12 +1,11 @@
 package io.muserver.rest;
 
 import jakarta.ws.rs.core.Response;
-import jakarta.ws.rs.ext.ExceptionMapper;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.util.HashMap;
-import java.util.Map;
+import java.util.ArrayList;
+import java.util.List;
 
 import static java.util.Collections.emptyList;
 
@@ -28,11 +27,15 @@ public class CustomExceptionMapperTest {
     @Before
     public void setup() {
         MuRuntimeDelegate.ensureSet();
-        Map<Class<? extends Throwable>, ExceptionMapper<? extends Throwable>> mappers = new HashMap<>();
-        mappers.put(ValidationException.class, exception -> Response.status(400).build());
-        mappers.put(ConcurrentException.class, exception -> Response.status(409).build());
-        mappers.put(NoContentException.class, exception -> null);
-        mappers.put(ServerException.class, exception -> { throw new RuntimeException("oops");});
+        List<JaxRSProviders.ExceptionMapperRegistration<?>> mappers = new ArrayList<>();
+        mappers.add(new JaxRSProviders.ExceptionMapperRegistration<>(ValidationException.class,
+            exception -> Response.status(400).build(), false));
+        mappers.add(new JaxRSProviders.ExceptionMapperRegistration<>(ConcurrentException.class,
+            exception -> Response.status(409).build(), false));
+        mappers.add(new JaxRSProviders.ExceptionMapperRegistration<>(NoContentException.class,
+            exception -> null, false));
+        mappers.add(new JaxRSProviders.ExceptionMapperRegistration<>(ServerException.class,
+            exception -> { throw new RuntimeException("oops");}, false));
         JaxRSProviders providers = new JaxRSProviders();
         providers.initialize(new EntityProviders(emptyList(), emptyList()), mappers, emptyList());
         mapper = new CustomExceptionMapper(providers);

--- a/src/test/java/io/muserver/rest/EntityProvidersTest.java
+++ b/src/test/java/io/muserver/rest/EntityProvidersTest.java
@@ -468,6 +468,23 @@ public class EntityProvidersTest {
     }
 
     @Test
+    public void readerPriorityWinsBeforeTypeSpecificity() {
+        @Priority(1)
+        class HighPriorityObjectReader extends ObjectReader {
+        }
+        @Priority(5000)
+        class LowPriorityStringReader extends MyStringReaderWriter {
+        }
+        MessageBodyReader<Object> objectReader = new HighPriorityObjectReader();
+        MessageBodyReader<String> stringReader = new LowPriorityStringReader();
+        EntityProviders providers = new EntityProviders(
+            asList(objectReader, stringReader), Collections.emptyList());
+
+        assertThat(providers.findReader(String.class, String.class, new Annotation[0],
+            jakarta.ws.rs.core.MediaType.TEXT_PLAIN_TYPE), Matchers.sameInstance(objectReader));
+    }
+
+    @Test
     public void customWriterOverridesMoreSpecificBuiltInWriter() throws Exception {
         @Path("numbers")
         class Sample {

--- a/src/test/java/io/muserver/rest/EntityProvidersTest.java
+++ b/src/test/java/io/muserver/rest/EntityProvidersTest.java
@@ -485,6 +485,38 @@ public class EntityProvidersTest {
     }
 
     @Test
+    public void writerSpecificityOnlyConsidersCompatibleMediaTypes() {
+        class StringWriter implements MessageBodyWriter<String> {
+            @Override
+            public boolean isWriteable(Class<?> type, Type genericType, Annotation[] annotations,
+                                       jakarta.ws.rs.core.MediaType mediaType) {
+                return type.equals(String.class);
+            }
+
+            @Override
+            public void writeTo(String value, Class<?> type, Type genericType, Annotation[] annotations,
+                                jakarta.ws.rs.core.MediaType mediaType, MultivaluedMap<String, Object> httpHeaders,
+                                OutputStream entityStream) {
+            }
+        }
+        @Priority(1)
+        @Produces({"application/json", "*/*"})
+        class HighPriorityWildcardWriter extends StringWriter {
+        }
+        @Priority(5000)
+        @Produces("text/plain")
+        class LowPriorityTextWriter extends StringWriter {
+        }
+        MessageBodyWriter<String> wildcard = new HighPriorityWildcardWriter();
+        MessageBodyWriter<String> text = new LowPriorityTextWriter();
+        EntityProviders providers = new EntityProviders(
+            Collections.emptyList(), asList(wildcard, text));
+
+        assertThat(providers.findWriter(String.class, String.class, new Annotation[0],
+            jakarta.ws.rs.core.MediaType.TEXT_PLAIN_TYPE), Matchers.sameInstance(text));
+    }
+
+    @Test
     public void customWriterOverridesMoreSpecificBuiltInWriter() throws Exception {
         @Path("numbers")
         class Sample {

--- a/src/test/java/io/muserver/rest/EntityProvidersTest.java
+++ b/src/test/java/io/muserver/rest/EntityProvidersTest.java
@@ -3,6 +3,7 @@ package io.muserver.rest;
 import io.muserver.MuServer;
 import io.muserver.Mutils;
 import io.muserver.ResponseInfo;
+import jakarta.annotation.Priority;
 import jakarta.ws.rs.*;
 import jakarta.ws.rs.core.GenericEntity;
 import jakarta.ws.rs.core.MultivaluedMap;
@@ -413,7 +414,10 @@ public class EntityProvidersTest {
 
     @Test
     public void broadApplicationReaderOverridesMoreSpecificBuiltInReader() {
-        ObjectReader applicationReader = new ObjectReader();
+        @Priority(Integer.MAX_VALUE)
+        class LowestPriorityObjectReader extends ObjectReader {
+        }
+        ObjectReader applicationReader = new LowestPriorityObjectReader();
         EntityProviders providers = new EntityProviders(
             Collections.singletonList(StringEntityProviders.stringEntityReaders.get(0)),
             Collections.singletonList(applicationReader),
@@ -424,6 +428,43 @@ public class EntityProvidersTest {
             String.class,
             new Annotation[0],
             jakarta.ws.rs.core.MediaType.TEXT_PLAIN_TYPE), Matchers.sameInstance(applicationReader));
+    }
+
+    @Test
+    public void lowerPriorityValueWinsForOtherwiseEquivalentReadersAndWriters() {
+        @Priority(200)
+        class LaterReaderWriter extends MyStringReaderWriter {
+        }
+        @Priority(100)
+        class EarlierReaderWriter extends MyStringReaderWriter {
+        }
+        MyStringReaderWriter later = new LaterReaderWriter();
+        MyStringReaderWriter earlier = new EarlierReaderWriter();
+        EntityProviders providers = new EntityProviders(
+            asList(later, earlier), asList(later, earlier));
+
+        assertThat(providers.findReader(String.class, String.class, new Annotation[0],
+            jakarta.ws.rs.core.MediaType.TEXT_PLAIN_TYPE), Matchers.sameInstance(earlier));
+        assertThat(providers.findWriter(String.class, String.class, new Annotation[0],
+            jakarta.ws.rs.core.MediaType.TEXT_PLAIN_TYPE), Matchers.sameInstance(earlier));
+    }
+
+    @Test
+    public void mediaTypeSpecificityWinsBeforePriority() {
+        @Priority(1)
+        @Consumes("*/*")
+        class HighPriorityWildcardReader extends MyStringReaderWriter.WithoutConsumes {
+        }
+        @Priority(5000)
+        @Consumes("application/json")
+        class LowPriorityJsonReader extends MyStringReaderWriter.WithoutConsumes {
+        }
+        MessageBodyReader<String> wildcard = new HighPriorityWildcardReader();
+        MessageBodyReader<String> json = new LowPriorityJsonReader();
+        EntityProviders providers = new EntityProviders(asList(wildcard, json), Collections.emptyList());
+
+        assertThat(providers.findReader(String.class, String.class, new Annotation[0],
+            jakarta.ws.rs.core.MediaType.APPLICATION_JSON_TYPE), Matchers.sameInstance(json));
     }
 
     @Test
@@ -502,6 +543,7 @@ public class EntityProvidersTest {
                 return new Dog();
             }
         }
+        @Priority(5000)
         class AnimalWriter implements MessageBodyWriter<Animal> {
             @Override
             public boolean isWriteable(Class<?> type, Type genericType, Annotation[] annotations, jakarta.ws.rs.core.MediaType mediaType) {
@@ -513,6 +555,7 @@ public class EntityProvidersTest {
                 entityStream.write("animal".getBytes(StandardCharsets.UTF_8));
             }
         }
+        @Priority(1)
         class ObjectWriter implements MessageBodyWriter<Object> {
             @Override
             public boolean isWriteable(Class<?> type, Type genericType, Annotation[] annotations, jakarta.ws.rs.core.MediaType mediaType) {

--- a/src/test/java/io/muserver/rest/ProvidersTest.java
+++ b/src/test/java/io/muserver/rest/ProvidersTest.java
@@ -215,8 +215,17 @@ public class ProvidersTest {
         Map<Class<? extends Throwable>, ExceptionMapper<? extends Throwable>> exceptionMappers,
         List<JaxRSProviders.ContextResolverRegistration<?>> contextResolvers) {
         JaxRSProviders providers = new JaxRSProviders();
-        providers.initialize(new EntityProviders(readers, writers), exceptionMappers, contextResolvers);
+        List<JaxRSProviders.ExceptionMapperRegistration<?>> mapperRegistrations = new ArrayList<>();
+        exceptionMappers.forEach((type, mapper) -> addExceptionMapper(mapperRegistrations, type, mapper));
+        providers.initialize(new EntityProviders(readers, writers), mapperRegistrations, contextResolvers);
         return providers;
+    }
+
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    private static void addExceptionMapper(List<JaxRSProviders.ExceptionMapperRegistration<?>> registrations,
+                                           Class<? extends Throwable> type,
+                                           ExceptionMapper<? extends Throwable> mapper) {
+        registrations.add(new JaxRSProviders.ExceptionMapperRegistration(type, mapper, false));
     }
 
     private static class Payload {


### PR DESCRIPTION
Stacked on #208.

## Summary

- honor `@Priority` when otherwise-equivalent message body readers and writers compete
- retain Mu Server's rule that application providers take precedence over built-ins
- select exception mappers by nearest mapped exception type, then application/built-in status, then priority
- preserve the existing replace-by-type `RestHandlerBuilder` exception-mapper API
- update the JAX-RS compliance notes and add ordering coverage

## Verification

- `mvn -q verify`