### PR TITLE
Mu4 concurrency follow-up 3: async ownership and cancellation contracts

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -268,6 +268,7 @@
                     <source>${jdk.version}</source>
                     <detectJavaApiLink>false</detectJavaApiLink>
                     <doclint>all</doclint>
+                    <excludePackageNames>io.muserver.internal</excludePackageNames>
                     <failOnWarnings>true</failOnWarnings>
                 </configuration>
                 <executions>

--- a/src/main/java/io/muserver/AsyncHandle.java
+++ b/src/main/java/io/muserver/AsyncHandle.java
@@ -3,10 +3,7 @@ package io.muserver;
 import org.jspecify.annotations.Nullable;
 
 import java.nio.ByteBuffer;
-import java.util.Objects;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Future;
-import java.util.concurrent.TimeUnit;
 
 /**
  * <p>A class to handle the request and response handling when using asynchronous request handling.</p>
@@ -25,14 +22,16 @@ public interface AsyncHandle {
     void setReadListener(RequestBodyListener readListener);
 
     /**
-     * Call this to indicate that the response is complete.
+     * Rejects subsequent writes and completes the exchange after all accepted writes drain.
      */
     void complete();
 
     /**
      * Call this to indicate that the response is complete.
-     * <p>If the <code>throwable</code> parameter is not null then the error will be logged and, if possible,
-     * a <code>500 Internal Server Error</code> message will be sent to the client.
+     * <p>A non-null error cancels queued writes and terminates active output before releasing its
+     * buffers. If output has not begun, the exception handler may send a 500 response; otherwise
+     * the HTTP/1 connection is closed or the HTTP/2 stream is reset. An active HTTP/2 socket
+     * frame may require closing its connection. Write futures fail independently of callback delivery.
      * @param throwable an exception to log, or null if there was no problem
      */
     void complete(@Nullable Throwable throwable);
@@ -43,6 +42,10 @@ public interface AsyncHandle {
      * <p>See {@link #write(ByteBuffer)} for an alternative that returns a future.</p>
      * <p>If {@link #complete()} or {@link #complete(Throwable)} has already been called, the callback is
      * invoked with an {@link IllegalStateException}.</p>
+     * <p>Multiple submissions are supported and written in order. Mu owns each buffer until its
+     * future completes or callback runs; do not modify or reuse it sooner. Waiting for completion
+     * before submitting more data provides backpressure. Do not mix concurrent blocking writes
+     * with these submissions. Callbacks use the application executor and can be dropped if it rejects.</p>
      * @param data The data to write
      * @param callback The callback when the write succeeds or fails
      */
@@ -54,56 +57,15 @@ public interface AsyncHandle {
      * <p>See {@link #write(ByteBuffer, DoneCallback)} for an alternative that uses a callback.</p>
      * <p>If {@link #complete()} or {@link #complete(Throwable)} has already been called, the returned future
      * fails with an {@link IllegalStateException}.</p>
+     * <p>Multiple submissions are supported and written in order. Mu owns each buffer until its
+     * future completes or callback runs; do not modify or reuse it sooner. Waiting for completion
+     * before submitting more data provides backpressure. Do not mix concurrent blocking writes
+     * with these submissions. Callbacks use the application executor and can be dropped if it rejects.</p>
      * @param data The data to write
-     * @return A future that is resolved when the write succeeds or fails.
+     * @return A future resolved after I/O releases the buffer, independently of application workers.
+     * Cancelling it cancels the asynchronous response and waits for active I/O to release its buffer.
      */
     Future<@Nullable Void> write(ByteBuffer data);
-
-    /**
-     * Executes an application continuation for this exchange.
-     *
-     * <p>Handles supplied by Mu Server dispatch the task to the request-handler
-     * execution domain when called from outside a Mu Server application callback.
-     * Tasks submitted by an application callback stay in the same execution turn and
-     * run after the current callback returns. This is useful when an asynchronous
-     * result becomes available on an executor that should not perform response
-     * serialization or invoke application callbacks.</p>
-     *
-     * <p>The default implementation runs the task immediately to retain compatibility
-     * with custom implementations of this interface.</p>
-     *
-     * @param task The application continuation to execute
-     */
-    default void executeApplicationTask(Runnable task) {
-        Objects.requireNonNull(task, "task").run();
-    }
-
-    /**
-     * Executes an application continuation after a delay.
-     *
-     * <p>Handles supplied by Mu Server use the server timer only to determine when the
-     * task is due, then dispatch the task to the request-handler execution domain. The
-     * returned future can be cancelled before the delay expires to prevent dispatch.
-     * Completion of the future does not guarantee that the application task has
-     * finished.</p>
-     *
-     * <p>The default implementation uses the JDK delayed executor and delegates to
-     * {@link #executeApplicationTask(Runnable)} to retain compatibility with custom implementations of
-     * this interface.</p>
-     *
-     * @param task The application continuation to execute
-     * @param delay The delay before execution
-     * @param unit The unit of {@code delay}
-     * @return A future representing the delayed execution
-     */
-    default Future<?> scheduleApplicationTask(Runnable task, long delay, TimeUnit unit) {
-        Objects.requireNonNull(task, "task");
-        Objects.requireNonNull(unit, "unit");
-        return CompletableFuture.runAsync(
-            () -> executeApplicationTask(task),
-            CompletableFuture.delayedExecutor(delay, unit)
-        );
-    }
 
     /**
      * Add a listener for when request processing is complete. One use of this is to detect early client disconnects

--- a/src/main/java/io/muserver/AsyncResponseOutput.java
+++ b/src/main/java/io/muserver/AsyncResponseOutput.java
@@ -1,0 +1,189 @@
+package io.muserver;
+
+import io.muserver.internal.FatalErrors;
+
+import org.jspecify.annotations.Nullable;
+import java.nio.ByteBuffer;
+import java.util.ArrayDeque;
+import java.util.Queue;
+import java.util.concurrent.*;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.Consumer;
+
+/** Serializes accepted output while keeping I/O outcomes independent of application workers. */
+final class AsyncResponseOutput {
+    @FunctionalInterface
+    interface Writer { void write(ByteBuffer data) throws Exception; }
+
+    private final Executor executor;
+    private final Writer writer;
+    private final Consumer<Boolean> abort;
+    private final SerialApplicationTasks callbacks;
+    private final ReentrantLock lock = new ReentrantLock();
+    private final Queue<PendingWrite> pending = new ArrayDeque<>();
+    private final CompletableFuture<@Nullable Void> completion = new CompletableFuture<>();
+    private boolean completionRequested;
+    private @Nullable Throwable failure;
+    private @Nullable PendingWrite active;
+    private boolean draining;
+    private final java.util.concurrent.atomic.AtomicBoolean abortRequested = new java.util.concurrent.atomic.AtomicBoolean();
+
+    AsyncResponseOutput(Executor executor, Writer writer, Consumer<Boolean> abort, SerialApplicationTasks callbacks) {
+        this.executor = executor;
+        this.writer = writer;
+        this.abort = abort;
+        this.callbacks = callbacks;
+    }
+
+    CompletableFuture<@Nullable Void> completion() { return completion; }
+
+    boolean completionIsPending() {
+        lock.lock();
+        try { return !completionRequested; }
+        finally { lock.unlock(); }
+    }
+
+    Future<@Nullable Void> write(ByteBuffer data, @Nullable DoneCallback callback) {
+        java.util.Objects.requireNonNull(data, "data");
+        PendingWrite write = new PendingWrite(data, callback);
+        boolean schedule = false;
+        boolean rejected;
+        lock.lock();
+        try {
+            rejected = completionRequested;
+            if (!rejected) {
+                pending.add(write);
+                if (!draining) { draining = true; schedule = true; }
+            }
+        } finally { lock.unlock(); }
+        if (rejected) {
+            write.finish(new IllegalStateException("The asynchronous response is already complete"));
+        } else if (schedule) {
+            try { executor.execute(this::drain); }
+            catch (RejectedExecutionException rejectedExecution) { fail(rejectedExecution); }
+        }
+        return write;
+    }
+
+    void complete(@Nullable Throwable cause) {
+        lock.lock();
+        try {
+            if (completionRequested) return;
+            completionRequested = true;
+            if (cause != null) failure = cause;
+        } finally { lock.unlock(); }
+        if (cause != null) fail(cause);
+        else finishIfDrained();
+    }
+
+    private void fail(Throwable cause) {
+        if (completion.isDone()) return;
+        Queue<PendingWrite> cancelled = new ArrayDeque<>();
+        boolean activeOutput;
+        lock.lock();
+        try {
+            completionRequested = true;
+            if (failure == null) failure = cause;
+            activeOutput = active != null;
+            if (!activeOutput) {
+                cancelled.addAll(pending);
+                pending.clear();
+                draining = false;
+            }
+        } finally { lock.unlock(); }
+        // The transport abort does not return buffers to callers. The I/O drain must
+        // acknowledge termination before active futures and callbacks can finish.
+        if (abortRequested.compareAndSet(false, true)) abort.accept(activeOutput);
+        for (PendingWrite write : cancelled) write.finish(cause);
+        if (!activeOutput) finishIfDrained();
+    }
+
+    private void drain() {
+        for (;;) {
+            PendingWrite write;
+            Throwable writeFailure;
+            lock.lock();
+            try {
+                write = pending.poll();
+                if (write == null) {
+                    draining = false;
+                    break;
+                }
+                active = write;
+                writeFailure = failure;
+            } finally { lock.unlock(); }
+            if (writeFailure == null) {
+                try { writer.write(write.data); }
+                catch (Throwable ioFailure) {
+                    writeFailure = ioFailure;
+                    fail(ioFailure);
+                }
+            }
+            lock.lock();
+            try {
+                if (failure != null) writeFailure = failure;
+            } finally { lock.unlock(); }
+            write.finish(writeFailure);
+            lock.lock();
+            try { active = null; } finally { lock.unlock(); }
+            if (writeFailure instanceof VirtualMachineError || writeFailure instanceof ThreadDeath) {
+                fail(writeFailure);
+                FatalErrors.rethrow(writeFailure);
+            }
+        }
+        finishIfDrained();
+    }
+
+    private void finishIfDrained() {
+        boolean finish;
+        Throwable terminalFailure;
+        lock.lock();
+        try {
+            finish = completionRequested && active == null && pending.isEmpty();
+            terminalFailure = failure;
+        } finally { lock.unlock(); }
+        if (finish) {
+            if (terminalFailure == null) completion.complete(null);
+            else completion.completeExceptionally(terminalFailure);
+        }
+    }
+
+    private final class PendingWrite implements Future<@Nullable Void> {
+        private final ByteBuffer data;
+        private final @Nullable DoneCallback callback;
+        private final CompletableFuture<@Nullable Void> result = new CompletableFuture<>();
+
+        PendingWrite(ByteBuffer data, @Nullable DoneCallback callback) {
+            this.data = data;
+            this.callback = callback;
+        }
+
+        void finish(@Nullable Throwable error) {
+            if (error == null) result.complete(null);
+            else result.completeExceptionally(error);
+            if (callback != null) callbacks.submit(() -> {
+                try { callback.onComplete(error); }
+                catch (Throwable callbackFailure) { fail(callbackFailure); FatalErrors.rethrow(callbackFailure); }
+            }, AsyncResponseOutput.this::fail);
+        }
+
+        @Override public boolean cancel(boolean mayInterruptIfRunning) {
+            if (result.isDone()) return false;
+            fail(new CancellationException("Asynchronous output was cancelled"));
+            boolean interrupted = false;
+            for (;;) {
+                try { result.get(); break; }
+                catch (InterruptedException e) { interrupted = true; }
+                catch (ExecutionException | CancellationException e) { break; }
+            }
+            if (interrupted) Thread.currentThread().interrupt();
+            return result.isCancelled();
+        }
+        @Override public boolean isCancelled() { return result.isCancelled(); }
+        @Override public boolean isDone() { return result.isDone(); }
+        @Override public @Nullable Void get() throws InterruptedException, ExecutionException { return result.get(); }
+        @Override public @Nullable Void get(long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
+            return result.get(timeout, unit);
+        }
+    }
+}

--- a/src/main/java/io/muserver/BaseHttpConnection.java
+++ b/src/main/java/io/muserver/BaseHttpConnection.java
@@ -136,7 +136,7 @@ abstract class BaseHttpConnection implements HttpConnection {
     }
 
     protected void handleExchangeException(Mu3Request muRequest, BaseResponse muResponse, Exception failure) throws Throwable {
-        if (muResponse.hasStartedSendingData()) {
+        if (muResponse.hasStartedSendingData() || muResponse.responseState().endState()) {
             // can't write a custom error at this point
             throw failure;
         } else {

--- a/src/main/java/io/muserver/BaseResponse.java
+++ b/src/main/java/io/muserver/BaseResponse.java
@@ -34,6 +34,14 @@ abstract class BaseResponse implements MuResponse {
         this.headers = headers;
     }
 
+    /** Cancels output that has reached the transport; safe to call from an I/O failure path. */
+    void abortAsyncOutput(boolean activeWrite) {
+        if (activeWrite || hasStartedSendingData()) {
+            setState(ResponseState.ERRORED);
+            ((BaseHttpConnection) request.connection()).forceShutdown();
+        }
+    }
+
     /**
      * Publishes a state transition. The first terminal state wins so that
      * concurrent cleanup cannot turn a failed exchange into a successful one.

--- a/src/main/java/io/muserver/ConnectionAcceptor.java
+++ b/src/main/java/io/muserver/ConnectionAcceptor.java
@@ -1,5 +1,7 @@
 package io.muserver;
 
+import io.muserver.internal.FatalErrors;
+
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -138,6 +140,7 @@ class ConnectionAcceptor {
                     throw submissionFailure;
                 }
             } catch (Throwable e) {
+            FatalErrors.rethrow(e);
                 if (Thread.interrupted() || e instanceof SocketException) {
                     log.info("Accept listening stopped");
                 } else {
@@ -295,6 +298,7 @@ class ConnectionAcceptor {
                 }
             }
         } catch (Throwable t) {
+            FatalErrors.rethrow(t);
             if (state == State.STARTED) {
                 log.error("Exception while doing timeouts", t);
             }
@@ -488,6 +492,7 @@ class ConnectionAcceptor {
                 con.start(clientIn, clientOut);
             }
         } catch (Throwable t) {
+            FatalErrors.rethrow(t);
             log.error("Unhandled exception for {}", con, t);
         } finally {
             server.getStatsImpl().onConnectionClosed(con);

--- a/src/main/java/io/muserver/Http1Connection.java
+++ b/src/main/java/io/muserver/Http1Connection.java
@@ -1,5 +1,7 @@
 package io.muserver;
 
+import io.muserver.internal.FatalErrors;
+
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -184,6 +186,7 @@ class Http1Connection extends BaseHttpConnection {
                             closeConnection = rejectRequestDueToHandlerOverload(muRequest, outputStream);
                         }
                     } catch (Throwable e) {
+            FatalErrors.rethrow(e);
                         closeConnection = true;
                         log.warn("Unrecoverable error for " + muRequest, e);
                         muResponse.setState(ResponseState.ERRORED);
@@ -225,6 +228,7 @@ class Http1Connection extends BaseHttpConnection {
                     completion.complete(handleExchange(request, response));
                 } catch (Throwable t) {
                     completion.completeExceptionally(t);
+                    FatalErrors.rethrow(t);
                 }
             }));
         } catch (RejectedExecutionException rejected) {
@@ -259,6 +263,7 @@ class Http1Connection extends BaseHttpConnection {
                 handled.complete(null);
             } catch (Throwable t) {
                 handled.completeExceptionally(t);
+                FatalErrors.rethrow(t);
             }
         };
         RejectedExecutionException rejected = server.tryExecuteHandlerTask(task);

--- a/src/main/java/io/muserver/Http2Connection.java
+++ b/src/main/java/io/muserver/Http2Connection.java
@@ -1,5 +1,7 @@
 package io.muserver;
 
+import io.muserver.internal.FatalErrors;
+
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -430,6 +432,7 @@ class Http2Connection extends BaseHttpConnection implements Http2Peer {
                 TimeUnit.MILLISECONDS
             ));
         } catch (RuntimeException | Error e) {
+            FatalErrors.rethrow(e);
             // The reader can consume and acknowledge this entry as soon as its
             // bytes reach the peer, including before flush() returns. Only fail
             // the connection if this writer still owns the pending entry.
@@ -605,6 +608,7 @@ class Http2Connection extends BaseHttpConnection implements Http2Peer {
     private boolean drainWritableFrames(OutputStream clientOut) throws IOException {
         Http2WriteCoordinator.WritableFrame candidate;
         while ((candidate = writeCoordinator.pollWritable()) != null) {
+            if (!candidate.beginWrite()) continue;
             try {
                 Http2Exception protocolError = candidate.protocolError();
                 LogicalHttp2Frame frame = protocolError == null
@@ -1321,6 +1325,11 @@ class Http2Connection extends BaseHttpConnection implements Http2Peer {
                 );
             }
         } catch (Throwable failure) {
+            if (failure instanceof VirtualMachineError || failure instanceof ThreadDeath) {
+                stream.abandonApplicationExchange();
+                onExchangeEnded(stream);
+                FatalErrors.rethrow(failure);
+            }
             if (stream.request.wasRateLimitRejected()) {
                 finishRateLimitedStream(stream, failure);
             } else {
@@ -1390,6 +1399,7 @@ class Http2Connection extends BaseHttpConnection implements Http2Peer {
             }
             stream.cleanup();
         } catch (Throwable e) {
+            FatalErrors.rethrow(e);
             if (e instanceof InterruptedException) {
                 Thread.currentThread().interrupt();
             }

--- a/src/main/java/io/muserver/Http2Response.java
+++ b/src/main/java/io/muserver/Http2Response.java
@@ -21,6 +21,14 @@ class Http2Response extends BaseResponse {
     }
 
     @Override
+    void abortAsyncOutput(boolean activeWrite) {
+        if (activeWrite || hasStartedSendingData()) {
+            setState(ResponseState.ERRORED);
+            stream.abortOutput(new IOException("Asynchronous HTTP/2 output was cancelled"));
+        }
+    }
+
+    @Override
     protected void cleanup() throws IOException, InterruptedException {
         if (responseState() == ResponseState.NOTHING) {
             // empty response body

--- a/src/main/java/io/muserver/Http2Stream.java
+++ b/src/main/java/io/muserver/Http2Stream.java
@@ -28,6 +28,9 @@ class Http2Stream implements ResponseInfo {
     // A monotonic published fence used to stop input delivery and to avoid
     // starting new response work after any thread has initiated a reset.
     private volatile boolean resetInitiated;
+    private final Object outputLock = new Object();
+    private @Nullable WriteTask activeWrite;
+    private boolean outputAborted;
     private volatile boolean applicationExchangeEnded;
     private volatile boolean protocolStateClosed;
     // Writer-published after the complete END_STREAM frame is handed to output
@@ -427,8 +430,41 @@ class Http2Stream implements ResponseInfo {
      */
     void blockingWrite(LogicalHttp2Frame frame) throws IOException, InterruptedException {
         WriteTask writeTask = new WriteTask(frame, true);
-        connection.write(writeTask);
-        writeTask.await(2, TimeUnit.HOURS);
+        synchronized (outputLock) {
+            if (resetInitiated) throw new IOException("HTTP/2 stream output is closed");
+            activeWrite = writeTask;
+        }
+        try {
+            connection.write(writeTask);
+            try {
+                writeTask.await();
+            } catch (InterruptedException interrupted) {
+                abortOutput(new IOException("Interrupted while writing HTTP/2 output", interrupted));
+                writeTask.awaitTermination();
+                throw interrupted;
+            }
+        } finally {
+            synchronized (outputLock) { activeWrite = null; }
+        }
+    }
+
+    void abortOutput(IOException reason) {
+        WriteTask writing;
+        boolean sendReset;
+        synchronized (outputLock) {
+            if (outputAborted) return;
+            outputAborted = true;
+            sendReset = !resetInitiated;
+            resetInitiated = true;
+            writing = activeWrite;
+        }
+        if (writing != null && writing.cancel(reason)) {
+            // A frame cannot be interrupted midway and followed by another frame.
+            connection.forceShutdown();
+        } else if (sendReset) {
+            connection.write(new Http2ResetStreamFrame(id, Http2ErrorCode.CANCEL.code()));
+        }
+        cancel(reason);
     }
 
     @Override

--- a/src/main/java/io/muserver/Http2WriteCoordinator.java
+++ b/src/main/java/io/muserver/Http2WriteCoordinator.java
@@ -57,11 +57,20 @@ final class Http2WriteCoordinator {
             }
         }
 
-        void complete() {
-            if (completesTask) {
-                onWriteCompleted(frame);
-                task.complete();
+        boolean beginWrite() {
+            if (task.beginWrite()) return true;
+            // A cancellation can race the credit reservation. No bytes reached the peer.
+            if (frame instanceof Http2DataFrame) {
+                int reserved = frame.flowControlSize();
+                connectionCredit += reserved;
+                streamCredits.computeIfPresent(frame.streamId(), (id, credit) -> credit + reserved);
             }
+            return false;
+        }
+
+        void complete() {
+            if (completesTask) onWriteCompleted(frame);
+            task.finishPart(completesTask);
         }
 
         void fail(Exception reason) {
@@ -384,6 +393,7 @@ final class Http2WriteCoordinator {
         for (Iterator<PendingWrite> iterator = pendingWrites.iterator(); iterator.hasNext(); ) {
             PendingWrite pending = iterator.next();
             WriteTask task = pending.task;
+            if (task.isCancelled()) { iterator.remove(); continue; }
             int streamId = task.frame().streamId();
             LogicalHttp2Frame frame = task.frame();
             if (connectionErrorPendingGoAway && !(frame instanceof Http2GoAway)) {

--- a/src/main/java/io/muserver/Mu3AsyncHandleImpl.java
+++ b/src/main/java/io/muserver/Mu3AsyncHandleImpl.java
@@ -1,5 +1,7 @@
 package io.muserver;
 
+import io.muserver.internal.FatalErrors;
+
 import org.jspecify.annotations.Nullable;
 
 import java.io.IOException;
@@ -12,59 +14,25 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
-class Mu3AsyncHandleImpl implements AsyncHandle {
+class Mu3AsyncHandleImpl implements AsyncHandle, io.muserver.internal.AsyncExecution {
     private final Mu3Request request;
     private final BaseResponse response;
-    private CompletableFuture<@Nullable Void> responseFuture = CompletableFuture.completedFuture(null);
-    private final CompletableFuture<@Nullable Void> completionFuture = new CompletableFuture<>();
-    private final Lock lock = new ReentrantLock();
-    // Guarded by lock. This is the terminal gate for response writes and exchange completion.
-    private boolean completionRequested;
+    private final AsyncResponseOutput output;
     private final Mu3ServerImpl server;
-    private final Executor ioExecutor;
     private final SerialApplicationTasks callbacks;
 
     Mu3AsyncHandleImpl(Mu3Request request, BaseResponse response, Mu3ServerImpl server) {
         this.request = request;
         this.response = response;
         this.server = server;
-        this.ioExecutor = server::executeInternalTask;
         this.callbacks = new SerialApplicationTasks(server);
+        this.output = new AsyncResponseOutput(server::executeInternalTask,
+            this::copyBufferToResponseOutput, response::abortAsyncOutput, callbacks);
     }
 
-    CompletableFuture<@Nullable Void> exchangeCompletion() {
-        CompletableFuture<@Nullable Void> exchangeCompletion = new CompletableFuture<>();
-        completionFuture.whenComplete((ignored, completionFailure) -> {
-            if (completionFailure != null) {
-                exchangeCompletion.completeExceptionally(completionCause(completionFailure));
-                return;
-            }
-            CompletableFuture<@Nullable Void> writes;
-            lock.lock();
-            try {
-                writes = responseFuture;
-            } finally {
-                lock.unlock();
-            }
-            writes.whenComplete((writeIgnored, writeFailure) -> {
-                if (writeFailure == null) {
-                    exchangeCompletion.complete(null);
-                } else {
-                    exchangeCompletion.completeExceptionally(completionCause(writeFailure));
-                }
-            });
-        });
-        return exchangeCompletion;
-    }
+    CompletableFuture<@Nullable Void> exchangeCompletion() { return output.completion(); }
 
-    boolean completionIsPending() {
-        lock.lock();
-        try {
-            return !completionRequested;
-        } finally {
-            lock.unlock();
-        }
-    }
+    boolean completionIsPending() { return output.completionIsPending(); }
 
     @Override
     public void setReadListener(RequestBodyListener readListener) {
@@ -108,6 +76,7 @@ class Mu3AsyncHandleImpl implements AsyncHandle {
                 read = clientIn.read(buffer);
             } catch (Throwable t) {
                 fail(t, true);
+                FatalErrors.rethrow(t);
                 return;
             }
             if (read == -1) {
@@ -133,6 +102,7 @@ class Mu3AsyncHandleImpl implements AsyncHandle {
                 });
             } catch (Throwable failure) {
                 fail(failure, true);
+                FatalErrors.rethrow(failure);
             }
         }
 
@@ -144,6 +114,7 @@ class Mu3AsyncHandleImpl implements AsyncHandle {
                 readListener.onComplete();
             } catch (Throwable t) {
                 complete(t);
+                FatalErrors.rethrow(t);
             } finally {
                 Mutils.closeSilently(clientIn);
             }
@@ -160,6 +131,7 @@ class Mu3AsyncHandleImpl implements AsyncHandle {
                         readListener.onError(failure);
                     } catch (Throwable listenerFailure) {
                         addSuppressedIfDifferent(failure, listenerFailure);
+                        FatalErrors.rethrow(listenerFailure);
                     } finally {
                         complete(failure);
                     }
@@ -170,76 +142,15 @@ class Mu3AsyncHandleImpl implements AsyncHandle {
         }
     }
 
-    @Override
-    public void complete() {
-        completeOnce(null);
+    @Override public void complete() { output.complete(null); }
+
+    @Override public void complete(@Nullable Throwable throwable) { output.complete(throwable); }
+
+    @Override public void write(ByteBuffer data, DoneCallback callback) {
+        output.write(data, Objects.requireNonNull(callback, "callback"));
     }
 
-    @Override
-    public void complete(@Nullable Throwable throwable) {
-        completeOnce(throwable);
-    }
-
-    private void completeOnce(@Nullable Throwable failure) {
-        lock.lock();
-        try {
-            if (completionRequested) {
-                return;
-            }
-            completionRequested = true;
-        } finally {
-            lock.unlock();
-        }
-        if (failure == null) {
-            completionFuture.complete(null);
-        } else {
-            completionFuture.completeExceptionally(failure);
-        }
-    }
-
-    @Override
-    public void write(ByteBuffer data, DoneCallback callback) {
-        Objects.requireNonNull(callback, "callback");
-        submitWrite(data).whenComplete((ignored, failure) -> callbacks.submit(() -> {
-            try {
-                callback.onComplete(failure == null ? null : completionCause(failure));
-            } catch (Throwable callbackFailure) {
-                complete(callbackFailure);
-            }
-        }, this::complete));
-    }
-
-    @Override
-    public Future<@Nullable Void> write(ByteBuffer data) {
-        return submitWrite(data);
-    }
-
-    private CompletableFuture<@Nullable Void> submitWrite(ByteBuffer data) {
-        Objects.requireNonNull(data, "data");
-        CompletableFuture<@Nullable Void> write;
-        lock.lock();
-        try {
-            if (completionRequested) return CompletableFuture.failedFuture(completedResponseWriteFailure());
-            write = responseFuture.thenRunAsync(() -> {
-                try {
-                    copyBufferToResponseOutput(data);
-                } catch (IOException e) {
-                    throw new CompletionException(e);
-                }
-            }, ioExecutor).thenApply(ignored -> null);
-            responseFuture = write;
-        } finally {
-            lock.unlock();
-        }
-        write.whenComplete((ignored, failure) -> {
-            if (failure != null) complete(completionCause(failure));
-        });
-        return write;
-    }
-
-    private static IllegalStateException completedResponseWriteFailure() {
-        return new IllegalStateException("The asynchronous response is already complete");
-    }
+    @Override public Future<@Nullable Void> write(ByteBuffer data) { return output.write(data, null); }
 
     @Override
     public void executeApplicationTask(Runnable task) {

--- a/src/main/java/io/muserver/Mu3Request.java
+++ b/src/main/java/io/muserver/Mu3Request.java
@@ -282,25 +282,29 @@ class Mu3Request implements MuRequest {
         return attributes;
     }
 
-    @Deprecated
     @Override
-    public synchronized AsyncHandle handleAsync() {
-        if (asyncHandle == null) {
-            asyncHandle = new Mu3AsyncHandleImpl(this,
-                Objects.requireNonNull(response, "The response has not been initialized"),
-                serverImpl());
+    public AsyncHandle handleAsync() {
+        Mu3AsyncHandleImpl handle;
+        boolean cancelled;
+        synchronized (this) {
+            if (asyncHandle == null) {
+                asyncHandle = new Mu3AsyncHandleImpl(this,
+                    Objects.requireNonNull(response, "The response has not been initialized"), serverImpl());
+            }
+            handle = asyncHandle;
+            cancelled = clientCancelled;
         }
-        if (clientCancelled) {
-            asyncHandle.complete();
-        }
-        return asyncHandle;
+        if (cancelled) handle.complete(new ClientDisconnectedException());
+        return handle;
     }
 
-    synchronized void onClientCancelled() {
-        clientCancelled = true;
-        if (asyncHandle != null) {
-            asyncHandle.complete();
+    void onClientCancelled() {
+        Mu3AsyncHandleImpl handle;
+        synchronized (this) {
+            clientCancelled = true;
+            handle = asyncHandle;
         }
+        if (handle != null) handle.complete(new ClientDisconnectedException());
     }
 
     @Override

--- a/src/main/java/io/muserver/Mu3ServerImpl.java
+++ b/src/main/java/io/muserver/Mu3ServerImpl.java
@@ -1,5 +1,7 @@
 package io.muserver;
 
+import io.muserver.internal.FatalErrors;
+
 import org.jspecify.annotations.Nullable;
 
 import java.io.IOException;
@@ -218,6 +220,7 @@ class Mu3ServerImpl implements MuServer {
             try {
                 task.run();
             } catch (Throwable taskFailure) {
+            FatalErrors.rethrow(taskFailure);
                 if (failure == null) {
                     failure = taskFailure;
                 } else if (failure != taskFailure) {
@@ -443,6 +446,7 @@ class Mu3ServerImpl implements MuServer {
         try {
             listener.onComplete(exchange);
         } catch (Throwable failure) {
+            FatalErrors.rethrow(failure);
             log.error("Error from response completion listener", failure);
         }
     }
@@ -462,6 +466,7 @@ class Mu3ServerImpl implements MuServer {
             try {
                 listener.onRejected(info);
             } catch (Throwable failure) {
+            FatalErrors.rethrow(failure);
                 log.error("Error from request reject listener", failure);
             }
         }

--- a/src/main/java/io/muserver/MuRequest.java
+++ b/src/main/java/io/muserver/MuRequest.java
@@ -240,10 +240,7 @@ public interface MuRequest {
      * <p>When finished, call {@link AsyncHandle#complete()}</p>
      * <p>If called more than once, then the async handle created from the first call is returned.</p>
      * @return An object that you can use to mark the response as complete.
-     * @deprecated this is less performant than using the standard blocking calls and is
-     *      retained for compatibility with existing users.
      */
-    @Deprecated
     AsyncHandle handleAsync();
 
     /**

--- a/src/main/java/io/muserver/SerialApplicationTasks.java
+++ b/src/main/java/io/muserver/SerialApplicationTasks.java
@@ -1,50 +1,45 @@
 package io.muserver;
 
+import java.util.ArrayDeque;
 import java.util.Queue;
-import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.RejectedExecutionException;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 
 /** One application's callback mailbox; never holds an I/O worker while callbacks run. */
 final class SerialApplicationTasks {
     private final Mu3ServerImpl server;
-    private final Queue<Entry> tasks = new ConcurrentLinkedQueue<>();
-    private final AtomicBoolean running = new AtomicBoolean();
+    private final Object lock = new Object();
+    private final Queue<Entry> tasks = new ArrayDeque<>();
+    private boolean scheduled;
 
     SerialApplicationTasks(Mu3ServerImpl server) { this.server = server; }
 
     void submit(Runnable task, Consumer<RejectedExecutionException> onRejected) {
-        tasks.add(new Entry(task, onRejected));
-        if (running.compareAndSet(false, true)) {
-            RejectedExecutionException rejected = server.executeTrackedApplicationTask(this::drain, "async callback");
-            if (rejected != null) {
-                Entry entry;
-                while ((entry = tasks.poll()) != null) entry.onRejected.accept(rejected);
-                running.set(false);
-                // A concurrent submit may have observed running before it was cleared.
-                if (!tasks.isEmpty()) scheduleRemaining();
-            }
+        synchronized (lock) {
+            tasks.add(new Entry(task, onRejected));
+            if (scheduled) return;
+            scheduled = true;
         }
-    }
-
-    private void scheduleRemaining() {
-        if (!running.compareAndSet(false, true)) return;
         RejectedExecutionException rejected = server.executeTrackedApplicationTask(this::drain, "async callback");
         if (rejected != null) {
-            Entry entry;
-            while ((entry = tasks.poll()) != null) entry.onRejected.accept(rejected);
-            running.set(false);
-            if (!tasks.isEmpty()) scheduleRemaining();
+            Queue<Entry> rejectedTasks;
+            synchronized (lock) {
+                rejectedTasks = new ArrayDeque<>(tasks);
+                tasks.clear();
+                scheduled = false;
+            }
+            for (Entry entry : rejectedTasks) entry.onRejected.accept(rejected);
         }
     }
 
     private void drain() {
         for (;;) {
             Entry entry;
-            while ((entry = tasks.poll()) != null) entry.task.run();
-            running.set(false);
-            if (tasks.isEmpty() || !running.compareAndSet(false, true)) return;
+            synchronized (lock) {
+                entry = tasks.poll();
+                if (entry == null) { scheduled = false; return; }
+            }
+            entry.task.run();
         }
     }
 

--- a/src/main/java/io/muserver/WebsocketConnection.java
+++ b/src/main/java/io/muserver/WebsocketConnection.java
@@ -1,5 +1,7 @@
 package io.muserver;
 
+import io.muserver.internal.FatalErrors;
+
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -275,6 +277,7 @@ class WebsocketConnection implements MuWebSocketSession {
             }
             boolean applicationFailure = failure instanceof ApplicationEventFailure;
             Throwable e = applicationFailure ? Objects.requireNonNull(failure.getCause()) : failure;
+            FatalErrors.rethrow(e);
             if ((!serverShutdownRequested.get() || applicationFailure)
                 && !errorEventQueued.get()
                 && lifecycle.state() != WebsocketSessionState.TIMED_OUT) {
@@ -497,6 +500,7 @@ class WebsocketConnection implements MuWebSocketSession {
                 task.completion.complete(null);
             } catch (Throwable failure) {
                 task.completion.completeExceptionally(failure);
+                FatalErrors.rethrow(failure);
             }
         }
     }

--- a/src/main/java/io/muserver/WriteTask.java
+++ b/src/main/java/io/muserver/WriteTask.java
@@ -21,17 +21,61 @@ class WriteTask {
         return frame;
     }
 
-    public void complete() {
-        if (completionCallback != null) {
-            completionCallback.countDown();
-        }
+    private boolean writing;
+    private boolean cancelled;
+    private boolean finished;
+
+    synchronized boolean beginWrite() {
+        if (cancelled || finished) return false;
+        writing = true;
+        return true;
     }
 
-    public void fail(Exception ex) {
+    synchronized boolean isCancelled() { return cancelled; }
+
+    /** Returns whether transport output must be aborted to release this task's buffer. */
+    synchronized boolean cancel(IOException reason) {
+        if (finished) return false;
+        cancelled = true;
+        error = reason;
+        if (!writing) finish();
+        return writing;
+    }
+
+    synchronized void finishPart(boolean last) {
+        writing = false;
+        if (last || cancelled) finish();
+    }
+
+    public synchronized void complete() { finishPart(true); }
+
+    public synchronized void fail(Exception ex) {
+        if (finished) return;
+        writing = false;
+        error = ex;
+        finish();
+    }
+
+    private void finish() {
+        finished = true;
+        if (completionCallback != null) completionCallback.countDown();
+    }
+
+    void await() throws InterruptedException, IOException {
+        if (completionCallback != null) completionCallback.await();
+        throwIfFailed();
+    }
+
+    /** Buffer ownership cannot be released just because the waiting thread was interrupted. */
+    void awaitTermination() {
+        boolean interrupted = false;
         if (completionCallback != null) {
-            error = ex;
-            completionCallback.countDown();
+            for (;;) {
+                try { completionCallback.await(); break; }
+                catch (InterruptedException e) { interrupted = true; }
+            }
         }
+        if (interrupted) Thread.currentThread().interrupt();
     }
 
     public void await(long timeout, TimeUnit unit) throws InterruptedException, IOException {
@@ -42,6 +86,10 @@ class WriteTask {
                 throw tio;
             }
         }
+        throwIfFailed();
+    }
+
+    private void throwIfFailed() throws IOException {
         Exception err = error;
         if (err != null) {
             if (err instanceof IOException) {

--- a/src/main/java/io/muserver/internal/AsyncExecution.java
+++ b/src/main/java/io/muserver/internal/AsyncExecution.java
@@ -1,0 +1,30 @@
+package io.muserver.internal;
+
+import io.muserver.AsyncHandle;
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Internal bridge between core exchange dispatch and JAX-RS. Not a supported extension API.
+ * @hidden
+ */
+public interface AsyncExecution {
+    void executeApplicationTask(Runnable task);
+    Future<?> scheduleApplicationTask(Runnable task, long delay, TimeUnit unit);
+
+    static AsyncExecution forHandle(AsyncHandle handle) {
+        if (handle instanceof AsyncExecution) return (AsyncExecution) handle;
+        return new AsyncExecution() {
+            @Override public void executeApplicationTask(Runnable task) {
+                Objects.requireNonNull(task, "task").run();
+            }
+            @Override public Future<?> scheduleApplicationTask(Runnable task, long delay, TimeUnit unit) {
+                Objects.requireNonNull(task, "task");
+                return CompletableFuture.runAsync(() -> executeApplicationTask(task),
+                    CompletableFuture.delayedExecutor(delay, unit));
+            }
+        };
+    }
+}

--- a/src/main/java/io/muserver/internal/FatalErrors.java
+++ b/src/main/java/io/muserver/internal/FatalErrors.java
@@ -1,0 +1,12 @@
+package io.muserver.internal;
+
+/** Fatal VM/thread failures are never converted to ordinary application failures.
+ * @hidden
+ */
+public final class FatalErrors {
+    private FatalErrors() { }
+    public static void rethrow(Throwable failure) {
+        if (failure instanceof VirtualMachineError) throw (VirtualMachineError) failure;
+        if (failure instanceof ThreadDeath) throw (ThreadDeath) failure;
+    }
+}

--- a/src/main/java/io/muserver/rest/AsyncResponseAdapter.java
+++ b/src/main/java/io/muserver/rest/AsyncResponseAdapter.java
@@ -1,5 +1,8 @@
 package io.muserver.rest;
 
+import io.muserver.internal.FatalErrors;
+import io.muserver.internal.AsyncExecution;
+
 import io.muserver.*;
 import jakarta.ws.rs.ServiceUnavailableException;
 import jakarta.ws.rs.container.AsyncResponse;
@@ -85,11 +88,12 @@ class AsyncResponseAdapter implements AsyncResponse, ResponseCompleteListener {
         }
         cancel(timeoutToCancel);
         try {
-            asyncHandle.executeApplicationTask(() -> processResponse(response));
+            AsyncExecution.forHandle(asyncHandle).executeApplicationTask(() -> processResponse(response));
         } catch (Throwable dispatchFailure) {
             exceptionWhileWriting = dispatchFailure;
             markDone();
             asyncHandle.complete(dispatchFailure);
+                FatalErrors.rethrow(dispatchFailure);
         }
         return true;
     }
@@ -106,6 +110,7 @@ class AsyncResponseAdapter implements AsyncResponse, ResponseCompleteListener {
                 Throwable failure = (Throwable) response;
                 exceptionWhileWriting = failure;
                 asyncHandle.complete(failure);
+                FatalErrors.rethrow(failure);
             } else {
                 resultConsumer.accept(response);
                 asyncHandle.complete();
@@ -114,8 +119,10 @@ class AsyncResponseAdapter implements AsyncResponse, ResponseCompleteListener {
             exceptionWhileWriting = responseFailure;
             try {
                 asyncHandle.complete(responseFailure);
+                FatalErrors.rethrow(responseFailure);
             } catch (Throwable completionFailure) {
                 addSuppressedIfDifferent(responseFailure, completionFailure);
+                FatalErrors.rethrow(completionFailure);
             }
         } finally {
             markDone();
@@ -162,7 +169,7 @@ class AsyncResponseAdapter implements AsyncResponse, ResponseCompleteListener {
             return true;
         }
 
-        Future<?> scheduled = asyncHandle.scheduleApplicationTask(
+        Future<?> scheduled = AsyncExecution.forHandle(asyncHandle).scheduleApplicationTask(
             () -> timeoutExpired(generation),
             time,
             unit
@@ -195,6 +202,7 @@ class AsyncResponseAdapter implements AsyncResponse, ResponseCompleteListener {
                 handler.handleTimeout(this);
             } catch (Throwable timeoutFailure) {
                 resume(timeoutFailure);
+                FatalErrors.rethrow(timeoutFailure);
                 return;
             }
             synchronized (stateLock) {

--- a/src/main/java/io/muserver/rest/RestHandler.java
+++ b/src/main/java/io/muserver/rest/RestHandler.java
@@ -1,5 +1,8 @@
 package io.muserver.rest;
 
+import io.muserver.internal.FatalErrors;
+import io.muserver.internal.AsyncExecution;
+
 import io.muserver.*;
 import jakarta.ws.rs.ClientErrorException;
 import jakarta.ws.rs.NotAllowedException;
@@ -161,6 +164,7 @@ public class RestHandler implements MuHandler {
                                 : completionCause((Throwable) stageFailure);
                             if (failure != null && !(failure instanceof Exception)) {
                                 asyncHandle.complete(failure);
+                FatalErrors.rethrow(failure);
                                 return;
                             }
                             @Nullable Object response = failure == null ? value : failure;
@@ -170,12 +174,14 @@ public class RestHandler implements MuHandler {
                                 asyncHandle.complete();
                             } catch (Throwable responseFailure) {
                                 asyncHandle.complete(responseFailure);
+                FatalErrors.rethrow(responseFailure);
                             }
                         };
                         try {
-                            asyncHandle.executeApplicationTask(continuation);
+                            AsyncExecution.forHandle(asyncHandle).executeApplicationTask(continuation);
                         } catch (Throwable dispatchFailure) {
                             asyncHandle.complete(dispatchFailure);
+                FatalErrors.rethrow(dispatchFailure);
                         }
                     });
                 } else {

--- a/src/test/java/io/muserver/AsyncOutputIntegrationTest.java
+++ b/src/test/java/io/muserver/AsyncOutputIntegrationTest.java
@@ -1,0 +1,60 @@
+package io.muserver;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.List;
+import java.util.concurrent.*;
+import okhttp3.Protocol;
+import okhttp3.Response;
+import static org.junit.jupiter.api.Assertions.*;
+import static scaffolding.ClientUtils.client;
+import static scaffolding.ClientUtils.request;
+
+@Timeout(15)
+class AsyncOutputIntegrationTest {
+    @ParameterizedTest @ValueSource(booleans = {false, true})
+    void aHandlerCanWaitForWriteIoWithOneApplicationWorker(boolean h2) throws Exception {
+        var application = Executors.newSingleThreadExecutor();
+        MuServer server = MuServerBuilder.httpServer().withHttp2Config(Http2ConfigBuilder.http2Enabled())
+            .withHandlerExecutor(application).addHandler((req, resp) -> {
+                AsyncHandle handle = req.handleAsync();
+                handle.write(ByteBuffer.wrap(new byte[]{1, 2, 3})).get(5, TimeUnit.SECONDS);
+                handle.complete();
+                return true;
+            }).start();
+        var transport = client.newBuilder().protocols(h2 ? List.of(Protocol.H2_PRIOR_KNOWLEDGE) : List.of(Protocol.HTTP_1_1)).build();
+        try (Response response = transport.newCall(request(server.uri()).build()).execute()) {
+            assertArrayEquals(new byte[]{1, 2, 3}, response.body().bytes());
+        } finally { server.stop(); application.shutdownNow(); transport.connectionPool().evictAll(); }
+    }
+
+    @Test void cancellingFlowControlledOutputResetsTheStreamAndKeepsTheConnectionUsable() throws Exception {
+        var handles = new CompletableFuture<AsyncHandle>();
+        var writing = new CompletableFuture<Future<?>>();
+        MuServer server = MuServerBuilder.httpServer().withHttp2Config(Http2ConfigBuilder.http2Enabled())
+            .addHandler((req, resp) -> {
+                AsyncHandle handle = req.handleAsync();
+                writing.complete(handle.write(ByteBuffer.wrap(new byte[20])));
+                handles.complete(handle);
+                return true;
+            }).start();
+        try (var client = new H2Client(); var con = client.connectClearText(server)) {
+            con.socket().setSoTimeout(5000);
+            con.handshake(new Http2Settings(false, 4096, 100, 0, 16384, 32768));
+            con.writeFrame(new Http2HeadersFrame(1, true, RFCTestUtils.getHelloHeaders("http", server.uri().getPort()))).flush();
+            con.readLogicalFrame(Http2HeadersFrame.class);
+            Future<?> output = writing.get(5, TimeUnit.SECONDS);
+            assertFalse(output.isDone());
+            handles.get(5, TimeUnit.SECONDS).complete(new IOException("cancel"));
+            assertEquals(1, con.readLogicalFrame(Http2ResetStreamFrame.class).streamId());
+            assertThrows(ExecutionException.class, () -> output.get(5, TimeUnit.SECONDS));
+            byte[] ping = {1, 2, 3, 4, 5, 6, 7, 8};
+            con.writeFrame(new Http2WindowUpdate(1, 100)).writeFrame(new Http2Ping(false, ping)).flush();
+            assertEquals(new Http2Ping(true, ping), con.readLogicalFrame(Http2Ping.class));
+        } finally { server.stop(); }
+    }
+}

--- a/src/test/java/io/muserver/AsyncResponseOutputTest.java
+++ b/src/test/java/io/muserver/AsyncResponseOutputTest.java
@@ -1,0 +1,112 @@
+package io.muserver;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.List;
+import java.util.concurrent.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+@Timeout(15)
+class AsyncResponseOutputTest {
+    private final ExecutorService application = Executors.newSingleThreadExecutor(task -> new Thread(task, "application"));
+    private final ExecutorService io = Executors.newCachedThreadPool();
+    private final Mu3ServerImpl server = (Mu3ServerImpl) MuServerBuilder.httpServer().withHandlerExecutor(application).start();
+
+    @AfterEach void stop() { server.stop(); application.shutdownNow(); io.shutdownNow(); }
+
+    @Test void acceptedWritesDrainInOrderWithoutWaitingForCallbacks() throws Exception {
+        var firstStarted = new CountDownLatch(1);
+        var releaseOutput = new CountDownLatch(1);
+        var releaseCallback = new CountDownLatch(1);
+        var firstCallback = new CountDownLatch(1);
+        var allCallbacks = new CountDownLatch(2);
+        var bytes = new CopyOnWriteArrayList<Byte>();
+        var delivered = new CopyOnWriteArrayList<Integer>();
+        var output = new AsyncResponseOutput(io, buffer -> {
+            firstStarted.countDown();
+            releaseOutput.await();
+            bytes.add(buffer.get());
+        }, active -> { }, new SerialApplicationTasks(server));
+        var first = output.write(ByteBuffer.wrap(new byte[]{1}), error -> {
+            assertNull(error);
+            assertEquals("application", Thread.currentThread().getName());
+            delivered.add(1);
+            firstCallback.countDown();
+            releaseCallback.await();
+            allCallbacks.countDown();
+        });
+        assertTrue(firstStarted.await(5, TimeUnit.SECONDS));
+        var second = output.write(ByteBuffer.wrap(new byte[]{2}), error -> {
+            assertNull(error);
+            delivered.add(2);
+            allCallbacks.countDown();
+        });
+        output.complete(null);
+        assertThrows(ExecutionException.class, () -> output.write(ByteBuffer.allocate(1), null).get());
+        try {
+            releaseOutput.countDown();
+            assertTrue(firstCallback.await(5, TimeUnit.SECONDS));
+            first.get(5, TimeUnit.SECONDS);
+            second.get(5, TimeUnit.SECONDS);
+            output.completion().get(5, TimeUnit.SECONDS);
+            assertEquals(List.of((byte) 1, (byte) 2), bytes);
+            assertEquals(List.of(1), delivered);
+        } finally { releaseCallback.countDown(); releaseOutput.countDown(); }
+        assertTrue(allCallbacks.await(5, TimeUnit.SECONDS));
+        assertEquals(List.of(1, 2), delivered);
+    }
+
+    @Test void failureKeepsActiveBufferOwnedUntilIoAcknowledgesAbort() throws Exception {
+        var started = new CountDownLatch(1);
+        var aborted = new CountDownLatch(1);
+        var acknowledge = new CountDownLatch(1);
+        var delivered = new CopyOnWriteArrayList<Integer>();
+        var callbacksDone = new CountDownLatch(3);
+        IOException expected = new IOException("stop output");
+        var output = new AsyncResponseOutput(io, buffer -> {
+            started.countDown();
+            acknowledge.await();
+            throw expected;
+        }, active -> aborted.countDown(), new SerialApplicationTasks(server));
+        var first = output.write(ByteBuffer.allocate(10), error -> { delivered.add(1); callbacksDone.countDown(); });
+        assertTrue(started.await(5, TimeUnit.SECONDS));
+        var second = output.write(ByteBuffer.allocate(10), error -> { delivered.add(2); callbacksDone.countDown(); });
+        var third = output.write(ByteBuffer.allocate(10), error -> { delivered.add(3); callbacksDone.countDown(); });
+        try {
+            output.complete(expected);
+            assertTrue(aborted.await(5, TimeUnit.SECONDS));
+            assertFalse(first.isDone());
+            assertFalse(output.completion().isDone());
+            acknowledge.countDown();
+            for (Future<?> future : List.of(first, second, third, output.completion())) {
+                assertSame(expected, assertThrows(ExecutionException.class, () -> future.get(5, TimeUnit.SECONDS)).getCause());
+            }
+            assertTrue(callbacksDone.await(5, TimeUnit.SECONDS));
+            assertEquals(List.of(1, 2, 3), delivered);
+        } finally { acknowledge.countDown(); }
+    }
+
+    @Test void cancellingTheReturnedFutureWaitsForBufferRelease() throws Exception {
+        var started = new CountDownLatch(1);
+        var aborted = new CountDownLatch(1);
+        var acknowledge = new CountDownLatch(1);
+        var output = new AsyncResponseOutput(io, buffer -> {
+            started.countDown();
+            acknowledge.await();
+        }, active -> aborted.countDown(), new SerialApplicationTasks(server));
+        Future<?> write = output.write(ByteBuffer.allocate(1), null);
+        assertTrue(started.await(5, TimeUnit.SECONDS));
+        Future<Boolean> cancellation = io.submit(() -> write.cancel(true));
+        try {
+            assertTrue(aborted.await(5, TimeUnit.SECONDS));
+            assertFalse(write.isDone());
+            assertFalse(cancellation.isDone());
+            acknowledge.countDown();
+            assertTrue(cancellation.get(5, TimeUnit.SECONDS));
+            assertTrue(write.isCancelled());
+        } finally { acknowledge.countDown(); }
+    }
+}

--- a/src/test/java/io/muserver/WriteTaskTest.java
+++ b/src/test/java/io/muserver/WriteTaskTest.java
@@ -1,0 +1,31 @@
+package io.muserver;
+
+import org.junit.jupiter.api.Test;
+import java.io.IOException;
+import java.util.concurrent.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+class WriteTaskTest {
+    @Test void cancelledQueuedDataCannotStartWriting() throws Exception {
+        WriteTask task = new WriteTask(new Http2DataFrame(1, false, new byte[]{1}, 0, 1), true);
+        IOException cancelled = new IOException("cancelled");
+        assertFalse(task.cancel(cancelled));
+        assertFalse(task.beginWrite());
+        assertSame(cancelled, assertThrows(IOException.class, task::await));
+    }
+
+    @Test void activeDataKeepsOwnershipUntilTheWriterTerminates() throws Exception {
+        WriteTask task = new WriteTask(new Http2DataFrame(1, false, new byte[]{1}, 0, 1), true);
+        assertTrue(task.beginWrite());
+        IOException cancelled = new IOException("cancelled");
+        assertTrue(task.cancel(cancelled));
+        var waiter = Executors.newSingleThreadExecutor();
+        Future<?> completion = waiter.submit(() -> { task.await(); return null; });
+        try {
+            assertThrows(TimeoutException.class, () -> completion.get(50, TimeUnit.MILLISECONDS));
+            task.finishPart(false);
+            assertSame(cancelled, assertThrows(ExecutionException.class, () -> completion.get(5, TimeUnit.SECONDS)).getCause());
+            assertFalse(task.beginWrite());
+        } finally { task.fail(cancelled); waiter.shutdownNow(); }
+    }
+}

--- a/src/test/java/io/muserver/rest/AsynchronousProcessingTest.java
+++ b/src/test/java/io/muserver/rest/AsynchronousProcessingTest.java
@@ -666,7 +666,7 @@ public class AsynchronousProcessingTest {
         }
     }
 
-    private static final class QueuedAsyncHandle implements AsyncHandle {
+    private static final class QueuedAsyncHandle implements AsyncHandle, io.muserver.internal.AsyncExecution {
         private final Queue<Runnable> applicationTasks = new ConcurrentLinkedQueue<>();
         private final Queue<Runnable> delayedTasks = new ConcurrentLinkedQueue<>();
         private final AtomicReference<ResponseCompleteListener> responseCompleteListener = new AtomicReference<>();


### PR DESCRIPTION
Keep handleAsync supported and move implementation dispatch methods from AsyncHandle into a hidden core/JAX-RS bridge, preserving custom-handle compatibility. Serialize accepted writes and their callbacks while completing I/O futures independently of application worker availability.

Successful completion drains accepted output and rejects later writes. Error completion cancels queued output, resets/aborts active output, and retains buffer ownership until I/O acknowledges termination. Future cancellation and interrupted HTTP/2 waits now cancel the underlying write; an active socket frame forces transport closure when necessary. Remove the unrelated two-hour waiter timeout. Preserve peer-reset fences without emitting an extra reset during cleanup.

Move cancellation future completion outside the request monitor and rethrow fatal VM/thread failures while retaining ordinary callback isolation.

Validation: full `mvn verify` on Temurin 11 passed: 1,742 tests, zero failures/errors, five existing skips; Javadoc packaging passed. New tests cover ordered output with a blocked callback, cancellation buffer ownership, a handler waiting for output on a single application worker, and flow-controlled HTTP/2 cancellation with continued connection progress.

Third of four follow-ups for #198, stacked on #213.