### PR TITLE
Support @Context Application

### DIFF
--- a/src/main/java/io/muserver/rest/ApplicationRegistrar.java
+++ b/src/main/java/io/muserver/rest/ApplicationRegistrar.java
@@ -76,6 +76,7 @@ final class ApplicationRegistrar {
         }
 
         RestHandlerBuilder builder = new RestHandlerBuilder();
+        builder.setApplication(application);
         List<Object> serverComponents = new ArrayList<>();
         for (Object component : components) {
             Objects.requireNonNull(component, "Application components must not contain null");

--- a/src/main/java/io/muserver/rest/README.md
+++ b/src/main/java/io/muserver/rest/README.md
@@ -383,7 +383,11 @@ allows injection of `MuRequest`, `MuResponse` and `ContainerRequestContext`.
 
 #### 10.2.1 Application 
 
-N/A. Will not implement, as there is no support for `Application`.
+- [x] Implemented for resource method parameters using `@Context Application`.
+
+Applications supplied through `RestHandlerBuilder.fromApplication(...)` or `SeBootstrap` are injected directly.
+For handlers configured with `RestHandlerBuilder`, Mu Server creates an immutable application snapshot containing
+the handler's resource instances and custom JAX-RS provider instances.
 
 #### 10.2.2 URIs and URI Templates 
 

--- a/src/main/java/io/muserver/rest/RestHandler.java
+++ b/src/main/java/io/muserver/rest/RestHandler.java
@@ -38,6 +38,7 @@ public class RestHandler implements MuHandler {
     private static final Logger log = LoggerFactory.getLogger(RestHandler.class);
 
     private final RequestMatcher requestMatcher;
+    private final Application application;
     private final JaxRSProviders providers;
     private final @Nullable MuHandler documentor;
     private final CustomExceptionMapper customExceptionMapper;
@@ -50,8 +51,9 @@ public class RestHandler implements MuHandler {
     private final List<WriterInterceptor> writerInterceptors;
     private final CollectionParameterStrategy collectionParameterStrategy;
 
-    RestHandler(JaxRSProviders providers, List<ResourceClass> roots, @Nullable MuHandler documentor, CustomExceptionMapper customExceptionMapper, FilterManagerThing filterManagerThing, CORSConfig corsConfig, List<ParamConverterProvider> paramConverterProviders, SchemaObjectCustomizer schemaObjectCustomizer, List<ReaderInterceptor> readerInterceptors, List<WriterInterceptor> writerInterceptors, CollectionParameterStrategy collectionParameterStrategy) {
+    RestHandler(Application application, JaxRSProviders providers, List<ResourceClass> roots, @Nullable MuHandler documentor, CustomExceptionMapper customExceptionMapper, FilterManagerThing filterManagerThing, CORSConfig corsConfig, List<ParamConverterProvider> paramConverterProviders, SchemaObjectCustomizer schemaObjectCustomizer, List<ReaderInterceptor> readerInterceptors, List<WriterInterceptor> writerInterceptors, CollectionParameterStrategy collectionParameterStrategy) {
         this.requestMatcher = new RequestMatcher(roots);
+        this.application = Objects.requireNonNull(application, "application");
         this.providers = providers;
         this.documentor = documentor;
         this.customExceptionMapper = customExceptionMapper;
@@ -97,7 +99,7 @@ public class RestHandler implements MuHandler {
                 ResourceMethod rm = matchedMethod.resourceMethod;
                 try {
                     Object instance = Objects.requireNonNull(
-                        invokeResourceMethod(requestContext, muResponse, matchedMethod, onSuspended, providers, collectionParameterStrategy),
+                        invokeResourceMethod(requestContext, muResponse, matchedMethod, onSuspended, application, providers, collectionParameterStrategy),
                         "Sub-resource locator returned null");
                     return ResourceClass.forSubResourceLocator(rm, instance.getClass(), instance, schemaObjectCustomizer, paramConverterProviders);
                 } catch (WebApplicationException wae) {
@@ -147,7 +149,7 @@ public class RestHandler implements MuHandler {
             };
 
 
-            @Nullable Object result = invokeResourceMethod(requestContext, muResponse, mm, suspendedParamCallback, providers, collectionParameterStrategy);
+            @Nullable Object result = invokeResourceMethod(requestContext, muResponse, mm, suspendedParamCallback, application, providers, collectionParameterStrategy);
 
             if (!muRequest.isAsync()) {
                 if (result instanceof CompletionStage) {
@@ -184,7 +186,7 @@ public class RestHandler implements MuHandler {
         return GenericTypeResolver.resolveTypeArgument(returnType, CompletionStage.class, 0);
     }
 
-    static @Nullable Object invokeResourceMethod(JaxRSRequest requestContext, MuResponse muResponse, RequestMatcher.MatchedMethod mm, Function<ResourceMethod, @Nullable Object> suspendedParamCallback, JaxRSProviders providers, CollectionParameterStrategy collectionParameterStrategy) throws Exception {
+    static @Nullable Object invokeResourceMethod(JaxRSRequest requestContext, MuResponse muResponse, RequestMatcher.MatchedMethod mm, Function<ResourceMethod, @Nullable Object> suspendedParamCallback, Application application, JaxRSProviders providers, CollectionParameterStrategy collectionParameterStrategy) throws Exception {
         ResourceMethod rm = mm.resourceMethod;
         @Nullable Object[] params = new Object[rm.methodHandle().getParameterCount()];
         for (ResourceMethodParam param : rm.params) {
@@ -192,7 +194,7 @@ public class RestHandler implements MuHandler {
             if (param.source() == ResourceMethodParam.ValueSource.MESSAGE_BODY) {
                 paramValue = readRequestEntity(requestContext, param);
             } else if (param.source() == ResourceMethodParam.ValueSource.CONTEXT) {
-                paramValue = getContextParam(requestContext, muResponse, mm, param, providers);
+                paramValue = getContextParam(requestContext, muResponse, mm, param, application, providers);
             } else if (param.source() == ResourceMethodParam.ValueSource.SUSPENDED) {
                 paramValue = suspendedParamCallback.apply(rm);
             } else {
@@ -397,7 +399,7 @@ public class RestHandler implements MuHandler {
         }
     }
 
-    private static @Nullable Object getContextParam(JaxRSRequest requestContext, MuResponse muResponse, RequestMatcher.MatchedMethod mm, ResourceMethodParam param, JaxRSProviders providers) {
+    private static @Nullable Object getContextParam(JaxRSRequest requestContext, MuResponse muResponse, RequestMatcher.MatchedMethod mm, ResourceMethodParam param, Application application, JaxRSProviders providers) {
         MuRequest request = requestContext.muRequest;
         Object paramValue;
         Class<?> type = param.type();
@@ -411,6 +413,8 @@ public class RestHandler implements MuHandler {
             paramValue = new JaxRsHttpHeadersAdapter(request.headers(), request.cookies());
         } else if (type.equals(Providers.class)) {
             paramValue = providers;
+        } else if (type.equals(Application.class)) {
+            paramValue = application;
         } else if (SecurityContext.class.isAssignableFrom(type)) {
             SecurityContext sc = requestContext.getSecurityContext();
             if (sc != null && !type.isAssignableFrom(sc.getClass())) {

--- a/src/main/java/io/muserver/rest/RestHandlerBuilder.java
+++ b/src/main/java/io/muserver/rest/RestHandlerBuilder.java
@@ -58,6 +58,7 @@ public class RestHandlerBuilder implements MuHandlerBuilder<RestHandler> {
     private CORSConfig corsConfig = CORSConfigBuilder.disabled().build();
     private final List<SchemaObjectCustomizer> schemaObjectCustomizers = new ArrayList<>();
     private @Nullable CollectionParameterStrategy collectionParameterStrategy;
+    private @Nullable Application application;
     {
         exceptionMappers.add(new JaxRSProviders.ExceptionMapperRegistration<>(
             Throwable.class, DEFAULT_EXCEPTION_MAPPER, true));
@@ -370,12 +371,18 @@ public class RestHandlerBuilder implements MuHandlerBuilder<RestHandler> {
      * Singleton resources must therefore be safe to use concurrently. Provider classes are instantiated once using a
      * public no-argument constructor. Application properties, features, dynamic features, automatic
      * discovery, and {@link jakarta.ws.rs.ApplicationPath} mounting are not supported.</p>
+     * <p>The supplied instance is available to resource methods using {@link jakarta.ws.rs.core.Context}
+     * {@code Application} parameters.</p>
      *
      * @param application The application configuration to adapt.
      * @return A builder containing the application's supported singleton components.
      */
     public static RestHandlerBuilder fromApplication(Application application) {
         return ApplicationRegistrar.from(application);
+    }
+
+    void setApplication(Application application) {
+        this.application = Objects.requireNonNull(application, "application");
     }
 
     /**
@@ -728,9 +735,54 @@ public class RestHandlerBuilder implements MuHandlerBuilder<RestHandler> {
             cps = CollectionParameterStrategy.NO_TRANSFORM;
         }
 
-        RestHandler handler = new RestHandler(providers, roots, documentor, customExceptionMapper, filterManagerThing,
+        Application application = this.application == null ? applicationSnapshot(readers, writers) : this.application;
+        RestHandler handler = new RestHandler(application, providers, roots, documentor, customExceptionMapper, filterManagerThing,
             corsConfig, paramConverterProviders, schemaObjectCustomizer, readerInterceptors, writerInterceptors, cps);
         providers.initialize(entityProviders, exceptionMappers, contextResolvers);
         return handler;
+    }
+
+    private Application applicationSnapshot(List<MessageBodyReader> readers, List<MessageBodyWriter> writers) {
+        Set<Object> singletons = new LinkedHashSet<>(resources);
+        singletons.addAll(readers);
+        singletons.addAll(writers);
+        singletons.addAll(customParamConverterProviders);
+        for (JaxRSProviders.ExceptionMapperRegistration<?> registration : exceptionMappers) {
+            if (!registration.isBuiltIn) {
+                singletons.add(registration.mapper);
+            }
+        }
+        for (JaxRSProviders.ContextResolverRegistration<?> registration : contextResolvers) {
+            singletons.add(registration.resolver);
+        }
+        singletons.addAll(preMatchRequestFilters);
+        singletons.addAll(requestFilters);
+        singletons.addAll(responseFilters);
+        singletons.addAll(readerInterceptors);
+        singletons.addAll(writerInterceptors);
+        return new RuntimeApplication(singletons);
+    }
+
+    private static final class RuntimeApplication extends Application {
+        private final Set<Object> singletons;
+
+        private RuntimeApplication(Set<Object> singletons) {
+            this.singletons = Collections.unmodifiableSet(new LinkedHashSet<>(singletons));
+        }
+
+        @Override
+        public Set<Class<?>> getClasses() {
+            return Collections.emptySet();
+        }
+
+        @Override
+        public Set<Object> getSingletons() {
+            return singletons;
+        }
+
+        @Override
+        public Map<String, Object> getProperties() {
+            return Collections.emptyMap();
+        }
     }
 }

--- a/src/main/java/io/muserver/rest/RestHandlerBuilder.java
+++ b/src/main/java/io/muserver/rest/RestHandlerBuilder.java
@@ -743,7 +743,8 @@ public class RestHandlerBuilder implements MuHandlerBuilder<RestHandler> {
     }
 
     private Application applicationSnapshot(List<MessageBodyReader> readers, List<MessageBodyWriter> writers) {
-        Set<Object> singletons = new LinkedHashSet<>(resources);
+        Set<Object> singletons = Collections.newSetFromMap(new IdentityHashMap<>());
+        singletons.addAll(resources);
         singletons.addAll(readers);
         singletons.addAll(writers);
         singletons.addAll(customParamConverterProviders);
@@ -767,7 +768,7 @@ public class RestHandlerBuilder implements MuHandlerBuilder<RestHandler> {
         private final Set<Object> singletons;
 
         private RuntimeApplication(Set<Object> singletons) {
-            this.singletons = Collections.unmodifiableSet(new LinkedHashSet<>(singletons));
+            this.singletons = Collections.unmodifiableSet(singletons);
         }
 
         @Override

--- a/src/test/java/io/muserver/rest/ApplicationTest.java
+++ b/src/test/java/io/muserver/rest/ApplicationTest.java
@@ -53,14 +53,17 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.sameInstance;
 import static org.junit.Assert.assertThrows;
 import static scaffolding.ClientUtils.call;
 import static scaffolding.ClientUtils.request;
@@ -110,6 +113,75 @@ public class ApplicationTest {
         assertThat(builder.customWriters(), contains(provider));
         assertThat(builder.customParamConverterProviders(), contains(provider));
         assertThat(builder.exceptionMappers(), hasEntry(SampleException.class, provider));
+    }
+
+    @Test
+    public void suppliedApplicationIsInjectedIntoSubResourceLocators() throws IOException {
+        AtomicReference<Application> injected = new AtomicReference<>();
+        class ChildResource {
+            @GET
+            public String get() {
+                return "injected";
+            }
+        }
+        @Path("application-injection")
+        class RootResource {
+            @Path("child")
+            public ChildResource child(@Context Application application) {
+                injected.set(application);
+                return new ChildResource();
+            }
+        }
+        Application application = singletonApplication(new RootResource());
+        server = ServerUtils.httpsServerForTest()
+            .addHandler(RestHandlerBuilder.fromApplication(application))
+            .start();
+
+        try (Response response = call(request(server.uri().resolve("/application-injection/child")))) {
+            assertThat(response.code(), is(200));
+            assertThat(response.body().string(), is("injected"));
+        }
+        assertThat(injected.get(), sameInstance(application));
+    }
+
+    @Test
+    public void regularBuildersExposeAnImmutableApplicationSnapshot() throws IOException {
+        AtomicReference<Application> injected = new AtomicReference<>();
+        @Path("application-snapshot")
+        class Resource {
+            @GET
+            public String get(@Context Application application) {
+                injected.set(application);
+                return "snapshotted";
+            }
+        }
+        Resource resource = new Resource();
+        SupportedProvider provider = new SupportedProvider();
+        ContextResolver<ApplicationContext> resolver = type -> new ApplicationContext("resolved");
+        RestHandlerBuilder builder = RestHandlerBuilder.restHandler(resource)
+            .addCustomReader(providers -> provider)
+            .addCustomWriter(providers -> provider)
+            .addCustomParamConverterProvider(provider)
+            .addExceptionMapper(SampleException.class, provider)
+            .addContextResolver(ApplicationContext.class, resolver)
+            .addRequestFilter(provider)
+            .addResponseFilter(provider)
+            .addReaderInterceptor(provider)
+            .addWriterInterceptor(provider);
+        server = ServerUtils.httpsServerForTest().addHandler(builder).start();
+
+        try (Response response = call(request(server.uri().resolve("/application-snapshot")))) {
+            assertThat(response.code(), is(200));
+            assertThat(response.body().string(), is("snapshotted"));
+        }
+
+        Application application = injected.get();
+        assertThat(application.getSingletons(), containsInAnyOrder(resource, provider, resolver));
+        assertThat(application.getSingletons(), hasSize(3));
+        assertThat(application.getClasses(), is(empty()));
+        assertThat(application.getProperties().entrySet(), is(empty()));
+        assertThrows(UnsupportedOperationException.class,
+            () -> application.getSingletons().add(new Object()));
     }
 
     @Test

--- a/src/test/java/io/muserver/rest/ApplicationTest.java
+++ b/src/test/java/io/muserver/rest/ApplicationTest.java
@@ -53,6 +53,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -182,6 +183,54 @@ public class ApplicationTest {
         assertThat(application.getProperties().entrySet(), is(empty()));
         assertThrows(UnsupportedOperationException.class,
             () -> application.getSingletons().add(new Object()));
+    }
+
+    @Test
+    public void applicationSnapshotDeduplicatesByIdentityRatherThanEquality() throws IOException {
+        AtomicReference<Application> injected = new AtomicReference<>();
+        AtomicInteger filterCalls = new AtomicInteger();
+        @Path("identity-application-snapshot")
+        class Resource {
+            @GET
+            public String get(@Context Application application) {
+                injected.set(application);
+                return "snapshotted";
+            }
+        }
+        class EqualFilter implements ContainerResponseFilter {
+            @Override
+            public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext) {
+                filterCalls.incrementAndGet();
+            }
+
+            @Override
+            public boolean equals(Object other) {
+                return other instanceof EqualFilter;
+            }
+
+            @Override
+            public int hashCode() {
+                return 1;
+            }
+        }
+        Resource resource = new Resource();
+        EqualFilter first = new EqualFilter();
+        EqualFilter second = new EqualFilter();
+        server = ServerUtils.httpsServerForTest()
+            .addHandler(RestHandlerBuilder.restHandler(resource)
+                .addResponseFilter(first)
+                .addResponseFilter(second))
+            .start();
+
+        try (Response response = call(request(server.uri().resolve("/identity-application-snapshot")))) {
+            assertThat(response.code(), is(200));
+        }
+
+        assertThat(filterCalls.get(), is(2));
+        Set<Object> singletons = injected.get().getSingletons();
+        assertThat(singletons, hasSize(3));
+        assertThat(singletons.stream().anyMatch(value -> value == first), is(true));
+        assertThat(singletons.stream().anyMatch(value -> value == second), is(true));
     }
 
     @Test

--- a/src/test/java/io/muserver/rest/MuSeBootstrapTest.java
+++ b/src/test/java/io/muserver/rest/MuSeBootstrapTest.java
@@ -6,6 +6,7 @@ import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.SeBootstrap;
 import jakarta.ws.rs.core.Application;
+import jakarta.ws.rs.core.Context;
 import okhttp3.OkHttpClient;
 import okhttp3.Response;
 import org.junit.Test;
@@ -25,6 +26,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static jakarta.ws.rs.SeBootstrap.Configuration.SSLClientAuthentication.MANDATORY;
 import static jakarta.ws.rs.SeBootstrap.Configuration.SSLClientAuthentication.NONE;
@@ -32,6 +34,7 @@ import static jakarta.ws.rs.SeBootstrap.Configuration.SSLClientAuthentication.OP
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.sameInstance;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
@@ -113,6 +116,41 @@ public class MuSeBootstrapTest {
                 assertThat(response.code(), is(200));
                 assertThat(response.body().string(), is("booted"));
             }
+        } finally {
+            instance.stop().toCompletableFuture().get(10, TimeUnit.SECONDS);
+        }
+    }
+
+    @Test
+    public void suppliedApplicationIsAvailableAsContext() throws Exception {
+        AtomicReference<Application> injected = new AtomicReference<>();
+        @Path("application-context")
+        class Resource {
+            @GET
+            public String get(@Context Application application) {
+                injected.set(application);
+                return "injected";
+            }
+        }
+        Application application = new Application() {
+            @Override
+            public Set<Object> getSingletons() {
+                return Set.of(new Resource());
+            }
+        };
+        SeBootstrap.Configuration configuration = SeBootstrap.Configuration.builder()
+            .port(SeBootstrap.Configuration.FREE_PORT)
+            .build();
+
+        SeBootstrap.Instance instance = SeBootstrap.start(application, configuration)
+            .toCompletableFuture().get(10, TimeUnit.SECONDS);
+        try {
+            try (Response response = call(request(instance.configuration().baseUriBuilder()
+                .path("application-context").build()))) {
+                assertThat(response.code(), is(200));
+                assertThat(response.body().string(), is("injected"));
+            }
+            assertThat(injected.get(), sameInstance(application));
         } finally {
             instance.stop().toCompletableFuture().get(10, TimeUnit.SECONDS);
         }


### PR DESCRIPTION
Stacked on #209 (which is itself stacked on #208).

## Summary

- support `@Context Application` on resource methods and sub-resource locators
- inject the exact `Application` instance supplied through `RestHandlerBuilder.fromApplication(...)` or `SeBootstrap`
- give ordinary builders an immutable, per-build `Application` snapshot containing resource instances and realized custom JAX-RS providers
- deduplicate providers registered for multiple contracts while excluding Mu-only helpers and built-ins
- update the JAX-RS compliance notes and add integration coverage

## Verification

- `mvn -q verify`