### PR TITLE
Fix mu4 bodyless response framing and incomplete response completion

### DIFF
--- a/src/main/java/io/muserver/BaseResponse.java
+++ b/src/main/java/io/muserver/BaseResponse.java
@@ -165,6 +165,22 @@ abstract class BaseResponse implements MuResponse {
         return null;
     }
 
+    protected final boolean suppressContent() {
+        return request.method().isHead() || !status().canHaveContent();
+    }
+
+    protected final void prepareBodylessResponseHeaders() {
+        if (status().canHaveContent()) return;
+        headers.remove(HeaderNames.TRANSFER_ENCODING);
+        if (status().noContentLengthHeader()) {
+            headers.remove(HeaderNames.CONTENT_LENGTH);
+        } else if (status().code() == 205) {
+            // Unlike 204/304, an empty HTTP/1 205 still needs explicit framing.
+            headers.set(HeaderNames.CONTENT_LENGTH, 0L);
+        }
+        // A 304 may retain the length of the selected representation.
+    }
+
 
     @Override
     public PrintWriter writer() {

--- a/src/main/java/io/muserver/Http1Connection.java
+++ b/src/main/java/io/muserver/Http1Connection.java
@@ -324,6 +324,7 @@ class Http1Connection extends BaseHttpConnection {
         try {
             muResponse.cleanup();
         } catch (Exception e) {
+            muResponse.setState(ResponseState.ERRORED);
             reallyClose = true;
         }
         return reallyClose;

--- a/src/main/java/io/muserver/Http1Response.java
+++ b/src/main/java/io/muserver/Http1Response.java
@@ -24,6 +24,7 @@ class Http1Response extends BaseResponse implements MuResponse, ResponseInfo {
         if (responseState() != ResponseState.NOTHING) {
             throw new IllegalStateException("Cannot write headers multiple times");
         }
+        prepareBodylessResponseHeaders();
         setState(ResponseState.WRITING_HEADERS);
 
         socketOut.write(status().http11ResponseLine());
@@ -53,12 +54,19 @@ class Http1Response extends BaseResponse implements MuResponse, ResponseInfo {
     @Override
     public OutputStream outputStream(int bufferSize) {
         if (wrappedOut == null) {
-            ContentEncoder responseEncoder = contentEncoder();
+            ContentEncoder responseEncoder = status().canHaveContent() ? contentEncoder() : null;
 
             long fixedLen = headers().getLong(HeaderNames.CONTENT_LENGTH.toString(), -1);
-            OutputStream rawOut = request.method().isHead() ? DiscardingOutputStream.INSTANCE : socketOut;
+            OutputStream rawOut = socketOut;
 
-            if (fixedLen == -1L) {
+            if (suppressContent()) {
+                if (request.method().isHead() && status().canHaveContent()
+                    && fixedLen == -1L && request.httpVersion() == HttpVersion.HTTP_1_1) {
+                    headers().set(HeaderNames.TRANSFER_ENCODING, HeaderValues.CHUNKED);
+                }
+                // Representation lengths on HEAD/304 do not describe bytes to write.
+                wrappedOut = DiscardingOutputStream.INSTANCE;
+            } else if (fixedLen == -1L) {
                 if (request.httpVersion() == HttpVersion.HTTP_1_1) {
                     headers().set(HeaderNames.TRANSFER_ENCODING, HeaderValues.CHUNKED);
                     wrappedOut = new ChunkedOutputStream(rawOut);
@@ -75,7 +83,9 @@ class Http1Response extends BaseResponse implements MuResponse, ResponseInfo {
 
             try {
                 writeStatusAndHeaders();
-                if (responseEncoder != null) {
+                if (suppressContent()) {
+                    socketOut.flush();
+                } else if (responseEncoder != null) {
                     wrappedOut = responseEncoder.wrapStream(request, this, wrappedOut);
                 }
             } catch (IOException e) {
@@ -91,11 +101,16 @@ class Http1Response extends BaseResponse implements MuResponse, ResponseInfo {
     void cleanup() throws IOException {
         if (responseState() == ResponseState.NOTHING) {
             // empty response body
-            if (!request.method().isHead() && status().canHaveContent() && !headers().contains(HeaderNames.CONTENT_LENGTH)) {
+            if (!suppressContent()
+                && !headers().contains(HeaderNames.CONTENT_LENGTH)) {
                 headers().set(HeaderNames.CONTENT_LENGTH, 0L);
             }
             writeStatusAndHeaders();
             socketOut.flush();
+            if (!request.method().isHead() && status().canHaveContent()
+                && headers().getLong(HeaderNames.CONTENT_LENGTH.toString(), 0L) > 0L) {
+                throw new IOException("Response completed without writing its declared body");
+            }
         } else {
             closeWriter();
             OutputStream out = wrappedOut;

--- a/src/main/java/io/muserver/Http1Response.java
+++ b/src/main/java/io/muserver/Http1Response.java
@@ -85,7 +85,8 @@ class Http1Response extends BaseResponse implements MuResponse, ResponseInfo {
                 writeStatusAndHeaders();
                 if (suppressContent()) {
                     socketOut.flush();
-                } else if (responseEncoder != null) {
+                }
+                if (responseEncoder != null) {
                     wrappedOut = responseEncoder.wrapStream(request, this, wrappedOut);
                 }
             } catch (IOException e) {

--- a/src/main/java/io/muserver/Http1Response.java
+++ b/src/main/java/io/muserver/Http1Response.java
@@ -54,7 +54,9 @@ class Http1Response extends BaseResponse implements MuResponse, ResponseInfo {
     @Override
     public OutputStream outputStream(int bufferSize) {
         if (wrappedOut == null) {
-            ContentEncoder responseEncoder = status().canHaveContent() ? contentEncoder() : null;
+            // A 304 still negotiates metadata for the selected representation.
+            ContentEncoder responseEncoder = status().canHaveContent() || status().code() == 304
+                ? contentEncoder() : null;
 
             long fixedLen = headers().getLong(HeaderNames.CONTENT_LENGTH.toString(), -1);
             OutputStream rawOut = socketOut;

--- a/src/main/java/io/muserver/Http2Response.java
+++ b/src/main/java/io/muserver/Http2Response.java
@@ -92,11 +92,8 @@ class Http2Response extends BaseResponse {
             } catch (IOException e) {
                 throw new UncheckedIOException(e);
             }
-            if (suppressContent()) {
-                wrappedOut = DiscardingOutputStream.INSTANCE;
-                return wrappedOut;
-            }
-            BufferedOutputStream os = new BufferedOutputStream(new Http2DataFrameOutputStream(stream), bufferSize);
+            OutputStream os = suppressContent() ? DiscardingOutputStream.INSTANCE
+                : new BufferedOutputStream(new Http2DataFrameOutputStream(stream), bufferSize);
             try {
                 wrappedOut = responseEncoder == null ? os : responseEncoder.wrapStream(request, this, os);
             } catch (IOException e) {

--- a/src/main/java/io/muserver/Http2Response.java
+++ b/src/main/java/io/muserver/Http2Response.java
@@ -46,6 +46,7 @@ class Http2Response extends BaseResponse {
         if (responseState() != ResponseState.NOTHING) {
             throw new IllegalStateException("Cannot write headers multiple times");
         }
+        prepareBodylessResponseHeaders();
         setState(ResponseState.WRITING_HEADERS);
         fields.add(0, new FieldLine(HeaderNames.PSEUDO_STATUS, HeaderString.valueOf(Integer.toString(status().code()), HeaderString.Type.VALUE)));
 
@@ -80,16 +81,20 @@ class Http2Response extends BaseResponse {
     @Override
     public OutputStream outputStream(int bufferSize) {
         if (wrappedOut == null) {
-            ContentEncoder responseEncoder = contentEncoder();
+            ContentEncoder responseEncoder = status().canHaveContent() ? contentEncoder() : null;
             // TODO don't do this here...
             try {
                 if (responseState() == ResponseState.NOTHING) {
-                    writeStatusAndHeaders(false);
+                    writeStatusAndHeaders(suppressContent());
                 }
             } catch (InterruptedException e) {
                 throw new RuntimeException("Interrupted while writing status headers", e);
             } catch (IOException e) {
                 throw new UncheckedIOException(e);
+            }
+            if (suppressContent()) {
+                wrappedOut = DiscardingOutputStream.INSTANCE;
+                return wrappedOut;
             }
             BufferedOutputStream os = new BufferedOutputStream(new Http2DataFrameOutputStream(stream), bufferSize);
             try {

--- a/src/main/java/io/muserver/Http2Response.java
+++ b/src/main/java/io/muserver/Http2Response.java
@@ -81,7 +81,9 @@ class Http2Response extends BaseResponse {
     @Override
     public OutputStream outputStream(int bufferSize) {
         if (wrappedOut == null) {
-            ContentEncoder responseEncoder = status().canHaveContent() ? contentEncoder() : null;
+            // A 304 still negotiates metadata for the selected representation.
+            ContentEncoder responseEncoder = status().canHaveContent() || status().code() == 304
+                ? contentEncoder() : null;
             // TODO don't do this here...
             try {
                 if (responseState() == ResponseState.NOTHING) {

--- a/src/main/java/io/muserver/HttpStatus.java
+++ b/src/main/java/io/muserver/HttpStatus.java
@@ -95,10 +95,10 @@ public class HttpStatus {
     }
 
     boolean noContentLengthHeader() {
-        return isInformational() || code == 204 || code == 304 || code == 205;
+        return isInformational() || code == 204;
     }
     boolean canHaveContent() {
-        return !noContentLengthHeader();
+        return !noContentLengthHeader() && code != 304 && code != 205;
     }
 
     /**

--- a/src/test/java/io/muserver/BodylessResponseTest.java
+++ b/src/test/java/io/muserver/BodylessResponseTest.java
@@ -1,0 +1,112 @@
+package io.muserver;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import scaffolding.ServerUtils;
+
+import java.net.Socket;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Locale;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
+
+import static io.muserver.RFCTestUtils.*;
+import static io.muserver.ResponseFramingTestSupport.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+class BodylessResponseTest {
+    static Stream<Arguments> http1Cases() {
+        return Stream.of("HTTP/1.0", "HTTP/1.1").flatMap(version ->
+            Stream.of(204, 205, 304).flatMap(status -> Arrays.stream(WriteStyle.values()).flatMap(style ->
+                Stream.of(false, true).map(gzip -> Arguments.of(version, status, style, gzip)))));
+    }
+
+    static Stream<Arguments> http2Cases() {
+        return Stream.of(204, 205, 304).flatMap(status -> Arrays.stream(WriteStyle.values()).flatMap(style ->
+            Stream.of(false, true).map(gzip -> Arguments.of(status, style, gzip))));
+    }
+
+    private static void respond(int status, WriteStyle style, MuRequest request, MuResponse response) throws Exception {
+        response.status(status);
+        response.contentType("text/plain");
+        // Existing representation metadata must be preserved for 304, removed for
+        // 204, and replaced by zero-length framing for 205.
+        if (style == WriteStyle.NONE || style == WriteStyle.EMPTY_STREAM || style == WriteStyle.EMPTY_WRITER) {
+            response.headers().set("content-length", "7");
+        }
+        writeBody(style, request, response);
+    }
+
+    @ParameterizedTest
+    @MethodSource("http1Cases")
+    void http1BodylessResponseLeavesNextResponseIntact(String version, int status, WriteStyle style, boolean gzip) throws Exception {
+        var completed = new CompletableFuture<ResponseInfo>();
+        try (var server = ServerUtils.httpsServerForTest("http")
+            .addResponseCompleteListener(completed::complete)
+            .addHandler(Method.GET, "/", (request, response, params) -> {
+                response.headers().set("connection", "keep-alive");
+                respond(status, style, request, response);
+            })
+            .addHandler(Method.GET, "/next", (request, response, params) -> response.write("next"))
+            .start();
+             var socket = new Socket("localhost", server.uri().getPort())) {
+            socket.setSoTimeout(2000);
+            String requests = "GET / " + version + "\r\nHost: localhost\r\nConnection: keep-alive\r\n"
+                + (gzip ? "Accept-Encoding: gzip\r\n" : "") + "\r\n"
+                + "GET /next " + version + "\r\nHost: localhost\r\nConnection: close\r\n\r\n";
+            socket.getOutputStream().write(requests.getBytes(StandardCharsets.US_ASCII));
+            String wire = new String(socket.getInputStream().readAllBytes(), StandardCharsets.US_ASCII);
+            assertTrue(wire.startsWith("HTTP/1.1 " + status), wire);
+            int headerEnd = wire.indexOf("\r\n\r\n");
+            String headers = wire.substring(0, headerEnd).toLowerCase(Locale.ROOT);
+            String afterHeaders = wire.substring(headerEnd + 4);
+            assertTrue(afterHeaders.startsWith("HTTP/1.1 200"), "Unexpected body bytes or lost next response: " + wire);
+            assertTrue(afterHeaders.endsWith("next"), wire);
+            assertFalse(headers.contains("transfer-encoding:"), headers);
+            if (status == 204) assertFalse(headers.contains("content-length:"), headers);
+            if (status == 205) assertTrue(headers.contains("content-length: 0"), headers);
+            if (status == 304 && (style == WriteStyle.NONE || style == WriteStyle.EMPTY_STREAM || style == WriteStyle.EMPTY_WRITER)) {
+                assertTrue(headers.contains("content-length: 7"), headers);
+            }
+            assertTrue(completed.get(2, TimeUnit.SECONDS).completedSuccessfully());
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("http2Cases")
+    void http2BodylessResponseEndsStreamWithoutContent(int status, WriteStyle style, boolean gzip) throws Exception {
+        var completed = new CompletableFuture<ResponseInfo>();
+        try (var server = ServerUtils.httpsServerForTest("h2")
+            .addResponseCompleteListener(completed::complete)
+            .addHandler(Method.GET, "/hello", (request, response, params) -> respond(status, style, request, response))
+            .start();
+             var client = new H2Client();
+             var con = client.connect(server)) {
+            con.socket().setSoTimeout(2000);
+            var headers = getHelloHeaders(server.uri().getPort());
+            if (gzip) headers.set("accept-encoding", "gzip");
+            con.handshake().writeFrame(new Http2HeadersFrame(1, true, headers)).flush();
+            var response = readIgnoringWindowUpdates(con, Http2HeadersFrame.class);
+            assertEquals(Integer.toString(status), response.headers().get(":status"));
+            int payload = 0;
+            if (!response.endStream()) {
+                Http2DataFrame frame;
+                do {
+                    frame = readIgnoringWindowUpdates(con, Http2DataFrame.class);
+                    payload += frame.payloadLength();
+                } while (!frame.endStream());
+            }
+            assertEquals(0, payload);
+            assertNull(response.headers().get("transfer-encoding"));
+            if (status == 204) assertNull(response.headers().get("content-length"));
+            if (status == 205) assertEquals("0", response.headers().get("content-length"));
+            if (status == 304 && (style == WriteStyle.NONE || style == WriteStyle.EMPTY_STREAM || style == WriteStyle.EMPTY_WRITER)) {
+                assertEquals("7", response.headers().get("content-length"));
+            }
+            assertTrue(completed.get(2, TimeUnit.SECONDS).completedSuccessfully());
+        }
+    }
+}

--- a/src/test/java/io/muserver/EmptyResponseTest.java
+++ b/src/test/java/io/muserver/EmptyResponseTest.java
@@ -7,6 +7,7 @@ import scaffolding.ClientUtils;
 import scaffolding.ServerUtils;
 
 import java.io.IOException;
+import java.net.HttpURLConnection;
 
 import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -29,6 +30,23 @@ public class EmptyResponseTest {
             assertThat(resp.header("hello"), equalTo("world"));
             assertThat(resp.header("Content-Length"), is("0"));
             assertThat(resp.body().bytes().length, is(0));
+        }
+    }
+
+    @Test
+    public void a205CompletesWithoutWaitingForConnectionClose() throws IOException {
+        server = ServerUtils.httpsServerForTest("http")
+            .addHandler(Method.GET, "/", (request, response, pathParams) -> response.status(205))
+            .start();
+
+        HttpURLConnection connection = (HttpURLConnection) server.uri().toURL().openConnection();
+        connection.setReadTimeout(2000);
+        try {
+            assertThat(connection.getResponseCode(), is(205));
+            assertThat(connection.getInputStream().read(), is(-1));
+            assertThat(connection.getHeaderField("Content-Length"), is("0"));
+        } finally {
+            connection.disconnect();
         }
     }
 

--- a/src/test/java/io/muserver/HeadContentEncoderTest.java
+++ b/src/test/java/io/muserver/HeadContentEncoderTest.java
@@ -1,0 +1,136 @@
+package io.muserver;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import scaffolding.ServerUtils;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.Socket;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Stream;
+
+import static io.muserver.RFCTestUtils.*;
+import static io.muserver.ResponseFramingTestSupport.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+class HeadContentEncoderTest {
+    static Stream<Arguments> cases() {
+        return Stream.of("http", "h2").flatMap(protocol -> Arrays.stream(WriteStyle.values()).flatMap(style ->
+            Stream.of(false, true).map(accept -> Arguments.of(protocol, style, accept))));
+    }
+
+    @ParameterizedTest
+    @MethodSource("cases")
+    void preparedHeadEncoderIsWrappedAndClosedWithoutSendingContent(String protocol, WriteStyle style, boolean accept) throws Exception {
+        var encoder = new StatefulEncoder(accept);
+        var completed = new CompletableFuture<ResponseInfo>();
+        try (var server = ServerUtils.httpsServerForTest(protocol)
+            .withContentEncoders(List.of(encoder))
+            .addResponseCompleteListener(info -> {
+                if (info.request().method().isHead()) completed.complete(info);
+            })
+            .addHandler(Method.HEAD, "/hello", (request, response, params) -> writeBody(style, request, response))
+            .addHandler(Method.GET, "/hello", (request, response, params) -> response.write("next"))
+            .start()) {
+            if (protocol.equals("http")) {
+                try (var socket = new Socket("localhost", server.uri().getPort())) {
+                    socket.setSoTimeout(2000);
+                    socket.getOutputStream().write(("HEAD /hello HTTP/1.1\r\nHost: localhost\r\n\r\n"
+                        + "GET /hello HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n")
+                        .getBytes(StandardCharsets.US_ASCII));
+                    String wire = new String(socket.getInputStream().readAllBytes(), StandardCharsets.US_ASCII);
+                    assertTrue(wire.startsWith("HTTP/1.1 200"), wire);
+                    assertTrue(wire.substring(wire.indexOf("\r\n\r\n") + 4).startsWith("HTTP/1.1 200"), wire);
+                    assertTrue(wire.endsWith("next"), wire);
+                }
+            } else {
+                try (var client = new H2Client(); var con = client.connect(server)) {
+                    con.socket().setSoTimeout(2000);
+                    var headers = getHelloHeaders(server.uri().getPort());
+                    headers.set(":method", "HEAD");
+                    con.handshake().writeFrame(new Http2HeadersFrame(1, true, headers)).flush();
+                    var response = readIgnoringWindowUpdates(con, Http2HeadersFrame.class);
+                    assertEquals("200", response.headers().get(":status"));
+                    assertTrue(response.endStream(), "HEAD must end without encoder DATA frames");
+                    con.writeFrame(new Http2HeadersFrame(3, true, getHelloHeaders(server.uri().getPort()))).flush();
+                    assertEquals("200", readIgnoringWindowUpdates(con, Http2HeadersFrame.class).headers().get(":status"));
+                    StringBuilder body = new StringBuilder();
+                    Http2DataFrame frame;
+                    do {
+                        frame = readIgnoringWindowUpdates(con, Http2DataFrame.class);
+                        body.append(frame.toUTF8());
+                    } while (!frame.endStream());
+                    assertEquals("next", body.toString());
+                }
+            }
+            assertTrue(completed.get(2, TimeUnit.SECONDS).completedSuccessfully());
+            assertEquals(style == WriteStyle.NONE ? 0 : 1, encoder.prepared.get());
+            int expectedWraps = accept && style != WriteStyle.NONE ? 1 : 0;
+            assertEquals(expectedWraps, encoder.wrapped.get(), "Successful preparation must be followed by wrapping");
+            assertEquals(expectedWraps, encoder.released.get(), "Encoder resources must be released on completion");
+            assertFalse(encoder.resourceHeld.get());
+            int expectedBytes = expectedWraps == 1 && style != WriteStyle.EMPTY_STREAM && style != WriteStyle.EMPTY_WRITER ? 5 : 0;
+            assertEquals(expectedBytes, encoder.bodyBytes.get());
+        }
+    }
+
+    private static final class StatefulEncoder implements ContentEncoder {
+        final boolean accept;
+        final AtomicInteger prepared = new AtomicInteger();
+        final AtomicInteger wrapped = new AtomicInteger();
+        final AtomicInteger released = new AtomicInteger();
+        final AtomicInteger bodyBytes = new AtomicInteger();
+        final AtomicBoolean resourceHeld = new AtomicBoolean();
+
+        StatefulEncoder(boolean accept) { this.accept = accept; }
+
+        @Override public String contentCoding() { return "test"; }
+
+        @Override
+        public boolean prepare(MuRequest request, MuResponse response) {
+            if (!request.method().isHead()) return false;
+            prepared.incrementAndGet();
+            if (accept) {
+                resourceHeld.set(true);
+                response.headers().set("content-encoding", contentCoding());
+                response.headers().remove("content-length");
+            }
+            return accept;
+        }
+
+        @Override
+        public OutputStream wrapStream(MuRequest request, MuResponse response, OutputStream stream) throws IOException {
+            wrapped.incrementAndGet();
+            assertTrue(resourceHeld.get());
+            stream.write("prefix".getBytes(StandardCharsets.US_ASCII));
+            return new OutputStream() {
+                private boolean closed;
+                @Override public void write(int b) throws IOException {
+                    bodyBytes.incrementAndGet();
+                    stream.write(b);
+                }
+                @Override public void flush() throws IOException { stream.flush(); }
+                @Override public void close() throws IOException {
+                    if (!closed) {
+                        closed = true;
+                        try {
+                            stream.write("suffix".getBytes(StandardCharsets.US_ASCII));
+                            stream.close();
+                        } finally {
+                            resourceHeld.set(false);
+                            released.incrementAndGet();
+                        }
+                    }
+                }
+            };
+        }
+    }
+}

--- a/src/test/java/io/muserver/HeadResponseFramingTest.java
+++ b/src/test/java/io/muserver/HeadResponseFramingTest.java
@@ -1,0 +1,103 @@
+package io.muserver;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import scaffolding.ServerUtils;
+
+import java.net.Socket;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
+
+import static io.muserver.RFCTestUtils.*;
+import static io.muserver.ResponseFramingTestSupport.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+class HeadResponseFramingTest {
+    static Stream<Arguments> writes() {
+        return Arrays.stream(WriteStyle.values()).flatMap(style -> Stream.of(
+            Arguments.of(style, false), Arguments.of(style, true)));
+    }
+
+    @ParameterizedTest
+    @MethodSource("writes")
+    void http1HeadHasNoDataAndConnectionRemainsUsable(WriteStyle style, boolean gzip) throws Exception {
+        var completed = new CompletableFuture<ResponseInfo>();
+        try (var server = ServerUtils.httpsServerForTest("http")
+            .addResponseCompleteListener(completed::complete)
+            .addHandler(Method.HEAD, "/", (request, response, params) -> {
+                response.contentType("text/plain");
+                if (style == WriteStyle.NONE || style == WriteStyle.EMPTY_STREAM || style == WriteStyle.EMPTY_WRITER) {
+                    response.headers().set("content-length", "5");
+                }
+                writeBody(style, request, response);
+            })
+            .addHandler(Method.GET, "/", (request, response, params) -> response.write("next"))
+            .start();
+             var socket = new Socket("localhost", server.uri().getPort())) {
+            socket.setSoTimeout(2000);
+            String requests = "HEAD / HTTP/1.1\r\nHost: localhost\r\n"
+                + (gzip ? "Accept-Encoding: gzip\r\n" : "") + "\r\n"
+                + "GET / HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n";
+            socket.getOutputStream().write(requests.getBytes(StandardCharsets.US_ASCII));
+            String wire = new String(socket.getInputStream().readAllBytes(), StandardCharsets.US_ASCII);
+            assertTrue(wire.startsWith("HTTP/1.1 200"), wire);
+            assertTrue(wire.substring(wire.indexOf("\r\n\r\n") + 4).startsWith("HTTP/1.1 200"), wire);
+            assertTrue(wire.endsWith("next"), wire);
+            assertTrue(completed.get(2, TimeUnit.SECONDS).completedSuccessfully());
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("writes")
+    void http2HeadHasNoDataAndConnectionRemainsUsable(WriteStyle style, boolean gzip) throws Exception {
+        var completed = new CompletableFuture<ResponseInfo>();
+        try (var server = ServerUtils.httpsServerForTest("h2")
+            .addResponseCompleteListener(completed::complete)
+            .addHandler(Method.HEAD, "/hello", (request, response, params) -> {
+                response.contentType("text/plain");
+                if (style == WriteStyle.NONE || style == WriteStyle.EMPTY_STREAM || style == WriteStyle.EMPTY_WRITER) {
+                    response.headers().set("content-length", "5");
+                }
+                writeBody(style, request, response);
+            })
+            .addHandler(Method.GET, "/hello", (request, response, params) -> response.write("next"))
+            .start();
+             var client = new H2Client();
+             var con = client.connect(server)) {
+            con.socket().setSoTimeout(2000);
+            var headers = getHelloHeaders(server.uri().getPort());
+            headers.set(":method", "HEAD");
+            if (gzip) headers.set("accept-encoding", "gzip");
+            con.handshake().writeFrame(new Http2HeadersFrame(1, true, headers)).flush();
+            var response = readIgnoringWindowUpdates(con, Http2HeadersFrame.class);
+            assertEquals("200", response.headers().get(":status"));
+            if (!gzip && (style == WriteStyle.WRITE || style == WriteStyle.NONE
+                || style == WriteStyle.EMPTY_STREAM || style == WriteStyle.EMPTY_WRITER)) {
+                assertEquals("5", response.headers().get("content-length"));
+            }
+            int bodyBytes = 0;
+            if (!response.endStream()) {
+                Http2DataFrame frame;
+                do {
+                    frame = readIgnoringWindowUpdates(con, Http2DataFrame.class);
+                    bodyBytes += frame.payloadLength();
+                } while (!frame.endStream());
+            }
+            assertEquals(0, bodyBytes, "HEAD sent DATA payload bytes");
+            assertTrue(completed.get(2, TimeUnit.SECONDS).completedSuccessfully());
+            con.writeFrame(new Http2HeadersFrame(3, true, getHelloHeaders(server.uri().getPort()))).flush();
+            assertEquals("200", readIgnoringWindowUpdates(con, Http2HeadersFrame.class).headers().get(":status"));
+            var body = new StringBuilder();
+            Http2DataFrame frame;
+            do {
+                frame = readIgnoringWindowUpdates(con, Http2DataFrame.class);
+                body.append(frame.toUTF8());
+            } while (!frame.endStream());
+            assertEquals("next", body.toString());
+        }
+    }
+}

--- a/src/test/java/io/muserver/IncompleteResponseTest.java
+++ b/src/test/java/io/muserver/IncompleteResponseTest.java
@@ -1,0 +1,89 @@
+package io.muserver;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import scaffolding.ServerUtils;
+
+import java.net.Socket;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class IncompleteResponseTest {
+    @ParameterizedTest
+    @CsvSource({"HTTP/1.0,none", "HTTP/1.1,none", "HTTP/1.1,stream-empty",
+        "HTTP/1.1,stream-short", "HTTP/1.1,writer-empty", "HTTP/1.1,writer-short",
+        "HTTP/1.1,closed-writer-short", "HTTP/1.1,async-none", "HTTP/1.1,async-short"})
+    void incompleteBodyClosesConnectionAndReportsFailure(String version, String style) throws Exception {
+        var completed = new CompletableFuture<ResponseInfo>();
+        var nextRequests = new AtomicInteger();
+        try (var server = ServerUtils.httpsServerForTest("http")
+            .addResponseCompleteListener(completed::complete)
+            .addHandler(Method.GET, "/", (request, response, params) -> {
+                response.headers().set("content-length", "5");
+                response.headers().set("connection", "keep-alive");
+                if (style.startsWith("async")) {
+                    var async = request.handleAsync();
+                    if (style.endsWith("short")) {
+                        async.write(ByteBuffer.wrap(new byte[] {'a', 'b'}), async::complete);
+                    } else {
+                        async.complete();
+                    }
+                } else if (style.contains("stream")) {
+                    var out = response.outputStream();
+                    if (style.endsWith("short")) out.write(new byte[] {'a', 'b'});
+                } else if (style.contains("writer")) {
+                    var writer = response.writer();
+                    if (style.endsWith("short")) writer.write("ab");
+                    if (style.startsWith("closed")) writer.close();
+                }
+            })
+            .addHandler(Method.GET, "/next", (request, response, params) -> {
+                nextRequests.incrementAndGet();
+                response.write("next");
+            }).start();
+             var socket = new Socket("localhost", server.uri().getPort())) {
+            socket.setSoTimeout(2000);
+            String requests = "GET / " + version + "\r\nHost: localhost\r\nConnection: keep-alive\r\n\r\n"
+                + "GET /next " + version + "\r\nHost: localhost\r\nConnection: close\r\n\r\n";
+            socket.getOutputStream().write(requests.getBytes(StandardCharsets.US_ASCII));
+            String wire = new String(socket.getInputStream().readAllBytes(), StandardCharsets.US_ASCII);
+            assertTrue(wire.startsWith("HTTP/1.1 200"), wire);
+            assertEquals(style.endsWith("short") ? "ab" : "", wire.substring(wire.indexOf("\r\n\r\n") + 4), wire);
+            assertEquals(0, nextRequests.get(), "An incomplete response connection was reused");
+            var info = completed.get(2, TimeUnit.SECONDS);
+            assertFalse(info.completedSuccessfully());
+            assertEquals(ResponseState.ERRORED, info.response().responseState());
+        }
+    }
+
+    @ParameterizedTest
+    @CsvSource({"0,none", "5,stream", "5,writer"})
+    void completeBodyKeepsConnectionReusable(int length, String style) throws Exception {
+        var completed = new CompletableFuture<ResponseInfo>();
+        try (var server = ServerUtils.httpsServerForTest("http")
+            .addResponseCompleteListener(completed::complete)
+            .addHandler(Method.GET, "/", (request, response, params) -> {
+                response.headers().set("content-length", length);
+                if (style.equals("stream")) response.outputStream().write("hello".getBytes(StandardCharsets.US_ASCII));
+                if (style.equals("writer")) response.writer().write("hello");
+            })
+            .addHandler(Method.GET, "/next", (request, response, params) -> response.write("next"))
+            .start();
+             var socket = new Socket("localhost", server.uri().getPort())) {
+            socket.setSoTimeout(2000);
+            socket.getOutputStream().write(("GET / HTTP/1.1\r\nHost: localhost\r\n\r\n"
+                + "GET /next HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n")
+                .getBytes(StandardCharsets.US_ASCII));
+            String wire = new String(socket.getInputStream().readAllBytes(), StandardCharsets.US_ASCII);
+            String afterHeaders = wire.substring(wire.indexOf("\r\n\r\n") + 4);
+            assertTrue(afterHeaders.startsWith((length == 0 ? "" : "hello") + "HTTP/1.1 200"), wire);
+            assertTrue(wire.endsWith("next"), wire);
+            assertTrue(completed.get(2, TimeUnit.SECONDS).completedSuccessfully());
+        }
+    }
+}

--- a/src/test/java/io/muserver/NotModifiedContentEncoderTest.java
+++ b/src/test/java/io/muserver/NotModifiedContentEncoderTest.java
@@ -1,0 +1,133 @@
+package io.muserver;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import scaffolding.ServerUtils;
+
+import java.io.FilterOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.Socket;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Stream;
+
+import static io.muserver.RFCTestUtils.*;
+import static io.muserver.ResponseFramingTestSupport.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+class NotModifiedContentEncoderTest {
+    static Stream<Arguments> cases() {
+        return Stream.of("HTTP/1.0", "HTTP/1.1", "h2").flatMap(protocol ->
+            Arrays.stream(WriteStyle.values()).filter(style -> style != WriteStyle.NONE).flatMap(style ->
+                Stream.of("gzip", "identity", "already-encoded").map(coding -> Arguments.of(protocol, style, coding))));
+    }
+
+    @ParameterizedTest
+    @MethodSource("cases")
+    void notModifiedNegotiatesLikeOkWithoutSendingContent(String protocol, WriteStyle style, String coding) throws Exception {
+        var prepared304 = new AtomicInteger();
+        var wrapped304 = new AtomicInteger();
+        var closed304 = new AtomicInteger();
+        var completed304 = new CompletableFuture<ResponseInfo>();
+        var gzip = GZIPEncoderBuilder.gzipEncoder().withMinGzipSize(0).withMimeTypesToGzip(Set.of("text/plain")).build();
+        var encoder = new ContentEncoder() {
+            @Override public String contentCoding() { return gzip.contentCoding(); }
+            @Override public boolean prepare(MuRequest request, MuResponse response) {
+                if (response.status().code() == 304) prepared304.incrementAndGet();
+                return gzip.prepare(request, response);
+            }
+            @Override public OutputStream wrapStream(MuRequest request, MuResponse response, OutputStream stream) throws IOException {
+                OutputStream encoded = gzip.wrapStream(request, response, stream);
+                if (response.status().code() != 304) return encoded;
+                wrapped304.incrementAndGet();
+                return new FilterOutputStream(encoded) {
+                    private boolean closed;
+                    @Override public void close() throws IOException {
+                        if (!closed) {
+                            closed = true;
+                            try { super.close(); } finally { closed304.incrementAndGet(); }
+                        }
+                    }
+                };
+            }
+        };
+        try (var server = ServerUtils.httpsServerForTest(protocol.equals("h2") ? "h2" : "http")
+            .withContentEncoders(List.of(encoder))
+            .addResponseCompleteListener(info -> {
+                if (info.response().status().code() == 304) completed304.complete(info);
+            })
+            .addHandler(Method.GET, "/hello", (request, response, params) -> {
+                response.status(request.headers().contains("if-none-match") ? 304 : 200);
+                response.contentType("text/plain");
+                response.headers().set("etag", "\"version1\"");
+                response.headers().set("vary", "accept-language");
+                if (coding.equals("already-encoded")) response.headers().set("content-encoding", "test");
+                writeBody(style, request, response);
+            }).start()) {
+            FieldBlock ok = exchange(server, protocol, coding, false);
+            FieldBlock notModified = exchange(server, protocol, coding, true);
+            assertTrue(completed304.get(2, TimeUnit.SECONDS).completedSuccessfully());
+            assertAll("304 must preserve the selected representation metadata",
+                () -> assertEquals(ok.get("vary"), notModified.get("vary")),
+                () -> assertEquals(ok.get("content-encoding"), notModified.get("content-encoding")),
+                () -> assertEquals(ok.get("content-length"), notModified.get("content-length")));
+            assertNull(notModified.get("transfer-encoding"));
+            assertEquals("\"version1\"", notModified.get("etag"));
+            assertEquals(1, prepared304.get());
+            int expectedWraps = coding.equals("gzip") ? 1 : 0;
+            assertEquals(expectedWraps, wrapped304.get());
+            assertEquals(expectedWraps, closed304.get());
+            if (coding.equals("gzip")) {
+                assertEquals("gzip", notModified.get("content-encoding"));
+                assertNull(notModified.get("content-length"), "Do not advertise the unencoded length for gzip");
+            }
+        }
+    }
+
+    private static FieldBlock exchange(MuServer server, String protocol, String coding, boolean conditional) throws Exception {
+        int expectedStatus = conditional ? 304 : 200;
+        if (protocol.equals("h2")) {
+            try (var client = new H2Client(); var con = client.connect(server)) {
+                con.socket().setSoTimeout(2000);
+                var headers = getHelloHeaders(server.uri().getPort());
+                headers.set("accept-encoding", coding.equals("identity") ? "identity" : "gzip");
+                if (conditional) headers.set("if-none-match", "\"version1\"");
+                con.handshake().writeFrame(new Http2HeadersFrame(1, true, headers)).flush();
+                var response = readIgnoringWindowUpdates(con, Http2HeadersFrame.class);
+                assertEquals(Integer.toString(expectedStatus), response.headers().get(":status"));
+                if (conditional) {
+                    assertTrue(response.endStream(), "304 must end without gzip DATA frames");
+                } else if (!response.endStream()) {
+                    Http2DataFrame frame;
+                    do { frame = readIgnoringWindowUpdates(con, Http2DataFrame.class); } while (!frame.endStream());
+                }
+                return response.headers();
+            }
+        }
+        try (var socket = new Socket("localhost", server.uri().getPort())) {
+            socket.setSoTimeout(2000);
+            String request = "GET /hello " + protocol + "\r\nHost: localhost\r\nConnection: close\r\n"
+                + "Accept-Encoding: " + (coding.equals("identity") ? "identity" : "gzip") + "\r\n"
+                + (conditional ? "If-None-Match: \"version1\"\r\n" : "") + "\r\n";
+            socket.getOutputStream().write(request.getBytes(StandardCharsets.US_ASCII));
+            String wire = new String(socket.getInputStream().readAllBytes(), StandardCharsets.ISO_8859_1);
+            assertTrue(wire.startsWith("HTTP/1.1 " + expectedStatus), wire);
+            int headerEnd = wire.indexOf("\r\n\r\n");
+            assertTrue(headerEnd > 0, wire);
+            if (conditional) assertEquals("", wire.substring(headerEnd + 4), "304 sent encoder output");
+            var headers = new FieldBlock();
+            for (String line : wire.substring(0, headerEnd).split("\r\n")) {
+                int colon = line.indexOf(':');
+                if (colon > 0) headers.add(line.substring(0, colon), line.substring(colon + 1).trim());
+            }
+            return headers;
+        }
+    }
+}

--- a/src/test/java/io/muserver/ResponseFramingAuditTest.java
+++ b/src/test/java/io/muserver/ResponseFramingAuditTest.java
@@ -5,7 +5,6 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import scaffolding.ServerUtils;
 
-import java.net.HttpURLConnection;
 import java.net.Socket;
 import java.nio.charset.StandardCharsets;
 
@@ -110,15 +109,19 @@ class ResponseFramingAuditTest {
         try (var server = ServerUtils.httpsServerForTest("http")
             .addHandler(Method.GET, "/", (request, response, params) -> {
                 response.headers().set("content-length", "5");
-            }).start()) {
-            HttpURLConnection connection = (HttpURLConnection) server.uri().toURL().openConnection();
-            connection.setReadTimeout(2000);
-            try {
-                assertEquals(200, connection.getResponseCode());
-                assertEquals(-1, connection.getInputStream().read());
-            } finally {
-                connection.disconnect();
-            }
+            }).start();
+             var socket = new Socket("localhost", server.uri().getPort())) {
+            socket.setSoTimeout(2000);
+            socket.getOutputStream().write("GET / HTTP/1.1\r\nHost: localhost\r\n\r\n"
+                .getBytes(StandardCharsets.US_ASCII));
+            // Read through transport EOF: HTTP clients differ in how they expose
+            // a closed response that contains fewer bytes than Content-Length.
+            String wire = new String(socket.getInputStream().readAllBytes(), StandardCharsets.US_ASCII);
+            assertTrue(wire.startsWith("HTTP/1.1 200"), wire);
+            int headerEnd = wire.indexOf("\r\n\r\n");
+            assertTrue(headerEnd > 0, wire);
+            assertTrue(wire.substring(0, headerEnd).contains("content-length: 5"), wire);
+            assertEquals("", wire.substring(headerEnd + 4), wire);
         }
     }
 }

--- a/src/test/java/io/muserver/ResponseFramingAuditTest.java
+++ b/src/test/java/io/muserver/ResponseFramingAuditTest.java
@@ -1,0 +1,124 @@
+package io.muserver;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import scaffolding.ServerUtils;
+
+import java.net.HttpURLConnection;
+import java.net.Socket;
+import java.nio.charset.StandardCharsets;
+
+import static io.muserver.RFCTestUtils.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+class ResponseFramingAuditTest {
+    @Test
+    void http10StreamingResponseClosesToDelimitContent() throws Exception {
+        try (var server = ServerUtils.httpsServerForTest("http")
+            .addHandler(Method.GET, "/", (request, response, params) -> response.sendChunk("hello"))
+            .start();
+             var socket = new Socket("localhost", server.uri().getPort())) {
+            socket.setSoTimeout(2000);
+            socket.getOutputStream().write("GET / HTTP/1.0\r\nHost: localhost\r\nConnection: keep-alive\r\n\r\n"
+                .getBytes(StandardCharsets.US_ASCII));
+            String wire = new String(socket.getInputStream().readAllBytes(), StandardCharsets.US_ASCII);
+            assertTrue(wire.startsWith("HTTP/1.1 200"), wire);
+            assertEquals("hello", wire.substring(wire.indexOf("\r\n\r\n") + 4), wire);
+        }
+    }
+
+    @Test
+    void http1HeadDiscardsContent() throws Exception {
+        try (var server = ServerUtils.httpsServerForTest("http")
+            .addHandler(Method.HEAD, "/", (request, response, params) -> response.write("hello"))
+            .start();
+             var socket = new Socket("localhost", server.uri().getPort())) {
+            socket.setSoTimeout(2000);
+            socket.getOutputStream().write("HEAD / HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n"
+                .getBytes(StandardCharsets.US_ASCII));
+            String wire = new String(socket.getInputStream().readAllBytes(), StandardCharsets.US_ASCII);
+            assertTrue(wire.startsWith("HTTP/1.1 200"), wire);
+            assertEquals("", wire.substring(wire.indexOf("\r\n\r\n") + 4), wire);
+        }
+    }
+
+    @Test
+    void http2Empty205EndsStream() throws Exception {
+        try (var server = ServerUtils.httpsServerForTest("h2")
+            .addHandler(Method.GET, "/hello", (request, response, params) -> response.status(205))
+            .start();
+             var client = new H2Client();
+             var con = client.connect(server)) {
+            con.socket().setSoTimeout(2000);
+            con.handshake().writeFrame(new Http2HeadersFrame(1, true, getHelloHeaders(server.uri().getPort()))).flush();
+            var response = readIgnoringWindowUpdates(con, Http2HeadersFrame.class);
+            assertEquals("205", response.headers().get(":status"));
+            assertTrue(response.endStream());
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {204, 205, 304})
+    void http1SuppressesContentForBodylessStatuses(int status) throws Exception {
+        try (var server = ServerUtils.httpsServerForTest("http")
+            .addHandler(Method.GET, "/", (request, response, params) -> {
+                response.status(status);
+                response.write("hello");
+            }).start();
+             var socket = new Socket("localhost", server.uri().getPort())) {
+            socket.setSoTimeout(2000);
+            socket.getOutputStream().write(("GET / HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n")
+                .getBytes(StandardCharsets.US_ASCII));
+            String wire = new String(socket.getInputStream().readAllBytes(), StandardCharsets.US_ASCII);
+            assertTrue(wire.startsWith("HTTP/1.1 " + status), wire);
+            assertEquals("", wire.substring(wire.indexOf("\r\n\r\n") + 4), wire);
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {200, 204, 205, 304})
+    void http2SuppressesContentForHeadAndBodylessStatuses(int status) throws Exception {
+        Method method = status == 200 ? Method.HEAD : Method.GET;
+        try (var server = ServerUtils.httpsServerForTest("h2")
+            .addHandler(method, "/hello", (request, response, params) -> {
+                response.status(status);
+                response.write("hello");
+            }).start();
+             var client = new H2Client();
+             var con = client.connect(server)) {
+            con.socket().setSoTimeout(2000);
+            var headers = getHelloHeaders(server.uri().getPort());
+            headers.set(":method", method.name());
+            con.handshake().writeFrame(new Http2HeadersFrame(1, true, headers)).flush();
+            var response = readIgnoringWindowUpdates(con, Http2HeadersFrame.class);
+            assertEquals(Integer.toString(status), response.headers().get(":status"));
+            int payloadBytes = 0;
+            if (!response.endStream()) {
+                Http2DataFrame frame;
+                do {
+                    frame = readIgnoringWindowUpdates(con, Http2DataFrame.class);
+                    payloadBytes += frame.payloadLength();
+                } while (!frame.endStream());
+            }
+            assertEquals(0, payloadBytes, "Unexpected response body for " + method + " status " + status);
+        }
+    }
+
+    @Test
+    void http1UnwrittenDeclaredBodyDoesNotHangClient() throws Exception {
+        try (var server = ServerUtils.httpsServerForTest("http")
+            .addHandler(Method.GET, "/", (request, response, params) -> {
+                response.headers().set("content-length", "5");
+            }).start()) {
+            HttpURLConnection connection = (HttpURLConnection) server.uri().toURL().openConnection();
+            connection.setReadTimeout(2000);
+            try {
+                assertEquals(200, connection.getResponseCode());
+                assertEquals(-1, connection.getInputStream().read());
+            } finally {
+                connection.disconnect();
+            }
+        }
+    }
+}

--- a/src/test/java/io/muserver/ResponseFramingTestSupport.java
+++ b/src/test/java/io/muserver/ResponseFramingTestSupport.java
@@ -1,0 +1,28 @@
+package io.muserver;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+
+final class ResponseFramingTestSupport {
+    enum WriteStyle { NONE, EMPTY_STREAM, EMPTY_WRITER, WRITE, STREAM, WRITER, CHUNK, ASYNC }
+
+    static void writeBody(WriteStyle style, MuRequest request, MuResponse response) throws Exception {
+        switch (style) {
+            case NONE: break;
+            case EMPTY_STREAM: response.outputStream(); break;
+            case EMPTY_WRITER: response.writer(); break;
+            case WRITE: response.write("hello"); break;
+            case STREAM:
+                response.outputStream().write('h');
+                response.outputStream().write("ello".getBytes(StandardCharsets.US_ASCII));
+                response.outputStream().flush();
+                break;
+            case WRITER: response.writer().write("hello"); break;
+            case CHUNK: response.sendChunk("hello"); break;
+            case ASYNC:
+                var async = request.handleAsync();
+                async.write(ByteBuffer.wrap("hello".getBytes(StandardCharsets.US_ASCII)), async::complete);
+                break;
+        }
+    }
+}


### PR DESCRIPTION
An empty HTTP/1 205 response left TCK clients waiting indefinitely because Mu kept the connection open without declaring the empty body. This change supplies zero-length framing for 205 and fixes related response completion problems in mu4's transport.

- Discard body writes for HEAD and 204/205/304 across HTTP/1 and HTTP/2, including streams, writers, chunks, async writes, and compression paths.
- Remove prohibited framing headers for 204, retain representation length for HEAD/304, and finish bodyless HTTP/2 responses with END_STREAM.
- Close incomplete HTTP/1 responses and report ERRORED when a handler declares a body but finishes without writing it. Pipelined requests can no longer append a subsequent response to that unfinished body.
- Allow empty HEAD output streams to complete without enforcing the representation's Content-Length as a required body size.

Tests were added and observed failing before each corresponding fix. Coverage includes HTTP/1.0, HTTP/1.1, HTTP/2, header preservation, gzip negotiation, async completion, connection reuse, and valid-response controls.

Validation with Temurin 11.0.32.1:

- Full Maven suite: 2,085 tests, zero failures/errors, five skipped. Two additional async cases were then added; the resulting 12-case incomplete-response suite passed.
- Final focused framing/lifecycle inventory: 218 passing cases.
- Full Jakarta REST 3.1 TCK harness: 829 passed, 76 unsupported, 130 blocked, two expected failures, and zero unexpected results across 1,037 cases.
- TCK execution: 23.92 seconds, versus an earlier master run of 24.56 seconds. These are single-run wall-clock measurements, excluding Maven build/setup.
