### PR TITLE
Mu4 concurrency follow-up 1: fix terminal races and callback tracking

### DIFF
--- a/src/main/java/io/muserver/ApplicationTaskTracker.java
+++ b/src/main/java/io/muserver/ApplicationTaskTracker.java
@@ -1,0 +1,62 @@
+package io.muserver;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.locks.Condition;
+import java.util.concurrent.locks.ReentrantLock;
+
+/** Tracks accepted callbacks until they run or Mu cancels them, without Phaser's party limit. */
+final class ApplicationTaskTracker {
+    private final ReentrantLock lock = new ReentrantLock();
+    private final Condition drained = lock.newCondition();
+    private long pending;
+
+    Registration register() {
+        lock.lock();
+        try {
+            pending++;
+            return new Registration();
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    boolean awaitUntil(long deadlineNanos) {
+        lock.lock();
+        try {
+            while (pending != 0) {
+                long remaining = MonotonicTime.nanosUntil(deadlineNanos);
+                if (remaining <= 0) {
+                    return false;
+                }
+                try {
+                    drained.awaitNanos(remaining);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    return false;
+                }
+            }
+            return true;
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    final class Registration implements AutoCloseable {
+        private final AtomicBoolean completed = new AtomicBoolean();
+
+        @Override
+        public void close() {
+            if (!completed.compareAndSet(false, true)) {
+                return;
+            }
+            lock.lock();
+            try {
+                if (--pending == 0) {
+                    drained.signalAll();
+                }
+            } finally {
+                lock.unlock();
+            }
+        }
+    }
+}

--- a/src/main/java/io/muserver/Http1Connection.java
+++ b/src/main/java/io/muserver/Http1Connection.java
@@ -209,6 +209,7 @@ class Http1Connection extends BaseHttpConnection {
                 closeConnection = closeConnection || state.get() != HttpConnectionState.OPEN || closed.get();
             }
         } catch (Exception e) {
+            if (e instanceof InterruptedException) Thread.currentThread().interrupt();
             // probably shouldn't log here so much for things like IO errors which would be common when clients disconnect
             log.error("Unhandled error at the socket", e);
         } finally {

--- a/src/main/java/io/muserver/Http2BodyInputStream.java
+++ b/src/main/java/io/muserver/Http2BodyInputStream.java
@@ -38,6 +38,8 @@ class Http2BodyInputStream extends InputStream implements RequestTrailersAccesso
     private final Condition hasData = lock.newCondition();
     private boolean requestBodyComplete;
     private boolean discarding;
+    /** The first terminal failure; independent of the contents of the data queue. */
+    private @org.jspecify.annotations.Nullable IOException failure;
     private @org.jspecify.annotations.Nullable FieldBlock trailers;
 
     private static final class EndOfStreamMarker {
@@ -158,9 +160,12 @@ class Http2BodyInputStream extends InputStream implements RequestTrailersAccesso
 
     public void onData(Http2DataFrame dataFrame, int flowControlSize) {
         int discardedCredit = 0;
+        int resetCredit = 0;
         lock.lock();
         try {
-            if (discarding) {
+            if (failure != null) {
+                resetCredit = flowControlSize;
+            } else if (discarding) {
                 discardedCredit = flowControlSize;
                 if (dataFrame.endStream()) {
                     requestBodyComplete = true;
@@ -187,6 +192,7 @@ class Http2BodyInputStream extends InputStream implements RequestTrailersAccesso
             lock.unlock();
         }
         returnReusableCredit(discardedCredit);
+        refundDiscardedCredit(resetCredit);
     }
 
     void discardRemaining() {
@@ -237,6 +243,7 @@ class Http2BodyInputStream extends InputStream implements RequestTrailersAccesso
         lock.lock();
         try {
             if (!isErrored()) {
+                failure = ex;
                 if (refundUnreadData) {
                     for (Object frame : frames) {
                         if (frame instanceof PendingDataFrame) {
@@ -246,7 +253,7 @@ class Http2BodyInputStream extends InputStream implements RequestTrailersAccesso
                 }
                 frames.clear();
                 frames.add(ex);
-                hasData.signal();
+                hasData.signalAll();
             }
         } finally {
             lock.unlock();
@@ -275,7 +282,7 @@ class Http2BodyInputStream extends InputStream implements RequestTrailersAccesso
     }
 
     private boolean isErrored() {
-        return frames.size() == 1 && frames.peek() instanceof Exception;
+        return failure != null;
     }
 
     void cancel(IOException reason) {

--- a/src/main/java/io/muserver/Mu3ServerImpl.java
+++ b/src/main/java/io/muserver/Mu3ServerImpl.java
@@ -10,12 +10,10 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.*;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Phaser;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static io.muserver.GZIPEncoderBuilder.gzipEncoder;
@@ -51,14 +49,7 @@ class Mu3ServerImpl implements MuServer {
     private final ScheduledExecutorService timerExecutor;
     private final boolean ownsTimerExecutor;
     private final ThreadLocal<ApplicationTaskContext> applicationTaskContext = new ThreadLocal<>();
-    private final Phaser detachedApplicationTasks = new Phaser() {
-        @Override
-        protected boolean onAdvance(int phase, int registeredParties) {
-            // Keep accepting tasks after an idle phase. Server.stop() can also be called
-            // again after an earlier bounded stop timed out.
-            return false;
-        }
-    };
+    private final ApplicationTaskTracker detachedApplicationTasks = new ApplicationTaskTracker();
     private final ThreadLocal<@Nullable DetachedApplicationTask> activeDetachedApplicationTask =
         new ThreadLocal<>();
     private final Mu3StatsImpl statsImpl = new Mu3StatsImpl();
@@ -158,38 +149,7 @@ class Mu3ServerImpl implements MuServer {
         if (activeDetachedApplicationTask.get() != null) {
             return true;
         }
-        return awaitDetachedApplicationTasks(
-            detachedApplicationTasks,
-            deadlineNanos
-        );
-    }
-
-    static boolean awaitDetachedApplicationTasks(
-        Phaser tasks,
-        long deadlineNanos
-    ) {
-        while (true) {
-            int phase = tasks.getPhase();
-            if (tasks.getRegisteredParties() == 0) {
-                return true;
-            }
-            long remainingNanos = Math.max(
-                0L,
-                MonotonicTime.nanosUntil(deadlineNanos)
-            );
-            try {
-                tasks.awaitAdvanceInterruptibly(
-                    phase,
-                    remainingNanos,
-                    TimeUnit.NANOSECONDS
-                );
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-                return false;
-            } catch (TimeoutException e) {
-                return false;
-            }
-        }
+        return detachedApplicationTasks.awaitUntil(deadlineNanos);
     }
 
     void executeResponseCompletionTask(Runnable task) {
@@ -205,7 +165,6 @@ class Mu3ServerImpl implements MuServer {
         boolean preferHandlerExecutor,
         String description
     ) {
-        detachedApplicationTasks.register();
         DetachedApplicationTask registration = new DetachedApplicationTask();
         Runnable trackedTask = () -> {
             DetachedApplicationTask previous = activeDetachedApplicationTask.get();
@@ -233,13 +192,10 @@ class Mu3ServerImpl implements MuServer {
 
     private final class DetachedApplicationTask {
         private @Nullable DetachedApplicationTask previous;
-        private boolean registered = true;
+        private final ApplicationTaskTracker.Registration registration = detachedApplicationTasks.register();
 
         private void deregister() {
-            if (registered) {
-                registered = false;
-                detachedApplicationTasks.arriveAndDeregister();
-            }
+            registration.close();
         }
     }
 

--- a/src/main/java/io/muserver/WebsocketConnection.java
+++ b/src/main/java/io/muserver/WebsocketConnection.java
@@ -13,6 +13,7 @@ import java.net.SocketTimeoutException;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.Queue;
+import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ExecutionException;
@@ -115,7 +116,7 @@ class WebsocketConnection implements MuWebSocketSession {
         }, settings.pingIntervalMillis, TimeUnit.MILLISECONDS);
     }
 
-    public void runAndBlockUntilDone(InputStream inputStream, OutputStream outputStream, byte[] readBuffer) throws Exception {
+    public void runAndBlockUntilDone(InputStream inputStream, OutputStream outputStream, byte[] readBuffer) throws InterruptedException, ApplicationEventFailure {
         this.inputStream = inputStream;
         this.outputStream = outputStream;
         this.buffer = ByteBuffer.wrap(readBuffer).flip();
@@ -262,8 +263,14 @@ class WebsocketConnection implements MuWebSocketSession {
             }
 
             // it's finished - the TCP connection will be closed
-        } catch (Throwable e) {
-            if (!serverShutdownRequested.get()
+        } catch (Throwable failure) {
+            if (failure instanceof InterruptedException) {
+                Thread.currentThread().interrupt();
+                throw (InterruptedException) failure;
+            }
+            boolean applicationFailure = failure instanceof ApplicationEventFailure;
+            Throwable e = applicationFailure ? Objects.requireNonNull(failure.getCause()) : failure;
+            if ((!serverShutdownRequested.get() || applicationFailure)
                 && !errorEventQueued.get()
                 && lifecycle.state() != WebsocketSessionState.TIMED_OUT) {
                 WebsocketSessionState errorState =
@@ -394,10 +401,12 @@ class WebsocketConnection implements MuWebSocketSession {
             });
     }
 
-    private void invokeApplicationEvent(ApplicationEvent event) throws Exception {
+    private void invokeApplicationEvent(ApplicationEvent event) throws InterruptedException, ApplicationEventFailure {
         if (eventsRunOnConnectionTask) {
             try {
                 callApplicationEvent(event);
+            } catch (Exception | Error failure) {
+                throw new ApplicationEventFailure(failure);
             } finally {
                 // A terminal event can be queued by a write attempted inside a callback.
                 // Drain it before returning to the blocking socket read.
@@ -412,14 +421,14 @@ class WebsocketConnection implements MuWebSocketSession {
             Thread.currentThread().interrupt();
             throw e;
         } catch (ExecutionException e) {
-            Throwable cause = e.getCause();
-            if (cause instanceof Exception) {
-                throw (Exception) cause;
-            }
-            if (cause instanceof Error) {
-                throw (Error) cause;
-            }
-            throw new MuException("Unexpected WebSocket callback failure", cause);
+            throw new ApplicationEventFailure(Objects.requireNonNull(e.getCause()));
+        }
+    }
+
+    /** Keeps application failures distinct from transport errors induced by shutdown. */
+    private static final class ApplicationEventFailure extends Exception {
+        private ApplicationEventFailure(Throwable cause) {
+            super(cause);
         }
     }
 
@@ -436,7 +445,7 @@ class WebsocketConnection implements MuWebSocketSession {
         }
     }
 
-    private void invokeApplicationError(Throwable cause, WebsocketSessionState errorState) throws Exception {
+    private void invokeApplicationError(Throwable cause, WebsocketSessionState errorState) throws InterruptedException, ApplicationEventFailure {
         if (errorEventQueued.compareAndSet(false, true)) {
             invokeApplicationEvent(errorEvent(cause, errorState));
         }

--- a/src/main/java/io/muserver/WebsocketPingTracker.java
+++ b/src/main/java/io/muserver/WebsocketPingTracker.java
@@ -2,90 +2,48 @@ package io.muserver;
 
 import org.jspecify.annotations.Nullable;
 
-import javax.crypto.Mac;
-import javax.crypto.spec.SecretKeySpec;
 import java.nio.ByteBuffer;
-import java.security.GeneralSecurityException;
-import java.security.MessageDigest;
-import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.UUID;
 
 /**
- * Creates authenticated automatic ping payloads and measures their echoed
- * pongs. RFC 6455 section 5.5.3 requires a pong response to copy the ping's
- * application data, so each payload can carry its own authenticated monotonic
- * send point without shared outstanding-ping state.
+ * Matches automatic pongs to outstanding pings. Each ping contributes at most
+ * one latency sample. The bounded ledger tolerates overlapping and missing
+ * pongs without retaining an unbounded history or accepting replayed samples.
  */
 final class WebsocketPingTracker {
-    private static final String HMAC_ALGORITHM = "HmacSHA256";
-    private static final int SECRET_LENGTH = 32;
-    private static final int TAG_LENGTH = 8;
-    private static final int PAYLOAD_LENGTH = Long.BYTES + TAG_LENGTH;
-
-    private final byte[] connectionSecret;
-
-    WebsocketPingTracker() {
-        this(randomSecret());
-    }
-
-    WebsocketPingTracker(byte[] connectionSecret) {
-        if (connectionSecret.length == 0) {
-            throw new IllegalArgumentException("The connection secret must not be empty");
-        }
-        this.connectionSecret = connectionSecret.clone();
-    }
+    static final int MAX_OUTSTANDING = 64;
+    private final Map<UUID, Long> outstanding = new LinkedHashMap<>();
 
     ByteBuffer newPingPayload() {
         return newPingPayload(System.nanoTime());
     }
 
-    ByteBuffer newPingPayload(long sentNanos) {
-        return ByteBuffer.allocate(PAYLOAD_LENGTH)
-            .putLong(sentNanos)
-            .put(authenticationTag(sentNanos))
+    synchronized ByteBuffer newPingPayload(long sentNanos) {
+        UUID id = UUID.randomUUID();
+        if (outstanding.size() == MAX_OUTSTANDING) {
+            var oldest = outstanding.keySet().iterator();
+            oldest.next();
+            oldest.remove();
+        }
+        outstanding.put(id, sentNanos);
+        return ByteBuffer.allocate(16)
+            .putLong(id.getMostSignificantBits())
+            .putLong(id.getLeastSignificantBits())
             .flip();
     }
 
-    @Nullable
-    Long pongLatencyMillis(ByteBuffer pongPayload) {
-        return pongLatencyMillis(pongPayload, System.nanoTime());
+    @Nullable Long pongLatencyMillis(ByteBuffer payload) {
+        return pongLatencyMillis(payload, System.nanoTime());
     }
 
-    @Nullable
-    Long pongLatencyMillis(ByteBuffer pongPayload, long receivedNanos) {
-        if (pongPayload.remaining() != PAYLOAD_LENGTH) {
+    synchronized @Nullable Long pongLatencyMillis(ByteBuffer payload, long receivedNanos) {
+        if (payload.remaining() != 16) {
             return null;
         }
-        int payloadOffset = pongPayload.position();
-        long sentNanos = pongPayload.getLong(payloadOffset);
-        byte[] suppliedTag = new byte[TAG_LENGTH];
-        ByteBuffer copy = pongPayload.duplicate();
-        copy.position(payloadOffset + Long.BYTES);
-        copy.get(suppliedTag);
-        if (!MessageDigest.isEqual(authenticationTag(sentNanos), suppliedTag)) {
-            return null;
-        }
-        return MonotonicTime.elapsedMillis(sentNanos, receivedNanos);
-    }
-
-    private byte[] authenticationTag(long sentNanos) {
-        try {
-            Mac mac = Mac.getInstance(HMAC_ALGORITHM);
-            mac.init(new SecretKeySpec(connectionSecret, HMAC_ALGORITHM));
-            byte[] timestamp = ByteBuffer.allocate(Long.BYTES)
-                .putLong(sentNanos)
-                .array();
-            return Arrays.copyOf(mac.doFinal(timestamp), TAG_LENGTH);
-        } catch (GeneralSecurityException e) {
-            throw new IllegalStateException(
-                HMAC_ALGORITHM + " is unavailable",
-                e
-            );
-        }
-    }
-
-    private static byte[] randomSecret() {
-        byte[] secret = new byte[SECRET_LENGTH];
-        HttpsConfigBuilder.random.nextBytes(secret);
-        return secret;
+        int offset = payload.position();
+        Long sentNanos = outstanding.remove(new UUID(payload.getLong(offset), payload.getLong(offset + 8)));
+        return sentNanos == null ? null : MonotonicTime.elapsedMillis(sentNanos, receivedNanos);
     }
 }

--- a/src/main/java/io/muserver/rest/AsyncResponseAdapter.java
+++ b/src/main/java/io/muserver/rest/AsyncResponseAdapter.java
@@ -95,6 +95,12 @@ class AsyncResponseAdapter implements AsyncResponse, ResponseCompleteListener {
     }
 
     private void processResponse(@Nullable Object response) {
+        synchronized (stateLock) {
+            if (state != State.RESUMING) {
+                return;
+            }
+            state = State.PROCESSING;
+        }
         try {
             if (response instanceof Throwable && !(response instanceof Exception)) {
                 Throwable failure = (Throwable) response;
@@ -332,6 +338,7 @@ class AsyncResponseAdapter implements AsyncResponse, ResponseCompleteListener {
     private enum State {
         SUSPENDED,
         RESUMING,
+        PROCESSING,
         DONE
     }
 }

--- a/src/test/java/io/muserver/ExecutionDomainsTest.java
+++ b/src/test/java/io/muserver/ExecutionDomainsTest.java
@@ -31,7 +31,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
-import java.util.concurrent.Phaser;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.ThreadPoolExecutor;
@@ -107,6 +106,13 @@ class ExecutionDomainsTest {
 
             server.stop();
             server = null;
+            client.setSoTimeout(1000);
+            try {
+                assertThat(client.getInputStream().read(), equalTo(-1));
+            } catch (java.net.SocketException reset) {
+                // Closing an accepted socket with unread input may send RST instead of FIN.
+                assertThat(client.isConnected(), is(true));
+            }
 
             releaseBlocker.countDown();
             blocker.get(5, TimeUnit.SECONDS);
@@ -120,6 +126,45 @@ class ExecutionDomainsTest {
             assertThat(handledRequests.get(), equalTo(0));
         } finally {
             releaseBlocker.countDown();
+        }
+    }
+
+    @Test
+    void handlerRejectionAfterFinalGoAwayStillSendsTheAdmittedResponse() throws Exception {
+        var submitting = new CountDownLatch(1);
+        var reject = new CountDownLatch(1);
+        var handler = track(new ThreadPoolExecutor(1, 1, 0, TimeUnit.MILLISECONDS,
+            new java.util.concurrent.SynchronousQueue<>()) {
+            @Override public void execute(Runnable task) {
+                submitting.countDown();
+                try {
+                    if (!reject.await(5, TimeUnit.SECONDS)) throw new AssertionError("Rejection not released");
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+                throw new RejectedExecutionException("full");
+            }
+        });
+        server = httpServer().withHttp2Config(Http2ConfigBuilder.http2Enabled())
+            .withHandlerExecutor(handler).start();
+        try (var client = new H2Client(); var connection = client.connectClearText(server)) {
+            connection.socket().setSoTimeout(5000);
+            connection.handshake();
+            var headers = new FieldBlock();
+            headers.set(":method", "GET");
+            headers.set(":scheme", "http");
+            headers.set(":authority", "localhost");
+            headers.set(":path", "/");
+            connection.writeFrame(new Http2HeadersFrame(1, true, headers)).flush();
+            assertThat(submitting.await(5, TimeUnit.SECONDS), is(true));
+            ((Http2Connection) server.activeConnections().iterator().next()).initiateGracefulShutdown();
+            connection.readLogicalFrame(Http2GoAway.class);
+            connection.readLogicalFrame(Http2GoAway.class);
+            reject.countDown();
+            assertThat(connection.readLogicalFrame(Http2HeadersFrame.class).headers().get(":status"), is("503"));
+            assertThat(connection.readLogicalFrame(Http2DataFrame.class).toUTF8(), is("503 Service Unavailable"));
+        } finally {
+            reject.countDown();
         }
     }
 
@@ -443,28 +488,20 @@ class ExecutionDomainsTest {
     }
 
     @Test
-    void detachedTaskWaitDoesNotWaitOnANewEmptyPhase() {
-        Phaser tasks = new Phaser(1) {
-            private boolean advanceBeforeReturningParties = true;
-
-            @Override
-            public int getRegisteredParties() {
-                int parties = super.getRegisteredParties();
-                if (advanceBeforeReturningParties) {
-                    advanceBeforeReturningParties = false;
-                    arriveAndDeregister();
-                }
-                return parties;
-            }
-        };
-
-        assertThat(
-            Mu3ServerImpl.awaitDetachedApplicationTasks(
-                tasks,
-                MonotonicTime.deadlineAfterMillis(100)
-            ),
-            is(true)
-        );
+    void detachedTaskTrackerSupportsLargeBatchesAndRepeatedDrains() {
+        var tasks = new ApplicationTaskTracker();
+        var registrations = new java.util.ArrayList<ApplicationTaskTracker.Registration>();
+        for (int i = 0; i < 70_000; i++) {
+            registrations.add(tasks.register());
+        }
+        assertThat(tasks.awaitUntil(System.nanoTime()), is(false));
+        registrations.forEach(ApplicationTaskTracker.Registration::close);
+        registrations.forEach(ApplicationTaskTracker.Registration::close);
+        assertThat(tasks.awaitUntil(System.nanoTime()), is(true));
+        try (var registration = tasks.register()) {
+            assertThat(tasks.awaitUntil(System.nanoTime()), is(false));
+        }
+        assertThat(tasks.awaitUntil(System.nanoTime()), is(true));
     }
 
     @Test
@@ -1871,6 +1908,44 @@ class ExecutionDomainsTest {
         } finally {
             releaseShutdown.countDown();
             webSocket.cancel();
+        }
+    }
+
+    @Test
+    void applicationFailureDuringWebSocketShutdownStillReachesOnError() throws Exception {
+        var handler = track(Executors.newSingleThreadExecutor(namedThreads("handler-")));
+        var session = new CompletableFuture<WebsocketConnection>();
+        var entered = new CountDownLatch(1);
+        var release = new CountDownLatch(1);
+        var observed = new CompletableFuture<Throwable>();
+        var expected = new IOException("application callback failed during shutdown");
+        server = httpServer().withHandlerExecutor(handler)
+            .addHandler(webSocketHandler((request, responseHeaders) -> new SimpleWebSocket() {
+                @Override public void onConnect(MuWebSocketSession connected) throws Exception {
+                    super.onConnect(connected);
+                    session.complete((WebsocketConnection) connected);
+                }
+                @Override public void onText(String message) throws Exception {
+                    entered.countDown();
+                    if (!release.await(5, TimeUnit.SECONDS)) throw new AssertionError("Callback not released");
+                    throw expected;
+                }
+                @Override public void onBinary(ByteBuffer payload) { }
+                @Override public void onServerShuttingDown() { }
+                @Override public void onError(Throwable cause) { observed.complete(cause); }
+            })).start();
+        WebSocket socket = client.newWebSocket(
+            request().url("ws" + server.uri().toString().substring(4)).build(), new WebSocketListener() { });
+        try {
+            WebsocketConnection connection = session.get(5, TimeUnit.SECONDS);
+            socket.send("fail");
+            assertThat(entered.await(5, TimeUnit.SECONDS), is(true));
+            connection.onServerShuttingDown();
+            release.countDown();
+            assertThat(observed.get(5, TimeUnit.SECONDS), is(expected));
+        } finally {
+            release.countDown();
+            socket.cancel();
         }
     }
 

--- a/src/test/java/io/muserver/Http2BodyInputStreamTest.java
+++ b/src/test/java/io/muserver/Http2BodyInputStreamTest.java
@@ -282,6 +282,23 @@ class Http2BodyInputStreamTest {
         assertThat(discardCallbackValue.get(), equalTo(0L));
     }
 
+    @Test
+    void dataAfterResetRefundsOnlyConnectionCreditAndCannotReplaceTheError() throws Exception {
+        var reusable = new AtomicLong();
+        var reset = new AtomicLong();
+        try (var body = new Http2BodyInputStream(100, reusable::addAndGet, reset::addAndGet)) {
+            body.onData(data("before", false), 9);
+            body.onStreamReset(new Http2ResetStreamFrame(1, Http2ErrorCode.CANCEL.code()));
+            body.discardRemaining();
+            body.onData(data("after", false), 8);
+            body.onData(data("", true), 4);
+            body.cancel(new IOException("second reset"));
+            assertThrows(IOException.class, body::read);
+            assertThat(reset.get(), equalTo(21L));
+            assertThat(reusable.get(), equalTo(0L));
+        }
+    }
+
     private Http2DataFrame data(String data, boolean eos) {
         byte[] bytes = data.getBytes(StandardCharsets.UTF_8);
         return new Http2DataFrame(1, eos, bytes, 0, bytes.length);

--- a/src/test/java/io/muserver/WebsocketPingTrackerTest.java
+++ b/src/test/java/io/muserver/WebsocketPingTrackerTest.java
@@ -10,11 +10,7 @@ import static org.hamcrest.Matchers.nullValue;
 
 class WebsocketPingTrackerTest {
 
-    private static final byte[] CONNECTION_SECRET =
-        new byte[]{1, 2, 3, 4, 5, 6, 7, 8};
-    private final WebsocketPingTracker tracker = new WebsocketPingTracker(
-        CONNECTION_SECRET
-    );
+    private final WebsocketPingTracker tracker = new WebsocketPingTracker();
 
     @Test
     void overlappingPingsRetainTheirOwnMonotonicSendPoints() {
@@ -23,7 +19,7 @@ class WebsocketPingTrackerTest {
 
         assertThat(tracker.pongLatencyMillis(secondPing, 6_000_000L), is(2L));
         assertThat(tracker.pongLatencyMillis(firstPing, 8_000_000L), is(7L));
-        assertThat(firstPing.getLong(0), is(1_000_000L));
+        assertThat(tracker.pongLatencyMillis(firstPing, 9_000_000L), nullValue());
     }
 
     @Test
@@ -44,7 +40,7 @@ class WebsocketPingTrackerTest {
         ByteBuffer tamperedTimestamp = tracker.newPingPayload(1L);
         tamperedTimestamp.putLong(0, 2L);
         ByteBuffer peerChosenTimestamp = ByteBuffer.allocate(16)
-            .put(CONNECTION_SECRET)
+            .putLong(123L)
             .putLong(2L)
             .flip();
 
@@ -52,4 +48,17 @@ class WebsocketPingTrackerTest {
         assertThat(tracker.pongLatencyMillis(peerChosenTimestamp, 3L), nullValue());
         assertThat(tracker.pongLatencyMillis(ByteBuffer.allocate(15), 2L), nullValue());
     }
+    @Test
+    void oldAndOtherConnectionPongsAreNotSamples() {
+        ByteBuffer oldest = tracker.newPingPayload(1L);
+        for (int i = 0; i < WebsocketPingTracker.MAX_OUTSTANDING; i++) {
+            tracker.newPingPayload(2L + i);
+        }
+        assertThat(tracker.pongLatencyMillis(oldest, 100L), nullValue());
+        ByteBuffer current = tracker.newPingPayload(100L);
+        assertThat(new WebsocketPingTracker().pongLatencyMillis(current, 101L), nullValue());
+        assertThat(tracker.pongLatencyMillis(current, 102L), is(0L));
+        assertThat(tracker.pongLatencyMillis(current, 103L), nullValue());
+    }
+
 }

--- a/src/test/java/io/muserver/rest/AsynchronousProcessingTest.java
+++ b/src/test/java/io/muserver/rest/AsynchronousProcessingTest.java
@@ -471,6 +471,23 @@ public class AsynchronousProcessingTest {
     }
 
     @Test
+    public void queuedResumeDoesNotSerializeAfterExchangeCompletion() {
+        var handle = new QueuedAsyncHandle();
+        var consumed = new AtomicInteger();
+        var response = new AsyncResponseAdapter(handle, ignored -> consumed.incrementAndGet());
+        assertThat(response.resume("late result"), is(true));
+        response.onComplete(new ResponseInfo() {
+            public long duration() { return 0; }
+            public boolean completedSuccessfully() { return true; }
+            public MuRequest request() { throw new UnsupportedOperationException(); }
+            public MuResponse response() { throw new UnsupportedOperationException(); }
+        });
+        handle.runNextApplicationTask();
+        assertThat(consumed.get(), is(0));
+        assertThat(response.isDone(), is(true));
+    }
+
+    @Test
     public void cancellationIsAtomicAndIdempotent() {
         var asyncHandle = new QueuedAsyncHandle();
         var sentResponse = new AtomicReference<Object>();


### PR DESCRIPTION
Fix the remaining terminal-state defects identified in #198: refund connection credit for DATA arriving after reset, prevent queued JAX-RS serialization after completion, report application WebSocket failures during shutdown, and accept each outstanding ping only once with bounded storage. Replace Phaser callback tracking with an idempotent counter/condition tracker that supports more than 65,535 pending callbacks.

Adds deterministic regressions for those cases, handler rejection after final GOAWAY, and closure of accepted sockets queued at shutdown. Validation: 104 targeted tests passed on Temurin 11 (ExecutionDomainsTest, Http2BodyInputStreamTest, WebsocketPingTrackerTest, AsynchronousProcessingTest).

First of four follow-ups, stacked on #195. Executor consolidation, admission, async contracts, and documentation follow separately.