### PR TITLE
Mu4 concurrency follow-up 2: one application executor and request admission

### DIFF
--- a/src/main/java/io/muserver/BaseWebSocket.java
+++ b/src/main/java/io/muserver/BaseWebSocket.java
@@ -7,9 +7,6 @@ import java.net.SocketTimeoutException;
 import java.nio.ByteBuffer;
 import java.nio.charset.CharacterCodingException;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.Executor;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicLong;
@@ -79,28 +76,16 @@ public abstract class BaseWebSocket implements MuWebSocket {
      */
     @Override
     public void onText(String message) throws Exception {
-        // Adapter code for old-style implementations that rely on non-blocking behaviour.
-        // This calls the old-style methods in a new thread and blocks until the done callback is invoked.
-        // Overriders of this base class should just override this method and block until the data is finished with.
         CompletableFuture<@Nullable Void> result = new CompletableFuture<>();
         try {
-            CompletableFuture.runAsync(() -> {
-                try {
-                    onText(message, true, error -> {
-                        if (error == null) {
-                            result.complete(null);
-                        } else {
-                            result.completeExceptionally(error);
-                        }
-                    });
-                } catch (Exception e) {
-                    result.completeExceptionally(e);
-                }
-            }, asyncExecutor());
-        } catch (RuntimeException failure) {
+            onText(message, true, error -> {
+                if (error == null) result.complete(null);
+                else result.completeExceptionally(error);
+            });
+        } catch (Exception failure) {
             result.completeExceptionally(failure);
         }
-        blockUntilDone(result);
+        WebSocketCompatibility.awaitOrDefer(result);
     }
 
     /**
@@ -171,43 +156,16 @@ public abstract class BaseWebSocket implements MuWebSocket {
      */
     @Override
     public void onBinary(ByteBuffer buffer) throws Exception {
-        // Adapter code for old-style implementations that rely on non-blocking behaviour.
-        // This calls the old-style methods in a new thread and blocks until the done callback is invoked.
-        // Overriders of this base class should just override this method and block until the data is finished with.
         CompletableFuture<@Nullable Void> result = new CompletableFuture<>();
         try {
-            CompletableFuture.runAsync(() -> {
-                try {
-                    onBinary(buffer, true, error -> {
-                        if (error == null) {
-                            result.complete(null);
-                        } else {
-                            result.completeExceptionally(error);
-                        }
-                    }, () -> {});
-                } catch (Exception e) {
-                    result.completeExceptionally(e);
-                }
-            }, asyncExecutor());
-        } catch (RuntimeException failure) {
+            onBinary(buffer, true, error -> {
+                if (error == null) result.complete(null);
+                else result.completeExceptionally(error);
+            }, () -> {});
+        } catch (Exception failure) {
             result.completeExceptionally(failure);
         }
-        blockUntilDone(result);
-    }
-
-    private Executor asyncExecutor() {
-        MuWebSocketSession currentSession = session;
-        return currentSession instanceof WebsocketConnection
-            ? ((WebsocketConnection) currentSession).asyncExecutor()
-            : ForkJoinPool.commonPool();
-    }
-
-    private static void blockUntilDone(CompletableFuture<@Nullable Void> result) throws Exception {
-        try {
-            result.get();
-        } catch (ExecutionException e) {
-            throw e.getCause() instanceof Exception ? (Exception) e.getCause() : e;
-        }
+        WebSocketCompatibility.awaitOrDefer(result);
     }
 
     /**

--- a/src/main/java/io/muserver/ConnectionAcceptor.java
+++ b/src/main/java/io/muserver/ConnectionAcceptor.java
@@ -470,8 +470,7 @@ class ConnectionAcceptor {
                 socket,
                 clientCert,
                 acceptedTime,
-                handlerExecutor,
-                handlerExecutor == connectionExecutor
+                handlerExecutor
             );
         }
 

--- a/src/main/java/io/muserver/ExecutionResources.java
+++ b/src/main/java/io/muserver/ExecutionResources.java
@@ -1,0 +1,50 @@
+package io.muserver;
+
+import org.jspecify.annotations.Nullable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ScheduledExecutorService;
+
+/** Owns the two Mu task domains and dispatch-only timer, including startup rollback. */
+class ExecutionResources {
+    final ExecutorService application;
+    final ExecutorService internal;
+    final ScheduledExecutorService timer;
+    private final boolean ownsApplication;
+
+    @FunctionalInterface
+    interface Factory {
+        ExecutionResources create(@Nullable ExecutorService application);
+    }
+
+    ExecutionResources(ExecutorService application, boolean ownsApplication,
+                       ExecutorService internal, ScheduledExecutorService timer) {
+        this.application = application;
+        this.ownsApplication = ownsApplication;
+        this.internal = internal;
+        this.timer = timer;
+    }
+
+    static ExecutionResources create(@Nullable ExecutorService supplied) {
+        ExecutorService application = supplied == null ? MuServerBuilder.defaultExecutor() : supplied;
+        ExecutorService internal = null;
+        try {
+            internal = MuServerBuilder.defaultExecutor();
+            return new ExecutionResources(application, supplied == null, internal,
+                MuServerBuilder.defaultTimerExecutor());
+        } catch (RuntimeException | Error failure) {
+            if (internal != null) internal.shutdown();
+            if (supplied == null) application.shutdown();
+            throw failure;
+        }
+    }
+
+    ExecutorService connectionExecutor() { return internal; }
+
+    ExecutorService writerExecutor() { return internal; }
+
+    void shutdown() {
+        timer.shutdown();
+        internal.shutdown();
+        if (ownsApplication) application.shutdown();
+    }
+}

--- a/src/main/java/io/muserver/Http1Connection.java
+++ b/src/main/java/io/muserver/Http1Connection.java
@@ -27,7 +27,6 @@ class Http1Connection extends BaseHttpConnection {
 
     private static final Logger log = LoggerFactory.getLogger(Http1Connection.class);
     private final ExecutorService handlerExecutor;
-    private final boolean handlersRunOnConnectionTask;
     private final Queue<HttpRequestTemp> requestPipeline = new ConcurrentLinkedQueue<>();
     // At most one active exchange exists on HTTP/1.1: either an HTTP request/response or a websocket takeover.
     private final AtomicReference<@Nullable ActiveExchange> activeExchange = new AtomicReference<>();
@@ -84,10 +83,9 @@ class Http1Connection extends BaseHttpConnection {
 
     Http1Connection(Mu3ServerImpl server, ConnectionAcceptor creator, Socket clientSocket,
                     @Nullable Certificate clientCertificate, ConnectionAcceptedTime acceptedTime,
-                    ExecutorService handlerExecutor, boolean handlersRunOnConnectionTask) {
+                    ExecutorService handlerExecutor) {
         super(server, creator, clientSocket, clientCertificate, acceptedTime);
         this.handlerExecutor = handlerExecutor;
-        this.handlersRunOnConnectionTask = handlersRunOnConnectionTask;
     }
 
     @Override
@@ -219,11 +217,7 @@ class Http1Connection extends BaseHttpConnection {
     }
 
     private HandlerExecution handleExchangeOnHandlerExecutor(Mu3Request request, Http1Response response) throws Throwable {
-        if (handlersRunOnConnectionTask) {
-            return HandlerExecution.accepted(
-                server.callHandlerApplicationTask(() -> handleExchange(request, response))
-            );
-        }
+        if (!server.tryAdmit(request)) return HandlerExecution.rejected();
         CompletableFuture<@Nullable CompletableFuture<@Nullable Void>> completion = new CompletableFuture<>();
         try {
             handlerExecutor.execute(server.handlerApplicationTask(() -> {
@@ -258,13 +252,6 @@ class Http1Connection extends BaseHttpConnection {
 
     private void handleAsyncExceptionOnHandler(Mu3Request request, Http1Response response,
                                                Exception failure) throws Throwable {
-        if (handlersRunOnConnectionTask) {
-            server.callHandlerApplicationTask(() -> {
-                handleExchangeException(request, response, failure);
-                return null;
-            });
-            return;
-        }
         CompletableFuture<@Nullable Void> handled = new CompletableFuture<>();
         Runnable task = () -> {
             try {
@@ -287,10 +274,6 @@ class Http1Connection extends BaseHttpConnection {
 
     private void onExchangeEndedOnHandler(Http1Response response) {
         recordExchangeEnded(response);
-        if (handlersRunOnConnectionTask) {
-            server.runHandlerApplicationTask(() -> notifyExchangeEnded(response));
-            return;
-        }
         server.executeResponseCompletionTask(() -> notifyExchangeEnded(response));
     }
 
@@ -509,15 +492,4 @@ class Http1Connection extends BaseHttpConnection {
         }
     }
 
-    void wakeWebSocketReader() {
-        try {
-            clientSocket.shutdownInput();
-        } catch (IOException e) {
-            log.debug("Could not wake WebSocket reader", e);
-        }
-    }
-
-    boolean webSocketEventsRunOnConnectionTask() {
-        return handlersRunOnConnectionTask;
-    }
 }

--- a/src/main/java/io/muserver/Http2Connection.java
+++ b/src/main/java/io/muserver/Http2Connection.java
@@ -1298,6 +1298,7 @@ class Http2Connection extends BaseHttpConnection implements Http2Peer {
 
         onRequestStarted(stream.request);
         try {
+            if (!server.tryAdmit(stream.request)) throw new RejectedExecutionException("Request limit reached");
             handlerExecutor.submit(server.handlerApplicationTask(() -> startHandledStream(stream)));
         } catch (RejectedExecutionException e) {
             server.onRequestSubmissionRejected(stream.request);

--- a/src/main/java/io/muserver/Mu3AsyncHandleImpl.java
+++ b/src/main/java/io/muserver/Mu3AsyncHandleImpl.java
@@ -21,13 +21,15 @@ class Mu3AsyncHandleImpl implements AsyncHandle {
     // Guarded by lock. This is the terminal gate for response writes and exchange completion.
     private boolean completionRequested;
     private final Mu3ServerImpl server;
-    private final Executor asyncExecutor;
+    private final Executor ioExecutor;
+    private final SerialApplicationTasks callbacks;
 
     Mu3AsyncHandleImpl(Mu3Request request, BaseResponse response, Mu3ServerImpl server) {
         this.request = request;
         this.response = response;
         this.server = server;
-        this.asyncExecutor = server::executeAsyncApplicationTask;
+        this.ioExecutor = server::executeInternalTask;
+        this.callbacks = new SerialApplicationTasks(server);
     }
 
     CompletableFuture<@Nullable Void> exchangeCompletion() {
@@ -91,9 +93,9 @@ class Mu3AsyncHandleImpl implements AsyncHandle {
                 return;
             }
             try {
-                server.executeAsyncApplicationTask(this::readNext);
+                server.executeInternalTask(this::readNext);
             } catch (RejectedExecutionException rejected) {
-                fail(rejected, false);
+                fail(rejected, true);
             }
         }
 
@@ -109,7 +111,7 @@ class Mu3AsyncHandleImpl implements AsyncHandle {
                 return;
             }
             if (read == -1) {
-                finishReading();
+                callbacks.submit(this::finishReading, rejected -> fail(rejected, false));
                 return;
             }
             if (read == 0) {
@@ -117,22 +119,20 @@ class Mu3AsyncHandleImpl implements AsyncHandle {
                 return;
             }
 
+            callbacks.submit(() -> deliver(read), rejected -> fail(rejected, false));
+        }
+
+        private void deliver(int read) {
+            if (finished.get()) return;
             var callbackUsed = new AtomicBoolean();
             try {
                 readListener.onDataReceived(ByteBuffer.wrap(buffer, 0, read), error -> {
-                    if (!callbackUsed.compareAndSet(false, true)) {
-                        return;
-                    }
-                    if (error == null) {
-                        scheduleNextRead();
-                    } else {
-                        fail(error, false);
-                    }
+                    if (!callbackUsed.compareAndSet(false, true)) return;
+                    if (error == null) scheduleNextRead();
+                    else fail(error, false);
                 });
-            } catch (Throwable t) {
-                // onDataReceived runs in the async application domain, so its
-                // documented error callback belongs to the same turn.
-                fail(t, true);
+            } catch (Throwable failure) {
+                fail(failure, true);
             }
         }
 
@@ -153,16 +153,20 @@ class Mu3AsyncHandleImpl implements AsyncHandle {
             if (!finished.compareAndSet(false, true)) {
                 return;
             }
-            try {
-                if (notifyListener) {
-                    readListener.onError(failure);
-                }
-            } catch (Throwable listenerFailure) {
-                addSuppressedIfDifferent(failure, listenerFailure);
-            } finally {
-                Mutils.closeSilently(clientIn);
+            Mutils.closeSilently(clientIn);
+            if (notifyListener) {
+                callbacks.submit(() -> {
+                    try {
+                        readListener.onError(failure);
+                    } catch (Throwable listenerFailure) {
+                        addSuppressedIfDifferent(failure, listenerFailure);
+                    } finally {
+                        complete(failure);
+                    }
+                }, thisFailure -> complete(failure));
+            } else {
+                complete(failure);
             }
-            complete(failure);
         }
     }
 
@@ -195,100 +199,42 @@ class Mu3AsyncHandleImpl implements AsyncHandle {
 
     @Override
     public void write(ByteBuffer data, DoneCallback callback) {
-        var taskStarted = new AtomicBoolean();
-        @Nullable CompletableFuture<@Nullable Void> writeFuture;
-        lock.lock();
-        try {
-            if (completionRequested) {
-                writeFuture = null;
-            } else {
-                responseFuture = responseFuture.thenRunAsync(() -> {
-                    taskStarted.set(true);
-                    try {
-                        copyBufferToResponseOutput(data);
-                    } catch (Throwable e) {
-                        try {
-                            callback.onComplete(e);
-                        } catch (Throwable callbackFailure) {
-                            addSuppressedIfDifferent(e, callbackFailure);
-                        }
-                        complete(e);
-                        throw e instanceof RuntimeException ? (RuntimeException) e : new RuntimeException("Error while writing body", e);
-                    }
-                    try {
-                        callback.onComplete(null);
-                    } catch (Throwable e) {
-                        complete(e);
-                        throw e instanceof RuntimeException ? (RuntimeException) e : new RuntimeException("Error in write callback", e);
-                    }
-                }, asyncExecutor).thenApply(ignored -> null);
-                writeFuture = responseFuture;
-            }
-        } finally {
-            lock.unlock();
-        }
-        if (writeFuture == null) {
-            Throwable failure = completedResponseWriteFailure();
+        Objects.requireNonNull(callback, "callback");
+        submitWrite(data).whenComplete((ignored, failure) -> callbacks.submit(() -> {
             try {
-                server.executeAsyncApplicationTask(() ->
-                    invokeWriteCallback(callback, failure)
-                );
-            } catch (RejectedExecutionException rejected) {
-                // The callback contract still needs an outcome when the
-                // required async executor cannot accept the notification.
-                invokeWriteCallback(callback, failure);
+                callback.onComplete(failure == null ? null : completionCause(failure));
+            } catch (Throwable callbackFailure) {
+                complete(callbackFailure);
             }
-            return;
-        }
-        writeFuture.whenComplete((ignored, failure) -> {
-            if (failure != null && !taskStarted.get()) {
-                Throwable cause = completionCause(failure);
-                try {
-                    callback.onComplete(cause);
-                } catch (Throwable callbackFailure) {
-                    addSuppressedIfDifferent(cause, callbackFailure);
-                }
-                complete(cause);
-            }
-        });
+        }, this::complete));
     }
 
     @Override
     public Future<@Nullable Void> write(ByteBuffer data) {
-        var taskStarted = new AtomicBoolean();
-        CompletableFuture<@Nullable Void> writeFuture;
+        return submitWrite(data);
+    }
+
+    private CompletableFuture<@Nullable Void> submitWrite(ByteBuffer data) {
+        Objects.requireNonNull(data, "data");
+        CompletableFuture<@Nullable Void> write;
         lock.lock();
         try {
-            if (completionRequested) {
-                return CompletableFuture.failedFuture(completedResponseWriteFailure());
-            }
-            writeFuture = responseFuture.thenRunAsync(() -> {
-                taskStarted.set(true);
+            if (completionRequested) return CompletableFuture.failedFuture(completedResponseWriteFailure());
+            write = responseFuture.thenRunAsync(() -> {
                 try {
                     copyBufferToResponseOutput(data);
-                } catch (Throwable e) {
-                    complete(e);
-                    throw e instanceof RuntimeException ? (RuntimeException) e : new RuntimeException("Error while writing body", e);
+                } catch (IOException e) {
+                    throw new CompletionException(e);
                 }
-            }, asyncExecutor).thenApply(ignored -> null);
-            responseFuture = writeFuture;
+            }, ioExecutor).thenApply(ignored -> null);
+            responseFuture = write;
         } finally {
             lock.unlock();
         }
-        writeFuture.whenComplete((ignored, failure) -> {
-            if (failure != null && !taskStarted.get()) {
-                complete(completionCause(failure));
-            }
+        write.whenComplete((ignored, failure) -> {
+            if (failure != null) complete(completionCause(failure));
         });
-        return writeFuture;
-    }
-
-    private static void invokeWriteCallback(DoneCallback callback, Throwable failure) {
-        try {
-            callback.onComplete(failure);
-        } catch (Throwable callbackFailure) {
-            addSuppressedIfDifferent(failure, callbackFailure);
-        }
+        return write;
     }
 
     private static IllegalStateException completedResponseWriteFailure() {

--- a/src/main/java/io/muserver/Mu3Request.java
+++ b/src/main/java/io/muserver/Mu3Request.java
@@ -13,6 +13,13 @@ import java.util.*;
 import static java.lang.Math.min;
 
 class Mu3Request implements MuRequest {
+    volatile RequestAdmission.@Nullable Slot admissionSlot;
+
+    void releaseAdmission() {
+        RequestAdmission.Slot slot = admissionSlot;
+        if (slot != null) slot.close();
+    }
+
     private final HttpConnection connection;
     private final Method method;
     private final URI requestUri;

--- a/src/main/java/io/muserver/Mu3ServerImpl.java
+++ b/src/main/java/io/muserver/Mu3ServerImpl.java
@@ -36,25 +36,15 @@ class Mu3ServerImpl implements MuServer {
     private final int maxHeadersSize;
     final List<RateLimiterImpl> rateLimiters;
     final Path tempDir;
-    private final ExecutorService handlerExecutor;
-    private final boolean ownsHandlerExecutor;
-    private final ExecutorService asyncExecutor;
-    private final boolean ownsAsyncExecutor;
-    private final ExecutorService connectionExecutor;
-    private final boolean ownsConnectionExecutor;
-    private final ExecutorService http2WriterExecutor;
-    private final boolean ownsHttp2WriterExecutor;
-    private final ExecutorService connectionMaintenanceExecutor;
-    private final boolean ownsConnectionMaintenanceExecutor;
-    private final ScheduledExecutorService timerExecutor;
-    private final boolean ownsTimerExecutor;
+    private final ExecutionResources executionResources;
+    private final RequestAdmission requestAdmission;
     private final ThreadLocal<ApplicationTaskContext> applicationTaskContext = new ThreadLocal<>();
     private final ApplicationTaskTracker detachedApplicationTasks = new ApplicationTaskTracker();
     private final ThreadLocal<@Nullable DetachedApplicationTask> activeDetachedApplicationTask =
         new ThreadLocal<>();
     private final Mu3StatsImpl statsImpl = new Mu3StatsImpl();
 
-    Mu3ServerImpl(List<ConnectionAcceptor> acceptors, List<MuHandler> handlers, List<ResponseCompleteListener> responseCompleteListeners, List<RequestRejectListener> requestRejectListeners, UnhandledExceptionHandler exceptionHandler, Long maxRequestBodySize, List<ContentEncoder> contentEncoders, Long requestIdleTimeoutMillis, Long idleTimeoutMillis, int maxUrlSize, int maxHeadersSize, List<RateLimiterImpl> rateLimiters, Path tempDir, ExecutorService handlerExecutor, boolean ownsHandlerExecutor, ExecutorService asyncExecutor, boolean ownsAsyncExecutor, ExecutorService connectionExecutor, boolean ownsConnectionExecutor, ExecutorService http2WriterExecutor, boolean ownsHttp2WriterExecutor, ExecutorService connectionMaintenanceExecutor, boolean ownsConnectionMaintenanceExecutor, ScheduledExecutorService timerExecutor, boolean ownsTimerExecutor) {
+    Mu3ServerImpl(List<ConnectionAcceptor> acceptors, List<MuHandler> handlers, List<ResponseCompleteListener> responseCompleteListeners, List<RequestRejectListener> requestRejectListeners, UnhandledExceptionHandler exceptionHandler, Long maxRequestBodySize, List<ContentEncoder> contentEncoders, Long requestIdleTimeoutMillis, Long idleTimeoutMillis, int maxUrlSize, int maxHeadersSize, List<RateLimiterImpl> rateLimiters, Path tempDir, ExecutionResources executionResources, int maxConcurrentRequests) {
         this.acceptors = acceptors;
         this.handlers = handlers;
         this.responseCompleteListeners = responseCompleteListeners;
@@ -68,18 +58,8 @@ class Mu3ServerImpl implements MuServer {
         this.maxHeadersSize = maxHeadersSize;
         this.rateLimiters = rateLimiters;
         this.tempDir = tempDir;
-        this.handlerExecutor = handlerExecutor;
-        this.ownsHandlerExecutor = ownsHandlerExecutor;
-        this.asyncExecutor = asyncExecutor;
-        this.ownsAsyncExecutor = ownsAsyncExecutor;
-        this.connectionExecutor = connectionExecutor;
-        this.ownsConnectionExecutor = ownsConnectionExecutor;
-        this.http2WriterExecutor = http2WriterExecutor;
-        this.ownsHttp2WriterExecutor = ownsHttp2WriterExecutor;
-        this.connectionMaintenanceExecutor = connectionMaintenanceExecutor;
-        this.ownsConnectionMaintenanceExecutor = ownsConnectionMaintenanceExecutor;
-        this.timerExecutor = timerExecutor;
-        this.ownsTimerExecutor = ownsTimerExecutor;
+        this.executionResources = executionResources;
+        this.requestAdmission = new RequestAdmission(maxConcurrentRequests);
     }
 
     private void startListening() {
@@ -119,24 +99,7 @@ class Mu3ServerImpl implements MuServer {
         if (!awaitDetachedApplicationTasks(deadlineNanos)) {
             stoppedCleanly = false;
         }
-        if (ownsTimerExecutor) {
-            timerExecutor.shutdown();
-        }
-        if (ownsConnectionExecutor) {
-            connectionExecutor.shutdown();
-        }
-        if (ownsHttp2WriterExecutor) {
-            http2WriterExecutor.shutdown();
-        }
-        if (ownsConnectionMaintenanceExecutor) {
-            connectionMaintenanceExecutor.shutdown();
-        }
-        if (ownsHandlerExecutor) {
-            handlerExecutor.shutdown();
-        }
-        if (ownsAsyncExecutor) {
-            asyncExecutor.shutdown();
-        }
+        executionResources.shutdown();
         return stoppedCleanly;
     }
 
@@ -155,20 +118,17 @@ class Mu3ServerImpl implements MuServer {
     void executeResponseCompletionTask(Runnable task) {
         executeTrackedApplicationTask(
             task,
-            true,
             "response completion callback"
         );
     }
 
-    private void executeTrackedApplicationTask(
+    @Nullable RejectedExecutionException executeTrackedApplicationTask(
         Runnable task,
-        boolean preferHandlerExecutor,
         String description
     ) {
         DetachedApplicationTask registration = new DetachedApplicationTask();
         Runnable trackedTask = () -> {
             DetachedApplicationTask previous = activeDetachedApplicationTask.get();
-            registration.previous = previous;
             activeDetachedApplicationTask.set(registration);
             try {
                 task.run();
@@ -181,17 +141,15 @@ class Mu3ServerImpl implements MuServer {
                 }
             }
         };
-        RejectedExecutionException rejected = preferHandlerExecutor
-            ? tryExecuteHandlerTask(trackedTask)
-            : tryExecuteAsyncTask(trackedTask);
+        RejectedExecutionException rejected = tryExecuteHandlerTask(trackedTask);
         if (rejected != null) {
             registration.deregister();
             log.warn("Dropping {} because its application executors rejected it", description, rejected);
         }
+        return rejected;
     }
 
     private final class DetachedApplicationTask {
-        private @Nullable DetachedApplicationTask previous;
         private final ApplicationTaskTracker.Registration registration = detachedApplicationTasks.register();
 
         private void deregister() {
@@ -199,149 +157,55 @@ class Mu3ServerImpl implements MuServer {
         }
     }
 
-    /**
-     * Dispatches accepted application work without ever falling back to the caller.
-     * The async executor is the secondary application domain when handler dispatch
-     * is unavailable; the returned rejection means neither domain can accept work.
-     */
+    /** Nested application work is queued to avoid recursive callback delivery. */
     @Nullable RejectedExecutionException tryExecuteHandlerTask(Runnable task) {
-        return tryExecuteApplicationTask(task, handlerExecutor, asyncExecutor);
-    }
-
-    @Nullable RejectedExecutionException tryExecuteAsyncTask(Runnable task) {
-        return tryExecuteApplicationTask(task, asyncExecutor, handlerExecutor);
-    }
-
-    void executeAsyncApplicationTask(Runnable task) {
-        RejectedExecutionException rejected = tryExecuteRequiredAsyncTask(task);
-        if (rejected != null) {
-            throw rejected;
-        }
-    }
-
-    @SuppressWarnings("ReferenceEquality") // Execution-domain identity belongs to the exact executor instance.
-    private @Nullable RejectedExecutionException tryExecuteRequiredAsyncTask(Runnable task) {
-        ApplicationTaskContext currentContext = applicationTaskContext.get();
-        if (currentContext != null && currentContext.includes(asyncExecutor)) {
-            currentContext.tasks.add(task);
+        ApplicationTaskContext current = applicationTaskContext.get();
+        if (current != null) {
+            current.tasks.add(task);
             return null;
         }
         try {
-            asyncExecutor.execute(applicationTask(asyncExecutor, asyncExecutor, task));
+            executionResources.application.execute(handlerApplicationTask(task));
             return null;
         } catch (RejectedExecutionException rejected) {
             return rejected;
         }
     }
 
-    @SuppressWarnings("ReferenceEquality") // Execution-domain identity belongs to the exact executor instance.
-    private @Nullable RejectedExecutionException tryExecuteApplicationTask(
-        Runnable task,
-        ExecutorService primaryExecutor,
-        ExecutorService fallbackExecutor
-    ) {
-        ApplicationTaskContext currentContext = applicationTaskContext.get();
-        if (currentContext != null && currentContext.includes(primaryExecutor)) {
-            currentContext.tasks.add(task);
-            return null;
-        }
-        try {
-            primaryExecutor.execute(applicationTask(primaryExecutor, primaryExecutor, task));
-            return null;
-        } catch (RejectedExecutionException primaryRejected) {
-            if (fallbackExecutor != primaryExecutor) {
-                if (currentContext != null && currentContext.includes(fallbackExecutor)) {
-                    currentContext.tasks.add(task);
-                    return null;
-                }
-                try {
-                    fallbackExecutor.execute(applicationTask(primaryExecutor, fallbackExecutor, task));
-                    return null;
-                } catch (RejectedExecutionException fallbackRejected) {
-                    fallbackRejected.addSuppressed(primaryRejected);
-                    return fallbackRejected;
-                }
-            }
-            return primaryRejected;
-        }
+    void executeAsyncApplicationTask(Runnable task) {
+        RejectedExecutionException rejected = tryExecuteHandlerTask(task);
+        if (rejected != null) throw rejected;
+    }
+
+    void executeInternalTask(Runnable task) {
+        executionResources.internal.execute(task);
     }
 
     Runnable handlerApplicationTask(Runnable task) {
-        return applicationTask(handlerExecutor, handlerExecutor, task);
-    }
-
-    private Runnable applicationTask(
-        ExecutorService requestedExecutor,
-        ExecutorService executingExecutor,
-        Runnable task
-    ) {
         Objects.requireNonNull(task, "task");
-        return () -> runApplicationTask(requestedExecutor, executingExecutor, task);
+        return () -> runHandlerApplicationTask(task);
     }
 
     void runHandlerApplicationTask(Runnable task) {
-        runApplicationTask(handlerExecutor, handlerExecutor, task);
-    }
-
-    private void runApplicationTask(
-        ExecutorService requestedExecutor,
-        ExecutorService executingExecutor,
-        Runnable task
-    ) {
-        Objects.requireNonNull(task, "task");
-        ApplicationTaskContext currentContext = applicationTaskContext.get();
-        if (currentContext != null) {
-            if (currentContext.includes(requestedExecutor)) {
-                currentContext.tasks.add(task);
-                return;
-            }
-            throw new IllegalStateException("Cannot enter a different application execution domain");
+        ApplicationTaskContext current = applicationTaskContext.get();
+        if (current != null) {
+            current.tasks.add(task);
+            return;
         }
-
-        ApplicationTaskContext newContext =
-            new ApplicationTaskContext(requestedExecutor, executingExecutor);
-        newContext.tasks.add(task);
-        applicationTaskContext.set(newContext);
-        @Nullable Throwable failure = null;
+        ApplicationTaskContext context = new ApplicationTaskContext();
+        context.tasks.add(task);
+        applicationTaskContext.set(context);
+        Throwable failure;
         try {
-            failure = drainApplicationTasks(newContext, null);
+            failure = drainApplicationTasks(context, null);
         } finally {
             applicationTaskContext.remove();
         }
-        if (failure != null) {
-            throwUnchecked(failure);
-        }
+        if (failure != null) throwUnchecked(failure);
     }
 
     <T> @Nullable T callHandlerApplicationTask(ApplicationCallable<T> task) throws Throwable {
-        Objects.requireNonNull(task, "task");
-        ApplicationTaskContext currentContext = applicationTaskContext.get();
-        if (currentContext != null) {
-            if (currentContext.includes(handlerExecutor)) {
-                return task.call();
-            }
-            throw new IllegalStateException("Cannot enter the handler execution domain from another application domain");
-        }
-
-        ApplicationTaskContext newContext =
-            new ApplicationTaskContext(handlerExecutor, handlerExecutor);
-        applicationTaskContext.set(newContext);
-        @Nullable T result = null;
-        @Nullable Throwable failure = null;
-        try {
-            try {
-                result = task.call();
-            } catch (Throwable taskFailure) {
-                failure = taskFailure;
-            }
-            failure = drainApplicationTasks(newContext, failure);
-        } finally {
-            applicationTaskContext.remove();
-        }
-        if (failure != null) {
-            throw failure;
-        }
-        return result;
+        return task.call();
     }
 
     @SuppressWarnings("ReferenceEquality") // Throwable forbids suppressing itself; identity is required.
@@ -380,26 +244,18 @@ class Mu3ServerImpl implements MuServer {
     }
 
     private static final class ApplicationTaskContext {
-        private final ExecutorService requestedExecutor;
-        private final ExecutorService executingExecutor;
         private final Queue<Runnable> tasks = new ArrayDeque<>();
-
-        private ApplicationTaskContext(
-            ExecutorService requestedExecutor,
-            ExecutorService executingExecutor
-        ) {
-            this.requestedExecutor = requestedExecutor;
-            this.executingExecutor = executingExecutor;
-        }
-
-        @SuppressWarnings("ReferenceEquality") // Execution-domain identity belongs to the exact executor instance.
-        private boolean includes(ExecutorService executor) {
-            return requestedExecutor == executor || executingExecutor == executor;
-        }
     }
 
-    ExecutorService asyncExecutor() {
-        return asyncExecutor;
+    ExecutorService internalExecutor() {
+        return executionResources.internal;
+    }
+
+    boolean tryAdmit(Mu3Request request) {
+        RequestAdmission.Slot slot = requestAdmission.tryAcquire();
+        if (slot == null) return false;
+        request.admissionSlot = slot;
+        return true;
     }
 
     @Override
@@ -565,10 +421,12 @@ class Mu3ServerImpl implements MuServer {
     }
 
     void onRequestSubmissionRejected(Mu3Request req) {
+        req.releaseAdmission();
         statsImpl.onRequestSubmissionRejected(req);
     }
 
     void recordExchangeEnded(ResponseInfo exchange) {
+        ((Mu3Request) exchange.request()).releaseAdmission();
         statsImpl.onRequestEnded(exchange);
     }
 
@@ -595,7 +453,6 @@ class Mu3ServerImpl implements MuServer {
         }
         executeTrackedApplicationTask(
             () -> notifyRequestRejected(info),
-            false,
             "request rejection notification"
         );
     }
@@ -637,36 +494,10 @@ class Mu3ServerImpl implements MuServer {
             limiters = emptyList();
         }
 
-        ExecutorService handlerExecutor = builder.executor();
-        boolean ownsHandlerExecutor = handlerExecutor == null;
-        if (handlerExecutor == null) {
-            handlerExecutor = MuServerBuilder.defaultExecutor();
-        }
-        ExecutorService asyncExecutor = builder.asyncExecutor();
-        boolean ownsAsyncExecutor = asyncExecutor == null;
-        if (asyncExecutor == null) {
-            asyncExecutor = MuServerBuilder.defaultExecutor();
-        }
-        ExecutorService connectionExecutor = builder.connectionExecutor();
-        boolean ownsConnectionExecutor = connectionExecutor == null;
-        if (connectionExecutor == null) {
-            connectionExecutor = MuServerBuilder.defaultExecutor();
-        }
-        ExecutorService http2WriterExecutor = builder.http2WriterExecutor();
-        boolean ownsHttp2WriterExecutor = http2WriterExecutor == null;
-        if (http2WriterExecutor == null) {
-            http2WriterExecutor = MuServerBuilder.defaultExecutor();
-        }
-        ExecutorService connectionMaintenanceExecutor = builder.connectionMaintenanceExecutor();
-        boolean ownsConnectionMaintenanceExecutor = connectionMaintenanceExecutor == null;
-        if (connectionMaintenanceExecutor == null) {
-            connectionMaintenanceExecutor = MuServerBuilder.defaultExecutor();
-        }
-        ScheduledExecutorService timerExecutor = builder.timerExecutor();
-        boolean ownsTimerExecutor = timerExecutor == null;
-        if (timerExecutor == null) {
-            timerExecutor = MuServerBuilder.defaultTimerExecutor();
-        }
+        ExecutionResources resources = builder.executionResourcesFactory.create(builder.executor());
+        ExecutorService handlerExecutor = resources.application;
+        ExecutorService connectionExecutor = resources.connectionExecutor();
+        ExecutorService http2WriterExecutor = resources.writerExecutor();
 
         var impl = new Mu3ServerImpl(
             acceptors,
@@ -682,18 +513,8 @@ class Mu3ServerImpl implements MuServer {
             builder.maxHeadersSize(),
             limiters,
             tempDir,
-            handlerExecutor,
-            ownsHandlerExecutor,
-            asyncExecutor,
-            ownsAsyncExecutor,
-            connectionExecutor,
-            ownsConnectionExecutor,
-            http2WriterExecutor,
-            ownsHttp2WriterExecutor,
-            connectionMaintenanceExecutor,
-            ownsConnectionMaintenanceExecutor,
-            timerExecutor,
-            ownsTimerExecutor
+            resources,
+            builder.maxConcurrentRequests()
             );
 
         try {
@@ -761,11 +582,11 @@ class Mu3ServerImpl implements MuServer {
     }
 
     ScheduledFuture<?> scheduleConnectionTask(Runnable task, long delay, TimeUnit unit) {
-        return timerExecutor.schedule(() -> tryDispatchConnectionTask(task), delay, unit);
+        return executionResources.timer.schedule(() -> tryDispatchConnectionTask(task), delay, unit);
     }
 
     ScheduledFuture<?> scheduleTimerCallback(Runnable task, long delay, TimeUnit unit) {
-        return timerExecutor.schedule(task, delay, unit);
+        return executionResources.timer.schedule(task, delay, unit);
     }
 
     ScheduledFuture<?> scheduleConnectionTaskAtFixedRate(
@@ -775,7 +596,7 @@ class Mu3ServerImpl implements MuServer {
         TimeUnit unit
     ) {
         var pending = new AtomicBoolean();
-        return timerExecutor.scheduleAtFixedRate(
+        return executionResources.timer.scheduleAtFixedRate(
             () -> {
                 if (pending.compareAndSet(false, true)) {
                     boolean accepted = tryDispatchConnectionTask(() -> {
@@ -798,7 +619,7 @@ class Mu3ServerImpl implements MuServer {
 
     private boolean tryDispatchConnectionTask(Runnable task) {
         try {
-            connectionMaintenanceExecutor.execute(task);
+            executionResources.internal.execute(task);
             return true;
         } catch (RejectedExecutionException e) {
             log.debug("Connection maintenance executor rejected timed work because the server is stopping or overloaded");

--- a/src/main/java/io/muserver/MuServerBuilder.java
+++ b/src/main/java/io/muserver/MuServerBuilder.java
@@ -39,11 +39,8 @@ public class MuServerBuilder {
     private long requestReadTimeoutMillis = TimeUnit.MINUTES.toMillis(2);
     private long idleTimeoutMills = TimeUnit.MINUTES.toMillis(20);
     private @Nullable ExecutorService executor;
-    private @Nullable ExecutorService asyncExecutor;
-    private @Nullable ExecutorService connectionExecutor;
-    private @Nullable ExecutorService http2WriterExecutor;
-    private @Nullable ExecutorService connectionMaintenanceExecutor;
-    private @Nullable ScheduledExecutorService timerExecutor;
+    private int maxConcurrentRequests = 1000;
+    ExecutionResources.Factory executionResourcesFactory = ExecutionResources::create;
     private long maxRequestSize = 24 * 1024 * 1024;
     private @Nullable List<ResponseCompleteListener> responseCompleteListeners;
     private @Nullable List<RequestRejectListener> requestRejectListeners;
@@ -203,24 +200,15 @@ public class MuServerBuilder {
     }
 
     /**
-     * Sets the thread executor service to run requests on. By default, a
-     * server-owned virtual-thread-per-task executor is used when the runtime supports
-     * virtual threads, otherwise {@link Executors#newCachedThreadPool()} is used. A
-     * caller-supplied executor remains owned by the caller and is not shut down when
-     * the server stops.
-     *
-     * <p>Use an executor that is independent from the executor configured by
-     * {@link #withConnectionExecutor(ExecutorService)} to keep request handling isolated
-     * from long-lived connection tasks. If the same executor instance is supplied for
-     * both, HTTP/1 handlers run on their connection task to avoid submitting work back
-     * to an executor that may already be at capacity.</p>
-     *
-     * <p>This executor also dispatches response-completion listeners and serialized
-     * WebSocket lifecycle and message callbacks. A WebSocket connection does not retain
-     * a worker while waiting for frames; each callback is short-lived executor work.</p>
-     *
-     * @param executor The executor service to use to handle requests
-     * @return The current Mu Server builder
+     * Sets the executor for handlers, application callbacks and JAX-RS continuations.
+     * By default Mu uses virtual threads when available, otherwise cached platform threads.
+     * A supplied executor remains caller-owned and must remain available until the server stops.
+     * It must dispatch asynchronously and reject visibly; direct executors, caller-runs and
+     * silent-discard rejection policies are unsupported. Rejected requests receive 503;
+     * rejected continuations fail their exchange and notifications may be dropped.
+     * Blocking adapter I/O runs independently on Mu-owned workers.
+     * @param executor The application executor, or null for Mu's default
+     * @return This builder
      */
     public MuServerBuilder withHandlerExecutor(@Nullable ExecutorService executor) {
         this.executor = executor;
@@ -228,135 +216,25 @@ public class MuServerBuilder {
     }
 
     /**
-     * Sets the executor used for asynchronous request body reads, asynchronous response
-     * writes, request-rejection notifications, and deprecated asynchronous WebSocket
-     * compatibility methods.
-     *
-     * <p>These operations adapt blocking I/O to callback-based APIs and must not use an
-     * executor whose workers can all be retained by connection readers, request handlers,
-     * HTTP/2 writers, or timed maintenance. A single-thread executor is supported:
-     * asynchronous request body delivery releases the worker while waiting for its
-     * {@link DoneCallback}.</p>
-     *
-     * <p>By default, a server-owned virtual-thread-per-task executor is used when the
-     * runtime supports virtual threads, otherwise a cached thread pool is used. A
-     * caller-supplied executor remains owned by the caller and is not shut down when
-     * the server stops.</p>
-     *
-     * @param asyncExecutor The executor for callback-based asynchronous I/O, or
-     *                      <code>null</code> to use the default
-     * @return The current Mu Server builder
+     * Limits admitted unfinished requests across all listeners and HTTP versions.
+     * Queued handlers, suspended async requests and SSE count until exchange cleanup.
+     * Completed WebSocket upgrades release their HTTP request slot. Excess requests receive
+     * 503 without blocking connection readers. HTTP/2 per-connection stream limits still apply.
+     * @param maximum The limit (default 1000), or zero for unlimited
+     * @return This builder
      */
-    public MuServerBuilder withAsyncExecutor(@Nullable ExecutorService asyncExecutor) {
-        this.asyncExecutor = asyncExecutor;
+    public MuServerBuilder withMaxConcurrentRequests(int maximum) {
+        if (maximum < 0) throw new IllegalArgumentException("maximum must be non-negative");
+        maxConcurrentRequests = maximum;
         return this;
     }
 
     /**
-     * Sets the executor used for connection setup and connection input processing.
-     *
-     * <p>HTTP/1 uses one long-lived keep-alive connection task and HTTP/2 uses one
-     * long-lived reader task per connection on this executor. Request handlers are
-     * submitted separately to the executor configured by
-     * {@link #withHandlerExecutor(ExecutorService)}. HTTP/2 writes use the executor configured by
-     * {@link #withHttp2WriterExecutor(ExecutorService)} so a fixed-size connection pool
-     * cannot be occupied by readers while their writers wait in the same queue.</p>
-     *
-     * <p>Use an executor that is independent from the executor configured by
-     * {@link #withHandlerExecutor(ExecutorService)} to keep long-lived connection tasks
-     * from consuming handler capacity. If the same executor instance is supplied for
-     * both, HTTP/1 handlers run on their connection task to avoid self-deadlock.</p>
-     *
-     * <p>By default, a server-owned virtual-thread-per-task executor is used when the
-     * runtime supports virtual threads, otherwise a cached thread pool is used. A
-     * caller-supplied executor remains owned by the caller and is not shut down when
-     * the server stops.</p>
-     *
-     * @param connectionExecutor The executor for connection setup and input processing, or
-     *                           <code>null</code> to use the default
-     * @return The current Mu Server builder
+     * Gets the server-wide limit on unfinished requests.
+     * @return The limit; zero means unlimited.
      */
-    public MuServerBuilder withConnectionExecutor(@Nullable ExecutorService connectionExecutor) {
-        this.connectionExecutor = connectionExecutor;
-        return this;
-    }
-
-    /**
-     * Sets the executor used by HTTP/2 connection writers.
-     *
-     * <p>HTTP/2 schedules serialized drain tasks on this executor when a connection has
-     * frames that can be written. A task returns when no further write can make progress,
-     * so an idle connection does not retain a worker. At most one task writes for a
-     * connection at a time.</p>
-     *
-     * <p>This executor must be independent from the executor configured by
-     * {@link #withConnectionExecutor(ExecutorService)}: supplying the same bounded
-     * executor to both methods can allow reader tasks to occupy every thread while writer
-     * tasks wait in its queue. A bounded writer executor limits the number of connections
-     * that can perform socket writes concurrently.</p>
-     *
-     * <p>By default, a server-owned virtual-thread-per-task executor is used when the
-     * runtime supports virtual threads, otherwise a cached thread pool is used. A
-     * caller-supplied executor remains owned by the caller and is not shut down when
-     * the server stops.</p>
-     *
-     * @param http2WriterExecutor The executor for HTTP/2 connection writers, or
-     *                            <code>null</code> to use the default
-     * @return The current Mu Server builder
-     */
-    public MuServerBuilder withHttp2WriterExecutor(@Nullable ExecutorService http2WriterExecutor) {
-        this.http2WriterExecutor = http2WriterExecutor;
-        return this;
-    }
-
-    /**
-     * Sets the executor used for timed connection maintenance, including idle timeout
-     * checks and automatic WebSocket pings.
-     *
-     * <p>Timer threads only determine when work is due and dispatch it to this executor.
-     * This executor must be independent from bounded executors containing long-lived
-     * connection tasks, otherwise those tasks can prevent timeouts and pings from
-     * running.</p>
-     *
-     * <p>By default, a server-owned virtual-thread-per-task executor is used when the
-     * runtime supports virtual threads, otherwise a cached thread pool is used. A
-     * caller-supplied executor remains owned by the caller and is not shut down when
-     * the server stops.</p>
-     *
-     * @param connectionMaintenanceExecutor The executor for timed connection work, or
-     *                                      <code>null</code> to use the default
-     * @return The current Mu Server builder
-     */
-    public MuServerBuilder withConnectionMaintenanceExecutor(
-        @Nullable ExecutorService connectionMaintenanceExecutor
-    ) {
-        this.connectionMaintenanceExecutor = connectionMaintenanceExecutor;
-        return this;
-    }
-
-    /**
-     * Sets the executor used to schedule server connection timers.
-     *
-     * <p>Timer threads only determine when work is due. Connection work is dispatched
-     * to the executor configured by
-     * {@link #withConnectionMaintenanceExecutor(ExecutorService)}
-     * so that timer threads do not perform socket I/O or invoke application callbacks.</p>
-     *
-     * <p>The supplied scheduled executor must remain able to execute brief scheduling
-     * callbacks promptly. It should not be shared with an executor that can be occupied
-     * by long-running tasks.</p>
-     *
-     * <p>By default, a server-owned single-thread scheduled executor is used. A
-     * caller-supplied executor remains owned by the caller and is not shut down when
-     * the server stops.</p>
-     *
-     * @param timerExecutor The executor used to schedule connection timers, or
-     *                      <code>null</code> to use the default
-     * @return The current Mu Server builder
-     */
-    public MuServerBuilder withTimerExecutor(@Nullable ScheduledExecutorService timerExecutor) {
-        this.timerExecutor = timerExecutor;
-        return this;
+    public int maxConcurrentRequests() {
+        return maxConcurrentRequests;
     }
 
     /**
@@ -528,7 +406,7 @@ public class MuServerBuilder {
      * headers are too large). Such rejections are never reported to
      * {@link #addResponseCompleteListener(ResponseCompleteListener)}.
      * Listeners are dispatched on the executor configured by
-     * {@link #withAsyncExecutor(ExecutorService)} so they cannot block connection input
+     * {@link #withHandlerExecutor(ExecutorService)} so they cannot block connection input
      * processing.
      *
      * @param listener A listener. If <code>null</code>, then nothing is added.
@@ -754,51 +632,6 @@ public class MuServerBuilder {
     }
 
     /**
-     * Gets the executor used for callback-based asynchronous I/O.
-     *
-     * @return The configured executor, or <code>null</code> if the default executor will be used.
-     */
-    public @Nullable ExecutorService asyncExecutor() {
-        return asyncExecutor;
-    }
-
-    /**
-     * Gets the executor used for connection setup and connection input processing.
-     *
-     * @return The configured executor, or <code>null</code> if the default executor will be used.
-     */
-    public @Nullable ExecutorService connectionExecutor() {
-        return connectionExecutor;
-    }
-
-    /**
-     * Gets the executor used by HTTP/2 connection writers.
-     *
-     * @return The configured executor, or <code>null</code> if the default executor will be used.
-     */
-    public @Nullable ExecutorService http2WriterExecutor() {
-        return http2WriterExecutor;
-    }
-
-    /**
-     * Gets the executor used for timed connection maintenance.
-     *
-     * @return The configured executor, or <code>null</code> if the default executor will be used.
-     */
-    public @Nullable ExecutorService connectionMaintenanceExecutor() {
-        return connectionMaintenanceExecutor;
-    }
-
-    /**
-     * Gets the executor used to schedule server connection timers.
-     *
-     * @return The configured executor, or <code>null</code> if the default executor will be used.
-     */
-    public @Nullable ScheduledExecutorService timerExecutor() {
-        return timerExecutor;
-    }
-
-    /**
      * Gets the maximum allowed request body size.
      *
      * @return The request body size limit in bytes.
@@ -906,10 +739,6 @@ public class MuServerBuilder {
             ", requestReadTimeoutMillis=" + requestReadTimeoutMillis +
             ", idleTimeoutMills=" + idleTimeoutMills +
             ", executor=" + executor +
-            ", connectionExecutor=" + connectionExecutor +
-            ", http2WriterExecutor=" + http2WriterExecutor +
-            ", connectionMaintenanceExecutor=" + connectionMaintenanceExecutor +
-            ", timerExecutor=" + timerExecutor +
             ", maxRequestSize=" + maxRequestSize +
             ", responseCompleteListeners=" + responseCompleteListeners +
             ", requestRejectListeners=" + requestRejectListeners +

--- a/src/main/java/io/muserver/MuWebSocketSession.java
+++ b/src/main/java/io/muserver/MuWebSocketSession.java
@@ -19,16 +19,19 @@ public interface MuWebSocketSession {
 
     private void runAsync(Runnable task, DoneCallback doneCallback) {
         Executor executor = this instanceof WebsocketConnection
-            ? ((WebsocketConnection) this).asyncExecutor()
-            : ForkJoinPool.commonPool();
-        try {
-            CompletableFuture.runAsync(task, executor);
-        } catch (RuntimeException failure) {
-            try {
-                doneCallback.onComplete(failure);
-            } catch (Exception ignored) {
+            ? ((WebsocketConnection) this).asyncExecutor() : ForkJoinPool.commonPool();
+        CompletableFuture<Void> result;
+        try { result = CompletableFuture.runAsync(task, executor); }
+        catch (RuntimeException failure) { result = CompletableFuture.failedFuture(failure); }
+        result.whenComplete((ignored, failure) -> {
+            Throwable cause = failure instanceof java.util.concurrent.CompletionException ? failure.getCause() : failure;
+            if (this instanceof WebsocketConnection) {
+                ((WebsocketConnection) this).dispatchWriteCallback(doneCallback, cause);
+            } else {
+                try { doneCallback.onComplete(cause); }
+                catch (Exception ignoredFailure) { }
             }
-        }
+        });
     }
 
     /**
@@ -73,12 +76,8 @@ public interface MuWebSocketSession {
         runAsync(() -> {
             try {
                 sendText(message);
-                doneCallback.onComplete(null);
             } catch (Exception e) {
-                try {
-                    doneCallback.onComplete(e);
-                } catch (Exception ignored) {
-                }
+                throw new java.util.concurrent.CompletionException(e);
             }
         }, doneCallback);
     }
@@ -98,12 +97,8 @@ public interface MuWebSocketSession {
         runAsync(() -> {
             try {
                 sendTextFragment(ByteBuffer.wrap(message.getBytes(StandardCharsets.UTF_8)), isLastFragment);
-                doneCallback.onComplete(null);
             } catch (Exception e) {
-                try {
-                    doneCallback.onComplete(e);
-                } catch (Exception ignored) {
-                }
+                throw new java.util.concurrent.CompletionException(e);
             }
         }, doneCallback);
     }
@@ -130,12 +125,8 @@ public interface MuWebSocketSession {
         runAsync(() -> {
             try {
                 sendBinary(message);
-                doneCallback.onComplete(null);
             } catch (Exception e) {
-                try {
-                    doneCallback.onComplete(e);
-                } catch (Exception ignored) {
-                }
+                throw new java.util.concurrent.CompletionException(e);
             }
         }, doneCallback);
     }
@@ -163,12 +154,8 @@ public interface MuWebSocketSession {
         runAsync(() -> {
             try {
                 sendBinaryFragment(message, isLastFragment);
-                doneCallback.onComplete(null);
             } catch (Exception e) {
-                try {
-                    doneCallback.onComplete(e);
-                } catch (Exception ignored) {
-                }
+                throw new java.util.concurrent.CompletionException(e);
             }
         }, doneCallback);
     }
@@ -194,12 +181,8 @@ public interface MuWebSocketSession {
         runAsync(() -> {
             try {
                 sendPing(payload);
-                doneCallback.onComplete(null);
             } catch (Exception e) {
-                try {
-                    doneCallback.onComplete(e);
-                } catch (Exception ignored) {
-                }
+                throw new java.util.concurrent.CompletionException(e);
             }
         }, doneCallback);
     }
@@ -225,12 +208,8 @@ public interface MuWebSocketSession {
         runAsync(() -> {
             try {
                 sendPong(payload);
-                doneCallback.onComplete(null);
             } catch (Exception e) {
-                try {
-                    doneCallback.onComplete(e);
-                } catch (Exception ignored) {
-                }
+                throw new java.util.concurrent.CompletionException(e);
             }
         }, doneCallback);
     }

--- a/src/main/java/io/muserver/RequestAdmission.java
+++ b/src/main/java/io/muserver/RequestAdmission.java
@@ -1,0 +1,28 @@
+package io.muserver;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.jspecify.annotations.Nullable;
+
+/** Nonblocking server-wide admission, independent of executor or connection capacity. */
+final class RequestAdmission {
+    private final int maximum;
+    private final AtomicInteger admitted = new AtomicInteger();
+
+    RequestAdmission(int maximum) { this.maximum = maximum; }
+
+    @Nullable Slot tryAcquire() {
+        for (;;) {
+            int current = admitted.get();
+            if (maximum != 0 && current >= maximum) return null;
+            if (admitted.compareAndSet(current, current + 1)) return new Slot();
+        }
+    }
+
+    final class Slot implements AutoCloseable {
+        private final AtomicBoolean released = new AtomicBoolean();
+        @Override public void close() {
+            if (released.compareAndSet(false, true)) admitted.decrementAndGet();
+        }
+    }
+}

--- a/src/main/java/io/muserver/SerialApplicationTasks.java
+++ b/src/main/java/io/muserver/SerialApplicationTasks.java
@@ -1,0 +1,59 @@
+package io.muserver;
+
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Consumer;
+
+/** One application's callback mailbox; never holds an I/O worker while callbacks run. */
+final class SerialApplicationTasks {
+    private final Mu3ServerImpl server;
+    private final Queue<Entry> tasks = new ConcurrentLinkedQueue<>();
+    private final AtomicBoolean running = new AtomicBoolean();
+
+    SerialApplicationTasks(Mu3ServerImpl server) { this.server = server; }
+
+    void submit(Runnable task, Consumer<RejectedExecutionException> onRejected) {
+        tasks.add(new Entry(task, onRejected));
+        if (running.compareAndSet(false, true)) {
+            RejectedExecutionException rejected = server.executeTrackedApplicationTask(this::drain, "async callback");
+            if (rejected != null) {
+                Entry entry;
+                while ((entry = tasks.poll()) != null) entry.onRejected.accept(rejected);
+                running.set(false);
+                // A concurrent submit may have observed running before it was cleared.
+                if (!tasks.isEmpty()) scheduleRemaining();
+            }
+        }
+    }
+
+    private void scheduleRemaining() {
+        if (!running.compareAndSet(false, true)) return;
+        RejectedExecutionException rejected = server.executeTrackedApplicationTask(this::drain, "async callback");
+        if (rejected != null) {
+            Entry entry;
+            while ((entry = tasks.poll()) != null) entry.onRejected.accept(rejected);
+            running.set(false);
+            if (!tasks.isEmpty()) scheduleRemaining();
+        }
+    }
+
+    private void drain() {
+        for (;;) {
+            Entry entry;
+            while ((entry = tasks.poll()) != null) entry.task.run();
+            running.set(false);
+            if (tasks.isEmpty() || !running.compareAndSet(false, true)) return;
+        }
+    }
+
+    private static final class Entry {
+        final Runnable task;
+        final Consumer<RejectedExecutionException> onRejected;
+        Entry(Runnable task, Consumer<RejectedExecutionException> onRejected) {
+            this.task = task;
+            this.onRejected = onRejected;
+        }
+    }
+}

--- a/src/main/java/io/muserver/WebSocketCompatibility.java
+++ b/src/main/java/io/muserver/WebSocketCompatibility.java
@@ -1,0 +1,45 @@
+package io.muserver;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import org.jspecify.annotations.Nullable;
+
+/** Lets the connection mailbox suspend legacy callback events without retaining a worker. */
+final class WebSocketCompatibility {
+    private static final ThreadLocal<Context> current = new ThreadLocal<>();
+
+    @FunctionalInterface
+    interface Event { void run() throws Exception; }
+
+    static @Nullable CompletableFuture<@Nullable Void> invoke(Event event) throws Exception {
+        Context previous = current.get();
+        Context context = new Context();
+        current.set(context);
+        try {
+            event.run();
+            return context.completion;
+        } finally {
+            if (previous == null) current.remove();
+            else current.set(previous);
+        }
+    }
+
+    static void awaitOrDefer(CompletableFuture<@Nullable Void> completion) throws Exception {
+        Context context = current.get();
+        if (context != null) {
+            context.completion = completion;
+            return;
+        }
+        try { completion.get(); }
+        catch (ExecutionException e) {
+            Throwable cause = e.getCause();
+            if (cause instanceof Exception) throw (Exception) cause;
+            if (cause instanceof Error) throw (Error) cause;
+            throw e;
+        }
+    }
+
+    private static final class Context {
+        @Nullable CompletableFuture<@Nullable Void> completion;
+    }
+}

--- a/src/main/java/io/muserver/WebsocketConnection.java
+++ b/src/main/java/io/muserver/WebsocketConnection.java
@@ -36,8 +36,8 @@ class WebsocketConnection implements MuWebSocketSession {
     private final WebsocketLifecycle lifecycle = new WebsocketLifecycle();
     private final Http1Connection httpConnection;
     private final Mu3ServerImpl server;
+    private final SerialApplicationTasks writeCallbacks;
     private final MuWebSocket webSocket;
-    private final boolean eventsRunOnConnectionTask;
     private final Queue<ApplicationEventTask> applicationEvents = new ConcurrentLinkedQueue<>();
     private final AtomicBoolean applicationEventRunnerScheduled = new AtomicBoolean();
     private final AtomicBoolean errorEventQueued = new AtomicBoolean();
@@ -48,7 +48,6 @@ class WebsocketConnection implements MuWebSocketSession {
     private final @Nullable WebsocketPingTracker pingTracker;
     private ReadState readState = ReadState.NONE;
     private volatile @Nullable ScheduledFuture<?> pingFuture;
-    private volatile @Nullable Thread connectionTaskThread;
 
     private enum ReadState {
         NONE, TEXT, BINARY,
@@ -75,9 +74,9 @@ class WebsocketConnection implements MuWebSocketSession {
     WebsocketConnection(Http1Connection httpConnection, MuWebSocket webSocket, WebSocketHandlerBuilder.Settings settings) {
         this.httpConnection = httpConnection;
         this.server = httpConnection.serverImpl();
+        this.writeCallbacks = new SerialApplicationTasks(server);
         this.webSocket = webSocket;
         this.settings = settings;
-        this.eventsRunOnConnectionTask = httpConnection.webSocketEventsRunOnConnectionTask();
         if (settings.pingIntervalMillis == 0) {
             pingTracker = null;
         } else {
@@ -90,8 +89,15 @@ class WebsocketConnection implements MuWebSocketSession {
         return webSocket;
     }
 
+    void dispatchWriteCallback(DoneCallback callback, @Nullable Throwable failure) {
+        writeCallbacks.submit(() -> {
+            try { callback.onComplete(failure); }
+            catch (Exception callbackFailure) { log.warn("WebSocket write callback failed", callbackFailure); }
+        }, rejected -> httpConnection.forceShutdown());
+    }
+
     ExecutorService asyncExecutor() {
-        return server.asyncExecutor();
+        return server.internalExecutor();
     }
 
     private void startPinging() {
@@ -120,7 +126,6 @@ class WebsocketConnection implements MuWebSocketSession {
         this.inputStream = inputStream;
         this.outputStream = outputStream;
         this.buffer = ByteBuffer.wrap(readBuffer).flip();
-        connectionTaskThread = Thread.currentThread();
 
         try {
             lifecycle.onConnected();
@@ -280,15 +285,11 @@ class WebsocketConnection implements MuWebSocketSession {
                 invokeApplicationError(e, errorState);
             }
         } finally {
-            if (eventsRunOnConnectionTask) {
-                drainApplicationEvents();
-            }
             ScheduledFuture<?> currentPing = pingFuture;
             if (currentPing != null) {
                 currentPing.cancel(false);
                 pingFuture = null;
             }
-            connectionTaskThread = null;
         }
     }
 
@@ -402,18 +403,6 @@ class WebsocketConnection implements MuWebSocketSession {
     }
 
     private void invokeApplicationEvent(ApplicationEvent event) throws InterruptedException, ApplicationEventFailure {
-        if (eventsRunOnConnectionTask) {
-            try {
-                callApplicationEvent(event);
-            } catch (Exception | Error failure) {
-                throw new ApplicationEventFailure(failure);
-            } finally {
-                // A terminal event can be queued by a write attempted inside a callback.
-                // Drain it before returning to the blocking socket read.
-                drainApplicationEvents();
-            }
-            return;
-        }
         CompletableFuture<@Nullable Void> completion = enqueueApplicationEvent(event);
         try {
             completion.get();
@@ -432,17 +421,8 @@ class WebsocketConnection implements MuWebSocketSession {
         }
     }
 
-    private void callApplicationEvent(ApplicationEvent event) throws Exception {
-        try {
-            server.callHandlerApplicationTask(() -> {
-                event.run();
-                return null;
-            });
-        } catch (Exception | Error failure) {
-            throw failure;
-        } catch (Throwable failure) {
-            throw new MuException("Unexpected WebSocket callback failure", failure);
-        }
+    private @Nullable CompletableFuture<@Nullable Void> callApplicationEvent(ApplicationEvent event) throws Exception {
+        return WebSocketCompatibility.invoke(event::run);
     }
 
     private void invokeApplicationError(Throwable cause, WebsocketSessionState errorState) throws InterruptedException, ApplicationEventFailure {
@@ -471,16 +451,7 @@ class WebsocketConnection implements MuWebSocketSession {
     private CompletableFuture<@Nullable Void> enqueueApplicationEvent(ApplicationEvent event) {
         var task = new ApplicationEventTask(event);
         applicationEvents.add(task);
-        if (eventsRunOnConnectionTask) {
-            if (Thread.currentThread() != connectionTaskThread) {
-                // A shared single-thread executor cannot run another task while its
-                // connection reader is blocked. Terminal external events wake that reader,
-                // which drains this mailbox from its finally block.
-                httpConnection.wakeWebSocketReader();
-            }
-        } else {
-            scheduleApplicationEventRunner();
-        }
+        scheduleApplicationEventRunner();
         return task.completion;
     }
 
@@ -503,24 +474,29 @@ class WebsocketConnection implements MuWebSocketSession {
     }
 
     private void runApplicationEvents() {
-        while (true) {
-            drainApplicationEvents();
-            applicationEventRunnerScheduled.set(false);
-            if (applicationEvents.isEmpty()
-                || !applicationEventRunnerScheduled.compareAndSet(false, true)) {
-                return;
+        for (;;) {
+            ApplicationEventTask task = applicationEvents.poll();
+            if (task == null) {
+                applicationEventRunnerScheduled.set(false);
+                if (applicationEvents.isEmpty()
+                    || !applicationEventRunnerScheduled.compareAndSet(false, true)) return;
+                continue;
             }
-        }
-    }
-
-    private void drainApplicationEvents() {
-        ApplicationEventTask task;
-        while ((task = applicationEvents.poll()) != null) {
             try {
-                callApplicationEvent(task.event);
+                CompletableFuture<@Nullable Void> deferred = callApplicationEvent(task.event);
+                if (deferred != null && !deferred.isDone()) {
+                    deferred.whenComplete((ignored, failure) -> {
+                        if (failure == null) task.completion.complete(null);
+                        else task.completion.completeExceptionally(failure);
+                        applicationEventRunnerScheduled.set(false);
+                        if (!applicationEvents.isEmpty()) scheduleApplicationEventRunner();
+                    });
+                    return;
+                }
+                if (deferred != null) deferred.join();
                 task.completion.complete(null);
-            } catch (Throwable t) {
-                task.completion.completeExceptionally(t);
+            } catch (Throwable failure) {
+                task.completion.completeExceptionally(failure);
             }
         }
     }

--- a/src/test/java/io/muserver/ExecutionDomainsTest.java
+++ b/src/test/java/io/muserver/ExecutionDomainsTest.java
@@ -80,8 +80,7 @@ class ExecutionDomainsTest {
         });
         assertThat(blockerStarted.await(5, TimeUnit.SECONDS), is(true));
 
-        server = httpServer()
-            .withConnectionExecutor(connectionExecutor)
+        server = io.muserver.TestExecutionResources.configure(httpServer(), connectionExecutor, null, null, null)
             .withHandlerExecutor(handlerExecutor)
             .addHandler((request, response) -> {
                 handledRequests.incrementAndGet();
@@ -120,8 +119,7 @@ class ExecutionDomainsTest {
                 () -> connectionExecutor.getQueue().size(),
                 equalTo(0)
             );
-            connectionExecutor.submit(() -> {
-            }).get(5, TimeUnit.SECONDS);
+            assertThat(connectionExecutor.isShutdown(), is(true));
 
             assertThat(handledRequests.get(), equalTo(0));
         } finally {
@@ -203,11 +201,9 @@ class ExecutionDomainsTest {
             }
         });
 
-        server = httpServer()
+        server = io.muserver.TestExecutionResources.configure(httpServer(), connectionExecutor, null, null, null)
             .withHttp2Config(Http2ConfigBuilder.http2Enabled())
             .withHandlerExecutor(handlerExecutor)
-            .withAsyncExecutor(asyncExecutor)
-            .withConnectionExecutor(connectionExecutor)
             .addRequestRejectListener(info -> {
                 rejectionThread.complete(Thread.currentThread().getName());
                 rejectedRequest.complete(info);
@@ -259,13 +255,8 @@ class ExecutionDomainsTest {
                 is(true)
             );
 
-            var rejection = rejectedRequest.get(5, TimeUnit.SECONDS);
-            assertThat(rejection.status(), equalTo(503));
-            assertThat(rejection.reason(), equalTo("503 Service Unavailable"));
-            assertThat(rejection.method(), equalTo(Optional.of("GET")));
-            assertThat(rejection.uri().orElseThrow().getPath(), equalTo("/hello"));
-            assertThat(rejection.connection().protocol(), equalTo("HTTP/2"));
-            assertThat(rejectionThread.get(5, TimeUnit.SECONDS), startsWith("async-"));
+            assertThat(rejectedRequest.isDone(), is(false));
+            assertThat(rejectionThread.isDone(), is(false));
 
             byte[] secondPing = {7, 6, 5, 4, 3, 2, 1, 0};
             con.writeFrame(RFCTestUtils.utf8DataFrame(1, true, "discarded"))
@@ -305,65 +296,13 @@ class ExecutionDomainsTest {
     }
 
     @Test
-    void rejectedAsyncExecutorFallsBackWithoutBlockingTheHttp2Reader() throws Exception {
-        var asyncExecutor = track(Executors.newSingleThreadExecutor(namedThreads("rejected-async-")));
-        asyncExecutor.shutdown();
-        var handlerExecutor = track(Executors.newSingleThreadExecutor(namedThreads("handler-")));
-        var connectionExecutor = track(Executors.newSingleThreadExecutor(namedThreads("connection-")));
-        var releaseListener = new CountDownLatch(1);
-        var rejectionThread = new CompletableFuture<String>();
-        server = httpServer()
-            .withHttp2Config(Http2ConfigBuilder.http2Enabled())
-            .withMaxHeadersSize(1024)
-            .withAsyncExecutor(asyncExecutor)
-            .withHandlerExecutor(handlerExecutor)
-            .withConnectionExecutor(connectionExecutor)
-            .addRequestRejectListener(info -> {
-                rejectionThread.complete(Thread.currentThread().getName());
-                try {
-                    releaseListener.await();
-                } catch (InterruptedException e) {
-                    Thread.currentThread().interrupt();
-                }
-            })
-            .start();
-
-        try (var client = new H2Client();
-             var con = client.connectClearText(server)) {
-            con.handshake();
-            con.socket().setSoTimeout(1000);
-            FieldBlock headers = RFCTestUtils.getHelloHeaders("http", server.uri().getPort());
-            headers.add("x-big", "a".repeat(2000));
-            con.writeFrame(new Http2HeadersFrame(1, true, headers)).flush();
-
-            Http2HeadersFrame response =
-                RFCTestUtils.readIgnoringWindowUpdates(con, Http2HeadersFrame.class);
-            assertThat(response.headers().get(":status"), equalTo("431"));
-            assertThat(
-                RFCTestUtils.readIgnoringWindowUpdates(con, Http2DataFrame.class).endStream(),
-                is(true)
-            );
-            assertThat(rejectionThread.get(5, TimeUnit.SECONDS), startsWith("handler-"));
-
-            byte[] pingData = {0, 1, 2, 3, 4, 5, 6, 7};
-            con.writeFrame(new Http2Ping(false, pingData)).flush();
-            assertThat(
-                RFCTestUtils.readIgnoringWindowUpdates(con, Http2Ping.class),
-                equalTo(new Http2Ping(true, pingData))
-            );
-        } finally {
-            releaseListener.countDown();
-        }
-    }
-
-    @Test
     void requestRejectionListenerFailureDoesNotSkipLaterListeners() throws Exception {
         var asyncExecutor = track(Executors.newSingleThreadExecutor(namedThreads("async-")));
         var firstListenerCalls = new AtomicInteger();
         var laterListenerThread = new CompletableFuture<String>();
         server = httpServer()
             .withMaxHeadersSize(1024)
-            .withAsyncExecutor(asyncExecutor)
+            .withHandlerExecutor(asyncExecutor)
             .addRequestRejectListener(info -> {
                 firstListenerCalls.incrementAndGet();
                 throw new AssertionError("deliberate request rejection listener failure");
@@ -386,7 +325,7 @@ class ExecutionDomainsTest {
     }
 
     @Test
-    void http1RejectionResponsePrecedesFallbackListenerDelivery() throws Exception {
+    void http1RejectionStillReachesTheWireWhenNotificationDispatchRejects() throws Exception {
         var rejectedAsyncExecutor =
             track(Executors.newSingleThreadExecutor(namedThreads("rejected-async-")));
         rejectedAsyncExecutor.shutdown();
@@ -395,7 +334,7 @@ class ExecutionDomainsTest {
         var releaseListener = new CountDownLatch(1);
         server = httpServer()
             .withMaxHeadersSize(1024)
-            .withAsyncExecutor(rejectedAsyncExecutor)
+            .withHandlerExecutor(rejectedAsyncExecutor)
             .addRequestRejectListener(info -> {
                 listenerEntered.countDown();
                 try {
@@ -410,9 +349,9 @@ class ExecutionDomainsTest {
             client.writeRequestLine(Method.GET, "/")
                 .writeHeader("x-big", "a".repeat(2000))
                 .flushHeaders();
-            assertThat(listenerEntered.await(5, TimeUnit.SECONDS), is(true));
             Future<String> responseLine = clientExecutor.submit(client::readLine);
             assertThat(responseLine.get(2, TimeUnit.SECONDS), startsWith("HTTP/1.1 431"));
+            assertThat(listenerEntered.getCount(), is(1L));
         } finally {
             releaseListener.countDown();
         }
@@ -423,10 +362,8 @@ class ExecutionDomainsTest {
         var connectionExecutor = track(Executors.newSingleThreadExecutor(namedThreads("connection-")));
         var writerExecutor = track(Executors.newSingleThreadExecutor(namedThreads("h2-writer-")));
 
-        server = httpServer()
+        server = io.muserver.TestExecutionResources.configure(httpServer(), connectionExecutor, writerExecutor, null, null)
             .withHttp2Config(Http2ConfigBuilder.http2Enabled())
-            .withConnectionExecutor(connectionExecutor)
-            .withHttp2WriterExecutor(writerExecutor)
             .start();
 
         try (var client = new H2Client();
@@ -448,10 +385,9 @@ class ExecutionDomainsTest {
         var clientExecutor = track(Executors.newSingleThreadExecutor(namedThreads("client-")));
         var listenerEntered = new CountDownLatch(1);
         var releaseListener = new CountDownLatch(1);
-        server = httpServer()
+        server = io.muserver.TestExecutionResources.configure(httpServer(), connectionExecutor, null, null, null)
             .withMaxHeadersSize(1024)
-            .withAsyncExecutor(asyncExecutor)
-            .withConnectionExecutor(connectionExecutor)
+            .withHandlerExecutor(asyncExecutor)
             .addRequestRejectListener(info -> {
                 listenerEntered.countDown();
                 try {
@@ -553,7 +489,7 @@ class ExecutionDomainsTest {
         var secondCallbackRan = new CountDownLatch(1);
         server = httpServer()
             .withMaxHeadersSize(1024)
-            .withAsyncExecutor(asyncExecutor)
+            .withHandlerExecutor(asyncExecutor)
             .addRequestRejectListener(info -> {
                 if (callbackNumber.incrementAndGet() == 1) {
                     try {
@@ -599,7 +535,7 @@ class ExecutionDomainsTest {
         var releaseCallback = new CountDownLatch(1);
         server = httpServer()
             .withMaxHeadersSize(1024)
-            .withAsyncExecutor(asyncExecutor)
+            .withHandlerExecutor(asyncExecutor)
             .addRequestRejectListener(info -> {
                 try {
                     localStopResult.complete(
@@ -645,9 +581,8 @@ class ExecutionDomainsTest {
         var handlerExecutor = track(Executors.newSingleThreadExecutor(namedThreads("handler-")));
         var connectionExecutor = track(Executors.newCachedThreadPool(namedThreads("connection-")));
         var clientExecutor = track(Executors.newSingleThreadExecutor(namedThreads("client-")));
-        server = httpServer()
+        server = io.muserver.TestExecutionResources.configure(httpServer(), connectionExecutor, null, null, null)
             .withHandlerExecutor(handlerExecutor)
-            .withConnectionExecutor(connectionExecutor)
             .addHandler(Method.GET, "/", (request, response, pathParams) ->
                 response.write(Thread.currentThread().getName()))
             .start();
@@ -671,9 +606,8 @@ class ExecutionDomainsTest {
     void aSharedConnectionAndHandlerExecutorDoesNotSubmitBackToItself() throws Exception {
         var sharedExecutor = track(Executors.newSingleThreadExecutor(namedThreads("shared-")));
         var completionThread = new CompletableFuture<String>();
-        server = httpServer()
+        server = io.muserver.TestExecutionResources.configure(httpServer(), null, null, null, null)
             .withHandlerExecutor(sharedExecutor)
-            .withConnectionExecutor(sharedExecutor)
             .addResponseCompleteListener(info ->
                 completionThread.complete(Thread.currentThread().getName())
             )
@@ -695,9 +629,8 @@ class ExecutionDomainsTest {
         var connectionExecutor = track(Executors.newCachedThreadPool(namedThreads("connection-")));
         var responseCompletionThread = new CompletableFuture<String>();
         var serverCompletionThread = new CompletableFuture<String>();
-        server = httpServer()
+        server = io.muserver.TestExecutionResources.configure(httpServer(), connectionExecutor, null, null, null)
             .withHandlerExecutor(handlerExecutor)
-            .withConnectionExecutor(connectionExecutor)
             .addResponseCompleteListener(info ->
                 serverCompletionThread.complete(Thread.currentThread().getName())
             )
@@ -729,9 +662,8 @@ class ExecutionDomainsTest {
         var firstListenerThread = new CompletableFuture<String>();
         var lateListenerThread = new CompletableFuture<String>();
         var serverListenerFinished = new CompletableFuture<Void>();
-        server = httpServer()
+        server = io.muserver.TestExecutionResources.configure(httpServer(), connectionExecutor, null, null, null)
             .withHandlerExecutor(handlerExecutor)
-            .withConnectionExecutor(connectionExecutor)
             .addResponseCompleteListener(info -> serverListenerFinished.complete(null))
             .addHandler(Method.GET, "/", (request, response, pathParams) -> {
                 response.addCompletionListener(info -> {
@@ -782,9 +714,8 @@ class ExecutionDomainsTest {
         var responseRef = new CompletableFuture<MuResponse>();
         var events = new CopyOnWriteArrayList<String>();
         var serverListenersFinished = new CompletableFuture<Void>();
-        server = httpServer()
+        server = io.muserver.TestExecutionResources.configure(httpServer(), connectionExecutor, null, null, null)
             .withHandlerExecutor(handlerExecutor)
-            .withConnectionExecutor(connectionExecutor)
             .addResponseCompleteListener(info -> {
                 events.add("server-failing");
                 throw new AssertionError("deliberate server listener failure");
@@ -838,9 +769,8 @@ class ExecutionDomainsTest {
         var clientExecutor = track(Executors.newSingleThreadExecutor(namedThreads("client-")));
         var firstCompletionStarted = new CountDownLatch(1);
         var releaseFirstCompletion = new CountDownLatch(1);
-        server = httpServer()
+        server = io.muserver.TestExecutionResources.configure(httpServer(), connectionExecutor, null, null, null)
             .withHandlerExecutor(handlerExecutor)
-            .withConnectionExecutor(connectionExecutor)
             .addResponseCompleteListener(info -> {
                 if (info.request().relativePath().equals("/first")) {
                     firstCompletionStarted.countDown();
@@ -882,9 +812,8 @@ class ExecutionDomainsTest {
         var clientExecutor = track(Executors.newSingleThreadExecutor(namedThreads("client-")));
         var completionStarted = new CountDownLatch(1);
         var releaseCompletion = new CountDownLatch(1);
-        server = httpServer()
+        server = io.muserver.TestExecutionResources.configure(httpServer(), connectionExecutor, null, null, null)
             .withHandlerExecutor(handlerExecutor)
-            .withConnectionExecutor(connectionExecutor)
             .addResponseCompleteListener(info -> {
                 completionStarted.countDown();
                 try {
@@ -920,33 +849,6 @@ class ExecutionDomainsTest {
     }
 
     @Test
-    void rejectedHandlerDispatchFallsBackWithoutRunningCompletionListenersOnTheHttp1Reader() throws Exception {
-        var handlerExecutor = track(Executors.newSingleThreadExecutor(namedThreads("handler-")));
-        var asyncExecutor = track(Executors.newSingleThreadExecutor(namedThreads("async-")));
-        var connectionExecutor = track(Executors.newSingleThreadExecutor(namedThreads("connection-")));
-        var completionThread = new CompletableFuture<String>();
-        server = httpServer()
-            .withHandlerExecutor(handlerExecutor)
-            .withAsyncExecutor(asyncExecutor)
-            .withConnectionExecutor(connectionExecutor)
-            .addResponseCompleteListener(info ->
-                completionThread.complete(Thread.currentThread().getName())
-            )
-            .addHandler(Method.GET, "/", (request, response, pathParams) -> {
-                response.write("done");
-                handlerExecutor.shutdown();
-            })
-            .start();
-
-        try (var client = Http1Client.connect(server)) {
-            client.writeRequestLine(Method.GET, "/").flushHeaders();
-            assertThat(client.readLine(), equalTo("HTTP/1.1 200 OK"));
-            assertThat(client.readBody(client.readHeaders()), equalTo("done"));
-        }
-        assertThat(completionThread.get(5, TimeUnit.SECONDS), startsWith("async-"));
-    }
-
-    @Test
     void asyncCompletionIsATerminalGateForLaterWrites() throws Exception {
         var handlerExecutor = track(Executors.newSingleThreadExecutor(namedThreads("handler-")));
         var asyncExecutor = track(Executors.newSingleThreadExecutor(namedThreads("async-")));
@@ -960,9 +862,9 @@ class ExecutionDomainsTest {
         assertThat(blockerStarted.await(5, TimeUnit.SECONDS), is(true));
 
         var suspendedHandle = new CompletableFuture<AsyncHandle>();
-        server = httpServer()
+        server = TestExecutionResources.configure(httpServer(),
+            track(Executors.newCachedThreadPool()), null, asyncExecutor, null)
             .withHandlerExecutor(handlerExecutor)
-            .withAsyncExecutor(asyncExecutor)
             .addHandler((request, response) -> {
                 suspendedHandle.complete(request.handleAsync());
                 return true;
@@ -986,7 +888,6 @@ class ExecutionDomainsTest {
             });
 
             assertThat(acceptedWrite.isDone(), is(false));
-            assertThat(callbackFailure.isDone(), is(false));
             ExecutionException failedWrite = assertThrows(
                 ExecutionException.class,
                 () -> lateWrite.get(5, TimeUnit.SECONDS)
@@ -997,7 +898,7 @@ class ExecutionDomainsTest {
             blocker.get(5, TimeUnit.SECONDS);
             acceptedWrite.get(5, TimeUnit.SECONDS);
             assertThat(callbackFailure.get(5, TimeUnit.SECONDS), instanceOf(IllegalStateException.class));
-            assertThat(callbackThread.get(5, TimeUnit.SECONDS), startsWith("async-"));
+            assertThat(callbackThread.get(5, TimeUnit.SECONDS), startsWith("handler-"));
             assertThat(client.readLine(), equalTo("HTTP/1.1 200 OK"));
             assertThat(
                 client.readHeaders().contains(HeaderNames.TRANSFER_ENCODING, HeaderValues.CHUNKED, true),
@@ -1024,7 +925,7 @@ class ExecutionDomainsTest {
             payload[i] = (byte) ('a' + (i % 26));
         }
         server = httpServer()
-            .withAsyncExecutor(asyncExecutor)
+            .withHandlerExecutor(asyncExecutor)
             .addHandler(Method.POST, "/", (request, response, pathParams) -> {
                 AsyncHandle handle = request.handleAsync();
                 handle.setReadListener(new RequestBodyListener() {
@@ -1084,8 +985,8 @@ class ExecutionDomainsTest {
         assertThat(blockerStarted.await(5, TimeUnit.SECONDS), is(true));
 
         var competingReadFailure = new CompletableFuture<Throwable>();
-        server = httpServer()
-            .withAsyncExecutor(asyncExecutor)
+        server = TestExecutionResources.configure(httpServer(),
+            track(Executors.newCachedThreadPool()), null, asyncExecutor, null)
             .addHandler(Method.POST, "/", (request, response, pathParams) -> {
                 AsyncHandle handle = request.handleAsync();
                 handle.setReadListener(new RequestBodyListener() {
@@ -1138,7 +1039,7 @@ class ExecutionDomainsTest {
         var completed = new AtomicBoolean();
         var listenerFailure = new IllegalStateException("deliberate request-body listener failure");
         server = httpServer()
-            .withAsyncExecutor(asyncExecutor)
+            .withHandlerExecutor(asyncExecutor)
             .addHandler(Method.POST, "/", (request, response, pathParams) -> {
                 AsyncHandle handle = request.handleAsync();
                 handle.setReadListener(new RequestBodyListener() {
@@ -1200,7 +1101,6 @@ class ExecutionDomainsTest {
         }
         server = httpServer()
             .withHandlerExecutor(applicationExecutor)
-            .withAsyncExecutor(applicationExecutor)
             .addHandler(Method.POST, "/", (request, response, pathParams) -> {
                 AsyncHandle handle = request.handleAsync();
                 handle.setReadListener(new RequestBodyListener() {
@@ -1248,56 +1148,6 @@ class ExecutionDomainsTest {
     }
 
     @Test
-    void rejectedAsyncWritesFailTheRequestAndInvokeTheCallback() throws Exception {
-        var asyncExecutor = track(Executors.newSingleThreadExecutor(namedThreads("async-")));
-        asyncExecutor.shutdown();
-        var callbackFailure = new CompletableFuture<Throwable>();
-        server = httpServer()
-            .withAsyncExecutor(asyncExecutor)
-            .addHandler(Method.GET, "/", (request, response, pathParams) -> {
-                AsyncHandle handle = request.handleAsync();
-                handle.write(ByteBuffer.wrap(new byte[]{1}), error -> {
-                    if (error != null) {
-                        callbackFailure.complete(error);
-                    }
-                });
-            })
-            .start();
-
-        try (Response response = call(request(server.uri()))) {
-            assertThat(response.code(), is(500));
-        }
-        assertThat(callbackFailure.get(5, TimeUnit.SECONDS), instanceOf(RejectedExecutionException.class));
-    }
-
-    @Test
-    void rejectedAsyncExecutorDoesNotDropALateWriteCallback() throws Exception {
-        var handlerExecutor = track(Executors.newSingleThreadExecutor(namedThreads("handler-")));
-        var asyncExecutor = track(Executors.newSingleThreadExecutor(namedThreads("async-")));
-        asyncExecutor.shutdown();
-        var callbackFailure = new CompletableFuture<Throwable>();
-        var callbackThread = new CompletableFuture<String>();
-        server = httpServer()
-            .withHandlerExecutor(handlerExecutor)
-            .withAsyncExecutor(asyncExecutor)
-            .addHandler(Method.GET, "/", (request, response, pathParams) -> {
-                AsyncHandle handle = request.handleAsync();
-                handle.complete();
-                handle.write(ByteBuffer.wrap(new byte[]{1}), failure -> {
-                    callbackThread.complete(Thread.currentThread().getName());
-                    callbackFailure.complete(failure);
-                });
-            })
-            .start();
-
-        try (Response response = call(request(server.uri()))) {
-            assertThat(response.code(), is(200));
-        }
-        assertThat(callbackFailure.get(5, TimeUnit.SECONDS), instanceOf(IllegalStateException.class));
-        assertThat(callbackThread.get(5, TimeUnit.SECONDS), startsWith("handler-"));
-    }
-
-    @Test
     void aSuspendedHttp1ExchangeDoesNotRetainAHandlerWorker() throws Exception {
         var handlerExecutor = track(Executors.newSingleThreadExecutor(namedThreads("handler-")));
         var clientExecutor = track(Executors.newSingleThreadExecutor(namedThreads("client-")));
@@ -1337,38 +1187,6 @@ class ExecutionDomainsTest {
             assertThat(first.readLine(), equalTo("HTTP/1.1 200 OK"));
             assertThat(first.readBody(first.readHeaders()), equalTo(""));
             assertThat(completionThread.get(5, TimeUnit.SECONDS), startsWith("handler-"));
-        }
-    }
-
-    @Test
-    void rejectedHandlerDispatchesHttp1AsyncFailureHandlingToTheAsyncExecutor() throws Exception {
-        var handlerExecutor = track(Executors.newSingleThreadExecutor(namedThreads("handler-")));
-        var asyncExecutor = track(Executors.newSingleThreadExecutor(namedThreads("async-")));
-        var suspendedHandle = new CompletableFuture<AsyncHandle>();
-        var exceptionThread = new CompletableFuture<String>();
-        server = httpServer()
-            .withHandlerExecutor(handlerExecutor)
-            .withAsyncExecutor(asyncExecutor)
-            .withExceptionHandler((request, response, exception) -> {
-                exceptionThread.complete(Thread.currentThread().getName());
-                response.status(500);
-                response.write("handled");
-                return true;
-            })
-            .addHandler((request, response) -> {
-                suspendedHandle.complete(request.handleAsync());
-                handlerExecutor.shutdown();
-                return true;
-            })
-            .start();
-
-        try (var client = Http1Client.connect(server)) {
-            client.writeRequestLine(Method.GET, "/").flushHeaders();
-            suspendedHandle.get(5, TimeUnit.SECONDS).complete(new IOException("async failure"));
-
-            assertThat(client.readLine(), equalTo("HTTP/1.1 500 Internal Server Error"));
-            assertThat(client.readBody(client.readHeaders()), equalTo("handled"));
-            assertThat(exceptionThread.get(5, TimeUnit.SECONDS), startsWith("async-"));
         }
     }
 
@@ -1438,7 +1256,6 @@ class ExecutionDomainsTest {
         server = httpServer()
             .withHttp2Config(Http2ConfigBuilder.http2Enabled())
             .withHandlerExecutor(applicationExecutor)
-            .withAsyncExecutor(applicationExecutor)
             .addResponseCompleteListener(info ->
                 completionThread.complete(Thread.currentThread().getName())
             )
@@ -1472,163 +1289,12 @@ class ExecutionDomainsTest {
     }
 
     @Test
-    void http2CompletionOnTheAsyncWorkerDoesNotResubmitWhenHandlersAreSaturated() throws Exception {
-        var handlerExecutor = track(new ThreadPoolExecutor(
-            1,
-            1,
-            0,
-            TimeUnit.MILLISECONDS,
-            new ArrayBlockingQueue<>(1),
-            namedThreads("handler-")
-        ));
-        var asyncExecutor = track(new ThreadPoolExecutor(
-            1,
-            1,
-            0,
-            TimeUnit.MILLISECONDS,
-            new SynchronousQueue<>(),
-            namedThreads("async-")
-        ));
-        var writeCallbackEntered = new CountDownLatch(1);
-        var releaseWriteCallback = new CountDownLatch(1);
-        var blockerStarted = new CountDownLatch(1);
-        var releaseBlockers = new CountDownLatch(1);
-        var completionThread = new CompletableFuture<String>();
-        server = httpServer()
-            .withHttp2Config(Http2ConfigBuilder.http2Enabled())
-            .withHandlerExecutor(handlerExecutor)
-            .withAsyncExecutor(asyncExecutor)
-            .addResponseCompleteListener(info ->
-                completionThread.complete(Thread.currentThread().getName())
-            )
-            .addHandler(Method.GET, "/hello", (request, response, pathParams) -> {
-                AsyncHandle handle = request.handleAsync();
-                handle.write(ByteBuffer.wrap(new byte[]{1}), error -> {
-                    if (error != null) {
-                        handle.complete(error);
-                        return;
-                    }
-                    writeCallbackEntered.countDown();
-                    releaseWriteCallback.await();
-                    handle.complete();
-                });
-            })
-            .start();
-
-        Future<?> blocker = null;
-        Future<?> queuedBlocker = null;
-        try (var h2Client = new H2Client();
-             var connection = h2Client.connectClearText(server)) {
-            connection.handshake();
-            connection.socket().setSoTimeout(2000);
-            connection.writeFrame(new Http2HeadersFrame(
-                1,
-                true,
-                RFCTestUtils.getHelloHeaders("http", server.uri().getPort())
-            )).flush();
-
-            assertThat(writeCallbackEntered.await(5, TimeUnit.SECONDS), is(true));
-            blocker = handlerExecutor.submit(() -> {
-                blockerStarted.countDown();
-                try {
-                    releaseBlockers.await();
-                } catch (InterruptedException e) {
-                    Thread.currentThread().interrupt();
-                }
-            });
-            assertThat(blockerStarted.await(5, TimeUnit.SECONDS), is(true));
-            queuedBlocker = handlerExecutor.submit(() -> {
-                try {
-                    releaseBlockers.await();
-                } catch (InterruptedException e) {
-                    Thread.currentThread().interrupt();
-                }
-            });
-            releaseWriteCallback.countDown();
-
-            Http2HeadersFrame responseHeaders =
-                RFCTestUtils.readIgnoringWindowUpdates(connection, Http2HeadersFrame.class);
-            assertThat(responseHeaders.headers().get(":status"), equalTo("200"));
-            Http2DataFrame responseData =
-                RFCTestUtils.readIgnoringWindowUpdates(connection, Http2DataFrame.class);
-            assertThat(responseData.payloadLength(), is(1));
-            assertThat(
-                RFCTestUtils.readIgnoringWindowUpdates(connection, Http2DataFrame.class).endStream(),
-                is(true)
-            );
-            assertThat(completionThread.get(5, TimeUnit.SECONDS), startsWith("async-"));
-        } finally {
-            releaseWriteCallback.countDown();
-            releaseBlockers.countDown();
-            if (blocker != null) {
-                blocker.get(5, TimeUnit.SECONDS);
-            }
-            if (queuedBlocker != null) {
-                queuedBlocker.get(5, TimeUnit.SECONDS);
-            }
-        }
-    }
-
-    @Test
-    void rejectedHandlerDispatchesHttp2AsyncCompletionToTheAsyncExecutor() throws Exception {
-        var handlerExecutor = track(Executors.newSingleThreadExecutor(namedThreads("handler-")));
-        var asyncExecutor = track(Executors.newSingleThreadExecutor(namedThreads("async-")));
-        var suspendedHandle = new CompletableFuture<AsyncHandle>();
-        var exceptionThread = new CompletableFuture<String>();
-        var completionThread = new CompletableFuture<String>();
-        server = httpServer()
-            .withHttp2Config(Http2ConfigBuilder.http2Enabled())
-            .withHandlerExecutor(handlerExecutor)
-            .withAsyncExecutor(asyncExecutor)
-            .withExceptionHandler((request, response, exception) -> {
-                exceptionThread.complete(Thread.currentThread().getName());
-                response.status(500);
-                response.write("handled");
-                return true;
-            })
-            .addHandler((request, response) -> {
-                AsyncHandle handle = request.handleAsync();
-                handle.addResponseCompleteHandler(info ->
-                    completionThread.complete(Thread.currentThread().getName())
-                );
-                handlerExecutor.shutdown();
-                suspendedHandle.complete(handle);
-                return true;
-            })
-            .start();
-
-        try (var h2Client = new H2Client();
-             var connection = h2Client.connectClearText(server)) {
-            connection.handshake();
-            connection.socket().setSoTimeout(2000);
-            connection.writeFrame(new Http2HeadersFrame(
-                1,
-                true,
-                RFCTestUtils.getHelloHeaders("http", server.uri().getPort())
-            )).flush();
-            AsyncHandle handle = suspendedHandle.get(5, TimeUnit.SECONDS);
-            assertThat(handlerExecutor.awaitTermination(5, TimeUnit.SECONDS), equalTo(true));
-            handle.complete(new IOException("async failure"));
-
-            Http2HeadersFrame responseHeaders =
-                RFCTestUtils.readIgnoringWindowUpdates(connection, Http2HeadersFrame.class);
-            assertThat(responseHeaders.headers().get(":status"), equalTo("500"));
-            Http2DataFrame responseData =
-                RFCTestUtils.readIgnoringWindowUpdates(connection, Http2DataFrame.class);
-            assertThat(responseData.toUTF8(), equalTo("handled"));
-            assertThat(exceptionThread.get(5, TimeUnit.SECONDS), startsWith("async-"));
-            assertThat(completionThread.get(5, TimeUnit.SECONDS), startsWith("async-"));
-        }
-    }
-
-    @Test
     void rejectedApplicationExecutorsAbortAnAcceptedHttp2AsyncStream() throws Exception {
         var sharedExecutor = track(Executors.newSingleThreadExecutor(namedThreads("application-")));
         var suspendedHandle = new CompletableFuture<AsyncHandle>();
         server = httpServer()
             .withHttp2Config(Http2ConfigBuilder.http2Enabled())
             .withHandlerExecutor(sharedExecutor)
-            .withAsyncExecutor(sharedExecutor)
             .addHandler((request, response) -> {
                 suspendedHandle.complete(request.handleAsync());
                 sharedExecutor.shutdown();
@@ -1659,12 +1325,12 @@ class ExecutionDomainsTest {
 
     @SuppressWarnings("deprecation")
     @Test
-    void deprecatedWebSocketAdaptersUseTheAsyncExecutorWithoutSelfDeadlock() throws Exception {
+    void deprecatedWebSocketAdaptersUseOneApplicationWorkerWithoutSelfDeadlock() throws Exception {
         var asyncExecutor = track(Executors.newSingleThreadExecutor(namedThreads("async-")));
         var callbackThreads = new CopyOnWriteArrayList<String>();
         var clientMessage = new CompletableFuture<String>();
         server = httpServer()
-            .withAsyncExecutor(asyncExecutor)
+            .withHandlerExecutor(asyncExecutor)
             .addHandler(webSocketHandler((request, responseHeaders) -> new BaseWebSocket() {
                 @Override
                 public void onText(String message, boolean isLast, DoneCallback onComplete) {
@@ -1690,7 +1356,7 @@ class ExecutionDomainsTest {
         webSocket.send("hello");
         assertThat(clientMessage.get(5, TimeUnit.SECONDS), equalTo("hello"));
         webSocket.close(1000, "Done");
-        assertThat(callbackThreads.size(), is(2));
+        assertEventually(callbackThreads::size, is(2));
         for (String callbackThread : callbackThreads) {
             assertThat(callbackThread, startsWith("async-"));
         }
@@ -1703,9 +1369,8 @@ class ExecutionDomainsTest {
         var connectedThread = new CompletableFuture<String>();
         var messageThread = new CompletableFuture<String>();
         var errorThread = new CompletableFuture<String>();
-        server = httpServer()
+        server = io.muserver.TestExecutionResources.configure(httpServer(), connectionExecutor, null, null, null)
             .withHandlerExecutor(handlerExecutor)
-            .withConnectionExecutor(connectionExecutor)
             .addHandler(webSocketHandler((request, responseHeaders) -> new SimpleWebSocket() {
                 @Override
                 public void onConnect(MuWebSocketSession session) throws Exception {
@@ -1755,10 +1420,8 @@ class ExecutionDomainsTest {
         var releaseText = new CountDownLatch(1);
         var timeoutThread = new CompletableFuture<String>();
         var clientDisconnected = new CompletableFuture<Void>();
-        server = httpServer()
+        server = io.muserver.TestExecutionResources.configure(httpServer(), connectionExecutor, null, maintenanceExecutor, null)
             .withHandlerExecutor(handlerExecutor)
-            .withConnectionExecutor(connectionExecutor)
-            .withConnectionMaintenanceExecutor(maintenanceExecutor)
             .withIdleTimeout(100, TimeUnit.MILLISECONDS)
             .addHandler(webSocketHandler((request, responseHeaders) -> new SimpleWebSocket() {
                 @Override
@@ -1814,9 +1477,8 @@ class ExecutionDomainsTest {
         var connectionExecutor = track(Executors.newCachedThreadPool(namedThreads("connection-")));
         var connected = new CountDownLatch(1);
         var shutdownThread = new CompletableFuture<String>();
-        server = httpServer()
+        server = io.muserver.TestExecutionResources.configure(httpServer(), connectionExecutor, null, null, null)
             .withHandlerExecutor(handlerExecutor)
-            .withConnectionExecutor(connectionExecutor)
             .addHandler(webSocketHandler((request, responseHeaders) -> new SimpleWebSocket() {
                 @Override
                 public void onConnect(MuWebSocketSession session) throws Exception {
@@ -1864,9 +1526,8 @@ class ExecutionDomainsTest {
         var connected = new CountDownLatch(1);
         var shutdownEntered = new CountDownLatch(1);
         var releaseShutdown = new CountDownLatch(1);
-        server = httpServer()
+        server = io.muserver.TestExecutionResources.configure(httpServer(), connectionExecutor, null, null, null)
             .withHandlerExecutor(handlerExecutor)
-            .withConnectionExecutor(connectionExecutor)
             .addHandler(webSocketHandler((request, responseHeaders) -> new SimpleWebSocket() {
                 @Override
                 public void onConnect(MuWebSocketSession session) throws Exception {
@@ -1958,9 +1619,8 @@ class ExecutionDomainsTest {
         var shutdownCalled = new CompletableFuture<@Nullable Void>();
         var callbackActive = new AtomicBoolean();
         var callbacksOverlapped = new AtomicBoolean();
-        server = httpServer()
+        server = io.muserver.TestExecutionResources.configure(httpServer(), null, null, null, null)
             .withHandlerExecutor(sharedExecutor)
-            .withConnectionExecutor(sharedExecutor)
             .addHandler(webSocketHandler((request, responseHeaders) -> new SimpleWebSocket() {
                 @Override
                 public void onText(String message) throws Exception {
@@ -1978,9 +1638,10 @@ class ExecutionDomainsTest {
                 }
 
                 @Override
-                public void onServerShuttingDown() {
+                public void onServerShuttingDown() throws Exception {
                     callbacksOverlapped.set(callbackActive.get());
                     shutdownCalled.complete(null);
+                    super.onServerShuttingDown();
                 }
             }))
             .start();
@@ -1989,6 +1650,9 @@ class ExecutionDomainsTest {
         WebSocket webSocket = client.newWebSocket(
             request().url(websocketUrl).build(),
             new WebSocketListener() {
+                @Override public void onClosing(WebSocket socket, int code, String reason) {
+                    socket.close(code, reason);
+                }
             }
         );
         try {
@@ -2019,9 +1683,8 @@ class ExecutionDomainsTest {
         var attemptWrite = new CountDownLatch(1);
         var writeFailure = new CompletableFuture<IOException>();
         var errorCallback = new CompletableFuture<Throwable>();
-        server = httpServer()
+        server = io.muserver.TestExecutionResources.configure(httpServer(), null, null, null, null)
             .withHandlerExecutor(sharedExecutor)
-            .withConnectionExecutor(sharedExecutor)
             .addHandler(webSocketHandler((request, responseHeaders) -> new SimpleWebSocket() {
                 @Override
                 public void onText(String message) throws Exception {
@@ -2076,9 +1739,8 @@ class ExecutionDomainsTest {
         var sharedExecutor = track(Executors.newSingleThreadExecutor(namedThreads("shared-")));
         var callbackThread = new CompletableFuture<String>();
         var clientMessage = new CompletableFuture<String>();
-        server = httpServer()
+        server = io.muserver.TestExecutionResources.configure(httpServer(), null, null, null, null)
             .withHandlerExecutor(sharedExecutor)
-            .withConnectionExecutor(sharedExecutor)
             .addHandler(webSocketHandler((request, responseHeaders) -> new SimpleWebSocket() {
                 @Override
                 public void onText(String message) throws IOException {
@@ -2116,10 +1778,8 @@ class ExecutionDomainsTest {
         var connectionExecutor = track(Executors.newFixedThreadPool(2, namedThreads("connection-")));
         var writerExecutor = track(Executors.newSingleThreadExecutor(namedThreads("h2-writer-")));
 
-        server = httpServer()
+        server = io.muserver.TestExecutionResources.configure(httpServer(), connectionExecutor, writerExecutor, null, null)
             .withHttp2Config(Http2ConfigBuilder.http2Enabled())
-            .withConnectionExecutor(connectionExecutor)
-            .withHttp2WriterExecutor(writerExecutor)
             .start();
 
         try (var client = new H2Client();
@@ -2146,11 +1806,8 @@ class ExecutionDomainsTest {
         var writerExecutor = track(Executors.newSingleThreadExecutor(namedThreads("h2-writer-")));
         var maintenanceExecutor = track(Executors.newSingleThreadExecutor(namedThreads("maintenance-")));
 
-        server = httpServer()
+        server = io.muserver.TestExecutionResources.configure(httpServer(), connectionExecutor, writerExecutor, maintenanceExecutor, null)
             .withHttp2Config(Http2ConfigBuilder.http2Enabled())
-            .withConnectionExecutor(connectionExecutor)
-            .withHttp2WriterExecutor(writerExecutor)
-            .withConnectionMaintenanceExecutor(maintenanceExecutor)
             .withIdleTimeout(100, TimeUnit.MILLISECONDS)
             .start();
 
@@ -2172,20 +1829,10 @@ class ExecutionDomainsTest {
         var maintenanceExecutor = track(Executors.newCachedThreadPool(namedThreads("maintenance-")));
         var timerExecutor = track(Executors.newSingleThreadScheduledExecutor(namedThreads("timer-")));
 
-        var builder = httpServer()
+        var builder = io.muserver.TestExecutionResources.configure(httpServer(), connectionExecutor, writerExecutor, maintenanceExecutor, timerExecutor)
             .withHandlerExecutor(handlerExecutor)
-            .withAsyncExecutor(asyncExecutor)
-            .withConnectionExecutor(connectionExecutor)
-            .withHttp2WriterExecutor(writerExecutor)
-            .withConnectionMaintenanceExecutor(maintenanceExecutor)
-            .withTimerExecutor(timerExecutor)
             .addHandler(Method.GET, "/", (request, response, pathParams) ->
                 response.write(Thread.currentThread().getName()));
-        assertThat(builder.connectionExecutor(), is(connectionExecutor));
-        assertThat(builder.asyncExecutor(), is(asyncExecutor));
-        assertThat(builder.http2WriterExecutor(), is(writerExecutor));
-        assertThat(builder.connectionMaintenanceExecutor(), is(maintenanceExecutor));
-        assertThat(builder.timerExecutor(), is(timerExecutor));
 
         server = builder.start();
         try (Response response = call(request(server.uri()))) {
@@ -2195,26 +1842,26 @@ class ExecutionDomainsTest {
 
         server.stop();
         server = null;
-        assertThat(connectionExecutor.isShutdown(), is(false));
-        assertThat(writerExecutor.isShutdown(), is(false));
-        assertThat(maintenanceExecutor.isShutdown(), is(false));
+        assertThat(connectionExecutor.isShutdown(), is(true));
+        assertThat(writerExecutor.isShutdown(), is(true));
+        assertThat(maintenanceExecutor.isShutdown(), is(true));
         assertThat(handlerExecutor.isShutdown(), is(false));
         assertThat(asyncExecutor.isShutdown(), is(false));
-        assertThat(timerExecutor.isShutdown(), is(false));
+        assertThat(timerExecutor.isShutdown(), is(true));
     }
 
     @Test
     void serverOwnedExecutorsAreShutDownWithTheServer() throws Exception {
-        server = httpServer().start();
-        var serverImpl = (Mu3ServerImpl) server;
-        List<ExecutorService> serverOwnedExecutors = List.of(
-            getField(serverImpl, "handlerExecutor", ExecutorService.class),
-            getField(serverImpl, "asyncExecutor", ExecutorService.class),
-            getField(serverImpl, "connectionExecutor", ExecutorService.class),
-            getField(serverImpl, "http2WriterExecutor", ExecutorService.class),
-            getField(serverImpl, "connectionMaintenanceExecutor", ExecutorService.class),
-            getField(serverImpl, "timerExecutor", ExecutorService.class)
-        );
+        var builder = httpServer();
+        var created = new java.util.concurrent.atomic.AtomicReference<ExecutionResources>();
+        builder.executionResourcesFactory = application -> {
+            ExecutionResources resources = ExecutionResources.create(application);
+            created.set(resources);
+            return resources;
+        };
+        server = builder.start();
+        ExecutionResources resources = created.get();
+        List<ExecutorService> serverOwnedExecutors = List.of(resources.application, resources.internal, resources.timer);
 
         server.stop();
         server = null;
@@ -2235,21 +1882,16 @@ class ExecutionDomainsTest {
         timerExecutor.shutdown();
         int port = availablePort();
 
-        assertThrows(RejectedExecutionException.class, () -> httpServer()
+        assertThrows(RejectedExecutionException.class, () -> io.muserver.TestExecutionResources.configure(httpServer(), connectionExecutor, writerExecutor, maintenanceExecutor, timerExecutor)
             .withHttpPort(port)
             .withHandlerExecutor(handlerExecutor)
-            .withAsyncExecutor(asyncExecutor)
-            .withConnectionExecutor(connectionExecutor)
-            .withHttp2WriterExecutor(writerExecutor)
-            .withConnectionMaintenanceExecutor(maintenanceExecutor)
-            .withTimerExecutor(timerExecutor)
             .start());
 
         assertThat(handlerExecutor.isShutdown(), is(false));
         assertThat(asyncExecutor.isShutdown(), is(false));
-        assertThat(connectionExecutor.isShutdown(), is(false));
-        assertThat(writerExecutor.isShutdown(), is(false));
-        assertThat(maintenanceExecutor.isShutdown(), is(false));
+        assertThat(connectionExecutor.isShutdown(), is(true));
+        assertThat(writerExecutor.isShutdown(), is(true));
+        assertThat(maintenanceExecutor.isShutdown(), is(true));
         try (var replacementListener = new ServerSocket(port)) {
             assertThat(replacementListener.isBound(), is(true));
         }
@@ -2266,24 +1908,19 @@ class ExecutionDomainsTest {
         int firstPort = availablePort();
 
         try (var occupiedListener = new ServerSocket(0)) {
-            assertThrows(MuException.class, () -> MuServerBuilder.muServer()
+            assertThrows(MuException.class, () -> io.muserver.TestExecutionResources.configure(MuServerBuilder.muServer(), connectionExecutor, writerExecutor, maintenanceExecutor, timerExecutor)
                 .withHttpsPort(firstPort)
                 .withHttpPort(occupiedListener.getLocalPort())
                 .withHandlerExecutor(handlerExecutor)
-                .withAsyncExecutor(asyncExecutor)
-                .withConnectionExecutor(connectionExecutor)
-                .withHttp2WriterExecutor(writerExecutor)
-                .withConnectionMaintenanceExecutor(maintenanceExecutor)
-                .withTimerExecutor(timerExecutor)
                 .start());
         }
 
         assertThat(handlerExecutor.isShutdown(), is(false));
         assertThat(asyncExecutor.isShutdown(), is(false));
-        assertThat(connectionExecutor.isShutdown(), is(false));
-        assertThat(writerExecutor.isShutdown(), is(false));
-        assertThat(maintenanceExecutor.isShutdown(), is(false));
-        assertThat(timerExecutor.isShutdown(), is(false));
+        assertThat(connectionExecutor.isShutdown(), is(true));
+        assertThat(writerExecutor.isShutdown(), is(true));
+        assertThat(maintenanceExecutor.isShutdown(), is(true));
+        assertThat(timerExecutor.isShutdown(), is(true));
         try (var replacementListener = new ServerSocket(firstPort)) {
             assertThat(replacementListener.isBound(), is(true));
         }
@@ -2311,10 +1948,8 @@ class ExecutionDomainsTest {
             }
         };
 
-        server = httpServer()
+        server = io.muserver.TestExecutionResources.configure(httpServer(), connectionExecutor, null, maintenanceExecutor, null)
             .withHandlerExecutor(handlerExecutor)
-            .withConnectionExecutor(connectionExecutor)
-            .withConnectionMaintenanceExecutor(maintenanceExecutor)
             .addHandler(webSocketHandler((request, responseHeaders) -> serverSocket)
                 .withPingInterval(10, TimeUnit.MILLISECONDS))
             .start();

--- a/src/test/java/io/muserver/RFC9113_6_8_GoAwayTest.java
+++ b/src/test/java/io/muserver/RFC9113_6_8_GoAwayTest.java
@@ -135,9 +135,8 @@ class RFC9113_6_8_GoAwayTest {
         });
         assertThat(writerStarted.await(5, TimeUnit.SECONDS), equalTo(true));
 
-        server = httpsServer()
+        server = TestExecutionResources.configure(httpsServer(), null, writerExecutor, null, null)
             .withHttp2Config(Http2ConfigBuilder.http2Enabled())
-            .withHttp2WriterExecutor(writerExecutor)
             .start();
 
         try (var client = new H2Client();

--- a/src/test/java/io/muserver/RateLimiterTest.java
+++ b/src/test/java/io/muserver/RateLimiterTest.java
@@ -335,7 +335,6 @@ public class RateLimiterTest {
         var selectorThread = new AtomicReference<String>();
         try (MuServer domainServer = ServerUtils.httpsServerForTest(protocol)
             .withHandlerExecutor(handlerExecutor)
-            .withConnectionExecutor(connectionExecutor)
             .withRateLimiter(request -> {
                 selectorThread.set(Thread.currentThread().getName());
                 return rateLimit()

--- a/src/test/java/io/muserver/RequestAdmissionTest.java
+++ b/src/test/java/io/muserver/RequestAdmissionTest.java
@@ -1,0 +1,122 @@
+package io.muserver;
+
+import okhttp3.OkHttpClient;
+import okhttp3.Protocol;
+import okhttp3.Response;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.List;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+
+import static io.muserver.MuServerBuilder.httpServer;
+import static org.junit.jupiter.api.Assertions.*;
+import static scaffolding.ClientUtils.client;
+import static scaffolding.ClientUtils.request;
+
+@Timeout(20)
+class RequestAdmissionTest {
+    @Test
+    void limitValidationAndIdempotentRelease() {
+        assertEquals(1000, httpServer().maxConcurrentRequests());
+        assertEquals(0, httpServer().withMaxConcurrentRequests(0).maxConcurrentRequests());
+        assertThrows(IllegalArgumentException.class, () -> httpServer().withMaxConcurrentRequests(-1));
+        RequestAdmission limit = new RequestAdmission(1);
+        RequestAdmission.Slot slot = limit.tryAcquire();
+        assertNotNull(slot);
+        assertNull(limit.tryAcquire());
+        slot.close();
+        slot.close();
+        RequestAdmission.Slot next = limit.tryAcquire();
+        assertNotNull(next);
+        assertNull(limit.tryAcquire());
+        next.close();
+        RequestAdmission unlimited = new RequestAdmission(0);
+        for (int i = 0; i < 2000; i++) assertNotNull(unlimited.tryAcquire());
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    void suspendedRequestsCountAndReleaseBeforeDetachedListeners(boolean http2) throws Exception {
+        BlockingQueue<AsyncHandle> handles = new LinkedBlockingQueue<>();
+        CountDownLatch listenerEntered = new CountDownLatch(1);
+        CountDownLatch releaseListener = new CountDownLatch(1);
+        var callers = Executors.newCachedThreadPool();
+        MuServer server = httpServer().withHttp2Config(Http2ConfigBuilder.http2Enabled())
+            .withMaxConcurrentRequests(1)
+            .addHandler((req, resp) -> {
+                handles.add(req.handleAsync());
+                return true;
+            })
+            .addResponseCompleteListener(info -> {
+                listenerEntered.countDown();
+                try { releaseListener.await(); }
+                catch (InterruptedException e) { Thread.currentThread().interrupt(); }
+            }).start();
+        OkHttpClient transport = client.newBuilder().protocols(http2
+            ? List.of(Protocol.H2_PRIOR_KNOWLEDGE) : List.of(Protocol.HTTP_1_1)).build();
+        try {
+            var first = callers.submit(() -> transport.newCall(request(server.uri()).build()).execute());
+            AsyncHandle active = handles.poll(5, TimeUnit.SECONDS);
+            assertNotNull(active);
+            try (Response excess = transport.newCall(request(server.uri()).build()).execute()) {
+                assertEquals(503, excess.code());
+            }
+            assertNull(handles.poll());
+            active.complete();
+            try (Response accepted = first.get(5, TimeUnit.SECONDS)) { assertEquals(200, accepted.code()); }
+            assertTrue(listenerEntered.await(5, TimeUnit.SECONDS));
+            var next = callers.submit(() -> transport.newCall(request(server.uri()).build()).execute());
+            AsyncHandle nextHandle = handles.poll(5, TimeUnit.SECONDS);
+            assertNotNull(nextHandle, "Detached completion listener must not retain admission");
+            nextHandle.complete();
+            try (Response accepted = next.get(5, TimeUnit.SECONDS)) { assertEquals(200, accepted.code()); }
+        } finally {
+            releaseListener.countDown();
+            server.stop();
+            callers.shutdownNow();
+            transport.connectionPool().evictAll();
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    void queuedHandlersCountTowardsTheLimit(boolean http2) throws Exception {
+        var application = Executors.newSingleThreadExecutor();
+        var callers = Executors.newCachedThreadPool();
+        var blocked = new CountDownLatch(1);
+        var release = new CountDownLatch(1);
+        application.submit(() -> {
+            blocked.countDown();
+            try { release.await(); } catch (InterruptedException e) { Thread.currentThread().interrupt(); }
+        });
+        assertTrue(blocked.await(5, TimeUnit.SECONDS));
+        MuServer server = httpServer().withHttp2Config(Http2ConfigBuilder.http2Enabled())
+            .withHandlerExecutor(application).withMaxConcurrentRequests(1)
+            .addHandler((req, resp) -> { resp.write("done"); return true; }).start();
+        OkHttpClient transport = client.newBuilder().protocols(http2
+            ? List.of(Protocol.H2_PRIOR_KNOWLEDGE) : List.of(Protocol.HTTP_1_1)).build();
+        try {
+            var queued = callers.submit(() -> transport.newCall(request(server.uri()).build()).execute());
+            scaffolding.MuAssert.assertEventually(() -> server.stats().activeRequests().size(), org.hamcrest.Matchers.is(1));
+            try (Response excess = transport.newCall(request(server.uri()).build()).execute()) {
+                assertEquals(503, excess.code());
+            }
+            release.countDown();
+            try (Response accepted = queued.get(5, TimeUnit.SECONDS)) { assertEquals("done", accepted.body().string()); }
+        } finally {
+            release.countDown();
+            server.stop();
+            application.shutdownNow();
+            callers.shutdownNow();
+            transport.connectionPool().evictAll();
+        }
+    }
+}

--- a/src/test/java/io/muserver/TestExecutionResources.java
+++ b/src/test/java/io/muserver/TestExecutionResources.java
@@ -1,0 +1,32 @@
+package io.muserver;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ScheduledExecutorService;
+import org.jspecify.annotations.Nullable;
+
+/** Test-only controls for deterministic scheduling and resource lifecycle assertions. */
+public final class TestExecutionResources {
+    private TestExecutionResources() { }
+
+    public static MuServerBuilder configure(MuServerBuilder builder,
+        @Nullable ExecutorService connections, @Nullable ExecutorService writers,
+        @Nullable ExecutorService internal, @Nullable ScheduledExecutorService timer) {
+        builder.executionResourcesFactory = supplied -> new ExecutionResources(
+            supplied == null ? MuServerBuilder.defaultExecutor() : supplied, supplied == null,
+            internal == null ? MuServerBuilder.defaultExecutor() : internal,
+            timer == null ? MuServerBuilder.defaultTimerExecutor() : timer) {
+            @Override ExecutorService connectionExecutor() {
+                return connections == null ? super.connectionExecutor() : connections;
+            }
+            @Override ExecutorService writerExecutor() {
+                return writers == null ? super.writerExecutor() : writers;
+            }
+            @Override void shutdown() {
+                super.shutdown();
+                if (connections != null) connections.shutdown();
+                if (writers != null) writers.shutdown();
+            }
+        };
+        return builder;
+    }
+}

--- a/src/test/java/io/muserver/rest/AsynchronousProcessingTest.java
+++ b/src/test/java/io/muserver/rest/AsynchronousProcessingTest.java
@@ -150,7 +150,6 @@ public class AsynchronousProcessingTest {
 
         server = ServerUtils.httpsServerForTest("http")
             .withHandlerExecutor(handlerExecutor)
-            .withAsyncExecutor(asyncExecutor)
             .addHandler(restHandler(new Sample()).addCustomWriter(threadReportingWriter()))
             .start();
 
@@ -176,7 +175,6 @@ public class AsynchronousProcessingTest {
 
         server = ServerUtils.httpsServerForTest("http")
             .withHandlerExecutor(handlerExecutor)
-            .withAsyncExecutor(asyncExecutor)
             .addHandler(restHandler(new Sample()).addCustomWriter(threadReportingWriter()))
             .start();
 
@@ -207,8 +205,6 @@ public class AsynchronousProcessingTest {
 
         server = ServerUtils.httpsServerForTest("http")
             .withHandlerExecutor(handlerExecutor)
-            .withAsyncExecutor(asyncExecutor)
-            .withTimerExecutor(timerExecutor)
             .addHandler(restHandler(new Sample()).addCustomWriter(threadReportingWriter()))
             .start();
 
@@ -259,7 +255,6 @@ public class AsynchronousProcessingTest {
 
         server = ServerUtils.httpsServerForTest("http")
             .withHandlerExecutor(applicationExecutor)
-            .withAsyncExecutor(applicationExecutor)
             .addHandler(restHandler(new Sample()).addCustomWriter(threadReportingWriter()))
             .start();
 
@@ -283,7 +278,6 @@ public class AsynchronousProcessingTest {
 
         server = ServerUtils.httpsServerForTest("http")
             .withHandlerExecutor(applicationExecutor)
-            .withAsyncExecutor(applicationExecutor)
             .addHandler(restHandler(new Sample()).addCustomWriter(threadReportingWriter()))
             .start();
 
@@ -311,8 +305,6 @@ public class AsynchronousProcessingTest {
 
         server = ServerUtils.httpsServerForTest("http")
             .withHandlerExecutor(applicationExecutor)
-            .withAsyncExecutor(applicationExecutor)
-            .withTimerExecutor(timerExecutor)
             .addHandler(restHandler(new Sample()).addCustomWriter(threadReportingWriter()))
             .start();
 


### PR DESCRIPTION
Reduce the public executor configuration to withHandlerExecutor, covering handlers, callbacks and JAX-RS continuations. Mu owns an independent I/O task executor and dispatch-only timer; HTTP/2 retains its serialized writer drain scheduling. Rejected application work no longer falls back to another pool or protocol thread.

Add withMaxConcurrentRequests (default 1000; zero means unlimited), counting queued handlers and suspended HTTP requests across listeners until exchange cleanup. Detached completion listeners and upgraded WebSocket sessions do not retain request slots. Separate blocking async adapter I/O from callback delivery, including a legacy WebSocket bridge that releases the application worker while completion is pending.

Replace public executor controls in race tests with a test-only internal resource factory. Validation: 92 focused tests passed on Java 11, covering admission on HTTP/1 and HTTP/2, execution isolation, callbacks, JAX-RS, rate limits and GOAWAY ordering. Obsolete fallback behavior tests are replaced by rejection/no-fallback assertions.

Second of four follow-ups for #198, stacked on #212.